### PR TITLE
Optimize usage overview queries

### DIFF
--- a/internal/api/usage_events.go
+++ b/internal/api/usage_events.go
@@ -13,13 +13,11 @@ import (
 )
 
 type usageEventsResponse struct {
-	Events     []usageEventPayload       `json:"events"`
-	Models     []string                  `json:"models"`
-	Sources    []usageSourceFilterOption `json:"sources"`
-	TotalCount int64                     `json:"total_count"`
-	Page       int                       `json:"page"`
-	PageSize   int                       `json:"page_size"`
-	TotalPages int                       `json:"total_pages"`
+	Events     []usageEventPayload `json:"events"`
+	TotalCount int64               `json:"total_count"`
+	Page       int                 `json:"page"`
+	PageSize   int                 `json:"page_size"`
+	TotalPages int                 `json:"total_pages"`
 }
 
 type usageSourceFilterOption struct {
@@ -60,32 +58,27 @@ func registerUsageEventsRoute(
 	usageProvider service.UsageProvider,
 	usageIdentityProvider service.UsageIdentityProvider,
 ) {
-	router.GET("/usage/events/filters", func(c *gin.Context) {
-		if usageProvider == nil {
-			c.JSON(http.StatusOK, usageEventFilterOptionsResponse{Models: []string{}, Sources: []usageSourceFilterOption{}})
-			return
-		}
-
-		options, err := usageProvider.ListUsageEventFilterOptions(c.Request.Context(), servicedto.UsageFilter{})
+	router.GET("/usage/events/filters/models", func(c *gin.Context) {
+		models, err := loadUsageEventModelFilterOptions(c, usageProvider)
 		if err != nil {
-			writeInternalError(c, "list usage event filter options failed", err)
+			writeInternalError(c, "list usage event model filter options failed", err)
 			return
 		}
+		c.JSON(http.StatusOK, gin.H{"models": models})
+	})
 
-		identities, err := loadUsageResolutionData(c, usageIdentityProvider)
+	router.GET("/usage/events/filters/sources", func(c *gin.Context) {
+		sources, err := loadUsageEventSourceFilterOptions(c, usageIdentityProvider)
 		if err != nil {
-			writeInternalError(c, "load usage resolution data failed", err)
+			writeInternalError(c, "list usage event source filter options failed", err)
 			return
 		}
-		c.JSON(http.StatusOK, usageEventFilterOptionsResponse{
-			Models:  options.Models,
-			Sources: buildUsageSourceFilterOptions(options.Sources, identities),
-		})
+		c.JSON(http.StatusOK, gin.H{"sources": sources})
 	})
 
 	router.GET("/usage/events", func(c *gin.Context) {
 		if usageProvider == nil {
-			c.JSON(http.StatusOK, usageEventsResponse{Events: []usageEventPayload{}, Models: []string{}, Sources: []usageSourceFilterOption{}, Page: 1, PageSize: servicedto.DefaultUsageEventsLimit})
+			c.JSON(http.StatusOK, usageEventsResponse{Events: []usageEventPayload{}, Page: 1, PageSize: servicedto.DefaultUsageEventsLimit})
 			return
 		}
 
@@ -113,8 +106,6 @@ func registerUsageEventsRoute(
 		resolver := newUsageIdentityResolver(identities)
 		c.JSON(http.StatusOK, usageEventsResponse{
 			Events:     buildUsageEventsPayload(rows.Events, resolver),
-			Models:     rows.Models,
-			Sources:    buildUsageSourceFilterOptions(rows.Sources, identities),
 			TotalCount: rows.TotalCount,
 			Page:       rows.Page,
 			PageSize:   rows.PageSize,
@@ -123,6 +114,7 @@ func registerUsageEventsRoute(
 	})
 }
 
+// Source 下拉提交的是 usage identity，进入仓储前转换成 auth_index 查询。
 func applyUsageEventsSourceFilter(filter *servicedto.UsageFilter) error {
 	if filter == nil {
 		return nil
@@ -133,11 +125,10 @@ func applyUsageEventsSourceFilter(filter *servicedto.UsageFilter) error {
 	}
 	filter.AuthIndex = source
 	filter.Source = ""
-	filter.Provider = ""
-	filter.AuthType = ""
 	return nil
 }
 
+// 列表结果先按 auth_index 解析展示名，再组装前端需要的事件 payload。
 func buildUsageEventsPayload(rows []servicedto.UsageEventRecord, resolver usageIdentityResolver) []usageEventPayload {
 	if len(rows) == 0 {
 		return []usageEventPayload{}
@@ -183,7 +174,27 @@ func usageEventPublicSource(row servicedto.UsageEventRecord, identity resolvedUs
 	}
 }
 
-func buildUsageSourceFilterOptions(sources []string, identities []entities.UsageIdentity) []usageSourceFilterOption {
+func loadUsageEventModelFilterOptions(c *gin.Context, usageProvider service.UsageProvider) ([]string, error) {
+	if usageProvider == nil {
+		return []string{}, nil
+	}
+	options, err := usageProvider.ListUsageEventFilterOptions(c.Request.Context(), servicedto.UsageFilter{})
+	if err != nil {
+		return nil, err
+	}
+	return options.Models, nil
+}
+
+func loadUsageEventSourceFilterOptions(c *gin.Context, usageIdentityProvider service.UsageIdentityProvider) ([]usageSourceFilterOption, error) {
+	identities, err := loadUsageResolutionData(c, usageIdentityProvider)
+	if err != nil {
+		return nil, err
+	}
+	return buildUsageSourceFilterOptions(identities), nil
+}
+
+// Source 筛选项从活跃身份生成，避免把 usage_events.source 当成可选项暴露给页面。
+func buildUsageSourceFilterOptions(identities []entities.UsageIdentity) []usageSourceFilterOption {
 	if len(identities) == 0 {
 		return []usageSourceFilterOption{}
 	}

--- a/internal/api/usage_events_test.go
+++ b/internal/api/usage_events_test.go
@@ -373,7 +373,7 @@ func TestUsageEventsPassesPaginationAndAuthIndexSourceFilter(t *testing.T) {
 	if provider.lastFilter.Page != 3 || provider.lastFilter.PageSize != 100 || provider.lastFilter.Offset != 200 {
 		t.Fatalf("expected pagination filter, got %+v", provider.lastFilter)
 	}
-	if provider.lastFilter.Model != "claude-sonnet" || provider.lastFilter.AuthIndex != "authidx-openai-main" || provider.lastFilter.AuthType != "" || provider.lastFilter.Provider != "" || provider.lastFilter.Source != "" || provider.lastFilter.Result != "failed" {
+	if provider.lastFilter.Model != "claude-sonnet" || provider.lastFilter.AuthIndex != "authidx-openai-main" || provider.lastFilter.Source != "" || provider.lastFilter.Result != "failed" {
 		t.Fatalf("expected source filter to be translated to auth_index only, got %+v", provider.lastFilter)
 	}
 	body := resp.Body.String()
@@ -393,21 +393,19 @@ func TestUsageEventsPassesAuthFileIdentitySourceFilterAsAuthIndex(t *testing.T) 
 	if resp.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", resp.Code)
 	}
-	if provider.lastFilter.AuthIndex != "auth-file-index" || provider.lastFilter.AuthType != "" || provider.lastFilter.Source != "" || provider.lastFilter.Provider != "" {
+	if provider.lastFilter.AuthIndex != "auth-file-index" || provider.lastFilter.Source != "" {
 		t.Fatalf("expected auth file identity source filter to use auth_index only, got %+v", provider.lastFilter)
 	}
 }
 
-func TestUsageEventsReturnsFilterOptions(t *testing.T) {
+func TestUsageEventsDoesNotReturnFilterOptions(t *testing.T) {
 	provider := &usageEventsStub{eventsPage: &servicedto.UsageEventsPage{
 		Events: []servicedto.UsageEventRecord{{
 			ID: 7, Timestamp: time.Date(2026, 4, 22, 11, 0, 0, 0, time.UTC), Model: "gpt-5", AuthType: "apikey", Provider: "Provider A", Source: "source-a", Failed: true,
 		}},
-		Models:     []string{"claude-sonnet", "gpt-5"},
-		Sources:    []string{"source-a", "source-b"},
 		TotalCount: 2, Page: 1, PageSize: 20, TotalPages: 1,
 	}}
-	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "", usageIdentitiesStub{items: []entities.UsageIdentity{{ID: 1, Name: "Claude Main", Prefix: "Team Prefix", AuthType: entities.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-a", Type: "openai", Provider: "Provider A", TotalRequests: 1}, {ID: 2, Name: "Provider A", AuthType: entities.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-b", Type: "openai", Provider: "Provider A", TotalRequests: 1}, {ID: 3, Name: "Auth User", AuthType: entities.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Identity: "auth-1", Type: "claude", Provider: "Claude", TotalRequests: 1}, {ID: 9, Name: "Deleted Source", AuthType: entities.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-deleted", Type: "openai", Provider: "Provider A", TotalRequests: 99, IsDeleted: true}}})
+	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "")
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/events", nil)
 	resp := httptest.NewRecorder()
 
@@ -417,27 +415,17 @@ func TestUsageEventsReturnsFilterOptions(t *testing.T) {
 		t.Fatalf("expected status 200, got %d", resp.Code)
 	}
 	body := resp.Body.String()
-	if !contains(body, `"models":["claude-sonnet","gpt-5"]`) {
-		t.Fatalf("expected model filter options, got %s", body)
-	}
-	if !contains(body, `"sources":[`) || !contains(body, `"value":"authidx-source-a"`) || !contains(body, `"label":"Claude Main"`) || !contains(body, `"displayName":"Claude Main(Team Prefix)"`) || !contains(body, `"value":"authidx-source-b"`) || !contains(body, `"label":"Provider A"`) || !contains(body, `"value":"auth-1"`) || !contains(body, `"label":"Auth User"`) {
-		t.Fatalf("expected identity source filter options with display names, got %s", body)
-	}
-	if contains(body, `"value":"auth:auth-1"`) || contains(body, `"value":"provider:Provider A"`) || contains(body, `"value":"provider:1"`) || contains(body, `"value":"provider:2"`) {
-		t.Fatalf("expected source filter values without prefixes, got %s", body)
-	}
-	if contains(body, `authidx-deleted`) || contains(body, `Deleted Source`) {
-		t.Fatalf("expected deleted source filter option to be omitted, got %s", body)
+	if contains(body, `"models":`) || contains(body, `"sources":`) {
+		t.Fatalf("expected events response to omit filter options, got %s", body)
 	}
 }
 
-func TestUsageEventFilterOptionsReturnsStableModelsAndSources(t *testing.T) {
+func TestUsageEventModelFilterOptionsReturnsStableModels(t *testing.T) {
 	provider := &usageEventsStub{eventFilterOptions: &servicedto.UsageEventFilterOptions{
-		Models:  []string{"claude-sonnet", "gpt-5"},
-		Sources: []string{"source-a", "source-b"},
+		Models: []string{"claude-sonnet", "gpt-5"},
 	}}
-	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "", usageIdentitiesStub{items: []entities.UsageIdentity{{ID: 1, Name: "Claude Main", AuthType: entities.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-a", Type: "openai", Provider: "Provider A", TotalRequests: 3}, {ID: 2, Name: "Provider A", AuthType: entities.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-b", Type: "openai", Provider: "Provider A"}, {ID: 3, Name: "Auth User", AuthType: entities.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Identity: "auth-1", Type: "claude", Provider: "Claude", TotalRequests: 2}, {ID: 4, Name: "Zero Request User", AuthType: entities.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Identity: "auth-zero", Type: "claude", Provider: "Claude"}, {ID: 5, Name: "Zero Provider", AuthType: entities.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-zero", Type: "openai", Provider: "Zero Provider"}, {ID: 6, Name: "Deleted Source", AuthType: entities.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-deleted", Type: "openai", Provider: "Deleted Provider", TotalRequests: 5, IsDeleted: true}}})
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/events/filters?range=24h&model=ignored&source=ignored&result=failed&page=3&page_size=20", nil)
+	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/events/filters/models?range=24h&model=ignored&source=ignored&result=failed&page=3&page_size=20", nil)
 	resp := httptest.NewRecorder()
 
 	router.ServeHTTP(resp, req)
@@ -446,17 +434,37 @@ func TestUsageEventFilterOptionsReturnsStableModelsAndSources(t *testing.T) {
 		t.Fatalf("expected status 200, got %d", resp.Code)
 	}
 	if provider.filterOptionCalls != 1 || provider.filterCalls != 0 {
-		t.Fatalf("expected filter options endpoint only, events=%d filterOptions=%d", provider.filterCalls, provider.filterOptionCalls)
+		t.Fatalf("expected model filter options endpoint only, events=%d filterOptions=%d", provider.filterCalls, provider.filterOptionCalls)
 	}
 	if provider.lastFilter.Range != "" || provider.lastFilter.StartTime != nil || provider.lastFilter.EndTime != nil || provider.lastFilter.Model != "" || provider.lastFilter.Source != "" || provider.lastFilter.Result != "" || provider.lastFilter.Page != 0 || provider.lastFilter.PageSize != 0 {
-		t.Fatalf("expected filters endpoint to ignore query filters, got %+v", provider.lastFilter)
+		t.Fatalf("expected model filters endpoint to ignore query filters, got %+v", provider.lastFilter)
 	}
 	body := resp.Body.String()
-	if !contains(body, `"models":["claude-sonnet","gpt-5"]`) {
+	if body != `{"models":["claude-sonnet","gpt-5"]}` {
 		t.Fatalf("expected stable model filter options, got %s", body)
 	}
+}
+
+func TestUsageEventSourceFilterOptionsReturnsIdentitySources(t *testing.T) {
+	provider := &usageEventsStub{}
+	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "", usageIdentitiesStub{items: []entities.UsageIdentity{{ID: 1, Name: "Claude Main", AuthType: entities.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-a", Type: "openai", Provider: "Provider A", TotalRequests: 3}, {ID: 2, Name: "Provider A", AuthType: entities.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-b", Type: "openai", Provider: "Provider A"}, {ID: 3, Name: "Auth User", AuthType: entities.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Identity: "auth-1", Type: "claude", Provider: "Claude", TotalRequests: 2}, {ID: 4, Name: "Zero Request User", AuthType: entities.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Identity: "auth-zero", Type: "claude", Provider: "Claude"}, {ID: 5, Name: "Zero Provider", AuthType: entities.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-source-zero", Type: "openai", Provider: "Zero Provider"}, {ID: 6, Name: "Deleted Source", AuthType: entities.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: "authidx-deleted", Type: "openai", Provider: "Deleted Provider", TotalRequests: 5, IsDeleted: true}}})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/events/filters/sources?range=24h&model=ignored&source=ignored&result=failed&page=3&page_size=20", nil)
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.Code)
+	}
+	if provider.filterOptionCalls != 0 || provider.filterCalls != 0 {
+		t.Fatalf("expected source filter options endpoint to use identities only, events=%d filterOptions=%d", provider.filterCalls, provider.filterOptionCalls)
+	}
+	body := resp.Body.String()
 	if !contains(body, `"sources":[`) || !contains(body, `"value":"authidx-source-a"`) || !contains(body, `"label":"Claude Main"`) || !contains(body, `"displayName":"Claude Main"`) || !contains(body, `"value":"auth-1"`) || !contains(body, `"label":"Auth User"`) {
 		t.Fatalf("expected stable identity source filter options with display names, got %s", body)
+	}
+	if contains(body, `"models"`) {
+		t.Fatalf("expected source filter options endpoint not to return models, got %s", body)
 	}
 	if contains(body, `"value":"auth:auth-1"`) || contains(body, `"value":"provider:Provider A"`) || contains(body, `"value":"provider:1"`) || contains(body, `"value":"provider:2"`) {
 		t.Fatalf("expected source filter values without prefixes, got %s", body)

--- a/internal/repository/dto/usage_events.go
+++ b/internal/repository/dto/usage_events.go
@@ -6,7 +6,6 @@ import "time"
 type UsageEventsPageRecord struct {
 	Events     []UsageEventRecord
 	Models     []string
-	Sources    []string
 	TotalCount int64
 	Page       int
 	PageSize   int
@@ -15,8 +14,7 @@ type UsageEventsPageRecord struct {
 
 // UsageEventFilterOptionsRecord 是 usage events 筛选项的仓储查询结果。
 type UsageEventFilterOptionsRecord struct {
-	Models  []string
-	Sources []string
+	Models []string
 }
 
 // UsageEventRecord 是单条 usage event 的查询结果。

--- a/internal/repository/dto/usage_query_filter.go
+++ b/internal/repository/dto/usage_query_filter.go
@@ -14,8 +14,6 @@ type UsageQueryFilter struct {
 	Model     string
 	Source    string
 	AuthIndex string
-	AuthType  string
-	Provider  string
 	Result    string
 }
 

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -15,23 +15,23 @@ func BuildUsageSnapshot(db *gorm.DB) (*dto.StatisticsSnapshot, error) {
 	return BuildUsageSnapshotWithFilter(db, dto.UsageQueryFilter{})
 }
 
+// Request Event Log Tab：先按列表条件统计总数，再加载当前页和筛选项。
 func ListUsageEventsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (*dto.UsageEventsPageRecord, error) {
 	if db == nil {
 		return nil, fmt.Errorf("database is nil")
 	}
 
-	baseQuery := db.Model(&entities.UsageEvent{})
-	baseQuery = applyUsageEventsListFilter(baseQuery, filter)
+	// 第一步：应用列表筛选，统计分页总数。
+	baseQuery := queryUsageEvents(db)
+	baseQuery = applyUsageEventListQuery(baseQuery, filter)
 
 	var totalCount int64
 	if err := baseQuery.Count(&totalCount).Error; err != nil {
 		return nil, fmt.Errorf("count usage events: %w", err)
 	}
-	modelFacets, err := listUsageEventFacetValues(db, filter, "model")
-	if err != nil {
-		return nil, err
-	}
-	sources, err := listUsageEventFacetValues(db, filter, "source")
+
+	// 第二步：model 筛选项只跟随时间窗口，不跟随当前列表筛选。
+	modelOptions, err := listUsageEventModelFilterOptions(db, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func ListUsageEventsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (*dto.U
 		offset = 0
 	}
 
-	query := applyUsageEventsListFilter(db.Model(&entities.UsageEvent{}), filter)
+	query := applyUsageEventListQuery(db.Model(&entities.UsageEvent{}), filter)
 	query = query.Order("timestamp DESC, id DESC").Limit(pageSize).Offset(offset)
 
 	var events []entities.UsageEvent
@@ -87,34 +87,38 @@ func ListUsageEventsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (*dto.U
 	if totalCount > 0 {
 		totalPages = int((totalCount + int64(pageSize) - 1) / int64(pageSize))
 	}
-	return &dto.UsageEventsPageRecord{Events: rows, Models: modelFacets, Sources: sources, TotalCount: totalCount, Page: page, PageSize: pageSize, TotalPages: totalPages}, nil
+	return &dto.UsageEventsPageRecord{Events: rows, Models: modelOptions, TotalCount: totalCount, Page: page, PageSize: pageSize, TotalPages: totalPages}, nil
 }
 
+// Request Event Log Filter Options：只按时间窗口收集 model 候选值。
 func ListUsageEventFilterOptionsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (*dto.UsageEventFilterOptionsRecord, error) {
 	if db == nil {
 		return nil, fmt.Errorf("database is nil")
 	}
-	models, err := listUsageEventFacetValues(db, filter, "model")
+	models, err := listUsageEventModelFilterOptions(db, filter)
 	if err != nil {
 		return nil, err
 	}
-	sources, err := listUsageEventFacetValues(db, filter, "source")
-	if err != nil {
-		return nil, err
-	}
-	return &dto.UsageEventFilterOptionsRecord{Models: models, Sources: sources}, nil
+	return &dto.UsageEventFilterOptionsRecord{Models: models}, nil
 }
 
-func listUsageEventFacetValues(db *gorm.DB, filter dto.UsageQueryFilter, column string) ([]string, error) {
-	query := applyUsageEventTimeFilter(db.Model(&entities.UsageEvent{}), filter)
+func listUsageEventModelFilterOptions(db *gorm.DB, filter dto.UsageQueryFilter) ([]string, error) {
+	// 第一步：model 候选值只来自 usage_events，并且只套用时间窗口。
+	query := applyUsageEventFilterOptionsQuery(queryUsageEvents(db), filter)
+
+	// 第二步：去重并排除空 model，保持下拉选项稳定排序。
 	var values []string
-	if err := query.Select("DISTINCT TRIM("+column+")").Where("TRIM("+column+") <> ''").Order("TRIM("+column+") ASC").Pluck(column, &values).Error; err != nil {
-		return nil, fmt.Errorf("load usage event %s facets: %w", column, err)
+	if err := query.Select("DISTINCT TRIM(model)").Where("TRIM(model) <> ''").Order("TRIM(model) ASC").Pluck("model", &values).Error; err != nil {
+		return nil, fmt.Errorf("load usage event model filter options: %w", err)
 	}
 	return values, nil
 }
 
-func applyUsageEventTimeFilter(query *gorm.DB, filter dto.UsageQueryFilter) *gorm.DB {
+func queryUsageEvents(db *gorm.DB) *gorm.DB {
+	return db.Model(&entities.UsageEvent{})
+}
+
+func applyUsageQueryWindow(query *gorm.DB, filter dto.UsageQueryFilter) *gorm.DB {
 	if filter.StartTime != nil {
 		query = query.Where("timestamp >= ?", filter.StartTime.UTC())
 	}
@@ -124,19 +128,30 @@ func applyUsageEventTimeFilter(query *gorm.DB, filter dto.UsageQueryFilter) *gor
 	return query
 }
 
-func applyUsageEventsListFilter(query *gorm.DB, filter dto.UsageQueryFilter) *gorm.DB {
-	query = applyUsageEventTimeFilter(query, filter)
+// Overview Tab 第一步：只应用时间窗口，后续 Overview 专属条件也从这里加。
+func applyUsageOverviewQuery(query *gorm.DB, filter dto.UsageQueryFilter) *gorm.DB {
+	return applyUsageQueryWindow(query, filter)
+}
+
+// Analysis Tab 第一步：只应用时间窗口，避免 Request Event Log 的筛选污染聚合。
+func applyUsageAnalysisTabQuery(query *gorm.DB, filter dto.UsageQueryFilter) *gorm.DB {
+	return applyUsageQueryWindow(query, filter)
+}
+
+// Request Event Log 筛选项第一步：只应用时间窗口，不叠加当前列表筛选。
+func applyUsageEventFilterOptionsQuery(query *gorm.DB, filter dto.UsageQueryFilter) *gorm.DB {
+	return applyUsageQueryWindow(query, filter)
+}
+
+// Request Event Log 列表第一步：在时间窗口上叠加 model/source/auth_index/result。
+func applyUsageEventListQuery(query *gorm.DB, filter dto.UsageQueryFilter) *gorm.DB {
+	query = applyUsageQueryWindow(query, filter)
 	if model := strings.TrimSpace(filter.Model); model != "" {
 		query = query.Where("TRIM(model) = ?", model)
 	}
-	if authType := strings.TrimSpace(filter.AuthType); authType != "" {
-		query = query.Where("TRIM(auth_type) = ?", authType)
-	}
-	if provider := strings.TrimSpace(filter.Provider); provider != "" {
-		query = query.Where("TRIM(provider) = ?", provider)
-	}
 	if source := strings.TrimSpace(filter.Source); source != "" {
-		if authIndex := strings.TrimSpace(filter.AuthIndex); authIndex != "" && strings.TrimSpace(filter.AuthType) == "oauth" {
+		if authIndex := strings.TrimSpace(filter.AuthIndex); authIndex != "" {
+			// 第二步：API 层会把 Source 下拉转成 auth_index，这里兼容直接传 source 的仓储调用。
 			query = query.Where("(TRIM(auth_index) = ? OR TRIM(source) = ?)", authIndex, source)
 		} else {
 			query = query.Where("TRIM(source) = ?", source)
@@ -153,12 +168,13 @@ func applyUsageEventsListFilter(query *gorm.DB, filter dto.UsageQueryFilter) *go
 	return query
 }
 
+// Analysis 第一步：按时间窗口做 API / model / API+model 聚合。
 func ListUsageAnalysisWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) ([]dto.UsageAnalysisAPIStatRecord, []dto.UsageAnalysisModelStatRecord, error) {
 	if db == nil {
 		return nil, nil, fmt.Errorf("database is nil")
 	}
 
-	baseQuery := applyUsageEventsListFilter(db.Model(&entities.UsageEvent{}), filter)
+	baseQuery := applyUsageAnalysisTabQuery(db.Model(&entities.UsageEvent{}), filter)
 
 	apiQuery := baseQuery.Session(&gorm.Session{})
 	apiQuery = apiQuery.Select(strings.Join([]string{
@@ -283,12 +299,13 @@ func ListUsageAnalysisWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) ([]dt
 	return resultAPIs, modelRows, nil
 }
 
+// Snapshot 先读事件，再按时间窗口在内存里汇总。
 func BuildUsageSnapshotWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (*dto.StatisticsSnapshot, error) {
 	if db == nil {
 		return nil, fmt.Errorf("database is nil")
 	}
 
-	events, err := loadUsageEventsWithFilter(db, filter)
+	events, err := loadUsageOverviewEventsWithFilter(db, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -296,12 +313,13 @@ func BuildUsageSnapshotWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (*dt
 	return buildUsageSnapshotFromEvents(events), nil
 }
 
+// Overview 先读事件，再组合窗口、系列和价格信息。
 func BuildUsageOverviewWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (*dto.UsageOverviewRecord, error) {
 	if db == nil {
 		return nil, fmt.Errorf("database is nil")
 	}
 
-	events, err := loadUsageEventsWithFilter(db, filter)
+	events, err := loadUsageOverviewEventsWithFilter(db, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -346,8 +364,9 @@ func buildUsageOverviewFromEvents(events []entities.UsageEvent, filter dto.Usage
 	return overview
 }
 
-func loadUsageEventsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) ([]entities.UsageEvent, error) {
-	query := applyUsageEventsListFilter(db.Model(&entities.UsageEvent{}), filter).Order("timestamp asc")
+// Overview 第二步：按时间窗口读事件，再交给内存汇总。
+func loadUsageOverviewEventsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) ([]entities.UsageEvent, error) {
+	query := applyUsageOverviewQuery(db.Model(&entities.UsageEvent{}), filter).Order("timestamp asc")
 
 	var events []entities.UsageEvent
 	if err := query.Find(&events).Error; err != nil {

--- a/internal/repository/usage_events_test.go
+++ b/internal/repository/usage_events_test.go
@@ -106,68 +106,38 @@ func TestListUsageEventsWithFilterAppliesModelSourceAndResultFilters(t *testing.
 	}
 }
 
-func TestListUsageEventsWithFilterAppliesProviderAuthTypeFilter(t *testing.T) {
-	db, err := OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "usage-events-provider-filter.db")})
-	if err != nil {
-		t.Fatalf("OpenDatabase returned error: %v", err)
-	}
-	closeTestDatabase(t, db)
-	events := []entities.UsageEvent{
-		{EventKey: "event-1", Model: "gpt-5", Timestamp: time.Date(2026, 4, 16, 9, 0, 0, 0, time.UTC), AuthType: "apikey", Provider: "OpenAI Mirror", Source: "sk-key-a", TotalTokens: 10},
-		{EventKey: "event-2", Model: "gpt-5", Timestamp: time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC), AuthType: "apikey", Provider: "OpenAI Mirror", Source: "sk-key-b", TotalTokens: 20},
-		{EventKey: "event-3", Model: "gpt-5", Timestamp: time.Date(2026, 4, 16, 11, 0, 0, 0, time.UTC), AuthType: "apikey", Provider: "Other Provider", Source: "sk-key-c", TotalTokens: 30},
-		{EventKey: "event-4", Model: "gpt-5", Timestamp: time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC), AuthType: "oauth", Provider: "OpenAI Mirror", Source: "oauth-source", AuthIndex: "auth-1", TotalTokens: 40},
-	}
-	if _, _, err := InsertUsageEvents(db, events); err != nil {
-		t.Fatalf("InsertUsageEvents returned error: %v", err)
-	}
-
-	page, err := ListUsageEventsWithFilter(db, dto.UsageQueryFilter{AuthType: "apikey", Provider: "OpenAI Mirror", Page: 1, PageSize: 20})
-	if err != nil {
-		t.Fatalf("ListUsageEventsWithFilter returned error: %v", err)
-	}
-	if page.TotalCount != 2 || len(page.Events) != 2 {
-		t.Fatalf("expected two matching provider events, got %+v", page)
-	}
-	for _, event := range page.Events {
-		if event.AuthType != "apikey" || event.Provider != "OpenAI Mirror" {
-			t.Fatalf("unexpected provider filtered event: %+v", event)
-		}
-	}
-}
-
-func TestListUsageEventsWithFilterAppliesAuthSourceOrAuthIndexFilter(t *testing.T) {
+func TestListUsageEventsWithFilterAppliesAuthIndexFilter(t *testing.T) {
 	db, err := OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "usage-events-auth-filter.db")})
 	if err != nil {
 		t.Fatalf("OpenDatabase returned error: %v", err)
 	}
 	closeTestDatabase(t, db)
 	events := []entities.UsageEvent{
-		{EventKey: "event-1", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 16, 9, 0, 0, 0, time.UTC), AuthType: "oauth", Source: "auth-1", AuthIndex: "1", TotalTokens: 10},
-		{EventKey: "event-2", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC), AuthType: "oauth", Source: "source-alias", AuthIndex: "auth-1", TotalTokens: 20},
-		{EventKey: "event-3", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 16, 11, 0, 0, 0, time.UTC), AuthType: "oauth", Source: "other", AuthIndex: "other", TotalTokens: 30},
-		{EventKey: "event-4", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC), AuthType: "apikey", Source: "auth-1", AuthIndex: "auth-1", Provider: "Provider A", TotalTokens: 40},
+		{EventKey: "event-1", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 16, 9, 0, 0, 0, time.UTC), Source: "auth-1", AuthIndex: "auth-1", TotalTokens: 10},
+		{EventKey: "event-2", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC), Source: "source-alias", AuthIndex: "auth-1", TotalTokens: 20},
+		{EventKey: "event-3", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 16, 11, 0, 0, 0, time.UTC), Source: "other", AuthIndex: "other", TotalTokens: 30},
+		{EventKey: "event-4", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC), Source: "auth-1", AuthIndex: "auth-1", Provider: "Provider A", TotalTokens: 40},
 	}
 	if _, _, err := InsertUsageEvents(db, events); err != nil {
 		t.Fatalf("InsertUsageEvents returned error: %v", err)
 	}
 
-	page, err := ListUsageEventsWithFilter(db, dto.UsageQueryFilter{AuthType: "oauth", Source: "auth-1", AuthIndex: "auth-1", Page: 1, PageSize: 20})
+	page, err := ListUsageEventsWithFilter(db, dto.UsageQueryFilter{Source: "auth-1", AuthIndex: "auth-1", Page: 1, PageSize: 20})
 	if err != nil {
 		t.Fatalf("ListUsageEventsWithFilter returned error: %v", err)
 	}
-	if page.TotalCount != 2 || len(page.Events) != 2 {
-		t.Fatalf("expected two matching auth events, got %+v", page)
+	if page.TotalCount != 3 || len(page.Events) != 3 {
+		t.Fatalf("expected three matching auth events, got %+v", page)
 	}
 	for _, event := range page.Events {
-		if event.AuthType != "oauth" || (event.Source != "auth-1" && event.AuthIndex != "auth-1") {
+		if event.AuthIndex != "auth-1" {
 			t.Fatalf("unexpected auth filtered event: %+v", event)
 		}
 	}
 }
 
-func TestListUsageEventFilterOptionsWithFilterReturnsStableOptions(t *testing.T) {
-	db, err := OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "usage-events-facets.db")})
+func TestListUsageEventFilterOptionsWithFilterReturnsStableModels(t *testing.T) {
+	db, err := OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "usage-events-filter-options.db")})
 	if err != nil {
 		t.Fatalf("OpenDatabase returned error: %v", err)
 	}
@@ -187,9 +157,6 @@ func TestListUsageEventFilterOptionsWithFilterReturnsStableOptions(t *testing.T)
 	}
 	if len(options.Models) != 2 || options.Models[0] != "claude-sonnet" || options.Models[1] != "gpt-5" {
 		t.Fatalf("expected stable model options, got %+v", options.Models)
-	}
-	if len(options.Sources) != 2 || options.Sources[0] != "source-a" || options.Sources[1] != "source-b" {
-		t.Fatalf("expected stable source options, got %+v", options.Sources)
 	}
 }
 

--- a/internal/repository/usage_test.go
+++ b/internal/repository/usage_test.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"cpa-usage-keeper/internal/repository/dto"
 	"path/filepath"
 	"testing"
 	"time"
@@ -129,46 +128,6 @@ func TestBuildUsageSnapshotPreservesStoredAPIKey(t *testing.T) {
 	}
 	if _, ok := snapshot.APIs["sk-live-secret-value"]; !ok {
 		t.Fatalf("expected repository snapshot to preserve stored API key")
-	}
-}
-
-func TestUsageAggregatesApplyModelSourceAuthAndResultFilters(t *testing.T) {
-	db := openUsageTestDatabase(t)
-	events := []entities.UsageEvent{
-		{EventKey: "event-1", APIGroupKey: "provider-a", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 16, 9, 0, 0, 0, time.UTC), Source: "source-a", AuthIndex: "1", Failed: false, TotalTokens: 35},
-		{EventKey: "event-2", APIGroupKey: "provider-a", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC), Source: "source-a", AuthIndex: "1", Failed: true, TotalTokens: 5},
-		{EventKey: "event-3", APIGroupKey: "provider-b", Model: "claude-opus", Timestamp: time.Date(2026, 4, 16, 11, 0, 0, 0, time.UTC), Source: "source-b", AuthIndex: "2", Failed: false, TotalTokens: 185},
-	}
-	if _, _, err := InsertUsageEvents(db, events); err != nil {
-		t.Fatalf("InsertUsageEvents returned error: %v", err)
-	}
-	filter := dto.UsageQueryFilter{Model: "claude-sonnet", Source: "source-a", AuthIndex: "1", Result: "success"}
-
-	snapshot, err := BuildUsageSnapshotWithFilter(db, filter)
-	if err != nil {
-		t.Fatalf("BuildUsageSnapshotWithFilter returned error: %v", err)
-	}
-	if snapshot.TotalRequests != 1 || snapshot.SuccessCount != 1 || snapshot.FailureCount != 0 || snapshot.TotalTokens != 35 {
-		t.Fatalf("expected snapshot to include only matching successful event, got %+v", snapshot)
-	}
-
-	overview, err := BuildUsageOverviewWithFilter(db, filter)
-	if err != nil {
-		t.Fatalf("BuildUsageOverviewWithFilter returned error: %v", err)
-	}
-	if overview.Summary.RequestCount != 1 || overview.Summary.TokenCount != 35 {
-		t.Fatalf("expected overview to include only matching successful event, got %+v", overview.Summary)
-	}
-
-	apis, models, err := ListUsageAnalysisWithFilter(db, filter)
-	if err != nil {
-		t.Fatalf("ListUsageAnalysisWithFilter returned error: %v", err)
-	}
-	if len(apis) != 1 || apis[0].APIGroupKey != "provider-a" || apis[0].TotalRequests != 1 || apis[0].FailureCount != 0 {
-		t.Fatalf("expected analysis API stats to include only matching successful event, got %+v", apis)
-	}
-	if len(models) != 1 || models[0].Model != "claude-sonnet" || models[0].TotalRequests != 1 || models[0].FailureCount != 0 {
-		t.Fatalf("expected analysis model stats to include only matching successful event, got %+v", models)
 	}
 }
 

--- a/internal/service/dto/usage.go
+++ b/internal/service/dto/usage.go
@@ -20,8 +20,6 @@ type UsageFilter struct {
 	Model     string
 	Source    string
 	AuthIndex string
-	AuthType  string
-	Provider  string
 	Result    string
 }
 
@@ -29,7 +27,6 @@ type UsageFilter struct {
 type UsageEventsPage struct {
 	Events     []UsageEventRecord
 	Models     []string
-	Sources    []string
 	TotalCount int64
 	Page       int
 	PageSize   int
@@ -38,8 +35,7 @@ type UsageEventsPage struct {
 
 // UsageEventFilterOptions 是 usage events 筛选项的服务层结果。
 type UsageEventFilterOptions struct {
-	Models  []string
-	Sources []string
+	Models []string
 }
 
 // UsageEventRecord 是单条 usage event 的服务层结果。

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -25,6 +25,7 @@ func (s *usageService) GetUsageWithFilter(_ context.Context, filter servicedto.U
 	})
 }
 
+// Usage 页面里的 Overview tab 只下传时间窗口，仓储层负责构建 overview 聚合。
 func (s *usageService) GetUsageOverview(_ context.Context, filter servicedto.UsageFilter) (*servicedto.UsageOverviewSnapshot, error) {
 	overview, err := repository.BuildUsageOverviewWithFilter(s.db, repodto.UsageQueryFilter{
 		Range:     filter.Range,
@@ -95,6 +96,7 @@ func mapUsageOverviewSeries(series repodto.UsageOverviewSeriesRecord) servicedto
 	}
 }
 
+// Usage 页面里的 Request Event Log tab 下传分页和列表筛选条件。
 func (s *usageService) ListUsageEvents(_ context.Context, filter servicedto.UsageFilter) (*servicedto.UsageEventsPage, error) {
 	page, err := repository.ListUsageEventsWithFilter(s.db, repodto.UsageQueryFilter{
 		StartTime: filter.StartTime,
@@ -106,8 +108,6 @@ func (s *usageService) ListUsageEvents(_ context.Context, filter servicedto.Usag
 		Model:     filter.Model,
 		Source:    filter.Source,
 		AuthIndex: filter.AuthIndex,
-		AuthType:  filter.AuthType,
-		Provider:  filter.Provider,
 		Result:    filter.Result,
 	})
 	if err != nil {
@@ -133,9 +133,10 @@ func (s *usageService) ListUsageEvents(_ context.Context, filter servicedto.Usag
 			TotalTokens:     row.TotalTokens,
 		})
 	}
-	return &servicedto.UsageEventsPage{Events: result, Models: page.Models, Sources: page.Sources, TotalCount: page.TotalCount, Page: page.Page, PageSize: page.PageSize, TotalPages: page.TotalPages}, nil
+	return &servicedto.UsageEventsPage{Events: result, Models: page.Models, TotalCount: page.TotalCount, Page: page.Page, PageSize: page.PageSize, TotalPages: page.TotalPages}, nil
 }
 
+// Usage 页面里的 Request Event Log tab 的 model 筛选项只按当前时间窗口加载候选值。
 func (s *usageService) ListUsageEventFilterOptions(_ context.Context, filter servicedto.UsageFilter) (*servicedto.UsageEventFilterOptions, error) {
 	options, err := repository.ListUsageEventFilterOptionsWithFilter(s.db, repodto.UsageQueryFilter{
 		StartTime: filter.StartTime,
@@ -144,9 +145,10 @@ func (s *usageService) ListUsageEventFilterOptions(_ context.Context, filter ser
 	if err != nil {
 		return nil, err
 	}
-	return &servicedto.UsageEventFilterOptions{Models: options.Models, Sources: options.Sources}, nil
+	return &servicedto.UsageEventFilterOptions{Models: options.Models}, nil
 }
 
+// Usage 页面里的 Analysis tab 只下传时间窗口，仓储层负责按 API 和 model 聚合。
 func (s *usageService) GetUsageAnalysis(_ context.Context, filter servicedto.UsageFilter) (*servicedto.UsageAnalysisSnapshot, error) {
 	apiRows, modelRows, err := repository.ListUsageAnalysisWithFilter(s.db, repodto.UsageQueryFilter{
 		StartTime: filter.StartTime,

--- a/web/src/components/usage/CostTrendChart.tsx
+++ b/web/src/components/usage/CostTrendChart.tsx
@@ -16,6 +16,7 @@ export interface CostTrendChartProps {
   isMobile: boolean;
   hourWindowHours?: number;
   endMs?: number;
+  includeFinalHourBucket?: boolean;
   preferredPeriod?: 'hour' | 'day';
 }
 
@@ -26,7 +27,8 @@ interface OverviewCostTrendSeries {
   costAvailable: boolean;
 }
 
-const formatHourLabel = (key: string): string => {
+const formatHourLabel = (key: string, isFinalBucket = false): string => {
+  if (isFinalBucket) return '24:00';
   const date = new Date(key);
   if (Number.isNaN(date.getTime())) return key;
   return `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
@@ -39,12 +41,12 @@ const startOfDayKey = (key: string): string => {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
 };
 
-const resolveHourBucketCount = (hourWindowHours?: number): number => {
+const resolveHourBucketCount = (hourWindowHours?: number, includeFinalBucket = false): number => {
   if (!Number.isFinite(hourWindowHours) || !hourWindowHours || hourWindowHours <= 0) {
-    return 24;
+    return includeFinalBucket ? 25 : 24;
   }
   const resolvedHours = Math.min(Math.max(Math.floor(hourWindowHours), 1), 24);
-  return resolvedHours >= 24 ? 24 : resolvedHours + 1;
+  return includeFinalBucket ? resolvedHours + 1 : resolvedHours >= 24 ? 24 : resolvedHours + 1;
 };
 
 const toUtcHourMs = (value: string | number): number => {
@@ -59,11 +61,13 @@ export function buildOverviewCostTrendSeries({
   period,
   hourWindowHours,
   endMs,
+  includeFinalHourBucket = false,
 }: {
   usage: UsageOverviewPayload | null;
   period: 'hour' | 'day';
   hourWindowHours?: number;
   endMs?: number;
+  includeFinalHourBucket?: boolean;
 }): OverviewCostTrendSeries {
   if (!usage) {
     return { labels: [], data: [], hasData: false, costAvailable: false };
@@ -82,7 +86,7 @@ export function buildOverviewCostTrendSeries({
     .sort(([left], [right]) => left.localeCompare(right));
 
   if (period === 'hour') {
-    const bucketCount = resolveHourBucketCount(hourWindowHours);
+    const bucketCount = resolveHourBucketCount(hourWindowHours, includeFinalHourBucket);
     const anchorMs = Number.isFinite(endMs) && endMs ? endMs : (hourlyEntries.length ? Date.parse(hourlyEntries[hourlyEntries.length - 1][0]) : Date.now());
     const currentHour = new Date(anchorMs);
     currentHour.setUTCMinutes(0, 0, 0);
@@ -90,7 +94,7 @@ export function buildOverviewCostTrendSeries({
     const earliestMs = currentHour.getTime() - ((bucketCount - 1) * hourMs);
     const labels = Array.from({ length: bucketCount }, (_, index) => {
       const bucketMs = earliestMs + (index * hourMs);
-      return formatHourLabel(new Date(bucketMs).toISOString());
+      return formatHourLabel(new Date(bucketMs).toISOString(), includeFinalHourBucket && index === bucketCount - 1);
     });
     const valueByHour = new Map(hourlyEntries.map(([label, value]) => [toUtcHourMs(label), Number(value ?? 0)]));
     const data = Array.from({ length: bucketCount }, (_, index) => {
@@ -153,6 +157,7 @@ export function CostTrendChart({
   isMobile,
   hourWindowHours,
   endMs,
+  includeFinalHourBucket = false,
   preferredPeriod = 'hour'
 }: CostTrendChartProps) {
   const { t } = useTranslation();
@@ -163,7 +168,7 @@ export function CostTrendChart({
   }, [preferredPeriod]);
 
   const { chartData, chartOptions, hasData, costAvailable } = useMemo(() => {
-    const series = buildOverviewCostTrendSeries({ usage, period, hourWindowHours, endMs });
+    const series = buildOverviewCostTrendSeries({ usage, period, hourWindowHours, endMs, includeFinalHourBucket });
 
     const data = {
       labels: series.labels,
@@ -197,7 +202,7 @@ export function CostTrendChart({
     };
 
     return { chartData: data, chartOptions: options, hasData: series.hasData, costAvailable: series.costAvailable };
-  }, [usage, period, isDark, isMobile, hourWindowHours, endMs, t]);
+  }, [usage, period, isDark, isMobile, hourWindowHours, endMs, includeFinalHourBucket, t]);
 
   const shouldRenderChart = chartData.labels.length > 0 && hasData;
   const showPricingHint = shouldShowCostPricingHint({ costAvailable, hasData });

--- a/web/src/components/usage/OverviewCharts.logic.test.ts
+++ b/web/src/components/usage/OverviewCharts.logic.test.ts
@@ -341,6 +341,42 @@ describe('overview chart data flow', () => {
     expect(withEvents.dataByCategory.input.some((value) => value > 0)).toBe(true);
   });
 
+  it('keeps today overview hour charts aligned to full-day boundary buckets', () => {
+    const chartUsage = {
+      ...overviewUsage.usage,
+      requests_by_hour: {
+        '2026-04-23T00:00:00Z': 11,
+        '2026-04-24T00:00:00Z': 0,
+      },
+      tokens_by_hour: {
+        '2026-04-23T00:00:00Z': 1100,
+        '2026-04-24T00:00:00Z': 0,
+      },
+    };
+
+    const requests = buildChartData(chartUsage, 'hour', 'requests', ['all'], {
+      hourWindowHours: 24,
+      endMs: Date.parse('2026-04-24T00:00:00Z'),
+      includeFinalHourBucket: true,
+    });
+    const tokens = buildChartData(chartUsage, 'hour', 'tokens', ['all'], {
+      hourWindowHours: 24,
+      endMs: Date.parse('2026-04-24T00:00:00Z'),
+      includeFinalHourBucket: true,
+    });
+
+    expect(requests.labels).toHaveLength(25);
+    expect(requests.labels[0]).toBe('00:00');
+    expect(requests.labels[24]).toBe('24:00');
+    expect(requests.datasets[0]?.data[0]).toBe(11);
+    expect(requests.datasets[0]?.data[24]).toBe(0);
+    expect(tokens.labels).toHaveLength(25);
+    expect(tokens.labels[0]).toBe('00:00');
+    expect(tokens.labels[24]).toBe('24:00');
+    expect(tokens.datasets[0]?.data[0]).toBe(1100);
+    expect(tokens.datasets[0]?.data[24]).toBe(0);
+  });
+
   it('keeps short-range overview hour charts aligned to backend partial-hour buckets', () => {
     const chartUsage = {
       ...overviewUsage.usage,
@@ -400,6 +436,37 @@ describe('overview chart data flow', () => {
     expect(requests.labels).toHaveLength(5);
     expect(requests.datasets[0]?.data).toEqual([0, 0, 1, 0, 2]);
     expect(tokens.datasets[0]?.data).toEqual([0, 0, 100, 0, 200]);
+  });
+
+  it('keeps today token breakdown hour buckets aligned to full-day boundary buckets', () => {
+    const series = buildTokenBreakdownChartSeries({
+      usage: {
+        ...overviewUsage,
+        hourly_series: {
+          ...overviewUsage.hourly_series!,
+          input_tokens: {
+            '2026-04-23T00:00:00Z': 100,
+            '2026-04-24T00:00:00Z': 0,
+          },
+          output_tokens: {
+            '2026-04-23T00:00:00Z': 50,
+            '2026-04-24T00:00:00Z': 0,
+          },
+          cached_tokens: {},
+          reasoning_tokens: {},
+        },
+      },
+      period: 'hour',
+      hourWindowHours: 24,
+      endMs: Date.parse('2026-04-24T00:00:00Z'),
+      includeFinalHourBucket: true,
+    });
+
+    expect(series.labels).toHaveLength(25);
+    expect(series.dataByCategory.input[0]).toBe(100);
+    expect(series.dataByCategory.input[24]).toBe(0);
+    expect(series.dataByCategory.output[0]).toBe(50);
+    expect(series.dataByCategory.output[24]).toBe(0);
   });
 
   it('fills token breakdown hour buckets across the latest 24 hours when only one bucket has data', () => {
@@ -473,6 +540,29 @@ describe('overview chart data flow', () => {
       dataset: { label: 'All' },
       parsed: { y: 2_500_000_000 },
     } as never)).toBe('All: 2.50B tokens');
+  });
+
+  it('keeps today cost trend hour buckets aligned to full-day boundary buckets', () => {
+    const series = buildOverviewCostTrendSeries({
+      usage: {
+        ...overviewUsage,
+        hourly_series: {
+          ...overviewUsage.hourly_series!,
+          cost: {
+            '2026-04-23T00:00:00Z': 1.25,
+            '2026-04-24T00:00:00Z': 0,
+          },
+        },
+      },
+      period: 'hour',
+      hourWindowHours: 24,
+      endMs: Date.parse('2026-04-24T00:00:00Z'),
+      includeFinalHourBucket: true,
+    });
+
+    expect(series.labels).toHaveLength(25);
+    expect(series.data[0]).toBe(1.25);
+    expect(series.data[24]).toBe(0);
   });
 
   it('formats token breakdown axis and tooltip values with K/M/B units', () => {

--- a/web/src/components/usage/OverviewCharts.logic.test.ts
+++ b/web/src/components/usage/OverviewCharts.logic.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { buildOverviewCostTrendSeries } from './CostTrendChart';
-import { buildTokenBreakdownChartSeries } from './TokenBreakdownChart';
-import { buildHourlyTokenBreakdown } from '@/utils/usage';
+import { buildTokenBreakdownChartOptions, buildTokenBreakdownChartSeries } from './TokenBreakdownChart';
+import { buildHourlyTokenBreakdown, formatCompactTokenValue } from '@/utils/usage';
 import { buildChartData, filterUsageByWindow } from '@/utils/usage';
 import type { UsageOverviewResponse, UsageEvent, UsageSnapshot } from '@/lib/types';
+import { buildChartOptions } from '@/utils/usage/chartConfig';
 
 const overviewUsage: UsageOverviewResponse = {
   usage: {
@@ -450,6 +451,51 @@ describe('overview chart data flow', () => {
 
     expect(series.labels).toHaveLength(5);
     expect(series.dataByCategory.input).toEqual([0, 0, 100, 0, 200]);
+  });
+
+  it('formats tokens trend axis and tooltip values with K/M/B units', () => {
+    const options = buildChartOptions({
+      period: 'hour',
+      labels: ['00:00'],
+      isDark: false,
+      isMobile: false,
+      valueFormatter: (value) => formatCompactTokenValue(value),
+      tooltipValueFormatter: (value) => formatCompactTokenValue(value, true),
+    });
+
+    const tickCallback = options.scales?.y?.ticks?.callback;
+    const tooltipLabel = options.plugins?.tooltip?.callbacks?.label;
+
+    expect(typeof tickCallback).toBe('function');
+    expect(tickCallback?.call({} as never, 1_500_000, 0, [])).toBe('1.50M');
+    expect(typeof tooltipLabel).toBe('function');
+    expect(tooltipLabel?.({
+      dataset: { label: 'All' },
+      parsed: { y: 2_500_000_000 },
+    } as never)).toBe('All: 2.50B tokens');
+  });
+
+  it('formats token breakdown axis and tooltip values with K/M/B units', () => {
+    const options = buildTokenBreakdownChartOptions({
+      period: 'hour',
+      labels: ['00:00'],
+      isDark: false,
+      isMobile: false,
+      stacked: true,
+    });
+
+    const tickCallback = options.scales?.y?.ticks?.callback;
+    const tooltipLabel = options.plugins?.tooltip?.callbacks?.label;
+
+    expect(options.scales?.y?.stacked).toBe(true);
+    expect(options.scales?.x?.stacked).toBe(true);
+    expect(typeof tickCallback).toBe('function');
+    expect(tickCallback?.call({} as never, 1_500_000, 0, [])).toBe('1.50M');
+    expect(typeof tooltipLabel).toBe('function');
+    expect(tooltipLabel?.({
+      dataset: { label: 'Input' },
+      parsed: { y: 2_500_000_000 },
+    } as never)).toBe('Input: 2.50B tokens');
   });
 
   it('keeps overview hour charts capped to the latest 24 hours even when the query range is 7d', () => {

--- a/web/src/components/usage/TokenBreakdownChart.tsx
+++ b/web/src/components/usage/TokenBreakdownChart.tsx
@@ -33,20 +33,22 @@ export type BuildTokenBreakdownChartSeriesOptions = {
   period: TokenBreakdownChartPeriod;
   hourWindowHours?: number;
   endMs?: number;
+  includeFinalHourBucket?: boolean;
 };
 
-const normalizeHourWindow = (hourWindowHours?: number): number => {
+const resolveHourBucketCount = (hourWindowHours?: number, includeFinalBucket = false): number => {
   if (!Number.isFinite(hourWindowHours) || !hourWindowHours || hourWindowHours <= 0) {
-    return 24;
+    return includeFinalBucket ? 25 : 24;
   }
   const resolvedHours = Math.min(Math.max(Math.floor(hourWindowHours), 1), 24);
-  return resolvedHours >= 24 ? 24 : resolvedHours + 1;
+  return includeFinalBucket ? resolvedHours + 1 : resolvedHours >= 24 ? 24 : resolvedHours + 1;
 };
 
 const formatHourBucketKey = (timestampMs: number): string => `${new Date(timestampMs).toISOString().slice(0, 13)}:00:00Z`;
 
-const formatChartLabel = (label: string, period: TokenBreakdownChartPeriod) => {
+const formatChartLabel = (label: string, period: TokenBreakdownChartPeriod, isFinalBucket = false) => {
   if (period !== 'hour') return label;
+  if (isFinalBucket) return '24:00';
   const date = new Date(label);
   if (Number.isNaN(date.getTime())) return label;
   return `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
@@ -56,11 +58,11 @@ const getTokenSource = (usage: UsageOverviewPayload | null, period: TokenBreakdo
   period === 'hour' ? (usage?.hourly_series ?? usage?.series) : (usage?.daily_series ?? usage?.series)
 );
 
-const buildHourlyLabels = (source: TokenSeriesSource | undefined, hourWindowHours?: number, endMs?: number) => {
+const buildHourlyLabels = (source: TokenSeriesSource | undefined, hourWindowHours?: number, endMs?: number, includeFinalBucket = false) => {
   const labels = Object.keys(source?.input_tokens ?? {}).sort((a, b) => a.localeCompare(b));
   if (labels.length === 0) return [];
 
-  const bucketCount = normalizeHourWindow(hourWindowHours);
+  const bucketCount = resolveHourBucketCount(hourWindowHours, includeFinalBucket);
   const latestLabelMs = Date.parse(labels[labels.length - 1]);
   const requestedEndMs = Number.isFinite(endMs) && endMs && endMs > 0 ? endMs : latestLabelMs;
   const currentHour = new Date(requestedEndMs);
@@ -75,14 +77,15 @@ export const buildTokenBreakdownChartSeries = ({
   period,
   hourWindowHours,
   endMs,
+  includeFinalHourBucket = false,
 }: BuildTokenBreakdownChartSeriesOptions): TokenBreakdownChartSeries => {
   const source = getTokenSource(usage, period);
   const labels = period === 'hour'
-    ? buildHourlyLabels(source, hourWindowHours, endMs)
+    ? buildHourlyLabels(source, hourWindowHours, endMs, includeFinalHourBucket)
     : Object.keys(source?.input_tokens ?? {}).sort((a, b) => a.localeCompare(b));
 
   return {
-    labels: labels.map((label) => formatChartLabel(label, period)),
+    labels: labels.map((label, index) => formatChartLabel(label, period, includeFinalHourBucket && index === labels.length - 1)),
     dataByCategory: {
       input: labels.map((label) => Number(source?.input_tokens?.[label] ?? 0)),
       output: labels.map((label) => Number(source?.output_tokens?.[label] ?? 0)),
@@ -99,6 +102,7 @@ export interface TokenBreakdownChartProps {
   isMobile: boolean;
   hourWindowHours?: number;
   endMs?: number;
+  includeFinalHourBucket?: boolean;
   preferredPeriod?: TokenBreakdownChartPeriod;
 }
 
@@ -155,6 +159,7 @@ export function TokenBreakdownChart({
   isMobile,
   hourWindowHours,
   endMs,
+  includeFinalHourBucket = false,
   preferredPeriod = 'hour'
 }: TokenBreakdownChartProps) {
   const { t } = useTranslation();
@@ -165,7 +170,7 @@ export function TokenBreakdownChart({
   }, [preferredPeriod]);
 
   const { chartData, chartOptions } = useMemo(() => {
-    const series = buildTokenBreakdownChartSeries({ usage, period, hourWindowHours, endMs });
+    const series = buildTokenBreakdownChartSeries({ usage, period, hourWindowHours, endMs, includeFinalHourBucket });
     const categoryLabels: Record<TokenCategory, string> = {
       input: t('usage_stats.input_tokens'),
       output: t('usage_stats.output_tokens'),
@@ -196,7 +201,7 @@ export function TokenBreakdownChart({
     });
 
     return { chartData: data, chartOptions: options };
-  }, [usage, period, isDark, isMobile, hourWindowHours, endMs, t]);
+  }, [usage, period, isDark, isMobile, hourWindowHours, endMs, includeFinalHourBucket, t]);
 
   return (
     <Card

--- a/web/src/components/usage/TokenBreakdownChart.tsx
+++ b/web/src/components/usage/TokenBreakdownChart.tsx
@@ -1,9 +1,10 @@
 import { useState, useMemo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Line } from 'react-chartjs-2';
+import type { ChartOptions } from 'chart.js';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
-import type { TokenCategory } from '@/utils/usage';
+import { formatCompactTokenValue, type TokenCategory } from '@/utils/usage';
 import { buildChartOptions, getHourChartMinWidth } from '@/utils/usage/chartConfig';
 import type { UsageOverviewPayload } from './hooks/useUsageData';
 import styles from '@/pages/UsagePage.module.scss';
@@ -101,6 +102,52 @@ export interface TokenBreakdownChartProps {
   preferredPeriod?: TokenBreakdownChartPeriod;
 }
 
+export const buildTokenBreakdownChartOptions = ({
+  period,
+  labels,
+  isDark,
+  isMobile,
+  stacked = false,
+}: {
+  period: TokenBreakdownChartPeriod;
+  labels: string[];
+  isDark: boolean;
+  isMobile: boolean;
+  stacked?: boolean;
+}): ChartOptions<'line'> => {
+  const baseOptions = buildChartOptions({ period, labels, isDark, isMobile });
+  return {
+    ...baseOptions,
+    plugins: {
+      ...baseOptions.plugins,
+      tooltip: {
+        ...baseOptions.plugins?.tooltip,
+        callbacks: {
+          label: (context) => {
+            const label = context.dataset.label ? `${context.dataset.label}: ` : '';
+            return `${label}${formatCompactTokenValue(Number(context.parsed.y ?? 0), true)}`;
+          },
+        },
+      },
+    },
+    scales: {
+      ...baseOptions.scales,
+      y: {
+        ...baseOptions.scales?.y,
+        stacked,
+        ticks: {
+          ...baseOptions.scales?.y?.ticks,
+          callback: (value) => formatCompactTokenValue(Number(value)),
+        },
+      },
+      x: {
+        ...baseOptions.scales?.x,
+        stacked,
+      },
+    },
+  };
+};
+
 export function TokenBreakdownChart({
   usage,
   loading,
@@ -140,21 +187,13 @@ export function TokenBreakdownChart({
       }))
     };
 
-    const baseOptions = buildChartOptions({ period, labels: series.labels, isDark, isMobile });
-    const options = {
-      ...baseOptions,
-      scales: {
-        ...baseOptions.scales,
-        y: {
-          ...baseOptions.scales?.y,
-          stacked: true
-        },
-        x: {
-          ...baseOptions.scales?.x,
-          stacked: true
-        }
-      }
-    };
+    const options = buildTokenBreakdownChartOptions({
+      period,
+      labels: series.labels,
+      isDark,
+      isMobile,
+      stacked: true,
+    });
 
     return { chartData: data, chartOptions: options };
   }, [usage, period, isDark, isMobile, hourWindowHours, endMs, t]);

--- a/web/src/components/usage/hooks/useChartData.ts
+++ b/web/src/components/usage/hooks/useChartData.ts
@@ -29,6 +29,7 @@ export interface UseChartDataOptions {
   isMobile: boolean;
   hourWindowHours?: number;
   endMs?: number;
+  includeFinalHourBucket?: boolean;
   preferredPeriod?: 'hour' | 'day';
 }
 
@@ -50,6 +51,7 @@ export function useChartData({
   isMobile,
   hourWindowHours,
   endMs,
+  includeFinalHourBucket = false,
   preferredPeriod = 'hour'
 }: UseChartDataOptions): UseChartDataReturn {
   const [requestsPeriod, setRequestsPeriod] = useState<'hour' | 'day'>(preferredPeriod);
@@ -63,14 +65,14 @@ export function useChartData({
   const requestsChartData = useMemo(() => {
     if (!usage) return { labels: [], datasets: [] };
     const source = requestsPeriod === 'hour' ? (usage.hourly_series ?? usage.series) : (usage.daily_series ?? usage.series);
-    return buildChartData(buildChartUsageFromOverview(usage, source), requestsPeriod, 'requests', chartLines, { hourWindowHours, endMs });
-  }, [usage, requestsPeriod, chartLines, hourWindowHours, endMs]);
+    return buildChartData(buildChartUsageFromOverview(usage, source), requestsPeriod, 'requests', chartLines, { hourWindowHours, endMs, includeFinalHourBucket });
+  }, [usage, requestsPeriod, chartLines, hourWindowHours, endMs, includeFinalHourBucket]);
 
   const tokensChartData = useMemo(() => {
     if (!usage) return { labels: [], datasets: [] };
     const source = tokensPeriod === 'hour' ? (usage.hourly_series ?? usage.series) : (usage.daily_series ?? usage.series);
-    return buildChartData(buildChartUsageFromOverview(usage, source), tokensPeriod, 'tokens', chartLines, { hourWindowHours, endMs });
-  }, [usage, tokensPeriod, chartLines, hourWindowHours, endMs]);
+    return buildChartData(buildChartUsageFromOverview(usage, source), tokensPeriod, 'tokens', chartLines, { hourWindowHours, endMs, includeFinalHourBucket });
+  }, [usage, tokensPeriod, chartLines, hourWindowHours, endMs, includeFinalHourBucket]);
 
   const requestsChartOptions = useMemo(
     () =>

--- a/web/src/components/usage/hooks/useChartData.ts
+++ b/web/src/components/usage/hooks/useChartData.ts
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect } from 'react';
 import type { ChartOptions } from 'chart.js';
-import { buildChartData, type ChartData } from '@/utils/usage';
+import { buildChartData, formatCompactTokenValue, type ChartData } from '@/utils/usage';
 import { buildChartOptions } from '@/utils/usage/chartConfig';
 import type { UsageOverviewPayload } from './useUsageData';
 import type { UsageOverviewSeries } from '@/lib/types';
@@ -89,7 +89,9 @@ export function useChartData({
         period: tokensPeriod,
         labels: tokensChartData.labels,
         isDark,
-        isMobile
+        isMobile,
+        valueFormatter: (value) => formatCompactTokenValue(value),
+        tooltipValueFormatter: (value) => formatCompactTokenValue(value, true)
       }),
     [tokensPeriod, tokensChartData.labels, isDark, isMobile]
   );

--- a/web/src/components/usage/hooks/useUsageData.test.ts
+++ b/web/src/components/usage/hooks/useUsageData.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeUsageOverviewRange } from './useUsageData';
+
+describe('normalizeUsageOverviewRange', () => {
+  it('preserves the 30d preset for overview requests', () => {
+    expect(normalizeUsageOverviewRange('30d')).toBe('30d');
+  });
+});

--- a/web/src/components/usage/hooks/useUsageData.ts
+++ b/web/src/components/usage/hooks/useUsageData.ts
@@ -25,8 +25,8 @@ export interface UseUsageDataOptions {
   enabled?: boolean;
 }
 
-const toRangeQuery = (value: string): UsageTimeRange => (
-  value === '4h' || value === '8h' || value === '12h' || value === '24h' || value === 'today' || value === '7d' || value === 'all' || value === 'custom'
+export const normalizeUsageOverviewRange = (value: string): UsageTimeRange => (
+  value === '4h' || value === '8h' || value === '12h' || value === '24h' || value === 'today' || value === '7d' || value === '30d' || value === 'all' || value === 'custom'
     ? value
     : 'all'
 );
@@ -44,7 +44,7 @@ export function useUsageData(options: UseUsageDataOptions = {}): UseUsageDataRet
   const lastRefreshedAtTs = useUsageStatsStore((state) => state.lastRefreshedAt);
   const loadUsageStats = useUsageStatsStore((state) => state.loadUsageStats);
 
-  const resolvedRange = toRangeQuery(range);
+  const resolvedRange = normalizeUsageOverviewRange(range);
   const requestStart = resolvedRange === 'custom' ? toCustomDateParam(customStart) : undefined;
   const requestEnd = resolvedRange === 'custom' ? toCustomDateParam(customEnd) : undefined;
   const customRangeReady = resolvedRange !== 'custom' || (requestStart !== undefined && requestEnd !== undefined);

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fetchUpdateCheck, fetchUsageEventFilterOptions, fetchUsageEvents, fetchUsageIdentities, triggerSync } from './api';
+import { fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchUsageIdentities, triggerSync } from './api';
 
 describe('fetchUsageEvents', () => {
   afterEach(() => {
@@ -7,21 +7,21 @@ describe('fetchUsageEvents', () => {
     vi.unstubAllGlobals();
   });
 
-  it('loads stable filter options without query params', async () => {
+  it('loads model filter options without query params', async () => {
     vi.stubGlobal('window', { __APP_BASE_PATH__: undefined });
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,
-      json: async () => ({ models: ['claude-sonnet'], sources: [{ value: 'source-a', label: 'Provider A' }] }),
+      json: async () => ({ models: ['claude-sonnet'] }),
     } as Response);
     const signal = new AbortController().signal;
 
-    const response = await fetchUsageEventFilterOptions(signal);
+    const response = await fetchUsageEventModelFilterOptions(signal);
 
     const [url, init] = fetchMock.mock.calls[0];
     const parsed = new URL(String(url), 'http://localhost');
 
     expect(response.models).toEqual(['claude-sonnet']);
-    expect(parsed.pathname).toBe('/api/v1/usage/events/filters');
+    expect(parsed.pathname).toBe('/api/v1/usage/events/filters/models');
     expect(parsed.search).toBe('');
     expect(parsed.searchParams.get('range')).toBeNull();
     expect(parsed.searchParams.get('start')).toBeNull();
@@ -31,6 +31,25 @@ describe('fetchUsageEvents', () => {
     expect(parsed.searchParams.get('model')).toBeNull();
     expect(parsed.searchParams.get('source')).toBeNull();
     expect(parsed.searchParams.get('result')).toBeNull();
+    expect(init).toMatchObject({ credentials: 'include', signal, cache: 'no-store' });
+  });
+
+  it('loads source filter options without query params', async () => {
+    vi.stubGlobal('window', { __APP_BASE_PATH__: undefined });
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ sources: [{ value: 'source-a', label: 'Provider A' }] }),
+    } as Response);
+    const signal = new AbortController().signal;
+
+    const response = await fetchUsageEventSourceFilterOptions(signal);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsed = new URL(String(url), 'http://localhost');
+
+    expect(response.sources).toEqual([{ value: 'source-a', label: 'Provider A' }]);
+    expect(parsed.pathname).toBe('/api/v1/usage/events/filters/sources');
+    expect(parsed.search).toBe('');
     expect(init).toMatchObject({ credentials: 'include', signal, cache: 'no-store' });
   });
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { AuthSessionResponse, PricingEntry, PricingResponse, StatusResponse, UpdateCheckResponse, UsageAnalysisResponse, UsageEventFilterOptionsResponse, UsedModelsResponse, UsageIdentitiesResponse, UsageEventsResponse, UsageOverviewResponse } from './types'
+import type { AuthSessionResponse, PricingEntry, PricingResponse, StatusResponse, UpdateCheckResponse, UsageAnalysisResponse, UsageEventModelFilterOptionsResponse, UsageEventSourceFilterOptionsResponse, UsedModelsResponse, UsageIdentitiesResponse, UsageEventsResponse, UsageOverviewResponse } from './types'
 
 export class ApiError extends Error {
   status: number
@@ -96,10 +96,18 @@ export interface FetchUsageEventsOptions {
   result?: string
 }
 
-export async function fetchUsageEventFilterOptions(signal?: AbortSignal): Promise<UsageEventFilterOptionsResponse> {
-  const response = await apiFetch(apiPath('/usage/events/filters'), { signal, cache: 'no-store' })
+export async function fetchUsageEventModelFilterOptions(signal?: AbortSignal): Promise<UsageEventModelFilterOptionsResponse> {
+  const response = await apiFetch(apiPath('/usage/events/filters/models'), { signal, cache: 'no-store' })
   if (!response.ok) {
-    await parseApiError(response, `Failed to load usage event filters: ${response.status}`)
+    await parseApiError(response, `Failed to load usage event model filters: ${response.status}`)
+  }
+  return response.json()
+}
+
+export async function fetchUsageEventSourceFilterOptions(signal?: AbortSignal): Promise<UsageEventSourceFilterOptionsResponse> {
+  const response = await apiFetch(apiPath('/usage/events/filters/sources'), { signal, cache: 'no-store' })
+  if (!response.ok) {
+    await parseApiError(response, `Failed to load usage event source filters: ${response.status}`)
   }
   return response.json()
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -158,16 +158,17 @@ export interface UsageSourceFilterOption {
 
 export interface UsageEventsResponse {
   events: UsageEvent[]
-  models: string[]
-  sources: UsageSourceFilterOption[]
   total_count: number
   page: number
   page_size: number
   total_pages: number
 }
 
-export interface UsageEventFilterOptionsResponse {
+export interface UsageEventModelFilterOptionsResponse {
   models: string[]
+}
+
+export interface UsageEventSourceFilterOptionsResponse {
   sources: UsageSourceFilterOption[]
 }
 

--- a/web/src/pages/UsagePage.logic.test.ts
+++ b/web/src/pages/UsagePage.logic.test.ts
@@ -331,7 +331,7 @@ describe('UsagePage Overview chart window', () => {
       filterWindow,
       fallbackEndMs: filterWindow.endMs ?? 0,
       resolvedRangeEndMs: Date.parse('2026-04-23T15:59:59.999Z'),
-    })).toBe(Date.parse('2026-04-23T15:59:59.999Z'));
+    })).toBe(Date.parse('2026-04-24T00:00:00.000Z'));
   });
 });
 

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -391,10 +391,10 @@ const toTimestampMs = (value: string | undefined): number | undefined => {
 };
 
 export const getOverviewChartEndMs = ({ timeRange, filterWindow, fallbackEndMs, resolvedRangeEndMs }: { timeRange: UsageTimeRange; filterWindow: UsageFilterWindow; fallbackEndMs: number; resolvedRangeEndMs?: number }) => {
-  if (resolvedRangeEndMs !== undefined) return resolvedRangeEndMs;
   if (timeRange === 'today' && filterWindow.startMs !== undefined) {
-    return filterWindow.startMs + 24 * 60 * 60 * 1000 - 1;
+    return filterWindow.startMs + 24 * 60 * 60 * 1000;
   }
+  if (resolvedRangeEndMs !== undefined) return resolvedRangeEndMs;
   return filterWindow.endMs ?? fallbackEndMs;
 };
 
@@ -598,6 +598,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     fallbackEndMs: lastRefreshedAt?.getTime() ?? Date.now(),
     resolvedRangeEndMs,
   });
+  const includeFinalHourBucket = timeRange === 'today';
   const preferredOverviewChartPeriod = getPreferredOverviewChartPeriod({
     windowMinutes: filterWindow.windowMinutes,
   });
@@ -1060,6 +1061,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     isMobile,
     hourWindowHours,
     endMs: filterWindowEndMs,
+    includeFinalHourBucket,
     preferredPeriod: preferredOverviewChartPeriod,
   });
 
@@ -1404,6 +1406,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                   isMobile={isMobile}
                   hourWindowHours={hourWindowHours}
                   endMs={filterWindowEndMs}
+                  includeFinalHourBucket={includeFinalHourBucket}
                   preferredPeriod={preferredOverviewChartPeriod}
                 />
 
@@ -1414,6 +1417,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                   isMobile={isMobile}
                   hourWindowHours={hourWindowHours}
                   endMs={filterWindowEndMs}
+                  includeFinalHourBucket={includeFinalHourBucket}
                   preferredPeriod={preferredOverviewChartPeriod}
                 />
               </>

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -14,7 +14,7 @@ import {
   Legend,
   Filler
 } from 'chart.js';
-import { ApiError, fetchStatus, fetchUpdateCheck, fetchUsageAnalysis, fetchUsageEventFilterOptions, fetchUsageEvents, fetchUsageIdentities } from '@/lib/api';
+import { ApiError, fetchStatus, fetchUpdateCheck, fetchUsageAnalysis, fetchUsageEventModelFilterOptions, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchUsageIdentities } from '@/lib/api';
 import type { StatusResponse, UsageAnalysisResponse, UsageEvent, UsageIdentity, UsageSourceFilterOption } from '@/lib/types';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { Select } from '@/components/ui/Select';
@@ -724,12 +724,15 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     eventsFilterOptionsRequestControllerRef.current = controller;
 
     try {
-      const response = await fetchUsageEventFilterOptions(controller.signal);
+      const [modelResponse, sourceResponse] = await Promise.all([
+        fetchUsageEventModelFilterOptions(controller.signal),
+        fetchUsageEventSourceFilterOptions(controller.signal),
+      ]);
       if (eventsFilterOptionsRequestControllerRef.current !== controller) {
         return;
       }
-      setEventsModelOptions(response.models ?? []);
-      setEventsSourceOptions(response.sources ?? []);
+      setEventsModelOptions(modelResponse.models ?? []);
+      setEventsSourceOptions(sourceResponse.sources ?? []);
     } catch (error) {
       if (controller.signal.aborted) {
         return;

--- a/web/src/utils/usage.ts
+++ b/web/src/utils/usage.ts
@@ -173,16 +173,19 @@ const normalizeHourWindow = (hourWindowHours?: number): number => {
 const resolveHourlyChartWindowHours = (hourWindowHours?: number): number =>
   normalizeHourWindow(hourWindowHours);
 
-const buildHourlyWindow = (hourWindowHours?: number, endMs?: number) => {
+const buildHourlyWindow = (hourWindowHours?: number, endMs?: number, includeFinalBucket = false) => {
   const resolvedHourWindow = resolveHourlyChartWindowHours(hourWindowHours);
-  const bucketCount = resolvedHourWindow >= 24 ? 24 : resolvedHourWindow + 1;
+  const bucketCount = includeFinalBucket ? resolvedHourWindow + 1 : resolvedHourWindow >= 24 ? 24 : resolvedHourWindow + 1;
   const hourMs = 60 * 60 * 1000;
   const currentHour = new Date(Number.isFinite(endMs) && endMs && endMs > 0 ? endMs : Date.now());
   currentHour.setUTCMinutes(0, 0, 0);
   const earliestTime = currentHour.getTime() - ((bucketCount - 1) * hourMs);
-  const labels = Array.from({ length: bucketCount }, (_, index) =>
-    formatHourLabel(formatHourBucketKey(earliestTime + index * hourMs))
-  );
+  const labels = Array.from({ length: bucketCount }, (_, index) => {
+    if (includeFinalBucket) {
+      return `${String(index).padStart(2, '0')}:00`;
+    }
+    return formatHourLabel(formatHourBucketKey(earliestTime + index * hourMs));
+  });
   return {
     hourMs,
     earliestTime,
@@ -531,7 +534,7 @@ export function buildChartData(
   period: 'hour' | 'day',
   metric: 'requests' | 'tokens',
   chartLines: string[],
-  options: { hourWindowHours?: number; endMs?: number } = {}
+  options: { hourWindowHours?: number; endMs?: number; includeFinalHourBucket?: boolean } = {}
 ): ChartData {
   const details = collectUsageDetails(usage);
   if (!details.length) {
@@ -543,13 +546,18 @@ export function buildChartData(
     if (!rawBucketKeys.length) {
       return { labels: [], datasets: [] };
     }
-    const bucketKeys = period === 'hour'
+    const hourWindow = period === 'hour'
       ? (() => {
         const endMs = options.endMs ?? Date.parse(rawBucketKeys[rawBucketKeys.length - 1]);
-        const { earliestTime, hourMs, labels } = buildHourlyWindow(options.hourWindowHours, endMs);
-        return labels.map((_, index) => formatHourBucketKey(earliestTime + index * hourMs));
+        const { earliestTime, hourMs, labels } = buildHourlyWindow(options.hourWindowHours, endMs, options.includeFinalHourBucket);
+        return {
+          bucketKeys: labels.map((_, index) => formatHourBucketKey(earliestTime + index * hourMs)),
+          labels,
+        };
       })()
-      : rawBucketKeys;
+      : null;
+    const bucketKeys = period === 'hour' ? hourWindow!.bucketKeys : rawBucketKeys;
+    const displayLabels = period === 'hour' ? hourWindow!.labels : rawBucketKeys;
     const datasets: ChartDataset[] = [];
     if (lines.includes('all')) {
       datasets.push({
@@ -583,7 +591,7 @@ export function buildChartData(
       });
     });
     return {
-      labels: bucketKeys.map((key) => (period === 'hour' ? formatHourLabel(key) : formatDayLabel(key))),
+      labels: displayLabels.map((key) => (period === 'hour' ? key : formatDayLabel(key))),
       datasets
     };
   }
@@ -594,7 +602,7 @@ export function buildChartData(
 
   if (period === 'hour') {
     const hourEndMs = resolveHourlyChartEndMs(details, options.hourWindowHours, options.endMs);
-    const { labels, earliestTime, lastBucketTime, hourMs } = buildHourlyWindow(options.hourWindowHours, hourEndMs);
+    const { labels, earliestTime, lastBucketTime, hourMs } = buildHourlyWindow(options.hourWindowHours, hourEndMs, options.includeFinalHourBucket);
     const bucketKeys = labels.map((_, index) => formatHourBucketKey(earliestTime + index * hourMs));
     bucketKeys.forEach((key) => orderedKeys.add(key));
 
@@ -671,15 +679,15 @@ export function buildChartData(
   };
 }
 
-export function buildHourlyTokenBreakdown(usage: UsagePayload | null, hourWindowHours = 24, endMs?: number) {
-  return buildTokenBreakdownSeries(usage, 'hour', hourWindowHours, endMs);
+export function buildHourlyTokenBreakdown(usage: UsagePayload | null, hourWindowHours = 24, endMs?: number, includeFinalBucket = false) {
+  return buildTokenBreakdownSeries(usage, 'hour', hourWindowHours, endMs, includeFinalBucket);
 }
 
 export function buildDailyTokenBreakdown(usage: UsagePayload | null) {
   return buildTokenBreakdownSeries(usage, 'day');
 }
 
-function buildTokenBreakdownSeries(usage: UsagePayload | null, period: 'hour' | 'day', hourWindowHours?: number, endMs?: number) {
+function buildTokenBreakdownSeries(usage: UsagePayload | null, period: 'hour' | 'day', hourWindowHours?: number, endMs?: number, includeFinalBucket = false) {
   const details = collectUsageDetails(usage);
   if (!details.length) {
     return { labels: [], dataByCategory: { input: [], output: [], cached: [], reasoning: [] } as Record<TokenCategory, number[]> };
@@ -687,7 +695,7 @@ function buildTokenBreakdownSeries(usage: UsagePayload | null, period: 'hour' | 
 
   if (period === 'hour') {
     const hourEndMs = resolveHourlyChartEndMs(details, hourWindowHours, endMs);
-    const { labels, earliestTime, lastBucketTime, hourMs } = buildHourlyWindow(hourWindowHours, hourEndMs);
+    const { labels, earliestTime, lastBucketTime, hourMs } = buildHourlyWindow(hourWindowHours, hourEndMs, includeFinalBucket);
     const dataByCategory = {
       input: new Array(labels.length).fill(0),
       output: new Array(labels.length).fill(0),
@@ -725,21 +733,21 @@ function buildTokenBreakdownSeries(usage: UsagePayload | null, period: 'hour' | 
   return { labels: keys.map((key) => formatDayLabel(key)), dataByCategory };
 }
 
-export function buildHourlyCostSeries(usage: UsagePayload | null, modelPrices: Record<string, ModelPrice>, hourWindowHours = 24, endMs?: number) {
-  return buildCostSeries(usage, modelPrices, 'hour', hourWindowHours, endMs);
+export function buildHourlyCostSeries(usage: UsagePayload | null, modelPrices: Record<string, ModelPrice>, hourWindowHours = 24, endMs?: number, includeFinalBucket = false) {
+  return buildCostSeries(usage, modelPrices, 'hour', hourWindowHours, endMs, includeFinalBucket);
 }
 
 export function buildDailyCostSeries(usage: UsagePayload | null, modelPrices: Record<string, ModelPrice>) {
   return buildCostSeries(usage, modelPrices, 'day');
 }
 
-function buildCostSeries(usage: UsagePayload | null, modelPrices: Record<string, ModelPrice>, period: 'hour' | 'day', hourWindowHours?: number, endMs?: number) {
+function buildCostSeries(usage: UsagePayload | null, modelPrices: Record<string, ModelPrice>, period: 'hour' | 'day', hourWindowHours?: number, endMs?: number, includeFinalBucket = false) {
   const details = collectUsageDetails(usage);
   if (!details.length) return { labels: [], data: [], hasData: false };
 
   if (period === 'hour') {
     const hourEndMs = resolveHourlyChartEndMs(details, hourWindowHours, endMs);
-    const { labels, earliestTime, lastBucketTime, hourMs } = buildHourlyWindow(hourWindowHours, hourEndMs);
+    const { labels, earliestTime, lastBucketTime, hourMs } = buildHourlyWindow(hourWindowHours, hourEndMs, includeFinalBucket);
     const data = new Array(labels.length).fill(0);
     let hasData = false;
 

--- a/web/src/utils/usage.ts
+++ b/web/src/utils/usage.ts
@@ -250,6 +250,11 @@ export function formatCompactNumber(value: number): string {
   return formatScaled(value / 1_000_000_000, 'B');
 }
 
+export function formatCompactTokenValue(value: number, withUnit = false): string {
+  const formatted = formatCompactNumber(value);
+  return withUnit ? `${formatted} tokens` : formatted;
+}
+
 export function formatFixedTwoDecimals(value: number): string {
   return new Intl.NumberFormat(undefined, {
     minimumFractionDigits: 2,

--- a/web/src/utils/usage/chartConfig.ts
+++ b/web/src/utils/usage/chartConfig.ts
@@ -21,6 +21,8 @@ export interface ChartConfigOptions {
   labels: string[];
   isDark: boolean;
   isMobile: boolean;
+  valueFormatter?: (value: number) => string;
+  tooltipValueFormatter?: (value: number) => string;
 }
 
 /**
@@ -30,7 +32,9 @@ export function buildChartOptions({
   period,
   labels,
   isDark,
-  isMobile
+  isMobile,
+  valueFormatter,
+  tooltipValueFormatter
 }: ChartConfigOptions): ChartOptions<'line'> {
   const pointRadius = isMobile && period === 'hour' ? 0 : isMobile ? 2 : 4;
   const tickFontSize = isMobile ? 10 : 12;
@@ -60,7 +64,16 @@ export function buildChartOptions({
         borderWidth: 1,
         padding: 10,
         displayColors: true,
-        usePointStyle: true
+        usePointStyle: true,
+        callbacks: (valueFormatter || tooltipValueFormatter)
+          ? {
+              label: (context) => {
+                const label = context.dataset.label ? `${context.dataset.label}: ` : '';
+                const formatter = tooltipValueFormatter ?? valueFormatter;
+                return `${label}${formatter ? formatter(Number(context.parsed.y ?? 0)) : ''}`;
+              }
+            }
+          : undefined
       }
     },
     scales: {
@@ -113,7 +126,10 @@ export function buildChartOptions({
         },
         ticks: {
           color: tickColor,
-          font: { size: tickFontSize }
+          font: { size: tickFontSize },
+          callback: valueFormatter
+            ? (value) => valueFormatter(Number(value))
+            : undefined
         }
       }
     },


### PR DESCRIPTION
## Summary
- Split Usage page query paths for Overview, Analysis tab, Request Event Log list, and Request Event Log filter options.
- Load Request Event Log model/source filters independently, with source options resolved from usage identities.
- Fix Overview chart regressions for token units, 30d summary range handling, and Today hourly buckets.

## Test plan
- [x] go test ./internal/repository ./internal/api
- [x] npm test
- [x] npm run typecheck
- [x] npm run build
- [x] Manual check at /cpa/ for Today/30d Overview charts and Request Event Log filters.