### PR TITLE
Add Traditional Chinese and language switcher

### DIFF
--- a/web/src/components/ui/LanguageSwitcher.module.scss
+++ b/web/src/components/ui/LanguageSwitcher.module.scss
@@ -1,0 +1,39 @@
+.languageSwitcher {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 4px;
+  min-height: 42px;
+  padding: 4px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--bg-secondary) 78%, transparent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.languagePill {
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 8px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+
+  &:hover {
+    color: var(--text-primary);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+  }
+}
+
+.languagePillActive {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);
+}

--- a/web/src/components/ui/LanguageSwitcher.tsx
+++ b/web/src/components/ui/LanguageSwitcher.tsx
@@ -1,0 +1,41 @@
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import i18n, { isSupportedLanguage, persistLanguage, type SupportedLanguage } from '@/i18n';
+import styles from './LanguageSwitcher.module.scss';
+
+const LANGUAGE_OPTIONS: ReadonlyArray<{ value: SupportedLanguage; label: string }> = [
+  { value: 'en', label: 'EN' },
+  { value: 'zh', label: '中' },
+  { value: 'zh-TW', label: '繁' }
+];
+
+export function LanguageSwitcher({ className = '' }: { className?: string }) {
+  const { t } = useTranslation();
+  const currentLanguage = isSupportedLanguage(i18n.language) ? i18n.language : 'en';
+
+  const handleLanguageChange = useCallback(async (language: SupportedLanguage) => {
+    if (currentLanguage === language) return;
+    await i18n.changeLanguage(language);
+    persistLanguage(language);
+  }, [currentLanguage]);
+
+  const switcherClassName = `${styles.languageSwitcher} ${className}`.trim();
+
+  return (
+    <div className={switcherClassName} role="group" aria-label={t('usage_stats.language_switch')}>
+      {LANGUAGE_OPTIONS.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          className={`${styles.languagePill} ${currentLanguage === option.value ? styles.languagePillActive : ''}`.trim()}
+          onClick={() => void handleLanguageChange(option.value)}
+          aria-label={`${t('usage_stats.language_switch')} ${option.label}`}
+          aria-pressed={currentLanguage === option.value}
+          title={t('usage_stats.language_switch')}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -3,14 +3,18 @@ import { initReactI18next } from 'react-i18next';
 
 const LANGUAGE_STORAGE_KEY = 'cpa-usage-keeper-language';
 const DEFAULT_LANGUAGE = 'en';
-const SUPPORTED_LANGUAGES = ['en', 'zh'] as const;
+export const SUPPORTED_LANGUAGES = ['en', 'zh', 'zh-TW'] as const;
 
-type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+export const isSupportedLanguage = (language: string | null): language is SupportedLanguage => (
+  SUPPORTED_LANGUAGES.includes(language as SupportedLanguage)
+);
 
 const getInitialLanguage = (): SupportedLanguage => {
   if (typeof window === 'undefined') return DEFAULT_LANGUAGE;
   const saved = window.localStorage.getItem(LANGUAGE_STORAGE_KEY);
-  return saved === 'zh' ? 'zh' : DEFAULT_LANGUAGE;
+  return isSupportedLanguage(saved) ? saved : DEFAULT_LANGUAGE;
 };
 
 const resources = {
@@ -395,6 +399,197 @@ const resources = {
         credential_top_chart_hint: '按请求量排名前 10 的凭证，并拆分展示成功与失败请求数'
       }
     }
+  },
+  'zh-TW': {
+    translation: {
+      common: {
+        loading: '載入中...',
+        save: '儲存',
+        cancel: '取消',
+        edit: '編輯',
+        delete: '刪除',
+        close: '關閉'
+      },
+      notification: {
+        download_failed: '下載失敗',
+        upload_failed: '上傳失敗',
+        refresh_failed: '重新整理失敗'
+      },
+      status_bar: {
+        success_short: '成功',
+        failure_short: '失敗',
+        no_requests: '尚無請求'
+      },
+      auth: {
+        login_title: '受保護的 Usage 存取',
+        login_subtitle: '請輸入已設定的登入密碼後，再進入 usage dashboard。',
+        password_label: '登入密碼',
+        password_placeholder: '請輸入密碼',
+        login_submit: '繼續進入',
+        invalid_password: '密碼錯誤',
+        login_failed: '目前無法完成登入',
+        session_expired: '登入狀態已失效，請重新登入。'
+      },
+      usage_stats: {
+        title: '用量',
+        refresh: '重新整理',
+        sync_now: '立即同步',
+        check_updates: '檢查更新',
+        update_check_dev_build: '目前是開發版本，暫時無法比較更新。',
+        update_check_new_version: '發現新版本：{{version}}',
+        update_check_latest: '目前已經是最新版本。',
+        update_check_failed: '暫時無法檢查更新，請稍後再試。',
+        dismiss_notice: '關閉',
+        export: '匯出',
+        import: '匯入',
+        export_success: '用量已匯出',
+        import_invalid: '匯入檔案無效',
+        import_success: '匯入完成：新增 {{added}}，略過 {{skipped}}，總計 {{total}}，失敗 {{failed}}',
+        last_updated: '最近更新',
+        tabs_aria_label: '用量頁面分區',
+        tab_overview: '總覽',
+        tab_analysis: 'API 與模型',
+        tab_events: '請求事件',
+        tab_credentials: '憑證',
+        tab_pricing: '定價',
+        range_filter: '範圍',
+        range_all: '全部',
+        range_4h: '4 小時',
+        range_8h: '8 小時',
+        range_12h: '12 小時',
+        range_24h: '24 小時',
+        range_today: '今天',
+        range_7d: '7 天',
+        range_30d: '30 天',
+        range_custom: '自訂',
+        custom_start: '開始日期',
+        custom_end: '結束日期',
+        custom_invalid: '開始日期不能晚於結束日期',
+        custom_incomplete: '請選擇完整的開始與結束日期',
+        no_data: '尚無資料',
+        requests_trend: '請求趨勢',
+        tokens_trend: 'Token 趨勢',
+        by_hour: '按小時',
+        by_day: '按天',
+        total_requests: '請求總數',
+        success_requests: '成功',
+        failed_requests: '失敗',
+        avg_time: '平均耗時',
+        total_time: '總耗時',
+        time: '耗時',
+        total_tokens: 'Token 總數',
+        cached_tokens: '快取',
+        reasoning_tokens: '推理',
+        rpm: 'RPM',
+        tpm: 'TPM',
+        rpm_30m: 'RPM（30 分鐘）',
+        tpm_30m: 'TPM（30 分鐘）',
+        total_cost: '總成本',
+        cost_need_price: '請先設定價格以計算成本',
+        cost_no_data: '尚無成本資料',
+        latency_unit_hint: '使用 {{field}}，單位 {{unit}}',
+        duration_unit_ms: '毫秒',
+        duration_unit_s: '秒',
+        duration_unit_m: '分鐘',
+        duration_unit_h: '小時',
+        duration_unit_d: '天',
+        filter_all: '全部',
+        clear_filters: '清除篩選',
+        export_csv: '匯出 CSV',
+        export_json: '匯出 JSON',
+        request_events_title: '請求事件記錄',
+        request_events_eyebrow: '事件流',
+        request_events_subtitle: '篩選、查看並匯出頁面中各項彙總資料背後的原始請求事件。',
+        request_events_showing: '顯示 {{shown}} / {{total}}',
+        request_events_filtered: '已篩選 {{count}} 筆',
+        request_events_filter_model: '模型',
+        request_events_filter_source: '來源',
+        request_events_filter_result: '結果',
+        request_events_filter_auth_index: '憑證',
+        request_events_empty_title: '尚無請求事件',
+        request_events_empty_desc: '開始產生流量後，請求事件會顯示在這裡。',
+        request_events_no_result_title: '沒有符合的請求事件',
+        request_events_no_result_desc: '可以嘗試清除篩選條件或放寬篩選範圍。',
+        request_events_count: '本頁 {{count}} 筆事件',
+        request_events_total_count: '共 {{count}} 筆事件',
+        request_events_rows_per_page: '大小',
+        request_events_page_control: '分頁（{{page}}/{{totalPages}}）',
+        request_events_page_label: '第 {{page}} / {{totalPages}} 頁',
+        request_events_page_empty: '第 0 / 0 頁',
+        request_events_previous_page: '上一頁',
+        request_events_next_page: '下一頁',
+        request_events_timestamp: '時間',
+        request_events_source: '來源',
+        request_events_auth_index: '憑證',
+        request_events_result: '結果',
+        model_name: '模型',
+        source_name: '來源',
+        auth_index: '認證索引',
+        result: '結果',
+        success: '成功',
+        failure: '失敗',
+        deleted: '已刪除',
+        requests_count: '請求數',
+        tokens_count: 'Token 數',
+        input_tokens: '輸入',
+        output_tokens: '輸出',
+        latency: '延遲',
+        credential_stats: '憑證統計',
+        credential_name: '憑證',
+        success_rate: '成功率',
+        api_details: 'API 詳細資料',
+        api_endpoint: 'API',
+        model_stats: '模型統計',
+        model_price_settings: '價格設定',
+        model_price_settings_title: '模型價格表',
+        model_price_settings_subtitle: '維護後端定價，讓 token 活動可以換算成成本分析。',
+        model_price_settings_eyebrow: '定價',
+        model_price_select_placeholder: '選擇模型',
+        model_price_configured: '已設定',
+        model_price_prompt: '輸入',
+        model_price_completion: '輸出',
+        model_price_cache: '快取',
+        saved_prices: '已儲存價格',
+        model_price_empty: '尚無已儲存價格',
+        token_breakdown: 'Token 組成',
+        token_breakdown_title: 'Token 組成',
+        cost_trend: '成本趨勢',
+        cost_trend_title: '成本趨勢',
+        service_health: '服務健康',
+        service_health_title: '請求健康時間軸',
+        service_health_subtitle: '用緊湊的可靠性條帶呈現目前篩選範圍內的請求結果，時間軸最多顯示 7 天細節。',
+        service_health_eyebrow: '穩定性',
+        service_health_window: '最近 7 天',
+        service_health_oldest: '最早',
+        service_health_newest: '最新',
+        service_health_block_label: '{{timeRange}}：{{summary}}',
+        healthy: '健康',
+        unhealthy: '異常',
+        chart_line_title: '圖表線條選擇',
+        chart_line_add: '新增線條',
+        chart_line_delete: '刪除',
+        chart_line_hint: '選擇你希望在趨勢圖中對比顯示的模型線條。',
+        chart_line_label: '線條 {{index}}',
+        chart_line_all_traffic: '全部流量',
+        theme_light: '淺色',
+        theme_dark: '深色',
+        theme_auto: '自動',
+        theme_switch: '主題切換',
+        language_switch: '語言切換',
+        api_details_title: 'API 用量拆分',
+        api_details_subtitle: '對比不同 API 面的請求量、Token 負載和預估成本。',
+        api_details_eyebrow: 'API 視圖',
+        model_stats_title: '模型表現表',
+        model_stats_subtitle: '按模型查看吞吐、延遲、穩定性與成本分布。',
+        model_stats_eyebrow: '模型視圖',
+        credential_stats_title: '憑證流量表',
+        credential_stats_subtitle: '按憑證身分與 provider 來源檢查請求可靠性。',
+        credential_stats_eyebrow: '憑證視圖',
+        credential_top_chart_eyebrow: '憑證排行',
+        credential_top_chart_title: '憑證請求',
+        credential_top_chart_hint: '按請求量排名前 10 的憑證，並拆分顯示成功與失敗請求數'
+      }
+    }
   }
 };
 
@@ -407,9 +602,9 @@ if (!i18n.isInitialized) {
   });
 }
 
