### PR TITLE
为linux二进制文件提供systemd服务和启动文档

### DIFF
--- a/.github/workflows/binary-dev-release.yml
+++ b/.github/workflows/binary-dev-release.yml
@@ -113,6 +113,7 @@ jobs:
           CGO_ENABLED=1 GOOS="${GOOS}" GOARCH="${GOARCH}" CC="${CC}" \
             go build -trimpath -ldflags="-s -w" -o "${package_dir}/cpa-usage-keeper" ./cmd/server/main.go
           cp .env.example README.md README.en.md LICENSE CONTRIBUTORS.md "${package_dir}/"
+          cp deploy/linux/cpa-usage-keeper.service "${package_dir}/"
           tar -czf "dist/${package_name}.tar.gz" -C dist "${package_name}"
 
       - name: Upload binary package artifact

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -66,6 +66,7 @@ jobs:
           CGO_ENABLED=1 GOOS="${GOOS}" GOARCH="${GOARCH}" CC="${CC}" \
             go build -trimpath -ldflags="-s -w" -o "${package_dir}/cpa-usage-keeper" ./cmd/server/main.go
           cp .env.example README.md README.en.md LICENSE CONTRIBUTORS.md "${package_dir}/"
+          cp deploy/linux/cpa-usage-keeper.service "${package_dir}/"
           tar -czf "dist/${package_name}.tar.gz" -C dist "${package_name}"
 
       - name: Upload binary package artifact

