### PR TITLE
feat: add usage import API and UI button

### DIFF
--- a/internal/api/auth_files_test.go
+++ b/internal/api/auth_files_test.go
@@ -19,7 +19,7 @@ func (s authFileStub) ListAuthFiles(context.Context) ([]models.AuthFile, error) 
 }
 
 func TestAuthFilesRouteReturnsEmptyResponseWithoutProvider(t *testing.T) {
-	router := NewRouter("", nil, nil, nil, nil, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, nil, nil, nil, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth-files", nil)
 	resp := httptest.NewRecorder()
 
@@ -37,7 +37,7 @@ func TestAuthFilesRouteReturnsStoredMetadata(t *testing.T) {
 		Email:     "user@example.com",
 		Type:      "claude",
 		Provider:  "anthropic",
-	}}}, nil, nil, AuthConfig{}, nil, "")
+	}}}, nil, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth-files", nil)
 	resp := httptest.NewRecorder()
 

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAuthSessionReportsAuthenticatedWhenDisabled(t *testing.T) {
-	router := NewRouter("", nil, nil, nil, nil, nil, AuthConfig{Enabled: false}, nil, "")
+	router := NewRouter("", nil, nil, nil, nil, nil, AuthConfig{Enabled: false}, nil, "", nil)
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/session", nil)
 
@@ -25,7 +25,7 @@ func TestAuthSessionReportsAuthenticatedWhenDisabled(t *testing.T) {
 func TestAuthProtectedRouteRequiresSessionWhenEnabled(t *testing.T) {
 	sessions := auth.NewSessionManager(time.Hour)
 	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
-	router := NewRouter("", nil, nil, nil, nil, nil, config, NewAuthHandler(config, sessions), "")
+	router := NewRouter("", nil, nil, nil, nil, nil, config, NewAuthHandler(config, sessions), "", nil)
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/overview", nil)
 
@@ -40,7 +40,7 @@ func TestAuthLoginSetsCookieAndUnlocksProtectedRoute(t *testing.T) {
 	sessions := auth.NewSessionManager(time.Hour)
 	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
 	handler := NewAuthHandler(config, sessions)
-	router := NewRouter("", nil, nil, nil, nil, nil, config, handler, "")
+	router := NewRouter("", nil, nil, nil, nil, nil, config, handler, "", nil)
 
 	loginResp := httptest.NewRecorder()
 	loginReq := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(`{"password":"secret"}`))
@@ -74,7 +74,7 @@ func TestAuthLoginSetsCookieAndUnlocksProtectedRoute(t *testing.T) {
 func TestAuthLoginRejectsWrongPassword(t *testing.T) {
 	sessions := auth.NewSessionManager(time.Hour)
 	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
-	router := NewRouter("", nil, nil, nil, nil, nil, config, NewAuthHandler(config, sessions), "")
+	router := NewRouter("", nil, nil, nil, nil, nil, config, NewAuthHandler(config, sessions), "", nil)
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(`{"password":"wrong"}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -89,7 +89,7 @@ func TestAuthLoginRejectsWrongPassword(t *testing.T) {
 func TestAuthLoginRateLimitsRepeatedFailures(t *testing.T) {
 	sessions := auth.NewSessionManager(time.Hour)
 	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
-	router := NewRouter("", nil, nil, nil, nil, nil, config, NewAuthHandler(config, sessions), "")
+	router := NewRouter("", nil, nil, nil, nil, nil, config, NewAuthHandler(config, sessions), "", nil)
 
 	for i := 0; i < 5; i++ {
 		resp := httptest.NewRecorder()
@@ -116,7 +116,7 @@ func TestAuthLoginRateLimitsRepeatedFailures(t *testing.T) {
 func TestAuthLoginAllowsCorrectPasswordAfterRateLimitThreshold(t *testing.T) {
 	sessions := auth.NewSessionManager(time.Hour)
 	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
-	router := NewRouter("", nil, nil, nil, nil, nil, config, NewAuthHandler(config, sessions), "")
+	router := NewRouter("", nil, nil, nil, nil, nil, config, NewAuthHandler(config, sessions), "", nil)
 
 	for i := 0; i < 5; i++ {
 		resp := httptest.NewRecorder()
@@ -144,7 +144,7 @@ func TestAuthLogoutDeletesSessionCookie(t *testing.T) {
 	sessions := auth.NewSessionManager(time.Hour)
 	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
 	handler := NewAuthHandler(config, sessions)
-	router := NewRouter("", nil, nil, nil, nil, nil, config, handler, "")
+	router := NewRouter("", nil, nil, nil, nil, nil, config, handler, "", nil)
 
 	loginResp := httptest.NewRecorder()
 	loginReq := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(`{"password":"secret"}`))
@@ -183,7 +183,7 @@ func TestSubpathAuthUsesPrefixedRoutesAndCookiePath(t *testing.T) {
 	sessions := auth.NewSessionManager(time.Hour)
 	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour, BasePath: "/cpa"}
 	handler := NewAuthHandler(config, sessions)
-	router := NewRouter("", nil, nil, nil, nil, nil, config, handler, "/cpa")
+	router := NewRouter("", nil, nil, nil, nil, nil, config, handler, "/cpa", nil)
 
 	sessionResp := httptest.NewRecorder()
 	sessionReq := httptest.NewRequest(http.MethodGet, "/cpa/api/v1/auth/session", nil)

--- a/internal/api/pricing_test.go
+++ b/internal/api/pricing_test.go
@@ -39,7 +39,7 @@ func (s *pricingStub) DeletePricing(_ context.Context, model string) error {
 }
 
 func TestPricingRoutesReturnEmptyResponsesWithoutProvider(t *testing.T) {
-	router := NewRouter("", nil, nil, nil, nil, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, nil, nil, nil, nil, AuthConfig{}, nil, "", nil)
 
 	usedReq := httptest.NewRequest(http.MethodGet, "/api/v1/models/used", nil)
 	usedResp := httptest.NewRecorder()
@@ -65,7 +65,7 @@ func TestPricingRoutesReturnConfiguredData(t *testing.T) {
 			CompletionPricePer1M: 15,
 			CachePricePer1M:      0.3,
 		}},
-	}, AuthConfig{}, nil, "")
+	}, AuthConfig{}, nil, "", nil)
 
 	usedReq := httptest.NewRequest(http.MethodGet, "/api/v1/models/used", nil)
 	usedResp := httptest.NewRecorder()
@@ -91,7 +91,7 @@ func TestUpdatePricingRoute(t *testing.T) {
 			CachePricePer1M:      0.3,
 		},
 	}
-	router := NewRouter("", nil, nil, nil, nil, provider, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, nil, nil, nil, provider, AuthConfig{}, nil, "", nil)
 
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/pricing/claude-sonnet", strings.NewReader(`{"prompt_price_per_1m":3,"completion_price_per_1m":15,"cache_price_per_1m":0.3}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -112,7 +112,7 @@ func TestUpdatePricingRouteAcceptsModelInBody(t *testing.T) {
 			CachePricePer1M:      0.3,
 		},
 	}
-	router := NewRouter("", nil, nil, nil, nil, provider, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, nil, nil, nil, provider, AuthConfig{}, nil, "", nil)
 
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/pricing", strings.NewReader(`{"model":"openai/gpt-4.1","prompt_price_per_1m":3,"completion_price_per_1m":15,"cache_price_per_1m":0.3}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -129,7 +129,7 @@ func TestUpdatePricingRouteAcceptsModelInBody(t *testing.T) {
 
 func TestDeletePricingRoute(t *testing.T) {
 	provider := &pricingStub{}
-	router := NewRouter("", nil, nil, nil, nil, provider, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, nil, nil, nil, provider, AuthConfig{}, nil, "", nil)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/pricing?model=openai%2Fgpt-4.1", nil)
 	resp := httptest.NewRecorder()

--- a/internal/api/provider_metadata_test.go
+++ b/internal/api/provider_metadata_test.go
@@ -20,7 +20,7 @@ func (s providerMetadataStub) ListProviderMetadata(context.Context) ([]models.Pr
 }
 
 func TestProviderMetadataRouteReturnsEmptyResponseWithoutProvider(t *testing.T) {
-	router := NewRouter("", nil, nil, nil, nil, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, nil, nil, nil, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/provider-metadata", nil)
 	resp := httptest.NewRecorder()
 
@@ -37,7 +37,7 @@ func TestProviderMetadataRouteReturnsStoredMetadata(t *testing.T) {
 		ProviderType: "openai",
 		DisplayName:  "ChatGPT Mirror",
 		ProviderKey:  "openai:ChatGPT Mirror",
-	}}}, nil, AuthConfig{}, nil, "")
+	}}}, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/provider-metadata", nil)
 	resp := httptest.NewRecorder()
 
@@ -56,7 +56,7 @@ func TestProviderMetadataRouteReturnsStoredMetadata(t *testing.T) {
 }
 
 func TestProviderMetadataRouteHidesInternalErrors(t *testing.T) {
-	router := NewRouter("", nil, nil, nil, providerMetadataStub{err: errors.New("database contains sk-secret-1234")}, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, nil, nil, providerMetadataStub{err: errors.New("database contains sk-secret-1234")}, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/provider-metadata", nil)
 	resp := httptest.NewRecorder()
 
@@ -78,7 +78,7 @@ func TestProviderMetadataRouteDisambiguatesSameNamedProviders(t *testing.T) {
 	router := NewRouter("", nil, nil, nil, providerMetadataStub{items: []models.ProviderMetadata{
 		{ID: 1, LookupKey: "sk-test-1234", ProviderType: "openai", DisplayName: "Shared"},
 		{ID: 2, LookupKey: "sk-test-5678", ProviderType: "openai", DisplayName: "Shared"},
-	}}, nil, AuthConfig{}, nil, "")
+	}}, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/provider-metadata", nil)
 	resp := httptest.NewRecorder()
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -15,6 +15,7 @@ import (
 	"cpa-usage-keeper/internal/poller"
 	"cpa-usage-keeper/internal/service"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 const appBasePathPlaceholder = "__APP_BASE_PATH__"
@@ -54,6 +55,7 @@ func NewRouter(
 	authConfig AuthConfig,
 	authHandler *authHandler,
 	basePath string,
+	db *gorm.DB,
 ) *gin.Engine {
 	router := gin.New()
 	router.Use(gin.Recovery())
@@ -83,6 +85,7 @@ func NewRouter(
 	registerAuthFileRoutes(protected, authFileProvider)
 	registerProviderMetadataRoutes(protected, providerMetadataProvider)
 	registerPricingRoutes(protected, pricingProvider)
+	registerUsageImportRoute(protected, db)
 
 	if staticDir != "" {
 		if info, err := os.Stat(staticDir); err == nil && info.IsDir() {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -36,7 +36,7 @@ func (s *syncStatusStub) SyncNow(context.Context) error {
 }
 
 func TestHealthzReturnsOK(t *testing.T) {
-	router := NewRouter("", nil, nil, nil, nil, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, nil, nil, nil, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	resp := httptest.NewRecorder()
 
@@ -56,7 +56,7 @@ func TestStatusReturnsPollerState(t *testing.T) {
 		LastError:   "boom",
 		LastWarning: "metadata unavailable",
 		LastStatus:  "completed_with_warnings",
-	}}, nil, nil, nil, nil, AuthConfig{}, nil, "")
+	}}, nil, nil, nil, nil, AuthConfig{}, nil, "", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
 	resp := httptest.NewRecorder()
@@ -80,7 +80,7 @@ func TestStatusReturnsProjectTimezone(t *testing.T) {
 	t.Cleanup(func() { time.Local = previousLocal })
 	time.Local = location
 
-	router := NewRouter("", nil, nil, nil, nil, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, nil, nil, nil, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -94,7 +94,7 @@ func TestStatusReturnsProjectTimezone(t *testing.T) {
 }
 
 func TestStatusReturnsEmptyStateWithoutProvider(t *testing.T) {
-	router := NewRouter("", nil, nil, nil, nil, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, nil, nil, nil, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -110,7 +110,7 @@ func TestStatusReturnsEmptyStateWithoutProvider(t *testing.T) {
 func TestManualSyncTriggersSyncRunner(t *testing.T) {
 	lastRunAt := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
 	syncer := &syncStatusStub{status: poller.Status{Running: true, LastRunAt: lastRunAt, LastStatus: "completed"}}
-	router := NewRouter("", syncer, nil, nil, nil, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", syncer, nil, nil, nil, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sync", nil)
 	resp := httptest.NewRecorder()
 
@@ -130,7 +130,7 @@ func TestManualSyncTriggersSyncRunner(t *testing.T) {
 
 func TestManualSyncReturnsConflictWhenAlreadyRunning(t *testing.T) {
 	syncer := &syncStatusStub{err: poller.ErrSyncAlreadyRunning}
-	router := NewRouter("", syncer, nil, nil, nil, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", syncer, nil, nil, nil, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sync", nil)
 	resp := httptest.NewRecorder()
 
@@ -146,7 +146,7 @@ func TestManualSyncReturnsWarningsAsSuccessfulStatus(t *testing.T) {
 		status: poller.Status{LastStatus: "completed_with_warnings", LastWarning: "metadata unavailable"},
 		err:    poller.ErrSyncCompletedWithWarnings,
 	}
-	router := NewRouter("", syncer, nil, nil, nil, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", syncer, nil, nil, nil, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sync", nil)
 	resp := httptest.NewRecorder()
 
@@ -163,7 +163,7 @@ func TestManualSyncReturnsWarningsAsSuccessfulStatus(t *testing.T) {
 
 func TestManualSyncRateLimitsRepeatedRequests(t *testing.T) {
 	syncer := &syncStatusStub{status: poller.Status{LastStatus: "completed"}}
-	router := NewRouter("", syncer, nil, nil, nil, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", syncer, nil, nil, nil, nil, AuthConfig{}, nil, "", nil)
 
 	firstResp := httptest.NewRecorder()
 	firstReq := httptest.NewRequest(http.MethodPost, "/api/v1/sync", nil)
@@ -188,7 +188,7 @@ func TestSubpathRoutesOnlyServePrefixedEndpoints(t *testing.T) {
 	router := NewRouter("", statusStub{status: poller.Status{
 		Running:   true,
 		LastRunAt: lastRunAt,
-	}}, nil, nil, nil, nil, AuthConfig{BasePath: "/cpa"}, nil, "/cpa")
+	}}, nil, nil, nil, nil, AuthConfig{BasePath: "/cpa"}, nil, "/cpa", nil)
 
 	for _, testCase := range []struct {
 		path       string
@@ -220,7 +220,7 @@ func TestSubpathStaticRoutesServeOnlyUnderPrefix(t *testing.T) {
 		t.Fatalf("write asset: %v", err)
 	}
 
-	router := NewRouter(staticDir, nil, nil, nil, nil, nil, AuthConfig{BasePath: "/cpa"}, nil, "/cpa")
+	router := NewRouter(staticDir, nil, nil, nil, nil, nil, AuthConfig{BasePath: "/cpa"}, nil, "/cpa", nil)
 
 	for _, testCase := range []struct {
 		path       string
@@ -252,7 +252,7 @@ func TestRootStaticRouteInjectsEmptyBasePath(t *testing.T) {
 		t.Fatalf("write index: %v", err)
 	}
 
-	router := NewRouter(staticDir, nil, nil, nil, nil, nil, AuthConfig{}, nil, "")
+	router := NewRouter(staticDir, nil, nil, nil, nil, nil, AuthConfig{}, nil, "", nil)
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	router.ServeHTTP(resp, req)

--- a/internal/api/usage_analysis_test.go
+++ b/internal/api/usage_analysis_test.go
@@ -82,7 +82,7 @@ func TestUsageAnalysisReturnsAggregatedRows(t *testing.T) {
 			LatencySampleCount: 2,
 		}},
 	}}
-	router := NewRouter("", nil, provider, nil, nil, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, provider, nil, nil, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/analysis?range=24h", nil)
 	resp := httptest.NewRecorder()
 
@@ -116,7 +116,7 @@ func TestUsageAnalysisReturnsAggregatedRows(t *testing.T) {
 }
 
 func TestUsageAnalysisRequiresAuthWhenEnabled(t *testing.T) {
-	router := NewRouter("", nil, &usageAnalysisStub{}, nil, nil, nil, AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}, nil, "")
+	router := NewRouter("", nil, &usageAnalysisStub{}, nil, nil, nil, AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/analysis", nil)
 	resp := httptest.NewRecorder()
 

--- a/internal/api/usage_events_test.go
+++ b/internal/api/usage_events_test.go
@@ -75,7 +75,7 @@ func TestUsageEventsReturnsFilteredRows(t *testing.T) {
 		CachedTokens:    1,
 		TotalTokens:     18,
 	}}}
-	router := NewRouter("", nil, provider, authFileStub{files: []models.AuthFile{{AuthIndex: "2", Email: "user@example.com", Type: "auth-file"}}}, providerMetadataStub{items: []models.ProviderMetadata{{LookupKey: "sk-provider-key", ProviderType: "openai", DisplayName: "OpenAI Mirror", ProviderKey: "openai:OpenAI Mirror"}}}, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, provider, authFileStub{files: []models.AuthFile{{AuthIndex: "2", Email: "user@example.com", Type: "auth-file"}}}, providerMetadataStub{items: []models.ProviderMetadata{{LookupKey: "sk-provider-key", ProviderType: "openai", DisplayName: "OpenAI Mirror", ProviderKey: "openai:OpenAI Mirror"}}}, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/events?range=24h", nil)
 	resp := httptest.NewRecorder()
 
@@ -122,7 +122,7 @@ func TestUsageEventsReturnsFilteredRows(t *testing.T) {
 
 func TestUsageEventsPassesPaginationAndServerFilters(t *testing.T) {
 	provider := &usageEventsStub{eventsPage: &service.UsageEventsPage{Events: []service.UsageEventRecord{}, TotalCount: 0, Page: 3, PageSize: 100, TotalPages: 0}}
-	router := NewRouter("", nil, provider, nil, providerMetadataStub{items: []models.ProviderMetadata{{LookupKey: "source-a", ProviderType: "openai", DisplayName: "Provider A", ProviderKey: "openai:Provider A"}}}, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, provider, nil, providerMetadataStub{items: []models.ProviderMetadata{{LookupKey: "source-a", ProviderType: "openai", DisplayName: "Provider A", ProviderKey: "openai:Provider A"}}}, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/events?page=3&page_size=100&model=claude-sonnet&source=openai:Provider%20A&result=failed", nil)
 	resp := httptest.NewRecorder()
 
@@ -152,7 +152,7 @@ func TestUsageEventsReturnsFilterOptions(t *testing.T) {
 		Sources:    []string{"source-a", "source-b"},
 		TotalCount: 2, Page: 1, PageSize: 20, TotalPages: 1,
 	}}
-	router := NewRouter("", nil, provider, authFileStub{files: []models.AuthFile{{AuthIndex: "1", Email: "user@example.com", Type: "auth-file"}}}, providerMetadataStub{items: []models.ProviderMetadata{{LookupKey: "source-a", ProviderType: "openai", DisplayName: "Provider A", ProviderKey: "openai:Provider A"}, {LookupKey: "source-b", ProviderType: "anthropic", DisplayName: "Provider B", ProviderKey: "anthropic:Provider B"}}}, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, provider, authFileStub{files: []models.AuthFile{{AuthIndex: "1", Email: "user@example.com", Type: "auth-file"}}}, providerMetadataStub{items: []models.ProviderMetadata{{LookupKey: "source-a", ProviderType: "openai", DisplayName: "Provider A", ProviderKey: "openai:Provider A"}, {LookupKey: "source-b", ProviderType: "anthropic", DisplayName: "Provider B", ProviderKey: "anthropic:Provider B"}}}, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/events", nil)
 	resp := httptest.NewRecorder()
 
@@ -178,7 +178,7 @@ func TestUsageEventFilterOptionsReturnsStableModelsAndSources(t *testing.T) {
 		Models:  []string{"claude-sonnet", "gpt-5"},
 		Sources: []string{"source-a", "source-b"},
 	}}
-	router := NewRouter("", nil, provider, authFileStub{files: []models.AuthFile{{AuthIndex: "1", Email: "user@example.com", Type: "auth-file"}}}, providerMetadataStub{items: []models.ProviderMetadata{{LookupKey: "source-a", ProviderType: "openai", DisplayName: "Provider A", ProviderKey: "openai:Provider A"}, {LookupKey: "source-b", ProviderType: "anthropic", DisplayName: "Provider B", ProviderKey: "anthropic:Provider B"}}}, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, provider, authFileStub{files: []models.AuthFile{{AuthIndex: "1", Email: "user@example.com", Type: "auth-file"}}}, providerMetadataStub{items: []models.ProviderMetadata{{LookupKey: "source-a", ProviderType: "openai", DisplayName: "Provider A", ProviderKey: "openai:Provider A"}, {LookupKey: "source-b", ProviderType: "anthropic", DisplayName: "Provider B", ProviderKey: "anthropic:Provider B"}}}, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/events/filters?range=24h&model=ignored&source=ignored&result=failed&page=3&page_size=20", nil)
 	resp := httptest.NewRecorder()
 
@@ -217,7 +217,7 @@ func TestUsageCredentialsReturnsAggregatedRows(t *testing.T) {
 		Failed:       true,
 		RequestCount: 1,
 	}}}
-	router := NewRouter("", nil, provider, authFileStub{files: []models.AuthFile{{AuthIndex: "2", Email: "user@example.com", Type: "auth-file"}}}, providerMetadataStub{items: []models.ProviderMetadata{{LookupKey: "sk-provider-key", ProviderType: "openai", DisplayName: "OpenAI Mirror", ProviderKey: "openai:OpenAI Mirror"}}}, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, provider, authFileStub{files: []models.AuthFile{{AuthIndex: "2", Email: "user@example.com", Type: "auth-file"}}}, providerMetadataStub{items: []models.ProviderMetadata{{LookupKey: "sk-provider-key", ProviderType: "openai", DisplayName: "OpenAI Mirror", ProviderKey: "openai:OpenAI Mirror"}}}, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/credentials?range=24h", nil)
 	resp := httptest.NewRecorder()
 

--- a/internal/api/usage_import.go
+++ b/internal/api/usage_import.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"cpa-usage-keeper/internal/cpa"
+	"cpa-usage-keeper/internal/models"
+	"cpa-usage-keeper/internal/repository"
+	"cpa-usage-keeper/internal/service"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+type usageImportHandler struct {
+	db *gorm.DB
+}
+
+type usageImportRequest struct {
+	Version int                    `json:"version"`
+	Usage   cpa.StatisticsSnapshot `json:"usage"`
+}
+
+type usageImportResponse struct {
+	Added   int `json:"added"`
+	Skipped int `json:"skipped"`
+	Total   int `json:"total"`
+	Failed  int `json:"failed"`
+}
+
+func registerUsageImportRoute(router gin.IRoutes, db *gorm.DB) {
+	handler := &usageImportHandler{db: db}
+	router.POST("/usage/import", handler.importUsage)
+}
+
+func (h *usageImportHandler) importUsage(c *gin.Context) {
+	data, err := c.GetRawData()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read request body"})
+		return
+	}
+
+	var req usageImportRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json"})
+		return
+	}
+
+	if req.Version != 0 && req.Version != 1 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported version, must be 0 or 1"})
+		return
+	}
+
+	snapshotRun := &models.SnapshotRun{
+		FetchedAt:  time.Now().UTC(),
+		CPABaseURL: "import",
+		Status:     "pending",
+		RawPayload: data,
+	}
+	if err := h.db.Create(snapshotRun).Error; err != nil {
+		writeInternalError(c, "create snapshot run for import", err)
+		return
+	}
+
+	events := service.FlattenUsageExport(snapshotRun.ID, cpa.UsageExport{
+		Version:    req.Version,
+		ExportedAt: time.Now().UTC(),
+		Usage:      req.Usage,
+	})
+
+	if len(events) == 0 {
+		if err := h.db.Model(&models.SnapshotRun{}).Where("id = ?", snapshotRun.ID).Updates(map[string]any{
+			"status":          "completed",
+			"inserted_events": 0,
+			"deduped_events":  0,
+		}).Error; err != nil {
+			writeInternalError(c, "finalize imported snapshot run", err)
+			return
+		}
+		c.JSON(http.StatusOK, usageImportResponse{})
+		return
+	}
+
+	inserted, deduped, err := repository.InsertUsageEvents(h.db, events)
+	if err != nil {
+		writeInternalError(c, "insert imported usage events", err)
+		return
+	}
+
+	failed := len(events) - inserted - deduped
+	if err := h.db.Model(&models.SnapshotRun{}).Where("id = ?", snapshotRun.ID).Updates(map[string]any{
+		"status":          "completed",
+		"inserted_events": inserted,
+		"deduped_events":  deduped,
+	}).Error; err != nil {
+		writeInternalError(c, "finalize imported snapshot run", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, usageImportResponse{
+		Added:   inserted,
+		Skipped: deduped,
+		Total:   inserted + deduped + failed,
+		Failed:  failed,
+	})
+}

--- a/internal/api/usage_overview_test.go
+++ b/internal/api/usage_overview_test.go
@@ -68,7 +68,7 @@ func TestUsageOverviewResponseIncludesResolvedRangeAndTimezone(t *testing.T) {
 	time.Local = location
 
 	provider := &usageFilterStub{overview: &service.UsageOverviewSnapshot{}}
-	router := NewRouter("", nil, provider, nil, nil, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, provider, nil, nil, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/overview?range=custom&start=2026-04-20&end=2026-04-21", nil)
 	resp := httptest.NewRecorder()
 
@@ -147,7 +147,7 @@ func TestUsageOverviewReturnsFilteredSnapshot(t *testing.T) {
 			}},
 		},
 	}}
-	router := NewRouter("", nil, provider, authFileStub{files: []models.AuthFile{{AuthIndex: "2", Email: "user@example.com", Type: "auth-file"}}}, nil, nil, AuthConfig{}, nil, "")
+	router := NewRouter("", nil, provider, authFileStub{files: []models.AuthFile{{AuthIndex: "2", Email: "user@example.com", Type: "auth-file"}}}, nil, nil, AuthConfig{}, nil, "", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/overview?range=24h", nil)
 	resp := httptest.NewRecorder()
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -113,6 +113,7 @@ func NewWithConfig(cfg config.Config) (*App, error) {
 			},
 			authHandler,
 			cfg.AppBasePath,
+			db,
 		),
 	}, nil
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -237,3 +237,25 @@ export async function deletePricing(model: string): Promise<void> {
     await parseApiError(response, `Failed to delete pricing: ${response.status}`)
   }
 }
+
+export interface UsageImportResult {
+  added: number
+  skipped: number
+  total: number
+  failed: number
+}
+
+export async function importUsage(snapshot: unknown, signal?: AbortSignal): Promise<UsageImportResult> {
+  const response = await apiFetch(apiPath('/usage/import'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(snapshot),
+    signal,
+  })
+  if (!response.ok) {
+    await parseApiError(response, `Failed to import usage: ${response.status}`)
+  }
+  return response.json()
+}

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -14,7 +14,7 @@ import {
   Legend,
   Filler
 } from 'chart.js';
-import { ApiError, fetchStatus, fetchUsageAnalysis, fetchUsageCredentials, fetchUsageEventFilterOptions, fetchUsageEvents, triggerSync } from '@/lib/api';
+import { ApiError, fetchStatus, fetchUsageAnalysis, fetchUsageCredentials, fetchUsageEventFilterOptions, fetchUsageEvents, importUsage, triggerSync } from '@/lib/api';
 import type { StatusResponse, UsageAnalysisResponse, UsageCredential, UsageEvent, UsageSourceFilterOption } from '@/lib/types';
 import { Button } from '@/components/ui/Button';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
@@ -445,6 +445,8 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   const loadedEventsFilterOptionsKeyRef = useRef('');
   const [manualRefreshLoading, setManualRefreshLoading] = useState(false);
   const [manualSyncLoading, setManualSyncLoading] = useState(false);
+  const [importLoading, setImportLoading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [credentialsLoading, setCredentialsLoading] = useState(false);
   const [credentialsError, setCredentialsError] = useState('');
   const [credentialsData, setCredentialsData] = useState<UsageCredential[]>([]);
@@ -914,6 +916,32 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     }
   }, [onAuthRequired, refreshActiveTab, t]);
 
+  const handleImportFile = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImportLoading(true);
+    try {
+      const text = await file.text();
+      const snapshot = JSON.parse(text);
+      const result = await importUsage(snapshot);
+      if (result.added > 0 || result.skipped > 0) {
+        await refreshActiveTab();
+      }
+      setStatusError('');
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 401) {
+        onAuthRequired?.();
+        return;
+      }
+      setStatusError(error instanceof SyntaxError ? t('usage_stats.import_invalid') : (error instanceof Error ? error.message : t('notification.refresh_failed')));
+    } finally {
+      setImportLoading(false);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    }
+  }, [onAuthRequired, refreshActiveTab, t]);
+
   useEffect(() => scheduleOverviewAutoRefresh({
     enabled: isOverviewTab,
     refreshOverview: loadUsage,
@@ -1149,6 +1177,22 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
               >
                 {manualSyncLoading ? t('common.loading') : t('usage_stats.sync_now')}
               </button>
+              <button
+                type="button"
+                className={styles.syncPill}
+                onClick={() => fileInputRef.current?.click()}
+                disabled={importLoading}
+                title={t('usage_stats.import')}
+              >
+                {importLoading ? t('common.loading') : t('usage_stats.import')}
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".json"
+                style={{ display: 'none' }}
+                onChange={handleImportFile}
+              />
             </div>
           </div>
         </header>


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/usage/import` endpoint that accepts a CPA usage export JSON file and inserts events into the SQLite database with automatic deduplication via `event_key` (SHA-256 hash).
- Add an **Import** button next to **Sync Now** in the web dashboard header, allowing users to select a `.json` file from their local machine.
- The import reuses the existing `FlattenUsageExport` → `InsertUsageEvents` pipeline (batch inserts of 100, with `ON CONFLICT DO NOTHING`), so re-importing the same file safely skips duplicates.
- A `SnapshotRun` record with `cPA_base_url = "import"` and `status = "completed"` is created for each import, preserving the audit trail alongside synced data.

## Changes

### Backend
- **`internal/api/usage_import.go`** (new): Handler for `POST /usage/import` that validates the request, creates a snapshot run, flattens the export into usage events, and inserts them with dedup. Returns `{added, skipped, total, failed}`.
- **`internal/api/router.go`**: Add `db *gorm.DB` parameter to `NewRouter`; register the `/usage/import` route on the authenticated group.
- **`internal/app/app.go`**: Pass `db` to `NewRouter`.
- **8 test files**: Add the new `db` parameter (`nil`) to all `NewRouter` calls.

### Frontend
- **`web/src/lib/api.ts`**: Add `importUsage(snapshot)` function that POSTs JSON to `/api/v1/usage/import`.
- **`web/src/pages/UsagePage.tsx`**: Add Import button with hidden file input alongside Sync Now. On success, refreshes the active tab. On error (including malformed JSON), shows the error in the existing `statusError` banner.
- **`web/src/i18n/index.ts`**: Already had `import`, `import_invalid`, and `import_success` keys — no changes needed.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `go build ./...` compiles cleanly
- [x] Manual test: import a CPA usage export JSON via the Import button and verify events appear in the dashboard
- [ ] Manual test: re-import the same file and confirm all events are skipped (dedup)
- [ ] Manual test: import an invalid JSON file and confirm error message shows