### PR TITLE
Clarify sync lifecycle and suppress expected miss logs

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -148,7 +148,8 @@ func newBackgroundRunner(syncService *service.SyncService, cfg config.Config) Ru
 	return poller.New(syncService, cfg.PollInterval)
 }
 
-// runTemporaryStartupSnapshotRunsCleanup 是临时启动清理入口，后续删除 snapshot_runs 临时治理时可直接移除。
+// runTemporaryStartupSnapshotRunsCleanup 是启动期额外执行的 snapshot_runs 治理入口，和每日清理共用 CleanupSnapshotRuns 语义。
+// 它只处理 snapshot_runs 并执行 VACUUM，不包含每日 CleanupStorage 中的 redis_usage_inboxes 清理。
 func runTemporaryStartupSnapshotRunsCleanup(db *gorm.DB) error {
 	logrus.Info("temporary snapshot runs cleanup started")
 	if _, err := repository.CleanupSnapshotRuns(db, time.Now()); err != nil {

--- a/internal/app/maintenance.go
+++ b/internal/app/maintenance.go
@@ -30,6 +30,7 @@ func NewStorageCleanupRunner(syncer StorageCleanupSyncer) *StorageCleanupRunner 
 	}
 }
 
+// Run 每天按项目本地时区 03:00 执行一次统一存储清理，失败只记录日志，不终止后台任务。
 func (r *StorageCleanupRunner) Run(ctx context.Context) error {
 	if err := r.validate(); err != nil {
 		return err
@@ -53,6 +54,7 @@ func (r *StorageCleanupRunner) Run(ctx context.Context) error {
 	}
 }
 
+// nextDailyCleanupAt 用 time.Local 计算下一次 03:00，因此 TZ 同时控制业务日期边界和清理触发时间。
 func nextDailyCleanupAt(now time.Time) time.Time {
 	localNow := now.In(time.Local)
 	cleanupAt := time.Date(localNow.Year(), localNow.Month(), localNow.Day(), 3, 0, 0, 0, time.Local)

--- a/internal/poller/redis_drain.go
+++ b/internal/poller/redis_drain.go
@@ -12,7 +12,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const redisInboxProcessInterval = 5 * time.Second // Redis inbox 处理频率固定在这里，后续如需配置优先改这里。
+// Redis inbox 处理频率固定为 5 秒：拉取任务只负责把 Redis 原始消息落库，处理任务按这个间隔独立消费本地 inbox。
+const redisInboxProcessInterval = 5 * time.Second
 
 type RedisBatchSyncer interface {
 	PullRedisUsageInbox(ctx context.Context) (*service.RedisInboxPullResult, error)
@@ -52,6 +53,7 @@ func NewRedisDrain(syncer RedisBatchSyncer, cfg RedisDrainConfig) *RedisDrain {
 	}
 }
 
+// Run 启动 Redis 连续同步：一个 goroutine 只执行 Pull，另一个 goroutine 只执行 Process，二者互不串行等待。
 func (d *RedisDrain) Run(ctx context.Context) error {
 	if err := d.validate(); err != nil {
 		return err
@@ -74,6 +76,7 @@ func (d *RedisDrain) Run(ctx context.Context) error {
 	return nil
 }
 
+// runPullLoop 只从 CPA Redis 队列 LPOP 数据并写入 redis_usage_inboxes，不解码、不写 usage_events、不创建 snapshot_runs。
 func (d *RedisDrain) runPullLoop(ctx context.Context) {
 	logrus.WithField("idle_interval", d.config.IdleInterval.String()).Info("redis inbox pull task started")
 	for {
@@ -100,6 +103,7 @@ func (d *RedisDrain) runPullLoop(ctx context.Context) {
 	}
 }
 
+// runProcessLoop 固定每 5 秒处理已落库的 inbox 行，失败行保留为可重试状态，坏消息单独标记不阻塞后续行。
 func (d *RedisDrain) runProcessLoop(ctx context.Context) {
 	logrus.WithField("interval", redisInboxProcessInterval.String()).Info("redis inbox process task started")
 	for {
@@ -151,6 +155,7 @@ func (d *RedisDrain) Status() Status {
 	}
 }
 
+// SyncNow 是手动同步入口：Redis 模式下先 Pull 一次再 Process 一次，保持用户手动触发时立即看到新数据的直觉。
 func (d *RedisDrain) SyncNow(ctx context.Context) error {
 	if err := d.validate(); err != nil {
 		return err
@@ -162,6 +167,7 @@ func (d *RedisDrain) SyncNow(ctx context.Context) error {
 	return err
 }
 
+// runRedisPull 只防止 Pull 自身重入，不阻塞 Process；这样 Redis 长轮询或退避不会跳过本地 inbox 处理周期。
 func (d *RedisDrain) runRedisPull(ctx context.Context) (*service.RedisInboxPullResult, error) {
 	d.mu.Lock()
 	if d.pullRunning {
@@ -182,6 +188,7 @@ func (d *RedisDrain) runRedisPull(ctx context.Context) (*service.RedisInboxPullR
 	return result, err
 }
 
+// runRedisProcess 只防止 Process 自身重入，不阻塞 Pull；Process 的输入必须来自已持久化的 redis_usage_inboxes。
 func (d *RedisDrain) runRedisProcess(ctx context.Context, syncMetadata bool) (*service.RedisBatchSyncResult, error) {
 	d.mu.Lock()
 	if d.processRunning {

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -171,17 +171,20 @@ func FindLatestUsageEventTimestamp(db *gorm.DB) (*time.Time, error) {
 	}
 
 	var event models.UsageEvent
-	if err := db.Select("timestamp").Order("timestamp DESC").Limit(1).Take(&event).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("find latest usage event timestamp: %w", err)
+	result := db.Select("timestamp").Order("timestamp DESC").Limit(1).Find(&event)
+	if result.Error != nil {
+		return nil, fmt.Errorf("find latest usage event timestamp: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return nil, nil
 	}
 
 	timestamp := event.Timestamp.UTC()
 	return &timestamp, nil
 }
 
+// CleanupSnapshotRuns 按项目本地日期保留今天和往前 7 天内每天最新的一条 snapshot_run。
+// 只要保留窗口内存在快照，其它 snapshot_runs 都会删除；如果窗口内没有任何快照，则直接返回避免误删全表。
 func CleanupSnapshotRuns(db *gorm.DB, now time.Time) (SnapshotRunsCleanupResult, error) {
 	if db == nil {
 		return SnapshotRunsCleanupResult{}, fmt.Errorf("database is nil")
@@ -216,6 +219,8 @@ func CleanupSnapshotRuns(db *gorm.DB, now time.Time) (SnapshotRunsCleanupResult,
 	return SnapshotRunsCleanupResult{Deleted: deleted.RowsAffected}, nil
 }
 
+// CleanupStorage 是每日维护任务的统一仓储清理入口：先清 Redis inbox，再清 snapshot_runs，最后执行 VACUUM。
+// VACUUM 必须在删除完成后单独执行，任何一步失败都会停止后续步骤并把已完成部分的结果返回给上层日志。
 func CleanupStorage(db *gorm.DB, now time.Time) (StorageCleanupResult, error) {
 	redisResult, err := CleanupRedisUsageInbox(db, now)
 	if err != nil {

--- a/internal/repository/redis_usage_inbox.go
+++ b/internal/repository/redis_usage_inbox.go
@@ -111,6 +111,8 @@ func ListPendingRedisUsageInbox(db *gorm.DB, limit int) ([]models.RedisUsageInbo
 	return rows, nil
 }
 
+// CleanupRedisUsageInbox 清理已完成和失败的 Redis inbox 原始消息，pending 数据永远不在这里删除。
+// processed 保留到下一个本地日开始后才清理；decode_failed/process_failed/discarded 保留 7 天便于排查。
 func CleanupRedisUsageInbox(db *gorm.DB, now time.Time) (RedisUsageInboxCleanupResult, error) {
 	localNow := now.In(time.Local)
 	localDayStart := time.Date(localNow.Year(), localNow.Month(), localNow.Day(), 0, 0, 0, 0, time.Local)

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -247,6 +246,8 @@ func (s *SyncService) SyncMetadata(ctx context.Context) error {
 	return err
 }
 
+// PullRedisUsageInbox 是 Redis 同步的拉取阶段：只 LPOP 队列消息并原样写入 redis_usage_inboxes。
+// 这个阶段不解码消息、不写 usage_events、不创建 snapshot_runs，保证 Redis 消费和本地处理职责分离。
 func (s *SyncService) PullRedisUsageInbox(ctx context.Context) (*RedisInboxPullResult, error) {
 	if err := s.validate(syncMetadataOptional); err != nil {
 		return nil, err
@@ -279,6 +280,8 @@ func (s *SyncService) PullRedisUsageInbox(ctx context.Context) (*RedisInboxPullR
 	return &RedisInboxPullResult{Status: "completed", InsertedRows: len(inboxRows)}, nil
 }
 
+// ProcessRedisUsageInbox 是 Redis 同步的本地处理阶段：只读取 pending/process_failed inbox 行并写入 usage_events。
+// Redis 路径不再写 snapshot_runs；成功处理后仅用 usage_event_key 记录 inbox 与最终事件的关联。
 func (s *SyncService) ProcessRedisUsageInbox(ctx context.Context, syncMetadata bool) (*RedisBatchSyncResult, error) {
 	if err := s.validate(syncMetadata); err != nil {
 		return nil, err
@@ -295,6 +298,7 @@ func (s *SyncService) ProcessRedisUsageInbox(ctx context.Context, syncMetadata b
 	return s.processRedisInboxRows(ctx, processableRows, fetchedAt, syncMetadata)
 }
 
+// CleanupRedisUsageInbox 只清理 Redis inbox 表，供测试和单独维护入口使用；每日任务使用 CleanupStorage 统一执行。
 func (s *SyncService) CleanupRedisUsageInbox(ctx context.Context) error {
 	if err := s.validate(syncMetadataOptional); err != nil {
 		return err
@@ -303,6 +307,7 @@ func (s *SyncService) CleanupRedisUsageInbox(ctx context.Context) error {
 	return err
 }
 
+// CleanupStorage 是每日 03:00 维护任务调用的统一入口：先清 Redis inbox，再清 snapshot_runs，最后 VACUUM 收缩 SQLite。
 func (s *SyncService) CleanupStorage(ctx context.Context) error {
 	if err := s.validate(syncMetadataOptional); err != nil {
 		return err
@@ -311,7 +316,8 @@ func (s *SyncService) CleanupStorage(ctx context.Context) error {
 	return err
 }
 
-// SyncRedisBatch 保留为手动兼容入口；后台 Redis drain 使用拆分后的 pull/process/cleanup 方法。
+// SyncRedisBatch 保留为兼容入口：先处理本地存量 inbox，空了再拉一次 Redis 并立即处理。
+// 后台任务不要调用它，后台必须使用拆分后的 PullRedisUsageInbox、ProcessRedisUsageInbox 和 CleanupStorage。
 func (s *SyncService) SyncRedisBatch(ctx context.Context, syncMetadata bool) (*RedisBatchSyncResult, error) {
 	if result, err := s.ProcessRedisUsageInbox(ctx, syncMetadata); err != nil || result == nil || !result.Empty {
 		return result, err
@@ -322,7 +328,8 @@ func (s *SyncService) SyncRedisBatch(ctx context.Context, syncMetadata bool) (*R
 	return s.ProcessRedisUsageInbox(ctx, syncMetadata)
 }
 
-// processRedisInboxRows 只从已落库的原始消息解码和写入事件，坏消息不会阻塞同批其它数据。
+// processRedisInboxRows 只从已落库的原始消息解码和写入事件，坏消息会标记为 decode_failed，不阻塞同批其它数据。
+// 可解码但入库失败的消息标记为 process_failed，后续 ProcessRedisUsageInbox 会按 id 顺序重试。
 func (s *SyncService) processRedisInboxRows(ctx context.Context, inboxRows []models.RedisUsageInbox, fetchedAt time.Time, syncMetadata bool) (*RedisBatchSyncResult, error) {
 	logrus.WithFields(logrus.Fields{
 		"row_count":     len(inboxRows),
@@ -397,7 +404,8 @@ func (s *SyncService) processRedisInboxRows(ctx context.Context, inboxRows []mod
 	}, returnErr
 }
 
-// SyncLegacyStatus 执行 legacy export 同步并返回最终状态。
+// SyncLegacyStatus 执行 legacy_export 回退路径并返回 snapshot_run 最终状态。
+// legacy_export 仍然会创建 snapshot_runs、保存原始导出 payload，并把 usage_events 关联到本次 snapshot_run。
 func (s *SyncService) SyncLegacyStatus(ctx context.Context) (string, error) {
 	if err := s.validate(syncMetadataRequired); err != nil {
 		return "", err
@@ -415,7 +423,8 @@ func (s *SyncService) SyncLegacyStatus(ctx context.Context) (string, error) {
 	return result.Status, err
 }
 
-// syncOnce 执行一次完整的 legacy 拉取、快照落库和事件写入流程。
+// syncOnce 执行一次完整的 legacy_export 同步：拉取导出、创建 snapshot_run、写 usage_events、同步 metadata 和备份。
+// 该路径用于 legacy_export 模式以及 auto 探测 Redis 不可用后的回退模式，不参与 Redis inbox 分阶段处理。
 func (s *SyncService) syncOnce(ctx context.Context) (*SyncResult, error) {
 	if err := s.validate(syncMetadataRequired); err != nil {
 		return nil, err
@@ -432,6 +441,7 @@ func (s *SyncService) syncOnce(ctx context.Context) (*SyncResult, error) {
 	return s.persistUsageResult(ctx, fetchedAt, fetchResult, fetchErr, true, true)
 }
 
+// persistRedisUsageEvents 是 Redis inbox 专用入库路径，只写 usage_events 和可选 metadata，不创建 snapshot_runs。
 func (s *SyncService) persistRedisUsageEvents(ctx context.Context, fetchResult *UsageFetchResult, syncMetadata bool) (*SyncResult, error) {
 	if fetchResult == nil {
 		return nil, fmt.Errorf("redis usage fetch result is nil")
@@ -490,7 +500,8 @@ func (s *SyncService) persistRedisUsageEvents(ctx context.Context, fetchResult *
 	return result, nil
 }
 
-// persistUsageResult 保存 legacy export 快照和 usage_events。
+// persistUsageResult 是 legacy_export 专用入库路径，负责 snapshot_runs 的完整生命周期和 usage_events 写入。
+// 即使拉取失败也会创建并 finalize snapshot_run，用于保留失败状态、HTTP 状态、错误信息和原始 payload 审计线索。
 func (s *SyncService) persistUsageResult(ctx context.Context, fetchedAt time.Time, fetchResult *UsageFetchResult, fetchErr error, syncMetadata bool, filterByWatermark bool) (*SyncResult, error) {
 	logrus.WithFields(logrus.Fields{
 		"sync_metadata":       syncMetadata,
@@ -736,7 +747,7 @@ func alignUsageEventKeysWithExistingCanonicalEvents(db *gorm.DB, events []models
 		}
 
 		var existing models.UsageEvent
-		err := db.Select("event_key").Where(
+		result := db.Select("event_key").Where(
 			"TRIM(api_group_key) = ? AND TRIM(model) = ? AND timestamp = ? AND TRIM(source) = ? AND TRIM(auth_index) = ? AND failed = ? AND input_tokens = ? AND output_tokens = ? AND reasoning_tokens = ? AND cached_tokens = ? AND total_tokens = ?",
 			strings.TrimSpace(events[i].APIGroupKey),
 			strings.TrimSpace(events[i].Model),
@@ -749,13 +760,13 @@ func alignUsageEventKeysWithExistingCanonicalEvents(db *gorm.DB, events []models
 			events[i].ReasoningTokens,
 			events[i].CachedTokens,
 			events[i].TotalTokens,
-		).Order("id ASC").Take(&existing).Error
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				canonicalEventKeys[canonicalKey] = incomingKey
-				continue
-			}
-			return nil, fmt.Errorf("find equivalent usage event: %w", err)
+		).Order("id ASC").Limit(1).Find(&existing)
+		if result.Error != nil {
+			return nil, fmt.Errorf("find equivalent usage event: %w", result.Error)
+		}
+		if result.RowsAffected == 0 {
+			canonicalEventKeys[canonicalKey] = incomingKey
+			continue
 		}
 		existingKey := strings.TrimSpace(existing.EventKey)
 		if existingKey != "" {
@@ -811,7 +822,8 @@ type legacyUsageFetcher struct {
 	}
 }
 
-// FetchUsage 从 legacy export 拉取用量数据，只记录状态和计数，不记录原始 payload。
+// FetchUsage 从 legacy export 接口拉取完整导出结果，保留 raw payload 给 persistUsageResult 写入 snapshot_runs。
+// 这是 Redis 队列不可用时的回退数据源，事件 key 仍在后续入库阶段与既有 canonical event 对齐。
 func (f legacyUsageFetcher) FetchUsage(ctx context.Context, _ time.Time) (*UsageFetchResult, error) {
 	if f.client == nil {
 		return nil, fmt.Errorf("legacy usage client is nil")

--- a/internal/service/sync_test.go
+++ b/internal/service/sync_test.go
@@ -315,6 +315,18 @@ func TestSyncOnceDeduplicatesExistingEvents(t *testing.T) {
 	}
 }
 
+func TestSyncOnceDoesNotLogExpectedEventAlignmentMiss(t *testing.T) {
+	db, logs := openSyncTestDatabaseWithLogs(t)
+	service := NewSyncServiceWithClient(db, "https://cpa.example.com", stubExportFetcher{result: successfulExportResult([]byte(`{"version":1}`))})
+
+	if _, err := service.SyncNow(context.Background()); err != nil {
+		t.Fatalf("SyncNow returned error: %v", err)
+	}
+	if strings.Contains(logs.String(), "record not found") {
+		t.Fatalf("expected normal event alignment miss not to be logged, got %s", logs.String())
+	}
+}
+
 func TestSyncOnceSkipsBackupWhenDisabled(t *testing.T) {
 	db, logs := openSyncTestDatabaseWithLogs(t)
 	backupWriter := &stubBackupWriter{path: "/tmp/export.json"}


### PR DESCRIPTION
## Summary
- Add explicit comments for Redis pull/process/cleanup, startup cleanup, and legacy_export responsibilities.
- Treat normal empty usage lookups as business misses instead of GORM record-not-found errors.
- Add regression coverage to prevent expected event alignment misses from logging `record not found`.

## Test plan
- [x] go test ./internal/service ./internal/repository ./internal/poller ./internal/app -count=1
- [x] npm --prefix ./web run build
- [x] Manual run with .env and observed no `record not found` logs after startup/process interval