--- a/README.en.md
+++ b/README.en.md
@@ -15,6 +15,7 @@ It relies on [CLIProxyAPI (CPA)](https://github.com/router-for-me/CLIProxyAPI) a
 - Built-in React dashboard
 - Optional password login protection
 - Local SQLite database backups with retention
+- Linux systemd service file
 - Docker / Docker Compose deployment
 
 ## Project Structure
@@ -75,6 +76,57 @@ Security and data notes:
 - For public deployments, enable `AUTH_ENABLED=true` and terminate HTTPS at your reverse proxy.
 - Login sessions are stored in process memory and become invalid after restart.
 - Redis inbox raw messages are cleaned up automatically: successful rows are kept until the end of the current day, and failed rows are kept for 7 days.
+
+## Linux Binary Service
+
+### Download
+
+Download the Linux binary package for your architecture from [Releases](https://github.com/Willxup/cpa-usage-keeper/releases/latest), or use the command line:
+
+```bash
+curl -L -o cpa-usage-keeper.tar.gz "<replace-with-linux-binary-download-url>"
+mkdir -p cpa-usage-keeper
+tar -xzf cpa-usage-keeper.tar.gz -C cpa-usage-keeper --strip-components=1
+cd cpa-usage-keeper
+```
+
+Copy the `linux_amd64` or `linux_arm64` package URL from Releases, then replace the placeholder in the command above.
+
+### Configure
+
+Copy and edit the example config. See the Configuration section above for the available options:
+
+```bash
+cp .env.example .env
+vim .env
+```
+
+### Run Directly
+
+```bash
+./cpa-usage-keeper
+```
+
+### Run With systemd
+
+The Linux binary package includes `cpa-usage-keeper.service`, which can be registered directly as a `systemd` service. After it starts, systemd keeps the process running after SSH or terminal sessions close.
+
+`systemd` requires an absolute `WorkingDirectory`. The `sed` command below writes the current directory into the service file automatically:
+
+```bash
+sudo cp cpa-usage-keeper.service /etc/systemd/system/cpa-usage-keeper.service # Copy the service file into the systemd unit directory.
+sudo sed -i "s|__CPA_USAGE_KEEPER_DIR__|$(pwd)|g" /etc/systemd/system/cpa-usage-keeper.service # Write the current directory as WorkingDirectory.
+sudo systemctl daemon-reload # Reload systemd unit files.
+sudo systemctl enable --now cpa-usage-keeper # Enable startup on boot and start the service now.
+```
+
+Useful commands:
+
+```bash
+sudo systemctl status cpa-usage-keeper # Show service status.
+sudo journalctl -u cpa-usage-keeper -f # Follow service logs.
+sudo systemctl restart cpa-usage-keeper # Restart the service.
+```
 
 ## Development
 

--- a/README.en.md
+++ b/README.en.md
@@ -77,57 +77,6 @@ Security and data notes:
 - Login sessions are stored in process memory and become invalid after restart.
 - Redis inbox raw messages are cleaned up automatically: successful rows are kept until the end of the current day, and failed rows are kept for 7 days.
 
-## Linux Binary Service
-
-### Download
-
-Download the Linux binary package for your architecture from [Releases](https://github.com/Willxup/cpa-usage-keeper/releases/latest), or use the command line:
-
-```bash
-curl -L -o cpa-usage-keeper.tar.gz "<replace-with-linux-binary-download-url>"
-mkdir -p cpa-usage-keeper
-tar -xzf cpa-usage-keeper.tar.gz -C cpa-usage-keeper --strip-components=1
-cd cpa-usage-keeper
-```
-
-Copy the `linux_amd64` or `linux_arm64` package URL from Releases, then replace the placeholder in the command above.
-
-### Configure
-
-Copy and edit the example config. See the Configuration section above for the available options:
-
-```bash
-cp .env.example .env
-vim .env
-```
-
-### Run Directly
-
-```bash
-./cpa-usage-keeper
-```
-
-### Run With systemd
-
-The Linux binary package includes `cpa-usage-keeper.service`, which can be registered directly as a `systemd` service. After it starts, systemd keeps the process running after SSH or terminal sessions close.
-
-`systemd` requires an absolute `WorkingDirectory`. The `sed` command below writes the current directory into the service file automatically:
-
-```bash
-sudo cp cpa-usage-keeper.service /etc/systemd/system/cpa-usage-keeper.service # Copy the service file into the systemd unit directory.
-sudo sed -i "s|__CPA_USAGE_KEEPER_DIR__|$(pwd)|g" /etc/systemd/system/cpa-usage-keeper.service # Write the current directory as WorkingDirectory.
-sudo systemctl daemon-reload # Reload systemd unit files.
-sudo systemctl enable --now cpa-usage-keeper # Enable startup on boot and start the service now.
-```
-
-Useful commands:
-
-```bash
-sudo systemctl status cpa-usage-keeper # Show service status.
-sudo journalctl -u cpa-usage-keeper -f # Follow service logs.
-sudo systemctl restart cpa-usage-keeper # Restart the service.
-```
-
 ## Development
 
 ### Prerequisites
@@ -180,6 +129,57 @@ npm --prefix ./web run test
 npm --prefix ./web run lint
 npm --prefix ./web run typecheck
 npm --prefix ./web run build
+```
+
+## Linux Binary Service
+
+### Download
+
+Download the Linux binary package for your architecture from [Releases](https://github.com/Willxup/cpa-usage-keeper/releases/latest), or use the command line:
+
+```bash
+curl -L -o cpa-usage-keeper.tar.gz "<replace-with-linux-binary-download-url>"
+mkdir -p cpa-usage-keeper
+tar -xzf cpa-usage-keeper.tar.gz -C cpa-usage-keeper --strip-components=1
+cd cpa-usage-keeper
+```
+
+Copy the `linux_amd64` or `linux_arm64` package URL from Releases, then replace the placeholder in the command above.
+
+### Configure
+
+Copy and edit the example config. See the Configuration section above for the available options:
+
+```bash
+cp .env.example .env
+vim .env
+```
+
+### Run Directly
+
+```bash
+./cpa-usage-keeper
+```
+
+### Run With systemd
+
+The Linux binary package includes `cpa-usage-keeper.service`, which can be registered directly as a `systemd` service. After it starts, systemd keeps the process running after SSH or terminal sessions close.
+
+`systemd` requires an absolute `WorkingDirectory`. The `sed` command below writes the current directory into the service file automatically:
+
+```bash
+sudo cp cpa-usage-keeper.service /etc/systemd/system/cpa-usage-keeper.service # Copy the service file into the systemd unit directory.
+sudo sed -i "s|__CPA_USAGE_KEEPER_DIR__|$(pwd)|g" /etc/systemd/system/cpa-usage-keeper.service # Write the current directory as WorkingDirectory.
+sudo systemctl daemon-reload # Reload systemd unit files.
+sudo systemctl enable --now cpa-usage-keeper # Enable startup on boot and start the service now.
+```
+
+Useful commands:
+
+```bash
+sudo systemctl status cpa-usage-keeper # Show service status.
+sudo journalctl -u cpa-usage-keeper -f # Follow service logs.
+sudo systemctl restart cpa-usage-keeper # Restart the service.
 ```
 
 ## Docker

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - 内置 React Dashboard
 - 可选密码登录保护
 - SQLite 数据库本地备份与保留策略
+- Linux systemd 服务文件
 - Docker / Docker Compose 部署
 
 ## 项目结构
@@ -75,6 +76,57 @@ cp .env.example .env
 - 公开部署建议开启 `AUTH_ENABLED=true`，并在反向代理层配置 HTTPS。
 - 登录 session 存在服务进程内存中，服务重启后已登录 session 会失效。
 - Redis inbox 原始消息会自动清理：成功数据保留到当天结束后清理，失败数据保留 7 天。
+
+## Linux 二进制运行
+
+### 下载
+
+在 [Releases](https://github.com/Willxup/cpa-usage-keeper/releases/latest) 下载对应架构的 Linux 二进制包，或使用命令行下载：
+
+```bash
+curl -L -o cpa-usage-keeper.tar.gz "<替换为 Linux 二进制包下载地址>"
+mkdir -p cpa-usage-keeper
+tar -xzf cpa-usage-keeper.tar.gz -C cpa-usage-keeper --strip-components=1
+cd cpa-usage-keeper
+```
+
+请在 Releases 页面复制 `linux_amd64` 或 `linux_arm64` 包的下载地址，并替换上面命令中的占位符。
+
+### 配置
+
+复制配置模板并编辑，具体配置项参考上方“配置”章节：
+
+```bash
+cp .env.example .env
+vim .env
+```
+
+### 直接运行
+
+```bash
+./cpa-usage-keeper
+```
+
+### systemd 常驻运行
+
+Linux 二进制包内置 `cpa-usage-keeper.service`，可直接注册为 `systemd` 服务。启动后进程由 systemd 托管，关闭 SSH 或终端不会结束进程。
+
+`systemd` 的 `WorkingDirectory` 需要绝对路径。下面的 `sed` 命令会把当前目录自动写入 service 文件：
+
+```bash
+sudo cp cpa-usage-keeper.service /etc/systemd/system/cpa-usage-keeper.service # 复制 service 文件到 systemd 目录
+sudo sed -i "s|__CPA_USAGE_KEEPER_DIR__|$(pwd)|g" /etc/systemd/system/cpa-usage-keeper.service # 写入当前目录作为 WorkingDirectory
+sudo systemctl daemon-reload # 重新加载 systemd 配置
+sudo systemctl enable --now cpa-usage-keeper # 设置开机自启并立即启动服务
+```
+
+常用命令：
+
+```bash
+sudo systemctl status cpa-usage-keeper # 查看服务状态
+sudo journalctl -u cpa-usage-keeper -f # 实时查看服务日志
+sudo systemctl restart cpa-usage-keeper # 重启服务
+```
 
 ## 本地开发
 

--- a/README.md
+++ b/README.md
@@ -77,57 +77,6 @@ cp .env.example .env
 - 登录 session 存在服务进程内存中，服务重启后已登录 session 会失效。
 - Redis inbox 原始消息会自动清理：成功数据保留到当天结束后清理，失败数据保留 7 天。
 
-## Linux 二进制运行
-
-### 下载
-
-在 [Releases](https://github.com/Willxup/cpa-usage-keeper/releases/latest) 下载对应架构的 Linux 二进制包，或使用命令行下载：
-
-```bash
-curl -L -o cpa-usage-keeper.tar.gz "<替换为 Linux 二进制包下载地址>"
-mkdir -p cpa-usage-keeper
-tar -xzf cpa-usage-keeper.tar.gz -C cpa-usage-keeper --strip-components=1
-cd cpa-usage-keeper
-```
-
-请在 Releases 页面复制 `linux_amd64` 或 `linux_arm64` 包的下载地址，并替换上面命令中的占位符。
-
-### 配置
-
-复制配置模板并编辑，具体配置项参考上方“配置”章节：
-
-```bash
-cp .env.example .env
-vim .env
-```
-
-### 直接运行
-
-```bash
-./cpa-usage-keeper
-```
-
-### systemd 常驻运行
-
-Linux 二进制包内置 `cpa-usage-keeper.service`，可直接注册为 `systemd` 服务。启动后进程由 systemd 托管，关闭 SSH 或终端不会结束进程。
-
-`systemd` 的 `WorkingDirectory` 需要绝对路径。下面的 `sed` 命令会把当前目录自动写入 service 文件：
-
-```bash
-sudo cp cpa-usage-keeper.service /etc/systemd/system/cpa-usage-keeper.service # 复制 service 文件到 systemd 目录
-sudo sed -i "s|__CPA_USAGE_KEEPER_DIR__|$(pwd)|g" /etc/systemd/system/cpa-usage-keeper.service # 写入当前目录作为 WorkingDirectory
-sudo systemctl daemon-reload # 重新加载 systemd 配置
-sudo systemctl enable --now cpa-usage-keeper # 设置开机自启并立即启动服务
-```
-
-常用命令：
-
-```bash
-sudo systemctl status cpa-usage-keeper # 查看服务状态
-sudo journalctl -u cpa-usage-keeper -f # 实时查看服务日志
-sudo systemctl restart cpa-usage-keeper # 重启服务
-```
-
 ## 本地开发
 
 ### 前置依赖
@@ -180,6 +129,57 @@ npm --prefix ./web run test
 npm --prefix ./web run lint
 npm --prefix ./web run typecheck
 npm --prefix ./web run build
+```
+
+## Linux 二进制运行
+
+### 下载
+
+在 [Releases](https://github.com/Willxup/cpa-usage-keeper/releases/latest) 下载对应架构的 Linux 二进制包，或使用命令行下载：
+
+```bash
+curl -L -o cpa-usage-keeper.tar.gz "<替换为 Linux 二进制包下载地址>"
+mkdir -p cpa-usage-keeper
+tar -xzf cpa-usage-keeper.tar.gz -C cpa-usage-keeper --strip-components=1
+cd cpa-usage-keeper
+```
+
+请在 Releases 页面复制 `linux_amd64` 或 `linux_arm64` 包的下载地址，并替换上面命令中的占位符。
+
+### 配置
+
+复制配置模板并编辑，具体配置项参考上方“配置”章节：
+
+```bash
+cp .env.example .env
+vim .env
+```
+
+### 直接运行
+
+```bash
+./cpa-usage-keeper
+```
+
+### systemd 常驻运行
+
+Linux 二进制包内置 `cpa-usage-keeper.service`，可直接注册为 `systemd` 服务。启动后进程由 systemd 托管，关闭 SSH 或终端不会结束进程。
+
+`systemd` 的 `WorkingDirectory` 需要绝对路径。下面的 `sed` 命令会把当前目录自动写入 service 文件：
+
+```bash
+sudo cp cpa-usage-keeper.service /etc/systemd/system/cpa-usage-keeper.service # 复制 service 文件到 systemd 目录
+sudo sed -i "s|__CPA_USAGE_KEEPER_DIR__|$(pwd)|g" /etc/systemd/system/cpa-usage-keeper.service # 写入当前目录作为 WorkingDirectory
+sudo systemctl daemon-reload # 重新加载 systemd 配置
+sudo systemctl enable --now cpa-usage-keeper # 设置开机自启并立即启动服务
+```
+
+常用命令：
+
+```bash
+sudo systemctl status cpa-usage-keeper # 查看服务状态
+sudo journalctl -u cpa-usage-keeper -f # 实时查看服务日志
+sudo systemctl restart cpa-usage-keeper # 重启服务
 ```
 
 ## Docker

--- a/deploy/linux/cpa-usage-keeper.service
+++ b/deploy/linux/cpa-usage-keeper.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=CPA Usage Keeper
+Documentation=https://github.com/Willxup/cpa-usage-keeper
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+# The README installation command replaces this placeholder with the package directory.
+WorkingDirectory=__CPA_USAGE_KEEPER_DIR__
+ExecStart=/bin/sh -c 'exec ./cpa-usage-keeper'
+Restart=on-failure
+RestartSec=5s
+TimeoutStopSec=30s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
您好，感谢您的review。
首先感谢您之前添加了二进制文件，方便我们直接使用。在linux使用时，我参考了cpa的文档，发现我们的二进制文件可以使用systemd长期运行，因此在文档里提及了使用流程。
主要做以下变动：

1. 同步中英文档，如何使用systemd长期运行、开机运行。
2. 在文档中增加`deploy\linux\cpa-usage-keeper.service`，用于systemd启动服务。
3. `binary-release.yml`和`binary-dev-release.yml`都增加了把 service 文件打进 Linux 二进制包的复制步骤。

最后感谢您的开源贡献，祝我们生活愉快。