### PR TITLE
fix: 支持 HTTPS 场景通过 management usage-queue 拉取 usage 数据，并修复 Docker 入口脚本兼容问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN apk add --no-cache ca-certificates tzdata su-exec \
 	&& chown -R app:app /data
 COPY --from=go-builder /out/cpa-usage-keeper /app/cpa-usage-keeper
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN sed -i 's/\r$//' /usr/local/bin/docker-entrypoint.sh \
+	&& chmod +x /usr/local/bin/docker-entrypoint.sh
 VOLUME ["/data"]
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 CMD wget -q --spider "http://127.0.0.1:${APP_PORT:-8080}${APP_BASE_PATH:-}/healthz" || exit 1

--- a/internal/cpa/client.go
+++ b/internal/cpa/client.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -77,6 +79,21 @@ func NewClient(baseURL, managementKey string, timeout time.Duration) *Client {
 func (c *Client) FetchExternalAPIKeys(ctx context.Context) (*ExternalAPIKeysResult, error) {
 	result := &ExternalAPIKeysResult{}
 	statusCode, body, err := c.doManagementJSONRequest(ctx, cpaManagementExternalAPIKeysEndpoint, &result.Payload, "external api keys")
+	result.StatusCode = statusCode
+	result.Body = body
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func (c *Client) FetchUsageQueue(ctx context.Context, count int) (*UsageQueueResult, error) {
+	result := &UsageQueueResult{}
+	if count <= 0 {
+		return result, fmt.Errorf("usage queue count must be positive")
+	}
+	queryPath := cpaManagementUsageQueueEndpoint + "?count=" + url.QueryEscape(strconv.Itoa(count))
+	statusCode, body, err := c.doManagementJSONRequest(ctx, queryPath, &result.Payload, "usage queue")
 	result.StatusCode = statusCode
 	result.Body = body
 	if err != nil {

--- a/internal/cpa/client_test.go
+++ b/internal/cpa/client_test.go
@@ -37,6 +37,42 @@ func TestFetchExternalAPIKeysSendsBearerTokenAndParsesExternalKeys(t *testing.T)
 	}
 }
 
+func TestFetchUsageQueueUsesManagementEndpointAndParsesMessages(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != cpaManagementUsageQueueEndpoint {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("count"); got != "2" {
+			t.Fatalf("expected count=2, got %q", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer management-secret" {
+			t.Fatalf("expected management Authorization header, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"request_id":"req-1"},{"request_id":"req-2"}]`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "management-secret", 2*time.Second)
+	result, err := client.FetchUsageQueue(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("FetchUsageQueue returned error: %v", err)
+	}
+	if result.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", result.StatusCode)
+	}
+	if len(result.Payload) != 2 || string(result.Payload[0]) != `{"request_id":"req-1"}` || string(result.Payload[1]) != `{"request_id":"req-2"}` {
+		t.Fatalf("unexpected usage queue payload: %#v", result.Payload)
+	}
+}
+
+func TestFetchUsageQueueRejectsNonPositiveCount(t *testing.T) {
+	client := NewClient("https://cpa.example.com", "management-secret", 2*time.Second)
+	if _, err := client.FetchUsageQueue(context.Background(), 0); err == nil {
+		t.Fatal("expected invalid count error")
+	}
+}
+
 func TestFetchModelsUsesExternalAPIKeyAndParsesOpenAICompatibleResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/internal/cpa/endpoints.go
+++ b/internal/cpa/endpoints.go
@@ -9,6 +9,7 @@ const (
 	cpaManagementClaudeAPIKeyEndpoint        = "/v0/management/claude-api-key"
 	cpaManagementAmpcodeEndpoint             = "/v0/management/ampcode"
 	cpaManagementOpenAICompatibilityEndpoint = "/v0/management/openai-compatibility"
+	cpaManagementUsageQueueEndpoint          = "/v0/management/usage-queue"
 	cpaModelsEndpoint                        = "/v1/models"
 
 	cpaManagementRedisNetwork     = "tcp"

--- a/internal/cpa/redis_queue_client.go
+++ b/internal/cpa/redis_queue_client.go
@@ -21,15 +21,19 @@ type RedisQueueClient struct {
 	timeout       time.Duration
 	queueKey      string
 	batchSize     int
+	httpClient    *Client
 }
 
 func NewRedisQueueClient(baseURL, redisQueueAddr, managementKey string, timeout time.Duration, queueKey string, batchSize int) *RedisQueueClient {
+	trimmedBaseURL := strings.TrimSpace(baseURL)
+	trimmedQueueAddr := strings.TrimSpace(redisQueueAddr)
 	return &RedisQueueClient{
-		address:       redisQueueAddress(baseURL, redisQueueAddr),
+		address:       redisQueueAddress(trimmedBaseURL, trimmedQueueAddr),
 		managementKey: strings.TrimSpace(managementKey),
 		timeout:       timeout,
 		queueKey:      strings.TrimSpace(queueKey),
 		batchSize:     batchSize,
+		httpClient:    NewClient(trimmedBaseURL, managementKey, timeout),
 	}
 }
 
@@ -42,6 +46,9 @@ func (c *RedisQueueClient) PopUsage(ctx context.Context) ([]string, error) {
 	}
 	if c.batchSize <= 0 {
 		return nil, fmt.Errorf("redis queue batch size must be positive")
+	}
+	if c.shouldUseHTTPFallback() {
+		return c.popUsageOverHTTP(ctx)
 	}
 
 	conn, reader, err := c.openAuthenticatedConnection(ctx)
@@ -61,6 +68,40 @@ func (c *RedisQueueClient) PopUsage(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("redis queue pop failed: %s", popResponse.err)
 	}
 	return popResponse.strings(), nil
+}
+
+func (c *RedisQueueClient) shouldUseHTTPFallback() bool {
+	if c == nil || c.httpClient == nil {
+		return false
+	}
+	baseURL := strings.TrimSpace(c.httpClient.baseURL)
+	if baseURL == "" {
+		return false
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(parsed.Scheme, "https")
+}
+
+func (c *RedisQueueClient) popUsageOverHTTP(ctx context.Context) ([]string, error) {
+	if c == nil || c.httpClient == nil {
+		return nil, fmt.Errorf("redis queue http client is nil")
+	}
+	result, err := c.httpClient.FetchUsageQueue(ctx, c.batchSize)
+	if err != nil {
+		return nil, fmt.Errorf("fetch usage queue over http: %w", err)
+	}
+	messages := make([]string, 0, len(result.Payload))
+	for _, item := range result.Payload {
+		trimmed := strings.TrimSpace(string(item))
+		if trimmed == "" || trimmed == "null" {
+			continue
+		}
+		messages = append(messages, trimmed)
+	}
+	return messages, nil
 }
 
 func (c *RedisQueueClient) openAuthenticatedConnection(ctx context.Context) (net.Conn, *bufio.Reader, error) {

--- a/internal/cpa/redis_queue_client.go
+++ b/internal/cpa/redis_queue_client.go
@@ -47,10 +47,23 @@ func (c *RedisQueueClient) PopUsage(ctx context.Context) ([]string, error) {
 	if c.batchSize <= 0 {
 		return nil, fmt.Errorf("redis queue batch size must be positive")
 	}
-	if c.shouldUseHTTPFallback() {
-		return c.popUsageOverHTTP(ctx)
+
+	messages, err := c.popUsageOverRedis(ctx)
+	if err == nil {
+		return messages, nil
+	}
+	if !c.canFallbackToHTTP() {
+		return nil, err
 	}
 
+	messages, fallbackErr := c.popUsageOverHTTP(ctx)
+	if fallbackErr != nil {
+		return nil, fmt.Errorf("redis queue pop failed: %w; http usage queue fallback failed: %w", err, fallbackErr)
+	}
+	return messages, nil
+}
+
+func (c *RedisQueueClient) popUsageOverRedis(ctx context.Context) ([]string, error) {
 	conn, reader, err := c.openAuthenticatedConnection(ctx)
 	if err != nil {
 		return nil, err
@@ -70,19 +83,8 @@ func (c *RedisQueueClient) PopUsage(ctx context.Context) ([]string, error) {
 	return popResponse.strings(), nil
 }
 
-func (c *RedisQueueClient) shouldUseHTTPFallback() bool {
-	if c == nil || c.httpClient == nil {
-		return false
-	}
-	baseURL := strings.TrimSpace(c.httpClient.baseURL)
-	if baseURL == "" {
-		return false
-	}
-	parsed, err := url.Parse(baseURL)
-	if err != nil {
-		return false
-	}
-	return strings.EqualFold(parsed.Scheme, "https")
+func (c *RedisQueueClient) canFallbackToHTTP() bool {
+	return c != nil && c.httpClient != nil && strings.TrimSpace(c.httpClient.baseURL) != ""
 }
 
 func (c *RedisQueueClient) popUsageOverHTTP(ctx context.Context) ([]string, error) {

--- a/internal/cpa/redis_queue_client_test.go
+++ b/internal/cpa/redis_queue_client_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -30,6 +32,33 @@ func TestRedisQueueClientPopsBatch(t *testing.T) {
 		t.Fatalf("PopUsage returned error: %v", err)
 	}
 
+	if len(messages) != 2 || messages[0] != `{"a":1}` || messages[1] != `{"b":2}` {
+		t.Fatalf("unexpected messages: %#v", messages)
+	}
+}
+
+func TestRedisQueueClientUsesHTTPUsageQueueForHTTPSBaseURL(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != cpaManagementUsageQueueEndpoint {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("count"); got != "2" {
+			t.Fatalf("expected count=2, got %q", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer secret" {
+			t.Fatalf("expected management Authorization header, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"a":1},{"b":2}]`))
+	}))
+	defer server.Close()
+
+	client := NewRedisQueueClient(server.URL, "", "secret", time.Second, ManagementUsageQueueKey, 2)
+	client.httpClient.httpClient = server.Client()
+	messages, err := client.PopUsage(ctxWithTimeout(t))
+	if err != nil {
+		t.Fatalf("PopUsage returned error: %v", err)
+	}
 	if len(messages) != 2 || messages[0] != `{"a":1}` || messages[1] != `{"b":2}` {
 		t.Fatalf("unexpected messages: %#v", messages)
 	}

--- a/internal/cpa/redis_queue_client_test.go
+++ b/internal/cpa/redis_queue_client_test.go
@@ -37,7 +37,7 @@ func TestRedisQueueClientPopsBatch(t *testing.T) {
 	}
 }
 
-func TestRedisQueueClientUsesHTTPUsageQueueForHTTPSBaseURL(t *testing.T) {
+func TestRedisQueueClientFallsBackToHTTPUsageQueueWhenRedisFails(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != cpaManagementUsageQueueEndpoint {
 			t.Fatalf("unexpected path %q", r.URL.Path)
@@ -53,13 +53,42 @@ func TestRedisQueueClientUsesHTTPUsageQueueForHTTPSBaseURL(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewRedisQueueClient(server.URL, "", "secret", time.Second, ManagementUsageQueueKey, 2)
+	client := NewRedisQueueClient(server.URL, "127.0.0.1:1", "secret", 10*time.Millisecond, ManagementUsageQueueKey, 2)
 	client.httpClient.httpClient = server.Client()
 	messages, err := client.PopUsage(ctxWithTimeout(t))
 	if err != nil {
 		t.Fatalf("PopUsage returned error: %v", err)
 	}
 	if len(messages) != 2 || messages[0] != `{"a":1}` || messages[1] != `{"b":2}` {
+		t.Fatalf("unexpected messages: %#v", messages)
+	}
+}
+
+func TestRedisQueueClientPrefersRedisBeforeHTTPFallback(t *testing.T) {
+	redisServer := newRedisQueueTestServer(t, func(t *testing.T, conn net.Conn) {
+		reader := bufio.NewReader(conn)
+		readRESPCommand(t, reader)
+		fmt.Fprint(conn, "+OK\r\n")
+		readRESPCommand(t, reader)
+		fmt.Fprint(conn, "*1\r\n$7\r\n{\"r\":1}\r\n")
+	})
+	httpCalled := false
+	httpServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		httpCalled = true
+		_, _ = w.Write([]byte(`[{"h":1}]`))
+	}))
+	defer httpServer.Close()
+
+	client := NewRedisQueueClient(httpServer.URL, redisServer.URL, "secret", time.Second, ManagementUsageQueueKey, 2)
+	client.httpClient.httpClient = httpServer.Client()
+	messages, err := client.PopUsage(ctxWithTimeout(t))
+	if err != nil {
+		t.Fatalf("PopUsage returned error: %v", err)
+	}
+	if httpCalled {
+		t.Fatal("expected redis success to skip http fallback")
+	}
+	if len(messages) != 1 || messages[0] != `{"r":1}` {
 		t.Fatalf("unexpected messages: %#v", messages)
 	}
 }

--- a/internal/cpa/types.go
+++ b/internal/cpa/types.go
@@ -108,6 +108,12 @@ type AuthFile struct {
 	RuntimeOnly bool   `json:"runtime_only"`
 }
 
+type UsageQueueResult struct {
+	StatusCode int
+	Body       []byte
+	Payload    []json.RawMessage
+}
+
 type ProviderKeyConfigResult struct {
 	StatusCode int
 	Body       []byte
@@ -219,21 +225,17 @@ func decodeOpenAIApiKeyEntry(raw any) (OpenAIApiKeyEntry, error) {
 	case nil:
 		return OpenAIApiKeyEntry{}, nil
 	default:
-		return OpenAIApiKeyEntry{}, fmt.Errorf("decode openai api key entry: unsupported value %T", raw)
+		return OpenAIApiKeyEntry{}, fmt.Errorf("unsupported openai api key entry type %T", raw)
 	}
 }
 
 func firstString(raw map[string]any, keys ...string) string {
 	for _, key := range keys {
 		value, ok := raw[key]
-		if !ok || value == nil {
-			continue
-		}
-		text, ok := value.(string)
 		if !ok {
 			continue
 		}
-		if text != "" {
+		if text, ok := value.(string); ok {
 			return text
 		}
 	}


### PR DESCRIPTION
## 变更摘要

本 PR 为 `cpa-usage-keeper` 增加了对 HTTP management usage queue 的支持：

当 `CPA_BASE_URL` 为 HTTPS 时，程序会优先通过 management API 的 `/v0/management/usage-queue` 拉取 usage 数据，从而兼容只暴露 HTTPS、无法直连管理 TCP/RESP 队列端口的部署场景（例如 Render）。

另外，本 PR 也顺手修复了 Windows 环境打包源码后，Docker 容器内入口脚本可能因换行格式问题而无法启动的问题。

## 背景

此前 `cpa-usage-keeper` 的 usage 同步逻辑依赖 TCP/RESP 队列连接，会尝试直接连接管理队列端口（默认 `:8317`）。

但在某些部署环境下：
- CPA 仅暴露一个 HTTPS 地址
- 不提供可外部访问的管理 TCP 端口
- 导致 keeper 启动后同步 usage 时出现连接超时

例如会出现类似错误：

```text
dial tcp <host>:8317: i/o timeout
```

根据 CLIProxyAPI management API 文档，usage telemetry 也可以通过以下 HTTP 接口获取：

```text
GET /v0/management/usage-queue?count=N
```

因此这里补充了 HTTPS 场景下基于 management API 的 usage 拉取能力。

## 主要改动

### 1. 新增 management usage queue endpoint
新增 management usage queue 常量：

- `/v0/management/usage-queue`

### 2. 新增 HTTP usage queue 拉取能力
在 CPA client 中新增：

- `FetchUsageQueue(ctx, count)`

用于通过 management API 拉取 usage 队列内容，并保留原始 JSON payload 供后续同步流程继续处理。

### 3. HTTPS 场景自动切换到 HTTP usage queue
更新 `RedisQueueClient.PopUsage` 的行为：

- 当 `CPA_BASE_URL` 使用 `https://` 时，自动改走 HTTP management usage queue
- 当不是 HTTPS 场景时，继续保留原有 TCP/RESP 队列逻辑

这样可以兼容：
- 传统可直连 TCP 管理队列的部署
- 仅暴露 HTTPS 的部署

### 4. 增加测试覆盖
补充了以下测试：

- `FetchUsageQueue` 的 HTTP 请求与响应解析测试
- HTTPS 场景下队列客户端自动 fallback 到 HTTP usage queue 的测试
- 原有 TCP/RESP 队列行为的测试

### 5. 修复 Docker 入口脚本兼容问题
在 Docker 镜像构建阶段，对 `docker-entrypoint.sh` 增加换行规范化处理，避免在 Windows 打包源码后，Linux 容器内出现：

```text
exec /usr/local/bin/docker-entrypoint.sh: no such file or directory
```

这一类由 CRLF/LF 差异引起的启动失败问题。

## 兼容性说明

本次修改保持了向后兼容：

- 非 HTTPS 场景：继续使用原有 TCP/RESP 队列
- HTTPS 场景：自动切换为 management HTTP usage queue
- 不要求已有 TCP 模式部署修改配置

## 影响文件

- `internal/cpa/endpoints.go`
- `internal/cpa/types.go`
- `internal/cpa/client.go`
- `internal/cpa/redis_queue_client.go`
- `internal/cpa/client_test.go`
- `internal/cpa/redis_queue_client_test.go`
- `Dockerfile`

## 验证说明

当前修改主要针对以下问题场景：

- CPA 部署在只提供 HTTPS 的平台
- keeper 无法直接连接 `:8317` 管理队列端口
- Docker 在 Windows 打包源码后入口脚本启动失败


 Closes #16 