### PR TITLE
Optimize SQLite schema migrations and indexes

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -3,17 +3,17 @@ package models
 import "time"
 
 type UsageEvent struct {
-	ID              uint      `gorm:"primaryKey"`
+	ID              uint      `gorm:"primaryKey;index:idx_usage_events_timestamp_id,sort:desc,priority:2;index:idx_usage_events_auth_type_auth_index_id,priority:3;index:idx_usage_events_auth_type_source_id,priority:3"`
 	EventKey        string    `gorm:"uniqueIndex:uniq_usage_events_event_key"`
-	APIGroupKey     string    `gorm:"index:idx_usage_events_api_group_key"`
-	Provider        string    `gorm:"column:provider"`
+	APIGroupKey     string    `gorm:"index:idx_usage_events_trim_api_group_key,expression:TRIM(api_group_key)"`
+	Provider        string    `gorm:"column:provider;index:idx_usage_events_trim_provider,expression:TRIM(provider)"`
 	Endpoint        string    `gorm:"column:endpoint"`
-	AuthType        string    `gorm:"column:auth_type"`
+	AuthType        string    `gorm:"column:auth_type;index:idx_usage_events_trim_auth_type,expression:TRIM(auth_type);index:idx_usage_events_auth_type_auth_index_id,priority:1;index:idx_usage_events_auth_type_source_id,priority:1"`
 	RequestID       string    `gorm:"column:request_id"`
-	Model           string    `gorm:"index:idx_usage_events_model"`
-	Timestamp       time.Time `gorm:"index:idx_usage_events_timestamp"`
-	Source          string    `gorm:"index:idx_usage_events_source"`
-	AuthIndex       string    `gorm:"index:idx_usage_events_auth_index"`
+	Model           string    `gorm:"index:idx_usage_events_model;index:idx_usage_events_trim_model,expression:TRIM(model)"`
+	Timestamp       time.Time `gorm:"index:idx_usage_events_timestamp_id,sort:desc,priority:1"`
+	Source          string    `gorm:"index:idx_usage_events_trim_source,expression:TRIM(source);index:idx_usage_events_auth_type_source_id,priority:2"`
+	AuthIndex       string    `gorm:"index:idx_usage_events_trim_auth_index,expression:TRIM(auth_index);index:idx_usage_events_auth_type_auth_index_id,priority:2"`
 	Failed          bool      `gorm:"index:idx_usage_events_failed"`
 	LatencyMS       int64
 	InputTokens     int64
@@ -25,18 +25,18 @@ type UsageEvent struct {
 }
 
 type RedisUsageInbox struct {
-	ID            uint   `gorm:"primaryKey"`
-	QueueKey      string `gorm:"not null;index"`
-	MessageHash   string `gorm:"not null;index"`
+	ID            uint   `gorm:"primaryKey;index:idx_redis_usage_inboxes_status_id,priority:2"`
+	QueueKey      string `gorm:"not null"`
+	MessageHash   string `gorm:"not null"`
 	RawMessage    string `gorm:"not null"`
-	Status        string `gorm:"not null;index"`
+	Status        string `gorm:"not null;index:idx_redis_usage_inboxes_status_id,priority:1;index:idx_redis_usage_inboxes_status_processed_at,priority:1;index:idx_redis_usage_inboxes_status_updated_at,priority:1;index:idx_redis_usage_inboxes_status_usage_event_key,priority:1"`
 	AttemptCount  int    `gorm:"not null;default:0"`
 	LastError     string
-	UsageEventKey string    `gorm:"index"`
-	PoppedAt      time.Time `gorm:"not null;index"`
-	ProcessedAt   *time.Time
+	UsageEventKey string     `gorm:"index:idx_redis_usage_inboxes_status_usage_event_key,priority:2"`
+	PoppedAt      time.Time  `gorm:"not null"`
+	ProcessedAt   *time.Time `gorm:"index:idx_redis_usage_inboxes_status_processed_at,priority:2"`
 	CreatedAt     time.Time
-	UpdatedAt     time.Time
+	UpdatedAt     time.Time `gorm:"index:idx_redis_usage_inboxes_status_updated_at,priority:2"`
 }
 
 type ModelPriceSetting struct {
@@ -57,12 +57,12 @@ const (
 )
 
 type UsageIdentity struct {
-	ID           uint `gorm:"primaryKey"`
-	Name         string
-	AuthType     UsageIdentityAuthType `gorm:"uniqueIndex:uniq_usage_identities_type_identity;index:idx_usage_identities_auth_type"`
-	AuthTypeName string                `gorm:"index:idx_usage_identities_auth_type_name"`
-	Identity     string                `gorm:"uniqueIndex:uniq_usage_identities_type_identity;index:idx_usage_identities_identity"`
-	Type         string                `gorm:"column:type"`
+	ID           uint                  `gorm:"primaryKey;index:idx_usage_identities_auth_type_name_id,priority:3"`
+	Name         string                `gorm:"index:idx_usage_identities_auth_type_name_id,priority:2"`
+	AuthType     UsageIdentityAuthType `gorm:"uniqueIndex:uniq_usage_identities_type_identity;index:idx_usage_identities_auth_type_name_id,priority:1;index:idx_usage_identities_auth_type_type,priority:1"`
+	AuthTypeName string
+	Identity     string `gorm:"uniqueIndex:uniq_usage_identities_type_identity"`
+	Type         string `gorm:"column:type;index:idx_usage_identities_auth_type_type,priority:2"`
 	Provider     string
 	LookupKey    string
 
@@ -75,15 +75,15 @@ type UsageIdentity struct {
 	CachedTokens    int64
 	TotalTokens     int64
 
-	LastAggregatedUsageEventID uint `gorm:"index:idx_usage_identities_last_aggregated_usage_event_id"`
+	LastAggregatedUsageEventID uint
 	FirstUsedAt                *time.Time
 	LastUsedAt                 *time.Time
 	StatsUpdatedAt             *time.Time
 
-	IsDeleted bool `gorm:"index:idx_usage_identities_is_deleted"`
+	IsDeleted bool
 	CreatedAt time.Time
 	UpdatedAt time.Time
-	DeletedAt *time.Time `gorm:"index:idx_usage_identities_deleted_at"`
+	DeletedAt *time.Time
 }
 
 func All() []any {

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -19,6 +20,10 @@ type StorageCleanupResult struct {
 }
 
 func OpenDatabase(cfg config.Config) (*gorm.DB, error) {
+	databaseExists, err := sqliteDatabaseFileExists(cfg.SQLitePath)
+	if err != nil {
+		return nil, err
+	}
 	dsn := sqliteDSN(cfg.SQLitePath)
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	if err != nil {
@@ -42,11 +47,22 @@ func OpenDatabase(cfg config.Config) (*gorm.DB, error) {
 		return nil, fmt.Errorf("enable sqlite foreign keys: %w", err)
 	}
 
+	hasTables, err := sqliteDatabaseHasTables(db)
+	if err != nil {
+		return nil, err
+	}
+	if !databaseExists || !hasTables {
+		if err := db.AutoMigrate(models.All()...); err != nil {
+			return nil, fmt.Errorf("auto migrate fresh database: %w", err)
+		}
+		if err := migration.MarkAllAsApplied(db); err != nil {
+			return nil, fmt.Errorf("mark schema migrations applied: %w", err)
+		}
+		return db, nil
+	}
+
 	if err := migration.Run(db); err != nil {
 		return nil, fmt.Errorf("run schema migrations: %w", err)
-	}
-	if err := db.AutoMigrate(models.All()...); err != nil {
-		return nil, fmt.Errorf("auto migrate database: %w", err)
 	}
 
 	return db, nil
@@ -58,6 +74,32 @@ func sqliteDSN(path string) string {
 		return trimmed
 	}
 	return trimmed + "?_busy_timeout=5000&_foreign_keys=on"
+}
+
+func sqliteDatabaseFileExists(path string) (bool, error) {
+	trimmed := strings.TrimSpace(path)
+	if before, _, ok := strings.Cut(trimmed, "?"); ok {
+		trimmed = before
+	}
+	if trimmed == "" || trimmed == ":memory:" {
+		return false, nil
+	}
+	_, err := os.Stat(trimmed)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("check sqlite database %s: %w", filepath.Clean(trimmed), err)
+}
+
+func sqliteDatabaseHasTables(db *gorm.DB) (bool, error) {
+	var count int64
+	if err := db.Raw("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'").Scan(&count).Error; err != nil {
+		return false, fmt.Errorf("check sqlite database tables: %w", err)
+	}
+	return count > 0, nil
 }
 
 func InsertUsageEvents(db *gorm.DB, events []models.UsageEvent) (int, int, error) {

--- a/internal/repository/db_test.go
+++ b/internal/repository/db_test.go
@@ -1,13 +1,16 @@
 package repository
 
 import (
+	"bytes"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"cpa-usage-keeper/internal/config"
 	"cpa-usage-keeper/internal/models"
+	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
@@ -31,6 +34,28 @@ func TestOpenDatabaseAutoMigratesCoreTables(t *testing.T) {
 	}
 	if !db.Migrator().HasTable("redis_usage_inboxes") {
 		t.Fatal("expected redis_usage_inboxes table to exist")
+	}
+}
+
+func TestOpenDatabaseCreatesFreshDatabaseFromCurrentSchemaWithoutRunningMigrations(t *testing.T) {
+	logs := captureRepositoryLogs(t)
+	dbPath := filepath.Join(t.TempDir(), "app.db")
+
+	db, err := OpenDatabase(config.Config{SQLitePath: dbPath})
+	if err != nil {
+		t.Fatalf("OpenDatabase returned error: %v", err)
+	}
+	closeTestDatabase(t, db)
+
+	var count int64
+	if err := db.Table("schema_migrations").Count(&count).Error; err != nil {
+		t.Fatalf("count schema migrations: %v", err)
+	}
+	if count != 13 {
+		t.Fatalf("expected fresh database to mark 13 migrations applied, got %d", count)
+	}
+	if strings.Contains(logs.String(), "schema migration started") {
+		t.Fatalf("expected fresh database creation not to run version migrations, got logs:\n%s", logs.String())
 	}
 }
 
@@ -191,4 +216,30 @@ func closeTestDatabase(t *testing.T, db *gorm.DB) {
 			t.Fatalf("close database: %v", err)
 		}
 	})
+}
+
+func captureRepositoryLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var logs bytes.Buffer
+	previousOutput := logrus.StandardLogger().Out
+	previousFormatter := logrus.StandardLogger().Formatter
+	previousLevel := logrus.GetLevel()
+	logrus.SetOutput(&logs)
+	logrus.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
+	logrus.SetLevel(logrus.InfoLevel)
+	t.Cleanup(func() {
+		logrus.SetOutput(previousOutput)
+		logrus.SetFormatter(previousFormatter)
+		logrus.SetLevel(previousLevel)
+	})
+	return &logs
+}
+
+func repositorySQLiteIndexExists(t *testing.T, db *gorm.DB, indexName string) bool {
+	t.Helper()
+	var count int64
+	if err := db.Raw("SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?", indexName).Scan(&count).Error; err != nil {
+		t.Fatalf("check sqlite index %s: %v", indexName, err)
+	}
+	return count == 1
 }

--- a/internal/repository/migration/20260503_snapshot_runs_test.go
+++ b/internal/repository/migration/20260503_snapshot_runs_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestOpenDatabaseDropsLegacySnapshotRunsTable(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "legacy.db")
+	seedPerformanceIndexMigrationDatabase(t, dbPath)
 	db, err := gorm.Open(sqlite.Open(testSQLiteDSN(dbPath)), &gorm.Config{})
 	if err != nil {
 		t.Fatalf("open legacy database: %v", err)

--- a/internal/repository/migration/20260503_usage_event_redis_fields.go
+++ b/internal/repository/migration/20260503_usage_event_redis_fields.go
@@ -10,6 +10,24 @@ import (
 )
 
 func addUsageEventRedisFieldsMigration(tx *gorm.DB) error {
+	if !tx.Migrator().HasTable(&models.RedisUsageInbox{}) {
+		if err := tx.Exec(`CREATE TABLE redis_usage_inboxes (
+			id integer PRIMARY KEY AUTOINCREMENT,
+			queue_key text NOT NULL,
+			message_hash text NOT NULL,
+			raw_message text NOT NULL,
+			status text NOT NULL,
+			attempt_count integer NOT NULL DEFAULT 0,
+			last_error text,
+			usage_event_key text,
+			popped_at datetime NOT NULL,
+			processed_at datetime,
+			created_at datetime,
+			updated_at datetime
+		)`).Error; err != nil {
+			return fmt.Errorf("create redis_usage_inboxes table: %w", err)
+		}
+	}
 	if !tx.Migrator().HasTable(&models.UsageEvent{}) {
 		return nil
 	}

--- a/internal/repository/migration/20260504_usage_identities_metadata_test.go
+++ b/internal/repository/migration/20260504_usage_identities_metadata_test.go
@@ -72,6 +72,7 @@ func TestOpenDatabaseUsageIdentityMigratesLegacyMetadataAndDropsOldTables(t *tes
 
 func TestOpenDatabaseSkipsUsageIdentityMetadataMigrationWhenLegacyTablesAreMissing(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "no-legacy-identities.db")
+	seedPerformanceIndexMigrationDatabase(t, dbPath)
 
 	db := openMigratedDatabase(t, dbPath)
 	defer closeOpenedDatabase(t, db)

--- a/internal/repository/migration/20260505_usage_identity_lookup_key_test.go
+++ b/internal/repository/migration/20260505_usage_identity_lookup_key_test.go
@@ -15,6 +15,29 @@ func TestOpenDatabaseAddsUsageIdentityLookupKeyToExistingTable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open legacy database: %v", err)
 	}
+	if err := db.Exec(`CREATE TABLE usage_events (
+		id integer PRIMARY KEY AUTOINCREMENT,
+		event_key text,
+		api_group_key text,
+		provider text,
+		endpoint text,
+		auth_type text,
+		request_id text,
+		model text,
+		timestamp datetime,
+		source text,
+		auth_index text,
+		failed numeric,
+		latency_ms integer,
+		input_tokens integer,
+		output_tokens integer,
+		reasoning_tokens integer,
+		cached_tokens integer,
+		total_tokens integer,
+		created_at datetime
+	)`).Error; err != nil {
+		t.Fatalf("create usage_events table: %v", err)
+	}
 	if err := db.Exec(`CREATE TABLE usage_identities (
 		id integer PRIMARY KEY AUTOINCREMENT,
 		name text,
@@ -50,6 +73,10 @@ func TestOpenDatabaseAddsUsageIdentityLookupKeyToExistingTable(t *testing.T) {
 		VALUES (?, ?, ?, ?, ?, ?)`, "OAuth", models.UsageIdentityAuthTypeAuthFile, "oauth", "auth-index", "claude", "Claude").Error; err != nil {
 		t.Fatalf("seed legacy oauth usage identity: %v", err)
 	}
+	if err := db.Exec(`INSERT INTO usage_events (event_key, api_group_key, provider, endpoint, auth_type, request_id, model, timestamp, source, auth_index, failed, latency_ms, input_tokens, output_tokens, total_tokens, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, "legacy-event", "group", "Claude", "/v1/messages", "apikey", "legacy-event", "claude-sonnet", "2026-05-05T00:00:00Z", "sk-legacy", "auth-index-legacy", false, 100, 1, 2, 3, "2026-05-05T00:00:00Z").Error; err != nil {
+		t.Fatalf("seed legacy usage event: %v", err)
+	}
 	closeOpenedDatabase(t, db)
 
 	db = openMigratedDatabase(t, dbPath)
@@ -67,11 +94,11 @@ func TestOpenDatabaseAddsUsageIdentityLookupKeyToExistingTable(t *testing.T) {
 	}
 
 	var apikey models.UsageIdentity
-	if err := db.Where("identity = ?", "sk-legacy").First(&apikey).Error; err != nil {
+	if err := db.Where("identity = ?", "auth-index-legacy").First(&apikey).Error; err != nil {
 		t.Fatalf("load migrated apikey identity: %v", err)
 	}
 	if apikey.LookupKey != "sk-legacy" {
-		t.Fatalf("expected AutoMigrate to preserve migrated lookup_key, got %+v", apikey)
+		t.Fatalf("expected migrated apikey lookup_key to be preserved, got %+v", apikey)
 	}
 
 	var oauth models.UsageIdentity

--- a/internal/repository/migration/20260506_usage_performance_indexes.go
+++ b/internal/repository/migration/20260506_usage_performance_indexes.go
@@ -1,0 +1,66 @@
+package migration
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+func addUsagePerformanceIndexesMigration(db *gorm.DB) error {
+	if !hasMigrationColumns(db, "usage_events", "timestamp", "model", "source", "auth_index", "auth_type", "provider", "api_group_key") ||
+		!hasMigrationColumns(db, "redis_usage_inboxes", "status", "processed_at", "updated_at", "usage_event_key") ||
+		!hasMigrationColumns(db, "usage_identities", "auth_type", "type", "name") {
+		return fmt.Errorf("missing required schema for performance index migration")
+	}
+
+	statements := []string{
+		"DROP INDEX IF EXISTS idx_usage_events_timestamp",
+		"DROP INDEX IF EXISTS idx_usage_events_api_group_key",
+		"DROP INDEX IF EXISTS idx_usage_events_source",
+		"DROP INDEX IF EXISTS idx_usage_events_auth_index",
+		"CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp_id ON usage_events(timestamp DESC, id DESC)",
+		"CREATE INDEX IF NOT EXISTS idx_usage_events_trim_model ON usage_events(TRIM(model))",
+		"CREATE INDEX IF NOT EXISTS idx_usage_events_trim_source ON usage_events(TRIM(source))",
+		"CREATE INDEX IF NOT EXISTS idx_usage_events_trim_auth_index ON usage_events(TRIM(auth_index))",
+		"CREATE INDEX IF NOT EXISTS idx_usage_events_trim_provider ON usage_events(TRIM(provider))",
+		"CREATE INDEX IF NOT EXISTS idx_usage_events_trim_auth_type ON usage_events(TRIM(auth_type))",
+		"CREATE INDEX IF NOT EXISTS idx_usage_events_trim_api_group_key ON usage_events(TRIM(api_group_key))",
+		"CREATE INDEX IF NOT EXISTS idx_usage_events_auth_type_auth_index_id ON usage_events(auth_type, auth_index, id)",
+		"CREATE INDEX IF NOT EXISTS idx_usage_events_auth_type_source_id ON usage_events(auth_type, source, id)",
+		"DROP INDEX IF EXISTS idx_redis_usage_inboxes_status",
+		"DROP INDEX IF EXISTS idx_redis_usage_inboxes_queue_key",
+		"DROP INDEX IF EXISTS idx_redis_usage_inboxes_message_hash",
+		"DROP INDEX IF EXISTS idx_redis_usage_inboxes_usage_event_key",
+		"DROP INDEX IF EXISTS idx_redis_usage_inboxes_popped_at",
+		"CREATE INDEX IF NOT EXISTS idx_redis_usage_inboxes_status_id ON redis_usage_inboxes(status, id)",
+		"CREATE INDEX IF NOT EXISTS idx_redis_usage_inboxes_status_processed_at ON redis_usage_inboxes(status, processed_at)",
+		"CREATE INDEX IF NOT EXISTS idx_redis_usage_inboxes_status_updated_at ON redis_usage_inboxes(status, updated_at)",
+		"CREATE INDEX IF NOT EXISTS idx_redis_usage_inboxes_status_usage_event_key ON redis_usage_inboxes(status, usage_event_key)",
+		"DROP INDEX IF EXISTS idx_usage_identities_auth_type",
+		"DROP INDEX IF EXISTS idx_usage_identities_auth_type_name",
+		"DROP INDEX IF EXISTS idx_usage_identities_identity",
+		"DROP INDEX IF EXISTS idx_usage_identities_is_deleted",
+		"DROP INDEX IF EXISTS idx_usage_identities_last_aggregated_usage_event_id",
+		"DROP INDEX IF EXISTS idx_usage_identities_deleted_at",
+		"CREATE INDEX IF NOT EXISTS idx_usage_identities_auth_type_name_id ON usage_identities(auth_type, name, id)",
+		"CREATE INDEX IF NOT EXISTS idx_usage_identities_auth_type_type ON usage_identities(auth_type, type)",
+	}
+	for _, statement := range statements {
+		if err := db.Exec(statement).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hasMigrationColumns(db *gorm.DB, table string, columns ...string) bool {
+	if !db.Migrator().HasTable(table) {
+		return false
+	}
+	for _, column := range columns {
+		if !db.Migrator().HasColumn(table, column) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/repository/migration/20260506_usage_performance_indexes_test.go
+++ b/internal/repository/migration/20260506_usage_performance_indexes_test.go
@@ -1,0 +1,197 @@
+package migration
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestOpenDatabaseAddsUsagePerformanceIndexes(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "legacy.db")
+	seedPerformanceIndexMigrationDatabase(t, dbPath)
+
+	db := openMigratedDatabase(t, dbPath)
+	defer closeOpenedDatabase(t, db)
+
+	for _, indexName := range []string{
+		"idx_usage_events_timestamp_id",
+		"idx_usage_events_trim_model",
+		"idx_usage_events_trim_source",
+		"idx_usage_events_trim_auth_index",
+		"idx_usage_events_trim_provider",
+		"idx_usage_events_trim_auth_type",
+		"idx_usage_events_trim_api_group_key",
+		"idx_usage_events_auth_type_auth_index_id",
+		"idx_usage_events_auth_type_source_id",
+		"idx_redis_usage_inboxes_status_id",
+		"idx_redis_usage_inboxes_status_processed_at",
+		"idx_redis_usage_inboxes_status_updated_at",
+		"idx_redis_usage_inboxes_status_usage_event_key",
+		"idx_usage_identities_auth_type_name_id",
+		"idx_usage_identities_auth_type_type",
+	} {
+		if !sqliteIndexExists(t, db, indexName) {
+			t.Fatalf("expected index %s to exist", indexName)
+		}
+	}
+
+	for _, indexName := range []string{
+		"idx_usage_events_timestamp",
+		"idx_usage_events_api_group_key",
+		"idx_usage_events_source",
+		"idx_usage_events_auth_index",
+		"idx_redis_usage_inboxes_status",
+		"idx_redis_usage_inboxes_queue_key",
+		"idx_redis_usage_inboxes_message_hash",
+		"idx_redis_usage_inboxes_usage_event_key",
+		"idx_redis_usage_inboxes_popped_at",
+		"idx_usage_identities_auth_type",
+		"idx_usage_identities_auth_type_name",
+		"idx_usage_identities_identity",
+		"idx_usage_identities_is_deleted",
+		"idx_usage_identities_last_aggregated_usage_event_id",
+		"idx_usage_identities_deleted_at",
+	} {
+		if sqliteIndexExists(t, db, indexName) {
+			t.Fatalf("expected redundant index %s to be removed", indexName)
+		}
+	}
+
+	var count int64
+	if err := db.Table("schema_migrations").Where("version = ?", "20260506_add_usage_performance_indexes").Count(&count).Error; err != nil {
+		t.Fatalf("count performance index migration: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected performance index migration to be recorded once, got %d", count)
+	}
+}
+
+func TestUsagePerformanceIndexMigrationFailsWhenRequiredSchemaIsMissing(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(testSQLiteDSN(filepath.Join(t.TempDir(), "legacy.db"))), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open incomplete legacy database: %v", err)
+	}
+	defer closeOpenedDatabase(t, db)
+	if err := db.Exec(`CREATE TABLE usage_events (
+		id integer PRIMARY KEY AUTOINCREMENT,
+		event_key text,
+		timestamp datetime
+	)`).Error; err != nil {
+		t.Fatalf("create incomplete usage_events table: %v", err)
+	}
+
+	err = Run(db)
+	if err == nil {
+		t.Fatal("expected migration to fail when required schema is missing")
+	}
+	if !strings.Contains(err.Error(), "missing required schema for performance index migration") {
+		t.Fatalf("expected missing schema error, got %v", err)
+	}
+}
+
+func TestUsagePerformanceIndexesSupportRepresentativeQueryPlans(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "legacy.db")
+	seedPerformanceIndexMigrationDatabase(t, dbPath)
+
+	db := openMigratedDatabase(t, dbPath)
+	defer closeOpenedDatabase(t, db)
+
+	assertQueryPlanUsesIndex(t, db, "idx_usage_events_timestamp_id", `
+		EXPLAIN QUERY PLAN SELECT id FROM usage_events
+		WHERE timestamp >= ? AND timestamp <= ?
+		ORDER BY timestamp DESC, id DESC
+		LIMIT 50`, "2026-05-01T00:00:00Z", "2026-05-07T00:00:00Z")
+
+	assertQueryPlanUsesIndex(t, db, "idx_usage_events_trim_model", `
+		EXPLAIN QUERY PLAN SELECT DISTINCT TRIM(model) FROM usage_events
+		WHERE TRIM(model) <> ''
+		ORDER BY TRIM(model) ASC`)
+
+	assertQueryPlanUsesIndex(t, db, "idx_usage_events_trim_source", `
+		EXPLAIN QUERY PLAN SELECT DISTINCT TRIM(source) FROM usage_events
+		WHERE TRIM(source) <> ''
+		ORDER BY TRIM(source) ASC`)
+
+	assertQueryPlanUsesIndex(t, db, "idx_usage_events_trim_auth_index", `
+		EXPLAIN QUERY PLAN SELECT id FROM usage_events
+		WHERE TRIM(auth_index) = ?`, "authidx-main")
+
+	assertQueryPlanUsesIndex(t, db, "idx_usage_events_trim_provider", `
+		EXPLAIN QUERY PLAN SELECT id FROM usage_events
+		WHERE TRIM(provider) = ?`, "Claude API")
+
+	assertQueryPlanUsesIndex(t, db, "idx_usage_events_trim_auth_type", `
+		EXPLAIN QUERY PLAN SELECT id FROM usage_events
+		WHERE TRIM(auth_type) = ?`, "oauth")
+
+	assertQueryPlanUsesIndex(t, db, "idx_usage_events_trim_api_group_key", `
+		EXPLAIN QUERY PLAN SELECT TRIM(api_group_key), COUNT(*) FROM usage_events
+		GROUP BY TRIM(api_group_key)`)
+
+	assertQueryPlanUsesIndex(t, db, "idx_usage_events_auth_type_auth_index_id", `
+		EXPLAIN QUERY PLAN SELECT id FROM usage_events
+		WHERE auth_type = ? AND auth_index = ? AND id > ?`, "oauth", "authidx-main", 100)
+
+	assertQueryPlanUsesIndex(t, db, "idx_usage_events_auth_type_source_id", `
+		EXPLAIN QUERY PLAN SELECT id FROM usage_events
+		WHERE auth_type = ? AND source = ? AND id > ?`, "apikey", "authidx-provider", 100)
+
+	assertQueryPlanUsesIndex(t, db, "idx_redis_usage_inboxes_status_id", `
+		EXPLAIN QUERY PLAN SELECT id FROM redis_usage_inboxes
+		WHERE status = ?
+		ORDER BY id ASC
+		LIMIT 1000`, "pending")
+
+	assertQueryPlanUsesIndex(t, db, "idx_redis_usage_inboxes_status_processed_at", `
+		EXPLAIN QUERY PLAN SELECT id FROM redis_usage_inboxes
+		WHERE status = ? AND processed_at IS NOT NULL AND processed_at < ?`, "processed", "2026-05-06T00:00:00Z")
+
+	assertQueryPlanUsesIndex(t, db, "idx_redis_usage_inboxes_status_updated_at", `
+		EXPLAIN QUERY PLAN SELECT id FROM redis_usage_inboxes
+		WHERE status IN (?, ?) AND updated_at < ?`, "decode_failed", "process_failed", "2026-05-06T00:00:00Z")
+
+	assertQueryPlanUsesIndex(t, db, "idx_redis_usage_inboxes_status_usage_event_key", `
+		EXPLAIN QUERY PLAN SELECT COUNT(*) FROM redis_usage_inboxes
+		WHERE status = ? AND usage_event_key = ?`, "processed", "event-main")
+
+	assertQueryPlanUsesIndex(t, db, "idx_usage_identities_auth_type_name_id", `
+		EXPLAIN QUERY PLAN SELECT id FROM usage_identities
+		ORDER BY auth_type ASC, name ASC, id ASC`)
+
+	assertQueryPlanUsesIndex(t, db, "idx_usage_identities_auth_type_type", `
+		EXPLAIN QUERY PLAN SELECT id FROM usage_identities
+		WHERE auth_type = ? AND type IN (?, ?)`, 2, "anthropic", "openai")
+}
+
+func sqliteIndexExists(t *testing.T, db *gorm.DB, indexName string) bool {
+	t.Helper()
+	var count int64
+	if err := db.Raw("SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?", indexName).Scan(&count).Error; err != nil {
+		t.Fatalf("check sqlite index %s: %v", indexName, err)
+	}
+	return count == 1
+}
+
+func assertQueryPlanUsesIndex(t *testing.T, db *gorm.DB, indexName string, query string, args ...any) {
+	t.Helper()
+	var rows []struct {
+		ID     int
+		Parent int
+		Unused int
+		Detail string
+	}
+	if err := db.Raw(query, args...).Scan(&rows).Error; err != nil {
+		t.Fatalf("explain query plan for %s: %v", indexName, err)
+	}
+	details := make([]string, 0, len(rows))
+	for _, row := range rows {
+		details = append(details, row.Detail)
+		if strings.Contains(row.Detail, indexName) {
+			return
+		}
+	}
+	t.Fatalf("expected query plan to use %s, got %s", indexName, strings.Join(details, " | "))
+}

--- a/internal/repository/migration/migration.go
+++ b/internal/repository/migration/migration.go
@@ -21,6 +21,7 @@ const (
 	migrationRemovePrefixUsageIdentities            = "20260504_remove_prefix_usage_identities"
 	migrationAddUsageIdentityLookupKey              = "20260505_add_usage_identity_lookup_key"
 	migrationMigrateAIProviderIdentitiesToAuthIndex = "20260505_migrate_ai_provider_identities_to_auth_index"
+	migrationAddUsagePerformanceIndexes             = "20260506_add_usage_performance_indexes"
 )
 
 type schemaMigration struct {
@@ -38,14 +39,36 @@ type databaseMigration struct {
 }
 
 func Run(db *gorm.DB) error {
-	if err := db.Exec("CREATE TABLE IF NOT EXISTS schema_migrations (version TEXT PRIMARY KEY, applied_at DATETIME NOT NULL)").Error; err != nil {
-		return fmt.Errorf("create schema_migrations table: %w", err)
+	if err := createSchemaMigrationsTable(db); err != nil {
+		return err
 	}
 
 	for _, migration := range orderedMigrations() {
 		if err := runSchemaMigration(db, migration); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func MarkAllAsApplied(db *gorm.DB) error {
+	if err := createSchemaMigrationsTable(db); err != nil {
+		return err
+	}
+	return db.Transaction(func(tx *gorm.DB) error {
+		now := time.Now().UTC()
+		for _, migration := range orderedMigrations() {
+			if err := tx.Exec("INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)", migration.version, now).Error; err != nil {
+				return fmt.Errorf("mark schema migration %s applied: %w", migration.version, err)
+			}
+		}
+		return nil
+	})
+}
+
+func createSchemaMigrationsTable(db *gorm.DB) error {
+	if err := db.Exec("CREATE TABLE IF NOT EXISTS schema_migrations (version TEXT PRIMARY KEY, applied_at DATETIME NOT NULL)").Error; err != nil {
+		return fmt.Errorf("create schema_migrations table: %w", err)
 	}
 	return nil
 }
@@ -64,6 +87,7 @@ func orderedMigrations() []databaseMigration {
 		{version: migrationRemovePrefixUsageIdentities, run: removePrefixUsageIdentitiesMigration},
 		{version: migrationAddUsageIdentityLookupKey, run: addUsageIdentityLookupKeyMigration},
 		{version: migrationMigrateAIProviderIdentitiesToAuthIndex, run: migrateAIProviderIdentitiesToAuthIndexMigration},
+		{version: migrationAddUsagePerformanceIndexes, run: addUsagePerformanceIndexesMigration},
 	}
 }
 

--- a/internal/repository/migration/migration_seed_test.go
+++ b/internal/repository/migration/migration_seed_test.go
@@ -320,6 +320,101 @@ func seedLegacyUsageIdentityTables(t *testing.T, dbPath string) {
 	}
 }
 
+func seedPerformanceIndexMigrationDatabase(t *testing.T, dbPath string) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(testSQLiteDSN(dbPath)), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open performance index migration database: %v", err)
+	}
+	defer closeOpenedDatabase(t, db)
+
+	statements := []string{
+		`CREATE TABLE usage_events (
+			id integer PRIMARY KEY AUTOINCREMENT,
+			event_key text,
+			api_group_key text,
+			provider text,
+			endpoint text,
+			auth_type text,
+			request_id text,
+			model text,
+			timestamp datetime,
+			source text,
+			auth_index text,
+			failed numeric,
+			latency_ms integer,
+			input_tokens integer,
+			output_tokens integer,
+			reasoning_tokens integer,
+			cached_tokens integer,
+			total_tokens integer,
+			created_at datetime
+		)`,
+		`CREATE UNIQUE INDEX uniq_usage_events_event_key ON usage_events(event_key)`,
+		`CREATE INDEX idx_usage_events_timestamp ON usage_events(timestamp)`,
+		`CREATE INDEX idx_usage_events_api_group_key ON usage_events(api_group_key)`,
+		`CREATE INDEX idx_usage_events_source ON usage_events(source)`,
+		`CREATE INDEX idx_usage_events_auth_index ON usage_events(auth_index)`,
+		`CREATE TABLE redis_usage_inboxes (
+			id integer PRIMARY KEY AUTOINCREMENT,
+			queue_key text NOT NULL,
+			message_hash text NOT NULL,
+			raw_message text NOT NULL,
+			status text NOT NULL,
+			attempt_count integer NOT NULL DEFAULT 0,
+			last_error text,
+			usage_event_key text,
+			popped_at datetime NOT NULL,
+			processed_at datetime,
+			created_at datetime,
+			updated_at datetime
+		)`,
+		`CREATE INDEX idx_redis_usage_inboxes_status ON redis_usage_inboxes(status)`,
+		`CREATE INDEX idx_redis_usage_inboxes_queue_key ON redis_usage_inboxes(queue_key)`,
+		`CREATE INDEX idx_redis_usage_inboxes_message_hash ON redis_usage_inboxes(message_hash)`,
+		`CREATE INDEX idx_redis_usage_inboxes_usage_event_key ON redis_usage_inboxes(usage_event_key)`,
+		`CREATE INDEX idx_redis_usage_inboxes_popped_at ON redis_usage_inboxes(popped_at)`,
+		`CREATE TABLE usage_identities (
+			id integer PRIMARY KEY AUTOINCREMENT,
+			name text,
+			auth_type integer,
+			auth_type_name text,
+			identity text,
+			type text,
+			provider text,
+			lookup_key text,
+			total_requests integer DEFAULT 0,
+			success_count integer DEFAULT 0,
+			failure_count integer DEFAULT 0,
+			input_tokens integer DEFAULT 0,
+			output_tokens integer DEFAULT 0,
+			reasoning_tokens integer DEFAULT 0,
+			cached_tokens integer DEFAULT 0,
+			total_tokens integer DEFAULT 0,
+			last_aggregated_usage_event_id integer DEFAULT 0,
+			first_used_at datetime,
+			last_used_at datetime,
+			stats_updated_at datetime,
+			is_deleted numeric DEFAULT false,
+			created_at datetime,
+			updated_at datetime,
+			deleted_at datetime
+		)`,
+		`CREATE UNIQUE INDEX uniq_usage_identities_type_identity ON usage_identities(auth_type, identity)`,
+		`CREATE INDEX idx_usage_identities_auth_type ON usage_identities(auth_type)`,
+		`CREATE INDEX idx_usage_identities_auth_type_name ON usage_identities(auth_type_name)`,
+		`CREATE INDEX idx_usage_identities_identity ON usage_identities(identity)`,
+		`CREATE INDEX idx_usage_identities_is_deleted ON usage_identities(is_deleted)`,
+		`CREATE INDEX idx_usage_identities_last_aggregated_usage_event_id ON usage_identities(last_aggregated_usage_event_id)`,
+		`CREATE INDEX idx_usage_identities_deleted_at ON usage_identities(deleted_at)`,
+	}
+	for _, statement := range statements {
+		if err := db.Exec(statement).Error; err != nil {
+			t.Fatalf("seed performance index schema with %q: %v", statement, err)
+		}
+	}
+}
+
 func seedLegacyRedisUsageTables(t *testing.T, dbPath string) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(testSQLiteDSN(dbPath)), &gorm.Config{})

--- a/internal/repository/migration/migration_support_test.go
+++ b/internal/repository/migration/migration_support_test.go
@@ -49,9 +49,6 @@ func openMigratedDatabase(t *testing.T, dbPath string) *gorm.DB {
 	if err := Run(db); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
-	if err := db.AutoMigrate(models.All()...); err != nil {
-		t.Fatalf("auto migrate database: %v", err)
-	}
 	return db
 }
 

--- a/internal/repository/migration/migration_test.go
+++ b/internal/repository/migration/migration_test.go
@@ -30,6 +30,7 @@ func TestOrderedMigrationsPreservesExecutionOrder(t *testing.T) {
 		"20260504_remove_prefix_usage_identities",
 		"20260505_add_usage_identity_lookup_key",
 		"20260505_migrate_ai_provider_identities_to_auth_index",
+		"20260506_add_usage_performance_indexes",
 	}
 	if len(got) != len(want) {
 		t.Fatalf("expected ordered migrations %v, got %v", want, got)
@@ -42,7 +43,10 @@ func TestOrderedMigrationsPreservesExecutionOrder(t *testing.T) {
 }
 
 func TestOpenDatabaseRunsSchemaMigrationsAndAddsUsageEventRedisFields(t *testing.T) {
-	db := openMigratedDatabase(t, filepath.Join(t.TempDir(), "app.db"))
+	dbPath := filepath.Join(t.TempDir(), "legacy.db")
+	seedLegacyRedisUsageTables(t, dbPath)
+
+	db := openMigratedDatabase(t, dbPath)
 	defer closeOpenedDatabase(t, db)
 
 	if !db.Migrator().HasTable("schema_migrations") {
@@ -74,6 +78,7 @@ func TestOpenDatabaseRunsSchemaMigrationsAndAddsUsageEventRedisFields(t *testing
 		"20260504_remove_prefix_usage_identities",
 		"20260505_add_usage_identity_lookup_key",
 		"20260505_migrate_ai_provider_identities_to_auth_index",
+		"20260506_add_usage_performance_indexes",
 	}
 	if len(versions) != len(expected) {
 		t.Fatalf("expected migration versions %v, got %v", expected, versions)
@@ -86,7 +91,8 @@ func TestOpenDatabaseRunsSchemaMigrationsAndAddsUsageEventRedisFields(t *testing
 }
 
 func TestOpenDatabaseMigrationsAreIdempotent(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "app.db")
+	dbPath := filepath.Join(t.TempDir(), "legacy.db")
+	seedLegacyRedisUsageTables(t, dbPath)
 
 	db := openMigratedDatabase(t, dbPath)
 	closeOpenedDatabase(t, db)
@@ -98,14 +104,15 @@ func TestOpenDatabaseMigrationsAreIdempotent(t *testing.T) {
 	if err := db.Table("schema_migrations").Count(&count).Error; err != nil {
 		t.Fatalf("count schema migrations: %v", err)
 	}
-	if count != 12 {
-		t.Fatalf("expected 12 applied migrations after reopening database, got %d", count)
+	if count != 13 {
+		t.Fatalf("expected 13 applied migrations after reopening database, got %d", count)
 	}
 }
 
 func TestOpenDatabaseLogsSchemaMigrations(t *testing.T) {
 	logs := captureMigrationLogs(t, logrus.InfoLevel)
-	dbPath := filepath.Join(t.TempDir(), "app.db")
+	dbPath := filepath.Join(t.TempDir(), "legacy.db")
+	seedLegacyRedisUsageTables(t, dbPath)
 
 	db := openMigratedDatabase(t, dbPath)
 	closeOpenedDatabase(t, db)


### PR DESCRIPTION
## Summary
- Add versioned SQLite performance index migration for usage events, usage identities, and Redis inbox business queries.
- Split fresh database initialization from old database migrations so fresh DBs use current models and old DBs run schema_migrations only.
- Remove deferred schema migration handling and add migration/query-plan coverage for the new index behavior.

## Test plan
- [x] go test ./internal/repository/migration -count=1
- [x] go test ./internal/repository -count=1
- [x] go test ./... -count=1
- [x] git diff --check