-export const persistLanguage = (language: string) => {
+export const persistLanguage = (language: SupportedLanguage) => {
   if (typeof window === 'undefined') return;
-  if (!SUPPORTED_LANGUAGES.includes(language as SupportedLanguage)) return;
+  if (!isSupportedLanguage(language)) return;
   window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
 };
 

--- a/web/src/pages/LoginPage.module.scss
+++ b/web/src/pages/LoginPage.module.scss
@@ -26,6 +26,11 @@
   }
 }
 
+.languageDock {
+  grid-column: 1 / -1;
+  justify-self: end;
+}
+
 .brandBlock {
   display: flex;
   flex-direction: column;

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
+import { LanguageSwitcher } from '@/components/ui/LanguageSwitcher';
 import styles from './LoginPage.module.scss';
 
 interface LoginPageProps {
@@ -23,6 +24,9 @@ export function LoginPage({ loading = false, error = '', onSubmit }: LoginPagePr
   return (
     <div className={styles.pageShell}>
       <div className={styles.frame}>
+        <div className={styles.languageDock}>
+          <LanguageSwitcher />
+        </div>
         <div className={styles.brandBlock}>
           <span className={styles.eyebrow}>CPA Usage Keeper</span>
           <h1 className={styles.title}>{t('auth.login_title')}</h1>

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -87,46 +87,6 @@
   }
 }
 
-.languageSwitcher {
-  display: inline-flex;
-  align-items: stretch;
-  gap: 4px;
-  min-height: 42px;
-  padding: 4px;
-  border-radius: 999px;
-  border: 1px solid var(--border-color);
-  background: color-mix(in srgb, var(--bg-secondary) 78%, transparent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
-}
-
-.languagePill {
-  border: 0;
-  background: transparent;
-  color: var(--text-secondary);
-  font: inherit;
-  font-size: 12px;
-  font-weight: 700;
-  padding: 8px 12px;
-  border-radius: 999px;
-  cursor: pointer;
-  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
-
-  &:hover {
-    color: var(--text-primary);
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--primary-color);
-    outline-offset: 2px;
-  }
-}
-
-.languagePillActive {
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);
-}
-
 .themeSwitcher {
   display: inline-flex;
   align-items: stretch;

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import i18n, { persistLanguage } from '@/i18n';
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -17,6 +16,7 @@ import {
 import { ApiError, fetchStatus, fetchUpdateCheck, fetchUsageAnalysis, fetchUsageEventModelFilterOptions, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchUsageIdentities } from '@/lib/api';
 import type { StatusResponse, UsageAnalysisResponse, UsageEvent, UsageIdentity, UsageSourceFilterOption } from '@/lib/types';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import { LanguageSwitcher } from '@/components/ui/LanguageSwitcher';
 import { Select } from '@/components/ui/Select';
 import { IconRefreshCw } from '@/components/ui/icons';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
@@ -412,7 +412,6 @@ const loadUsageTab = (): UsageTab => {
 
 export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   const { t } = useTranslation();
-  const currentLanguage = i18n.language === 'zh' ? 'zh' : 'en';
   const isMobile = useMediaQuery('(max-width: 768px)');
   const theme = useThemeStore((state) => state.theme);
   const resolvedTheme = useThemeStore((state) => state.resolvedTheme);
@@ -1025,12 +1024,6 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     }
   }, [eventsModelFilter, eventsModelOptions, eventsResultFilter, eventsSourceFilter, eventsSourceOptions, resetEventsPage]);
 
-  const handleLanguageChange = useCallback(async (language: 'en' | 'zh') => {
-    if (currentLanguage === language) return;
-    await i18n.changeLanguage(language);
-    persistLanguage(language);
-  }, [currentLanguage]);
-
   const lastSyncAt = useMemo(() => {
     if (!status?.last_run_at) return null;
     const parsed = new Date(status.last_run_at);
@@ -1141,26 +1134,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
             <span className={styles.eyebrow}>CPA Usage Keeper</span>
           </div>
           <div className={styles.topBarActions}>
-            <div className={styles.languageSwitcher} role="group" aria-label={t('usage_stats.language_switch')}>
-              <button
-                type="button"
-                className={`${styles.languagePill} ${currentLanguage === 'en' ? styles.languagePillActive : ''}`.trim()}
-                onClick={() => void handleLanguageChange('en')}
-                aria-pressed={currentLanguage === 'en'}
-                title={t('usage_stats.language_switch')}
-              >
-                EN
-              </button>
-              <button
-                type="button"
-                className={`${styles.languagePill} ${currentLanguage === 'zh' ? styles.languagePillActive : ''}`.trim()}
-                onClick={() => void handleLanguageChange('zh')}
-                aria-pressed={currentLanguage === 'zh'}
-                title={t('usage_stats.language_switch')}
-              >
-                中
-              </button>
-            </div>
+            <LanguageSwitcher />
             <div className={styles.themeSwitcher} role="tablist" aria-label={t('usage_stats.theme_switch')}>
               {themeOptions.map((option) => {
                 const active = theme === option.value;


### PR DESCRIPTION
The dashboard already had English and Simplified Chinese resources, but language selection was only available after authentication. This adds a Traditional Chinese locale and reuses one language switcher on both the login and usage screens so users can enter the app in their preferred written Chinese variant.

Constraint: Keep this change focused on translation and language-selection UI only

Confidence: high

Scope-risk: narrow

Directive: Keep new locale additions wired through the shared LanguageSwitcher so login and authenticated screens stay consistent

Tested: npm --prefix ./web run typecheck

Tested: npm --prefix ./web run lint (passes with existing UsagePage hook dependency warning)

Tested: npm --prefix ./web test (84 passed)

Tested: npm --prefix ./web run build

Not-tested: End-to-end authenticated dashboard against a real CPA backend