### PR TITLE
Batch SQLite repository writes

### DIFF
--- a/internal/api/usage_events.go
+++ b/internal/api/usage_events.go
@@ -202,7 +202,8 @@ func buildUsageSourceFilterOptions(sources []string, identities []models.UsageId
 	options := make([]usageSourceFilterOption, 0, len(identities))
 	seen := make(map[string]struct{}, len(identities))
 	for _, identity := range identities {
-		if identity.TotalRequests == 0 {
+		// Source 下拉只展示活跃且有流量的身份，避免已删除身份继续出现在筛选项里。
+		if identity.IsDeleted || identity.TotalRequests == 0 {
 			continue
 		}
 		option, ok := usageSourceFilterOptionFromIdentity(identity)

--- a/internal/api/usage_events_test.go
+++ b/internal/api/usage_events_test.go
@@ -191,7 +191,7 @@ func TestUsageEventsReturnsFilterOptions(t *testing.T) {
 		Sources:    []string{"source-a", "source-b"},
 		TotalCount: 2, Page: 1, PageSize: 20, TotalPages: 1,
 	}}
-	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "", usageIdentitiesStub{items: []models.UsageIdentity{{ID: 1, Name: "Claude Main", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-a", Type: "openai", Provider: "Provider A", TotalRequests: 1}, {ID: 2, Name: "Provider A", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-b", Type: "openai", Provider: "Provider A", TotalRequests: 1}, {ID: 3, Name: "Auth User", AuthType: models.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Identity: "auth-1", Type: "claude", Provider: "Claude", TotalRequests: 1}}})
+	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "", usageIdentitiesStub{items: []models.UsageIdentity{{ID: 1, Name: "Claude Main", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-a", Type: "openai", Provider: "Provider A", TotalRequests: 1}, {ID: 2, Name: "Provider A", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-b", Type: "openai", Provider: "Provider A", TotalRequests: 1}, {ID: 3, Name: "Auth User", AuthType: models.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Identity: "auth-1", Type: "claude", Provider: "Claude", TotalRequests: 1}, {ID: 9, Name: "Deleted Source", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-deleted", Type: "openai", Provider: "Provider A", TotalRequests: 99, IsDeleted: true}}})
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/events", nil)
 	resp := httptest.NewRecorder()
 
@@ -210,6 +210,9 @@ func TestUsageEventsReturnsFilterOptions(t *testing.T) {
 	if contains(body, `"value":"auth:auth-1"`) || contains(body, `"value":"provider:Provider A"`) || contains(body, `"value":"provider:1"`) || contains(body, `"value":"provider:2"`) {
 		t.Fatalf("expected source filter values without prefixes, got %s", body)
 	}
+	if contains(body, `authidx-deleted`) || contains(body, `Deleted Source`) {
+		t.Fatalf("expected deleted source filter option to be omitted, got %s", body)
+	}
 }
 
 func TestUsageEventFilterOptionsReturnsStableModelsAndSources(t *testing.T) {
@@ -217,7 +220,7 @@ func TestUsageEventFilterOptionsReturnsStableModelsAndSources(t *testing.T) {
 		Models:  []string{"claude-sonnet", "gpt-5"},
 		Sources: []string{"source-a", "source-b"},
 	}}
-	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "", usageIdentitiesStub{items: []models.UsageIdentity{{ID: 1, Name: "Claude Main", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-a", Type: "openai", Provider: "Provider A", TotalRequests: 3}, {ID: 2, Name: "Provider A", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-b", Type: "openai", Provider: "Provider A"}, {ID: 3, Name: "Auth User", AuthType: models.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Identity: "auth-1", Type: "claude", Provider: "Claude", TotalRequests: 2}, {ID: 4, Name: "Zero Request User", AuthType: models.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Identity: "auth-zero", Type: "claude", Provider: "Claude"}, {ID: 5, Name: "Zero Provider", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-zero", Type: "openai", Provider: "Zero Provider"}}})
+	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "", usageIdentitiesStub{items: []models.UsageIdentity{{ID: 1, Name: "Claude Main", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-a", Type: "openai", Provider: "Provider A", TotalRequests: 3}, {ID: 2, Name: "Provider A", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-b", Type: "openai", Provider: "Provider A"}, {ID: 3, Name: "Auth User", AuthType: models.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Identity: "auth-1", Type: "claude", Provider: "Claude", TotalRequests: 2}, {ID: 4, Name: "Zero Request User", AuthType: models.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Identity: "auth-zero", Type: "claude", Provider: "Claude"}, {ID: 5, Name: "Zero Provider", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-zero", Type: "openai", Provider: "Zero Provider"}, {ID: 6, Name: "Deleted Source", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-deleted", Type: "openai", Provider: "Deleted Provider", TotalRequests: 5, IsDeleted: true}}})
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/events/filters?range=24h&model=ignored&source=ignored&result=failed&page=3&page_size=20", nil)
 	resp := httptest.NewRecorder()
 
@@ -244,6 +247,36 @@ func TestUsageEventFilterOptionsReturnsStableModelsAndSources(t *testing.T) {
 	}
 	if contains(body, `Zero Request User`) || contains(body, `Zero Provider`) || contains(body, `auth-zero`) || contains(body, `authidx-source-zero`) {
 		t.Fatalf("expected zero-request source filter options to be omitted, got %s", body)
+	}
+	if contains(body, `Deleted Source`) || contains(body, `Deleted Provider`) || contains(body, `authidx-deleted`) {
+		t.Fatalf("expected deleted source filter options to be omitted, got %s", body)
+	}
+}
+
+func TestUsageCredentialsIgnoresDeletedUsageIdentityResolution(t *testing.T) {
+	provider := &usageEventsStub{credentialStats: []service.UsageCredentialStat{{
+		Source:       "sk-deleted-provider-key",
+		Failed:       false,
+		RequestCount: 2,
+	}}}
+	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "", usageIdentitiesStub{items: []models.UsageIdentity{{ID: 77, Name: "Deleted Provider", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "sk-deleted-provider-key", Type: "openai", Provider: "Deleted Provider", IsDeleted: true}}})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/credentials", nil)
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.Code)
+	}
+	body := resp.Body.String()
+	if !contains(body, `"credentials":[`) || !contains(body, `"total_count":2`) {
+		t.Fatalf("unexpected response body: %s", body)
+	}
+	if contains(body, `Deleted Provider`) || contains(body, `"source_key":"provider:77"`) {
+		t.Fatalf("expected deleted identity resolution to be ignored, got %s", body)
+	}
+	if contains(body, `sk-deleted-provider-key`) {
+		t.Fatalf("expected raw API key to stay redacted when deleted identity is ignored, got %s", body)
 	}
 }
 

--- a/internal/api/usage_identities_test.go
+++ b/internal/api/usage_identities_test.go
@@ -12,11 +12,19 @@ import (
 )
 
 type usageIdentitiesStub struct {
-	items []models.UsageIdentity
-	err   error
+	items       []models.UsageIdentity
+	activeItems []models.UsageIdentity
+	err         error
 }
 
 func (s usageIdentitiesStub) ListUsageIdentities(context.Context) ([]models.UsageIdentity, error) {
+	return s.items, s.err
+}
+
+func (s usageIdentitiesStub) ListActiveUsageIdentities(context.Context) ([]models.UsageIdentity, error) {
+	if s.activeItems != nil {
+		return s.activeItems, s.err
+	}
 	return s.items, s.err
 }
 

--- a/internal/api/usage_resolution.go
+++ b/internal/api/usage_resolution.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// loadUsageResolutionData 为 Request Events 和 Credentials 加载 source 解析所需的活跃 usage identities。
 func loadUsageResolutionData(
 	c *gin.Context,
 	usageIdentityProvider service.UsageIdentityProvider,
@@ -13,5 +14,7 @@ func loadUsageResolutionData(
 	if usageIdentityProvider == nil {
 		return []models.UsageIdentity{}, nil
 	}
-	return usageIdentityProvider.ListUsageIdentities(c.Request.Context())
+
+	// Request Events 的 Source 下拉和 Credentials 的展示解析只需要活跃身份，直接调用 SQL 层 active-only 查询。
+	return usageIdentityProvider.ListActiveUsageIdentities(c.Request.Context())
 }

--- a/internal/api/usage_source_resolution.go
+++ b/internal/api/usage_source_resolution.go
@@ -14,11 +14,16 @@ type usageSourceResolver struct {
 	providerRawByKey   map[string]string
 }
 
+// newUsageSourceResolver 把活跃 usage identity 建成内存索引，供 Credentials 和事件展示快速解析 source。
 func newUsageSourceResolver(identities []models.UsageIdentity) usageSourceResolver {
 	authIdentities := make(map[string]models.UsageIdentity, len(identities))
 	providerIdentities := make(map[string]models.UsageIdentity, len(identities))
 	providerRawByKey := make(map[string]string, len(identities))
 	for _, identity := range identities {
+		// resolver 索引只收录活跃身份，避免 deleted identity 影响 Credentials 和事件展示解析。
+		if identity.IsDeleted {
+			continue
+		}
 		key := strings.TrimSpace(identity.Identity)
 		if key == "" {
 			continue
@@ -48,6 +53,7 @@ type usageSourceResolution struct {
 	SourceKey   string
 }
 
+// usageSourceResolutionFromIdentity 从 provider identity 生成前端展示名、类型和稳定 source_key。
 func usageSourceResolutionFromIdentity(item models.UsageIdentity, fallbackIdentity string) usageSourceResolution {
 	identityType := safeAIProviderDisplayValue(item.Type, fallbackIdentity, "")
 	displayName := firstNonEmptyString(
@@ -67,6 +73,7 @@ func usageSourceResolutionFromIdentity(item models.UsageIdentity, fallbackIdenti
 	}
 }
 
+// rawSourceForPublicValue 把前端传回的 provider source_key 还原成真实 source，用于后端过滤 usage_events。
 func (r usageSourceResolver) rawSourceForPublicValue(value string) string {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -78,7 +85,9 @@ func (r usageSourceResolver) rawSourceForPublicValue(value string) string {
 	return trimmed
 }
 
+// resolve 按 provider source、auth_index、fallback 推断的顺序解析一条 usage 记录的前端展示来源。
 func (r usageSourceResolver) resolve(rawSource string, authIndex string) usageSourceResolution {
+	// 优先用 API key source 匹配 AI provider identity，确保 provider 展示名和 source_key 稳定。
 	normalizedSource := strings.TrimSpace(rawSource)
 	if normalizedSource != "" {
 		if item, ok := r.providerIdentities[normalizedSource]; ok {
@@ -86,6 +95,7 @@ func (r usageSourceResolver) resolve(rawSource string, authIndex string) usageSo
 		}
 	}
 
+	// provider source 没有命中时，再用 oauth/auth file 的 auth_index 解析账号身份。
 	normalizedAuthIndex := strings.TrimSpace(authIndex)
 	if normalizedAuthIndex != "" {
 		if identity, ok := r.authIdentities[normalizedAuthIndex]; ok {
@@ -98,6 +108,7 @@ func (r usageSourceResolver) resolve(rawSource string, authIndex string) usageSo
 		}
 	}
 
+	// 没有 identity 命中时走安全 fallback，避免把原始 API key 暴露给前端。
 	if normalizedSource == "" {
 		return usageSourceResolution{DisplayName: "-", SourceKey: "raw:-"}
 	}
@@ -121,10 +132,12 @@ func (r usageSourceResolver) resolve(rawSource string, authIndex string) usageSo
 	}
 }
 
+// uintToString 统一把数据库 ID 转成 source_key 使用的字符串片段。
 func uintToString(value uint) string {
 	return strconv.FormatUint(uint64(value), 10)
 }
 
+// firstNonEmptyString 按优先级返回第一个非空展示字段。
 func firstNonEmptyString(values ...string) string {
 	for _, value := range values {
 		trimmed := strings.TrimSpace(value)
@@ -135,6 +148,7 @@ func firstNonEmptyString(values ...string) string {
 	return ""
 }
 
+// looksLikeEmail 识别邮箱类 source，邮箱本身可作为安全展示值。
 func looksLikeEmail(value string) bool {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -144,6 +158,7 @@ func looksLikeEmail(value string) bool {
 	return atIndex > 0 && atIndex < len(trimmed)-1 && strings.Contains(trimmed[atIndex+1:], ".")
 }
 
+// inferUsageProviderType 在没有 metadata 命中时，根据 source 特征推断 provider 类型作为兜底展示。
 func inferUsageProviderType(source string) string {
 	value := strings.ToLower(strings.TrimSpace(source))
 	switch {

--- a/internal/repository/batch.go
+++ b/internal/repository/batch.go
@@ -1,3 +1,4 @@
 package repository
 
+// 仓储层统一使用 900 行作为默认批量写入大小，避免 SQLite 变量数量超过限制。
 const defaultRepositoryInsertBatchSize = 900

--- a/internal/repository/batch.go
+++ b/internal/repository/batch.go
@@ -1,0 +1,3 @@
+package repository
+
+const defaultRepositoryInsertBatchSize = 900

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -70,9 +70,12 @@ func InsertUsageEvents(db *gorm.DB, events []models.UsageEvent) (int, int, error
 
 	inserted := 0
 
+	// 按仓储默认批次拆分写入，避免单条 INSERT 的 SQLite 变量数量过多。
 	for start := 0; start < len(events); start += defaultRepositoryInsertBatchSize {
 		end := min(start+defaultRepositoryInsertBatchSize, len(events))
 		batch := events[start:end]
+
+		// 每批仍按 event_key 去重，保持原有重复事件忽略语义。
 		result := db.Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "event_key"}},
 			DoNothing: true,

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -68,11 +68,10 @@ func InsertUsageEvents(db *gorm.DB, events []models.UsageEvent) (int, int, error
 		return 0, 0, nil
 	}
 
-	const batchSize = 100
 	inserted := 0
 
-	for start := 0; start < len(events); start += batchSize {
-		end := min(start+batchSize, len(events))
+	for start := 0; start < len(events); start += defaultRepositoryInsertBatchSize {
+		end := min(start+defaultRepositoryInsertBatchSize, len(events))
 		batch := events[start:end]
 		result := db.Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "event_key"}},

--- a/internal/repository/redis_usage_inbox.go
+++ b/internal/repository/redis_usage_inbox.go
@@ -39,6 +39,7 @@ func InsertRedisUsageInboxMessages(db *gorm.DB, inputs []RedisInboxInsert) ([]mo
 	}
 
 	rows := make([]models.RedisUsageInbox, 0, len(inputs))
+	// 先把 Redis 原始消息转换成 inbox 行，后续落库只处理标准化后的模型数据。
 	for _, input := range inputs {
 		hash := sha256.Sum256([]byte(input.RawMessage))
 		rows = append(rows, models.RedisUsageInbox{
@@ -52,6 +53,7 @@ func InsertRedisUsageInboxMessages(db *gorm.DB, inputs []RedisInboxInsert) ([]mo
 	}
 
 	if err := db.Transaction(func(tx *gorm.DB) error {
+		// Redis 拉取批次仍由配置控制；这里只把数据库写入拆成安全大小。
 		return tx.CreateInBatches(&rows, defaultRepositoryInsertBatchSize).Error
 	}); err != nil {
 		return nil, err

--- a/internal/repository/redis_usage_inbox.go
+++ b/internal/repository/redis_usage_inbox.go
@@ -52,7 +52,7 @@ func InsertRedisUsageInboxMessages(db *gorm.DB, inputs []RedisInboxInsert) ([]mo
 	}
 
 	if err := db.Transaction(func(tx *gorm.DB) error {
-		return tx.Create(&rows).Error
+		return tx.CreateInBatches(&rows, defaultRepositoryInsertBatchSize).Error
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/repository/redis_usage_inbox_test.go
+++ b/internal/repository/redis_usage_inbox_test.go
@@ -49,6 +49,40 @@ func TestInsertRedisUsageInboxMessagesPersistsPendingRows(t *testing.T) {
 	}
 }
 
+func TestInsertRedisUsageInboxMessagesBatchesLargeInsertSet(t *testing.T) {
+	db := openTestDatabase(t)
+	poppedAt := time.Date(2026, 5, 6, 13, 0, 0, 0, time.UTC)
+	inputs := make([]RedisInboxInsert, 0, 901)
+	for i := 0; i < 901; i++ {
+		inputs = append(inputs, RedisInboxInsert{
+			QueueKey:   "queue",
+			RawMessage: fmt.Sprintf(`{"request_id":"large-%04d"}`, i),
+			PoppedAt:   poppedAt.Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	rows, err := InsertRedisUsageInboxMessages(db, inputs)
+	if err != nil {
+		t.Fatalf("InsertRedisUsageInboxMessages returned error: %v", err)
+	}
+	if len(rows) != len(inputs) {
+		t.Fatalf("expected %d returned rows, got %d", len(inputs), len(rows))
+	}
+	for i, row := range rows {
+		if row.ID == 0 {
+			t.Fatalf("expected row %d to have an ID", i)
+		}
+	}
+
+	var count int64
+	if err := db.Model(&models.RedisUsageInbox{}).Where("status = ?", RedisUsageInboxStatusPending).Count(&count).Error; err != nil {
+		t.Fatalf("count pending inbox rows: %v", err)
+	}
+	if count != int64(len(inputs)) {
+		t.Fatalf("expected %d pending inbox rows, got %d", len(inputs), count)
+	}
+}
+
 func TestInsertRedisUsageInboxMessagesAllowsEmptyInput(t *testing.T) {
 	db := openTestDatabase(t)
 

--- a/internal/repository/usage_identities.go
+++ b/internal/repository/usage_identities.go
@@ -21,15 +21,15 @@ func ReplaceUsageIdentitiesForAuthType(ctx context.Context, db *gorm.DB, identit
 	normalized, incomingIdentities := normalizeUsageIdentities(identities, authType)
 
 	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// 先恢复或写入本次同步到的身份，保证后续 stale 删除只处理缺失项。
+		// 先写入或恢复本次同步到的身份，确保 CPA 返回的 deleted row 会重新变为 active。
 		if err := upsertUsageIdentities(tx, normalized); err != nil {
 			return err
 		}
 
-		// 再按 auth_type 范围标记本次没有出现的身份为 deleted。
+		// 再按 auth_type 范围只对当前 active 身份做 stale 对比；未返回且已 deleted 的历史行不刷新 deleted_at。
 		return markStaleUsageIdentitiesDeleted(
 			tx,
-			tx.Model(&models.UsageIdentity{}).Where("auth_type = ?", authType),
+			tx.Model(&models.UsageIdentity{}).Where("auth_type = ? AND is_deleted = ?", authType, false),
 			incomingIdentities,
 			now,
 			"mark stale usage identities deleted",
@@ -47,7 +47,7 @@ func ReplaceUsageIdentitiesForProviderTypes(ctx context.Context, db *gorm.DB, id
 	types := normalizeProviderTypes(providerTypes)
 
 	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// 先 upsert 本次成功拉到的 provider identity，避免后续 stale 标记误删活跃项。
+		// 先 upsert 本次成功拉到的 provider identity，CPA 返回的历史 deleted provider 会在这里恢复 active。
 		if err := upsertUsageIdentities(tx, normalized); err != nil {
 			return err
 		}
@@ -58,9 +58,9 @@ func ReplaceUsageIdentitiesForProviderTypes(ctx context.Context, db *gorm.DB, id
 		// fetched provider type 也按批次切分，避免极端情况下 type IN 变量过多。
 		for start := 0; start < len(types); start += defaultRepositoryInsertBatchSize {
 			end := min(start+defaultRepositoryInsertBatchSize, len(types))
-			// 每批只处理本次成功 fetch 的 provider type，未 fetch 的类型保持现状。
+			// 每批只处理本次成功 fetch 的 provider type；未返回且仍 active 的身份才会被标记 deleted。
 			query := tx.Model(&models.UsageIdentity{}).
-				Where("auth_type = ?", models.UsageIdentityAuthTypeAIProvider).
+				Where("auth_type = ? AND is_deleted = ?", models.UsageIdentityAuthTypeAIProvider, false).
 				Where("type IN ?", types[start:end])
 			if err := markStaleUsageIdentitiesDeleted(tx, query, incomingIdentities, now, "mark stale provider usage identities deleted"); err != nil {
 				return err
@@ -76,9 +76,23 @@ func ListUsageIdentities(ctx context.Context, db *gorm.DB) ([]models.UsageIdenti
 		return nil, fmt.Errorf("database is nil")
 	}
 
+	// usage identities 页面需要展示 active/deleted 全量历史，因此这里不加 is_deleted 条件。
 	var identities []models.UsageIdentity
 	if err := db.WithContext(ctx).Order("auth_type asc, name asc, id asc").Find(&identities).Error; err != nil {
 		return nil, fmt.Errorf("list usage identities: %w", err)
+	}
+	return identities, nil
+}
+
+func ListActiveUsageIdentities(ctx context.Context, db *gorm.DB) ([]models.UsageIdentity, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database is nil")
+	}
+
+	// 解析和筛选场景只需要活跃身份，直接在 SQL 层过滤 deleted rows，避免无效数据进入内存 resolver。
+	var identities []models.UsageIdentity
+	if err := db.WithContext(ctx).Where("is_deleted = ?", false).Order("auth_type asc, name asc, id asc").Find(&identities).Error; err != nil {
+		return nil, fmt.Errorf("list active usage identities: %w", err)
 	}
 	return identities, nil
 }
@@ -88,6 +102,7 @@ func AggregateUsageIdentityStats(ctx context.Context, db *gorm.DB, now time.Time
 		return fmt.Errorf("database is nil")
 	}
 
+	// 聚合统计需要覆盖 active/deleted 全量身份，避免历史已删除身份停止累计对应 usage_events。
 	var identities []models.UsageIdentity
 	if err := db.WithContext(ctx).Find(&identities).Error; err != nil {
 		return fmt.Errorf("list usage identities for aggregation: %w", err)
@@ -298,7 +313,7 @@ func upsertUsageIdentities(tx *gorm.DB, identities []models.UsageIdentity) error
 		return nil
 	}
 
-	// 使用相同的冲突更新语义，只把单条大 INSERT 拆成多批执行。
+	// 使用相同的冲突更新语义，CPA 本次返回的身份需要恢复为 active，同时保留历史统计字段。
 	if err := tx.Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "auth_type"}, {Name: "identity"}},
 		DoUpdates: clause.Assignments(map[string]any{

--- a/internal/repository/usage_identities.go
+++ b/internal/repository/usage_identities.go
@@ -17,13 +17,16 @@ func ReplaceUsageIdentitiesForAuthType(ctx context.Context, db *gorm.DB, identit
 		return fmt.Errorf("database is nil")
 	}
 
+	// 先统一清洗和去重输入，后续 upsert 与 stale 判断都使用同一组 identity。
 	normalized, incomingIdentities := normalizeUsageIdentities(identities, authType)
 
 	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// 先恢复或写入本次同步到的身份，保证后续 stale 删除只处理缺失项。
 		if err := upsertUsageIdentities(tx, normalized); err != nil {
 			return err
 		}
 
+		// 再按 auth_type 范围标记本次没有出现的身份为 deleted。
 		return markStaleUsageIdentitiesDeleted(
 			tx,
 			tx.Model(&models.UsageIdentity{}).Where("auth_type = ?", authType),
@@ -39,10 +42,12 @@ func ReplaceUsageIdentitiesForProviderTypes(ctx context.Context, db *gorm.DB, id
 		return fmt.Errorf("database is nil")
 	}
 
+	// Provider metadata 只允许刷新 AI provider 身份，输入类型和 identity 先统一规范化。
 	normalized, incomingIdentities := normalizeUsageIdentities(identities, models.UsageIdentityAuthTypeAIProvider)
 	types := normalizeProviderTypes(providerTypes)
 
 	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// 先 upsert 本次成功拉到的 provider identity，避免后续 stale 标记误删活跃项。
 		if err := upsertUsageIdentities(tx, normalized); err != nil {
 			return err
 		}
@@ -50,8 +55,10 @@ func ReplaceUsageIdentitiesForProviderTypes(ctx context.Context, db *gorm.DB, id
 			return nil
 		}
 
+		// fetched provider type 也按批次切分，避免极端情况下 type IN 变量过多。
 		for start := 0; start < len(types); start += defaultRepositoryInsertBatchSize {
 			end := min(start+defaultRepositoryInsertBatchSize, len(types))
+			// 每批只处理本次成功 fetch 的 provider type，未 fetch 的类型保持现状。
 			query := tx.Model(&models.UsageIdentity{}).
 				Where("auth_type = ?", models.UsageIdentityAuthTypeAIProvider).
 				Where("type IN ?", types[start:end])
@@ -250,11 +257,13 @@ func normalizeProviderTypes(providerTypes []string) []string {
 }
 
 func markStaleUsageIdentitiesDeleted(tx *gorm.DB, query *gorm.DB, incomingIdentities []string, now time.Time, context string) error {
+	// 把本次同步到的 identity 放进内存集合，避免生成超大的 identity NOT IN SQL。
 	incoming := make(map[string]struct{}, len(incomingIdentities))
 	for _, identity := range incomingIdentities {
 		incoming[identity] = struct{}{}
 	}
 
+	// 只从数据库读取候选行的最小字段，后续在 Go 中判断哪些行已经 stale。
 	var candidates []struct {
 		ID       uint
 		Identity string
@@ -263,6 +272,7 @@ func markStaleUsageIdentitiesDeleted(tx *gorm.DB, query *gorm.DB, incomingIdenti
 		return fmt.Errorf("%s: %w", context, err)
 	}
 
+	// 候选行中没有出现在本次输入里的 ID，就是需要标记删除的 stale 数据。
 	staleIDs := make([]uint, 0)
 	for _, candidate := range candidates {
 		if _, ok := incoming[candidate.Identity]; ok {
@@ -270,6 +280,8 @@ func markStaleUsageIdentitiesDeleted(tx *gorm.DB, query *gorm.DB, incomingIdenti
 		}
 		staleIDs = append(staleIDs, candidate.ID)
 	}
+
+	// stale ID 也按批次更新，避免 id IN 在数据量大时再次触发 SQLite 变量上限。
 	for start := 0; start < len(staleIDs); start += defaultRepositoryInsertBatchSize {
 		end := min(start+defaultRepositoryInsertBatchSize, len(staleIDs))
 		if err := tx.Model(&models.UsageIdentity{}).
@@ -286,6 +298,7 @@ func upsertUsageIdentities(tx *gorm.DB, identities []models.UsageIdentity) error
 		return nil
 	}
 
+	// 使用相同的冲突更新语义，只把单条大 INSERT 拆成多批执行。
 	if err := tx.Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "auth_type"}, {Name: "identity"}},
 		DoUpdates: clause.Assignments(map[string]any{

--- a/internal/repository/usage_identities.go
+++ b/internal/repository/usage_identities.go
@@ -24,18 +24,13 @@ func ReplaceUsageIdentitiesForAuthType(ctx context.Context, db *gorm.DB, identit
 			return err
 		}
 
-		query := tx.Model(&models.UsageIdentity{}).Where("auth_type = ?", authType)
-		if len(incomingIdentities) > 0 {
-			query = query.Where("identity NOT IN ?", incomingIdentities)
-		}
-		if err := query.Updates(map[string]any{
-			"is_deleted": true,
-			"deleted_at": now,
-		}).Error; err != nil {
-			return fmt.Errorf("mark stale usage identities deleted: %w", err)
-		}
-
-		return nil
+		return markStaleUsageIdentitiesDeleted(
+			tx,
+			tx.Model(&models.UsageIdentity{}).Where("auth_type = ?", authType),
+			incomingIdentities,
+			now,
+			"mark stale usage identities deleted",
+		)
 	})
 }
 
@@ -55,17 +50,14 @@ func ReplaceUsageIdentitiesForProviderTypes(ctx context.Context, db *gorm.DB, id
 			return nil
 		}
 
-		query := tx.Model(&models.UsageIdentity{}).
-			Where("auth_type = ?", models.UsageIdentityAuthTypeAIProvider).
-			Where("type IN ?", types)
-		if len(incomingIdentities) > 0 {
-			query = query.Where("identity NOT IN ?", incomingIdentities)
-		}
-		if err := query.Updates(map[string]any{
-			"is_deleted": true,
-			"deleted_at": now,
-		}).Error; err != nil {
-			return fmt.Errorf("mark stale provider usage identities deleted: %w", err)
+		for start := 0; start < len(types); start += defaultRepositoryInsertBatchSize {
+			end := min(start+defaultRepositoryInsertBatchSize, len(types))
+			query := tx.Model(&models.UsageIdentity{}).
+				Where("auth_type = ?", models.UsageIdentityAuthTypeAIProvider).
+				Where("type IN ?", types[start:end])
+			if err := markStaleUsageIdentitiesDeleted(tx, query, incomingIdentities, now, "mark stale provider usage identities deleted"); err != nil {
+				return err
+			}
 		}
 
 		return nil
@@ -257,6 +249,38 @@ func normalizeProviderTypes(providerTypes []string) []string {
 	return types
 }
 
+func markStaleUsageIdentitiesDeleted(tx *gorm.DB, query *gorm.DB, incomingIdentities []string, now time.Time, context string) error {
+	incoming := make(map[string]struct{}, len(incomingIdentities))
+	for _, identity := range incomingIdentities {
+		incoming[identity] = struct{}{}
+	}
+
+	var candidates []struct {
+		ID       uint
+		Identity string
+	}
+	if err := query.Select("id, identity").Find(&candidates).Error; err != nil {
+		return fmt.Errorf("%s: %w", context, err)
+	}
+
+	staleIDs := make([]uint, 0)
+	for _, candidate := range candidates {
+		if _, ok := incoming[candidate.Identity]; ok {
+			continue
+		}
+		staleIDs = append(staleIDs, candidate.ID)
+	}
+	for start := 0; start < len(staleIDs); start += defaultRepositoryInsertBatchSize {
+		end := min(start+defaultRepositoryInsertBatchSize, len(staleIDs))
+		if err := tx.Model(&models.UsageIdentity{}).
+			Where("id IN ?", staleIDs[start:end]).
+			Updates(map[string]any{"is_deleted": true, "deleted_at": now}).Error; err != nil {
+			return fmt.Errorf("%s: %w", context, err)
+		}
+	}
+	return nil
+}
+
 func upsertUsageIdentities(tx *gorm.DB, identities []models.UsageIdentity) error {
 	if len(identities) == 0 {
 		return nil
@@ -274,7 +298,7 @@ func upsertUsageIdentities(tx *gorm.DB, identities []models.UsageIdentity) error
 			"deleted_at":     nil,
 			"updated_at":     gorm.Expr("excluded.updated_at"),
 		}),
-	}).Create(&identities).Error; err != nil {
+	}).CreateInBatches(&identities, defaultRepositoryInsertBatchSize).Error; err != nil {
 		return fmt.Errorf("upsert usage identities: %w", err)
 	}
 	return nil

--- a/internal/repository/usage_identities_test.go
+++ b/internal/repository/usage_identities_test.go
@@ -105,7 +105,7 @@ func TestUsageIdentityReplaceForAuthTypeMarksStaleRowsDeletedAndPreservesStats(t
 	}
 }
 
-func TestUsageIdentityReplaceForAuthTypeRestoresDeletedIdentity(t *testing.T) {
+func TestUsageIdentityReplaceForAuthTypeRevivesDeletedIdentity(t *testing.T) {
 	db := openTestDatabase(t)
 	ctx := context.Background()
 	deletedAt := time.Date(2026, 5, 3, 10, 0, 0, 0, time.UTC)
@@ -128,7 +128,7 @@ func TestUsageIdentityReplaceForAuthTypeRestoresDeletedIdentity(t *testing.T) {
 
 	err := ReplaceUsageIdentitiesForAuthType(ctx, db, []models.UsageIdentity{
 		{
-			Name:         "Restored",
+			Name:         "Incoming Deleted",
 			AuthTypeName: "oauth",
 			Identity:     "auth-1",
 			Type:         "account",
@@ -143,12 +143,12 @@ func TestUsageIdentityReplaceForAuthTypeRestoresDeletedIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListUsageIdentities returned error: %v", err)
 	}
-	restored := usageIdentitiesByIdentity(rows)["auth-1"]
-	if restored.IsDeleted || restored.DeletedAt != nil {
-		t.Fatalf("expected deleted identity to be restored, got %+v", restored)
+	deletedRow := usageIdentitiesByIdentity(rows)["auth-1"]
+	if deletedRow.IsDeleted || deletedRow.DeletedAt != nil {
+		t.Fatalf("expected incoming deleted identity to be restored active, got %+v", deletedRow)
 	}
-	if restored.Name != "Restored" || restored.Provider != "claude-code" || restored.TotalRequests != 7 {
-		t.Fatalf("expected metadata update with stats preserved, got %+v", restored)
+	if deletedRow.Name != "Incoming Deleted" || deletedRow.Provider != "claude-code" || deletedRow.TotalRequests != 7 {
+		t.Fatalf("expected restored identity metadata update with stats preserved, got %+v", deletedRow)
 	}
 }
 
@@ -348,12 +348,126 @@ func TestUsageIdentityReplaceForProviderTypesWithEmptyProviderTypesDoesNotDelete
 		}
 	}
 
-	restored := byIdentity["provider-restore"]
-	if restored.IsDeleted || restored.DeletedAt != nil {
-		t.Fatalf("expected incoming provider identity restored, got %+v", restored)
+	deletedProvider := byIdentity["provider-restore"]
+	if deletedProvider.IsDeleted || deletedProvider.DeletedAt != nil {
+		t.Fatalf("expected incoming deleted provider identity to be restored active, got %+v", deletedProvider)
 	}
-	if restored.Name != "Restored Provider" || restored.Provider != "Anthropic Updated" || restored.AuthTypeName != "apikey" || restored.TotalRequests != 9 {
-		t.Fatalf("expected incoming provider identity updated with stats preserved, got %+v", restored)
+	if deletedProvider.Name != "Restored Provider" || deletedProvider.Provider != "Anthropic Updated" || deletedProvider.AuthTypeName != "apikey" || deletedProvider.TotalRequests != 9 {
+		t.Fatalf("expected restored provider identity updated with stats preserved, got %+v", deletedProvider)
+	}
+}
+
+func TestUsageIdentityReplaceForAuthTypeKeepsAlreadyDeletedRowsOutOfStaleCompare(t *testing.T) {
+	db := openTestDatabase(t)
+	ctx := context.Background()
+	oldDeletedAt := time.Date(2026, 5, 2, 9, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC)
+
+	seed := []models.UsageIdentity{
+		{Name: "Active Stale", AuthType: models.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Identity: "auth-active-stale", Type: "account", Provider: "claude"},
+		{Name: "Already Deleted", AuthType: models.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Identity: "auth-already-deleted", Type: "account", Provider: "claude", IsDeleted: true, DeletedAt: &oldDeletedAt},
+	}
+	if err := db.Create(&seed).Error; err != nil {
+		t.Fatalf("seed usage identities: %v", err)
+	}
+
+	if err := ReplaceUsageIdentitiesForAuthType(ctx, db, nil, models.UsageIdentityAuthTypeAuthFile, now); err != nil {
+		t.Fatalf("ReplaceUsageIdentitiesForAuthType returned error: %v", err)
+	}
+
+	rows, err := ListUsageIdentities(ctx, db)
+	if err != nil {
+		t.Fatalf("ListUsageIdentities returned error: %v", err)
+	}
+	byIdentity := usageIdentitiesByIdentity(rows)
+
+	activeStale := byIdentity["auth-active-stale"]
+	if !activeStale.IsDeleted || activeStale.DeletedAt == nil || !activeStale.DeletedAt.Equal(now) {
+		t.Fatalf("expected active stale auth identity to be deleted at %s, got %+v", now, activeStale)
+	}
+
+	alreadyDeleted := byIdentity["auth-already-deleted"]
+	if !alreadyDeleted.IsDeleted || alreadyDeleted.DeletedAt == nil || !alreadyDeleted.DeletedAt.Equal(oldDeletedAt) {
+		t.Fatalf("expected already deleted auth identity to keep deleted_at %s, got %+v", oldDeletedAt, alreadyDeleted)
+	}
+}
+
+func TestUsageIdentityReplaceForProviderTypesKeepsAlreadyDeletedRowsOutOfStaleCompare(t *testing.T) {
+	db := openTestDatabase(t)
+	ctx := context.Background()
+	oldDeletedAt := time.Date(2026, 5, 2, 9, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC)
+
+	seed := []models.UsageIdentity{
+		{Name: "OpenAI Active Stale", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "openai-active-stale", Type: "openai", Provider: "OpenAI"},
+		{Name: "OpenAI Already Deleted", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "openai-already-deleted", Type: "openai", Provider: "OpenAI", IsDeleted: true, DeletedAt: &oldDeletedAt},
+		{Name: "Gemini Untouched", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "gemini-untouched", Type: "gemini", Provider: "Gemini"},
+	}
+	if err := db.Create(&seed).Error; err != nil {
+		t.Fatalf("seed usage identities: %v", err)
+	}
+
+	if err := ReplaceUsageIdentitiesForProviderTypes(ctx, db, nil, []string{"openai"}, now); err != nil {
+		t.Fatalf("ReplaceUsageIdentitiesForProviderTypes returned error: %v", err)
+	}
+
+	rows, err := ListUsageIdentities(ctx, db)
+	if err != nil {
+		t.Fatalf("ListUsageIdentities returned error: %v", err)
+	}
+	byIdentity := usageIdentitiesByIdentity(rows)
+
+	activeStale := byIdentity["openai-active-stale"]
+	if !activeStale.IsDeleted || activeStale.DeletedAt == nil || !activeStale.DeletedAt.Equal(now) {
+		t.Fatalf("expected active stale provider identity to be deleted at %s, got %+v", now, activeStale)
+	}
+
+	alreadyDeleted := byIdentity["openai-already-deleted"]
+	if !alreadyDeleted.IsDeleted || alreadyDeleted.DeletedAt == nil || !alreadyDeleted.DeletedAt.Equal(oldDeletedAt) {
+		t.Fatalf("expected already deleted provider identity to keep deleted_at %s, got %+v", oldDeletedAt, alreadyDeleted)
+	}
+
+	gemini := byIdentity["gemini-untouched"]
+	if gemini.IsDeleted || gemini.DeletedAt != nil {
+		t.Fatalf("expected unscoped provider type untouched, got %+v", gemini)
+	}
+}
+
+func TestUsageIdentityListActiveExcludesDeletedRows(t *testing.T) {
+	db := openTestDatabase(t)
+	ctx := context.Background()
+	deletedAt := time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC)
+
+	seed := []models.UsageIdentity{
+		{Name: "Active Auth", AuthType: models.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Identity: "auth-active", Type: "account", Provider: "claude"},
+		{Name: "Deleted Auth", AuthType: models.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Identity: "auth-deleted", Type: "account", Provider: "claude", IsDeleted: true, DeletedAt: &deletedAt},
+		{Name: "Active Provider", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "provider-active", Type: "openai", Provider: "OpenAI"},
+		{Name: "Deleted Provider", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "provider-deleted", Type: "openai", Provider: "OpenAI", IsDeleted: true, DeletedAt: &deletedAt},
+	}
+	if err := db.Create(&seed).Error; err != nil {
+		t.Fatalf("seed usage identities: %v", err)
+	}
+
+	rows, err := ListActiveUsageIdentities(ctx, db)
+	if err != nil {
+		t.Fatalf("ListActiveUsageIdentities returned error: %v", err)
+	}
+
+	got := make([]string, 0, len(rows))
+	for _, row := range rows {
+		got = append(got, row.Identity)
+		if row.IsDeleted {
+			t.Fatalf("expected only active identities, got deleted row %+v", row)
+		}
+	}
+	want := []string{"auth-active", "provider-active"}
+	if len(got) != len(want) {
+		t.Fatalf("expected active identities %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected active identities ordered as %v, got %v", want, got)
+		}
 	}
 }
 

--- a/internal/repository/usage_identities_test.go
+++ b/internal/repository/usage_identities_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -203,6 +204,112 @@ func TestUsageIdentityReplaceForProviderTypesMarksOnlyScopedProviderTypesDeleted
 	anthropic := byIdentity["anthropic-new"]
 	if anthropic.ID == 0 || anthropic.IsDeleted || anthropic.AuthType != models.UsageIdentityAuthTypeAIProvider {
 		t.Fatalf("expected new provider identity active, got %+v", anthropic)
+	}
+}
+
+func TestUsageIdentityReplaceForAuthTypeBatchesLargeUpsertAndMarksStaleRowsDeleted(t *testing.T) {
+	db := openTestDatabase(t)
+	ctx := context.Background()
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+
+	stale := models.UsageIdentity{
+		Name:     "Stale Auth",
+		AuthType: models.UsageIdentityAuthTypeAuthFile,
+		Identity: "auth-stale",
+		Type:     "account",
+		Provider: "claude",
+	}
+	if err := db.Create(&stale).Error; err != nil {
+		t.Fatalf("seed stale auth identity: %v", err)
+	}
+
+	identities := make([]models.UsageIdentity, 0, 2218)
+	for i := 0; i < 2218; i++ {
+		identities = append(identities, models.UsageIdentity{
+			Name:         fmt.Sprintf("Auth %04d", i),
+			AuthTypeName: "oauth",
+			Identity:     fmt.Sprintf("auth-%04d", i),
+			Type:         "account",
+			Provider:     "claude-code",
+		})
+	}
+
+	if err := ReplaceUsageIdentitiesForAuthType(ctx, db, identities, models.UsageIdentityAuthTypeAuthFile, now); err != nil {
+		t.Fatalf("ReplaceUsageIdentitiesForAuthType returned error: %v", err)
+	}
+
+	var activeCount int64
+	if err := db.Model(&models.UsageIdentity{}).Where("auth_type = ? AND is_deleted = ?", models.UsageIdentityAuthTypeAuthFile, false).Count(&activeCount).Error; err != nil {
+		t.Fatalf("count active auth identities: %v", err)
+	}
+	if activeCount != int64(len(identities)) {
+		t.Fatalf("expected %d active auth identities, got %d", len(identities), activeCount)
+	}
+
+	var storedStale models.UsageIdentity
+	if err := db.Where("identity = ?", "auth-stale").First(&storedStale).Error; err != nil {
+		t.Fatalf("load stale auth identity: %v", err)
+	}
+	if !storedStale.IsDeleted || storedStale.DeletedAt == nil || !storedStale.DeletedAt.Equal(now) {
+		t.Fatalf("expected stale auth identity to be deleted at %s, got %+v", now, storedStale)
+	}
+}
+
+func TestUsageIdentityReplaceForProviderTypesBatchesLargeUpsertAndDeletesOnlyScopedStaleRows(t *testing.T) {
+	db := openTestDatabase(t)
+	ctx := context.Background()
+	now := time.Date(2026, 5, 6, 12, 30, 0, 0, time.UTC)
+
+	seed := []models.UsageIdentity{
+		{Name: "OpenAI Stale", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "openai-stale", Type: "openai", Provider: "OpenAI"},
+		{Name: "Gemini Untouched", AuthType: models.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "gemini-untouched", Type: "gemini", Provider: "Gemini"},
+		{Name: "Auth Untouched", AuthType: models.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Identity: "auth-untouched", Type: "account", Provider: "claude"},
+	}
+	if err := db.Create(&seed).Error; err != nil {
+		t.Fatalf("seed usage identities: %v", err)
+	}
+
+	identities := make([]models.UsageIdentity, 0, 2218)
+	for i := 0; i < 2218; i++ {
+		identities = append(identities, models.UsageIdentity{
+			Name:         fmt.Sprintf("OpenAI %04d", i),
+			AuthTypeName: "apikey",
+			Identity:     fmt.Sprintf("openai-%04d", i),
+			Type:         "openai",
+			Provider:     "OpenAI",
+			LookupKey:    fmt.Sprintf("sk-openai-%04d", i),
+		})
+	}
+
+	if err := ReplaceUsageIdentitiesForProviderTypes(ctx, db, identities, []string{"openai"}, now); err != nil {
+		t.Fatalf("ReplaceUsageIdentitiesForProviderTypes returned error: %v", err)
+	}
+
+	var activeOpenAI int64
+	if err := db.Model(&models.UsageIdentity{}).Where("auth_type = ? AND type = ? AND is_deleted = ?", models.UsageIdentityAuthTypeAIProvider, "openai", false).Count(&activeOpenAI).Error; err != nil {
+		t.Fatalf("count active openai identities: %v", err)
+	}
+	if activeOpenAI != int64(len(identities)) {
+		t.Fatalf("expected %d active openai identities, got %d", len(identities), activeOpenAI)
+	}
+
+	rows, err := ListUsageIdentities(ctx, db)
+	if err != nil {
+		t.Fatalf("ListUsageIdentities returned error: %v", err)
+	}
+	byIdentity := usageIdentitiesByIdentity(rows)
+
+	openAIStale := byIdentity["openai-stale"]
+	if !openAIStale.IsDeleted || openAIStale.DeletedAt == nil || !openAIStale.DeletedAt.Equal(now) {
+		t.Fatalf("expected scoped stale provider identity to be deleted, got %+v", openAIStale)
+	}
+	gemini := byIdentity["gemini-untouched"]
+	if gemini.IsDeleted || gemini.DeletedAt != nil {
+		t.Fatalf("expected unmentioned provider type untouched, got %+v", gemini)
+	}
+	auth := byIdentity["auth-untouched"]
+	if auth.IsDeleted || auth.DeletedAt != nil {
+		t.Fatalf("expected auth identity untouched, got %+v", auth)
 	}
 }
 

--- a/internal/service/usage_identities_service.go
+++ b/internal/service/usage_identities_service.go
@@ -10,6 +10,7 @@ import (
 
 type UsageIdentityProvider interface {
 	ListUsageIdentities(context.Context) ([]models.UsageIdentity, error)
+	ListActiveUsageIdentities(context.Context) ([]models.UsageIdentity, error)
 }
 
 type usageIdentityService struct {
@@ -21,5 +22,11 @@ func NewUsageIdentityService(db *gorm.DB) UsageIdentityProvider {
 }
 
 func (s *usageIdentityService) ListUsageIdentities(ctx context.Context) ([]models.UsageIdentity, error) {
+	// identities 页面需要全量历史，包含已删除身份，用于展示 deleted 状态和统计数据。
 	return repository.ListUsageIdentities(ctx, s.db)
+}
+
+func (s *usageIdentityService) ListActiveUsageIdentities(ctx context.Context) ([]models.UsageIdentity, error) {
+	// source 解析和筛选只需要活跃身份，过滤条件下推到 repository 的 SQL 查询中执行。
+	return repository.ListActiveUsageIdentities(ctx, s.db)
 }

--- a/web/src/components/usage/CredentialStatsCard.test.ts
+++ b/web/src/components/usage/CredentialStatsCard.test.ts
@@ -64,6 +64,7 @@ describe('CredentialStatsCard helpers', () => {
         auth_type_name: 'apikey',
         identity: 'sk-a***1234',
         type: 'openai',
+        total_requests: 1,
       }),
     ] satisfies UsageIdentity[];
 
@@ -72,20 +73,29 @@ describe('CredentialStatsCard helpers', () => {
     expect(rows[0].type).toBe('openai');
   });
 
-  it('falls back to success plus failure when total count is empty', () => {
+  it('omits credentials whose total request count is zero', () => {
     const credentials = [
       usageIdentity({
-        identity: 'fallback-total',
+        id: 1,
+        identity: 'empty',
         success_count: 3,
         failure_count: 2,
         total_requests: 0,
       }),
+      usageIdentity({
+        id: 2,
+        identity: 'active',
+        success_count: 4,
+        failure_count: 1,
+        total_requests: 5,
+      }),
     ] satisfies UsageIdentity[];
 
     const rows = buildCredentialRows(credentials);
+    const topRows = getTopCredentialRows(rows);
 
-    expect(rows[0].total).toBe(5);
-    expect(rows[0].successRate).toBe(60);
+    expect(rows.map((row) => row.displayName)).toEqual(['active']);
+    expect(topRows.map((row) => row.displayName)).toEqual(['active']);
   });
 
   it('returns only the top 10 non-empty credential rows', () => {

--- a/web/src/components/usage/CredentialStatsCard.tsx
+++ b/web/src/components/usage/CredentialStatsCard.tsx
@@ -24,13 +24,14 @@ export interface CredentialRow {
 
 export function buildCredentialRows(credentials: UsageIdentity[]): CredentialRow[] {
   return credentials
+    .filter((credential) => Number(credential.total_requests) > 0)
     .map((credential) => {
       const displayName = String(credential.name || credential.identity || '').trim() || '-';
       const sourceType = String(credential.type || credential.auth_type_name || '').trim();
       const key = String(credential.id || credential.identity || '').trim() || displayName;
       const success = Number(credential.success_count) || 0;
       const failure = Number(credential.failure_count) || 0;
-      const total = Number(credential.total_requests) || success + failure;
+      const total = Number(credential.total_requests) || 0;
       return {
         key,
         displayName,


### PR DESCRIPTION
## Summary
- Fixes #49 by batching usage identity upserts with a repository default batch size of 900.
- Fixes #48 by keeping usage identity active/deleted semantics aligned for returned, stale, and user-facing rows.
- Removes large `identity NOT IN` stale-deletion queries by selecting candidates and updating stale IDs in bounded batches.
- Batches Redis inbox database inserts without changing Redis pull batch configuration.

## Test plan
- [x] go test ./internal/repository -run 'TestUsageIdentityReplaceFor(AuthType|ProviderTypes)Batches|TestInsertRedisUsageInboxMessagesBatchesLargeInsertSet' -count=1
- [x] go test ./internal/repository -count=1
- [x] go test ./internal/service -run 'TestSyncMetadata|TestSyncRedisBatch|TestPullRedisUsageInbox' -count=1
- [x] go test ./internal/config ./internal/cpa -run 'RedisQueueBatchSize|RedisQueueClient' -count=1
- [x] go test ./... -count=1
- [x] git diff --check