### PR TITLE
test: add follow-up coverage for request event costs

### DIFF
--- a/web/src/components/usage/RequestEventsDetailsCard.test.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.test.tsx
@@ -142,4 +142,15 @@ describe('RequestEventsDetailsCard pagination', () => {
     expect(html).not.toContain('Export CSV');
     expect(html).not.toContain('Export JSON');
   });
+
+  it('shows per-event cost when model pricing exists', () => {
+    const html = renderCard({
+      modelPrices: {
+        'claude-sonnet': { prompt: 15, completion: 75, cache: 1.5 },
+      },
+    });
+
+    expect(html).toContain('Total Cost');
+    expect(html).toContain('$0.0057');
+  });
 });

--- a/web/src/components/usage/RequestEventsDetailsCard.test.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.test.tsx
@@ -40,6 +40,7 @@ const renderCard = (props: Partial<React.ComponentProps<typeof RequestEventsDeta
       modelFilter="__all__"
       sourceFilter="__all__"
       resultFilter="__all__"
+      modelPrices={{}}
       onPageChange={() => undefined}
       onPageSizeChange={() => undefined}
       onModelFilterChange={() => undefined}

--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -6,9 +6,9 @@ import { EmptyState } from '@/components/ui/EmptyState';
 import { Select } from '@/components/ui/Select';
 import type { UsageEvent, UsageSourceFilterOption } from '@/lib/types';
 import {
+  calculateCost,
   formatDurationMs,
   formatUsd,
-  isAnthropicStyleProvider,
   LATENCY_SOURCE_FIELD,
   normalizeAuthIndex,
   type ModelPrice,
@@ -144,14 +144,23 @@ export function RequestEventsDetailsCard({
       const totalTokens = Math.max(toNumber(event.tokens?.total_tokens), 0);
       const latencyMs = Number.isFinite(event.latency_ms) ? event.latency_ms : null;
       const pricing = modelPrices[model];
-      const promptTokens = isAnthropicStyleProvider(sourceType)
-        ? inputTokens
-        : Math.max(inputTokens - cachedTokens, 0);
-      const cost = pricing
-        ? (promptTokens / 1_000_000) * pricing.prompt +
-          (outputTokens / 1_000_000) * pricing.completion +
-          (cachedTokens / 1_000_000) * pricing.cache
-        : 0;
+      const cost = calculateCost({
+        timestamp,
+        source,
+        source_raw: sourceRaw,
+        source_type: sourceType,
+        auth_index: authIndex,
+        failed: event.failed === true,
+        latency_ms: latencyMs ?? 0,
+        tokens: {
+          input_tokens: inputTokens,
+          output_tokens: outputTokens,
+          reasoning_tokens: reasoningTokens,
+          cached_tokens: cachedTokens,
+          total_tokens: totalTokens,
+        },
+        __modelName: model,
+      }, modelPrices);
 
       return {
         id: event.id ? String(event.id) : `${timestamp}-${model}-${sourceRaw || source}-${authIndex}-${index}`,

--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -5,7 +5,13 @@ import { Card } from '@/components/ui/Card';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { Select } from '@/components/ui/Select';
 import type { UsageEvent, UsageSourceFilterOption } from '@/lib/types';
-import { formatDurationMs, LATENCY_SOURCE_FIELD, normalizeAuthIndex } from '@/utils/usage';
+import {
+  formatDurationMs,
+  formatUsd,
+  LATENCY_SOURCE_FIELD,
+  normalizeAuthIndex,
+  type ModelPrice,
+} from '@/utils/usage';
 import { downloadBlob } from '@/utils/download';
 import styles from '@/pages/UsagePage.module.scss';
 
@@ -42,6 +48,8 @@ type RequestEventRow = {
   reasoningTokens: number;
   cachedTokens: number;
   totalTokens: number;
+  cost: number;
+  hasPrice: boolean;
 };
 
 export interface RequestEventsDetailsCardProps {
@@ -57,6 +65,7 @@ export interface RequestEventsDetailsCardProps {
   modelFilter: string;
   sourceFilter: string;
   resultFilter: string;
+  modelPrices: Record<string, ModelPrice>;
   onPageChange: (page: number) => void;
   onPageSizeChange: (pageSize: number) => void;
   onModelFilterChange: (model: string) => void;
@@ -100,6 +109,7 @@ export function RequestEventsDetailsCard({
   modelFilter,
   sourceFilter,
   resultFilter,
+  modelPrices,
   onPageChange,
   onPageSizeChange,
   onModelFilterChange,
@@ -132,6 +142,13 @@ export function RequestEventsDetailsCard({
       const cachedTokens = Math.max(toNumber(event.tokens?.cached_tokens), 0);
       const totalTokens = Math.max(toNumber(event.tokens?.total_tokens), 0);
       const latencyMs = Number.isFinite(event.latency_ms) ? event.latency_ms : null;
+      const pricing = modelPrices[model];
+      const promptTokens = Math.max(inputTokens - cachedTokens, 0);
+      const cost = pricing
+        ? (promptTokens / 1_000_000) * pricing.prompt +
+          (outputTokens / 1_000_000) * pricing.completion +
+          (cachedTokens / 1_000_000) * pricing.cache
+        : 0;
 
       return {
         id: event.id ? String(event.id) : `${timestamp}-${model}-${sourceRaw || source}-${authIndex}-${index}`,
@@ -151,9 +168,11 @@ export function RequestEventsDetailsCard({
         reasoningTokens,
         cachedTokens,
         totalTokens,
+        cost,
+        hasPrice: Boolean(pricing),
       };
     });
-  }, [events, i18n.language]);
+  }, [events, i18n.language, modelPrices]);
 
   const hasLatencyData = useMemo(() => rows.some((row) => row.latencyMs !== null), [rows]);
 
@@ -239,6 +258,7 @@ export function RequestEventsDetailsCard({
       'reasoning_tokens',
       'cached_tokens',
       'total_tokens',
+      'cost_usd',
     ];
 
     const csvRows = rows.map((row) =>
@@ -255,6 +275,7 @@ export function RequestEventsDetailsCard({
         row.reasoningTokens,
         row.cachedTokens,
         row.totalTokens,
+        row.hasPrice ? row.cost.toFixed(6) : '',
       ]
         .map((value) => encodeCsv(value))
         .join(',')
@@ -286,6 +307,7 @@ export function RequestEventsDetailsCard({
         cached_tokens: row.cachedTokens,
         total_tokens: row.totalTokens,
       },
+      ...(row.hasPrice ? { cost_usd: Number(row.cost.toFixed(6)) } : {}),
     }));
 
     const content = JSON.stringify(payload, null, 2);
@@ -432,6 +454,7 @@ export function RequestEventsDetailsCard({
                   <th>{t('usage_stats.reasoning_tokens')}</th>
                   <th>{t('usage_stats.cached_tokens')}</th>
                   <th>{t('usage_stats.total_tokens')}</th>
+                  <th>{t('usage_stats.total_cost')}</th>
                 </tr>
               </thead>
               <tbody>
@@ -475,6 +498,9 @@ export function RequestEventsDetailsCard({
                     <td>{row.reasoningTokens.toLocaleString()}</td>
                     <td>{row.cachedTokens.toLocaleString()}</td>
                     <td>{row.totalTokens.toLocaleString()}</td>
+                    <td title={row.hasPrice ? undefined : t('usage_stats.cost_need_price')}>
+                      {row.hasPrice ? formatUsd(row.cost) : '-'}
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -8,6 +8,7 @@ import type { UsageEvent, UsageSourceFilterOption } from '@/lib/types';
 import {
   formatDurationMs,
   formatUsd,
+  isAnthropicStyleProvider,
   LATENCY_SOURCE_FIELD,
   normalizeAuthIndex,
   type ModelPrice,
@@ -143,7 +144,9 @@ export function RequestEventsDetailsCard({
       const totalTokens = Math.max(toNumber(event.tokens?.total_tokens), 0);
       const latencyMs = Number.isFinite(event.latency_ms) ? event.latency_ms : null;
       const pricing = modelPrices[model];
-      const promptTokens = Math.max(inputTokens - cachedTokens, 0);
+      const promptTokens = isAnthropicStyleProvider(sourceType)
+        ? inputTokens
+        : Math.max(inputTokens - cachedTokens, 0);
       const cost = pricing
         ? (promptTokens / 1_000_000) * pricing.prompt +
           (outputTokens / 1_000_000) * pricing.completion +

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -1449,6 +1449,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                   modelFilter={eventsModelFilter}
                   sourceFilter={eventsSourceFilter}
                   resultFilter={eventsResultFilter}
+                  modelPrices={modelPrices}
                   onPageChange={setEventsPage}
                   onPageSizeChange={handleEventsPageSizeChange}
                   onModelFilterChange={handleEventsModelFilterChange}

--- a/web/src/utils/usage.test.ts
+++ b/web/src/utils/usage.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { buildChartData, buildUsageFromDetails, filterUsageByWindow, filterUsageSnapshot, resolveUsageFilterWindow, sanitizeChartLines } from '@/utils/usage';
+import { buildChartData, buildUsageFromDetails, calculateCost, filterUsageByWindow, filterUsageSnapshot, resolveUsageFilterWindow, sanitizeChartLines } from '@/utils/usage';
 import type { UsageSnapshot } from '@/lib/types';
 
 afterEach(() => {
@@ -205,5 +205,56 @@ describe('resolveUsageFilterWindow', () => {
 describe('sanitizeChartLines', () => {
   it('falls back to all when persisted lines no longer exist in the current overview payload', () => {
     expect(sanitizeChartLines(['stale-model'], ['gpt-5.4', 'gpt-5.4-mini'])).toEqual(['all']);
+  });
+});
+
+describe('calculateCost', () => {
+  const prices = { 'm': { prompt: 15, completion: 75, cache: 1.5 } };
+  const baseDetail = {
+    timestamp: '',
+    source: '',
+    auth_index: '',
+    failed: false,
+    latency_ms: 0,
+    __modelName: 'm',
+  };
+
+  it('treats input as containing cached for OpenAI-style providers', () => {
+    const cost = calculateCost(
+      {
+        ...baseDetail,
+        source_type: 'openai',
+        tokens: { input_tokens: 1000, output_tokens: 100, reasoning_tokens: 0, cached_tokens: 600, total_tokens: 1100 },
+      },
+      prices,
+    );
+    // promptTokens = 1000 - 600 = 400 → 400*15 + 100*75 + 600*1.5 = 6000+7500+900 = 14400 micro-units
+    expect(cost).toBeCloseTo((400 * 15 + 100 * 75 + 600 * 1.5) / 1_000_000, 9);
+  });
+
+  it('treats input as excluding cached for Anthropic-style providers', () => {
+    const cost = calculateCost(
+      {
+        ...baseDetail,
+        source_type: 'claude',
+        tokens: { input_tokens: 400, output_tokens: 100, reasoning_tokens: 0, cached_tokens: 600, total_tokens: 500 },
+      },
+      prices,
+    );
+    // promptTokens stays 400 (no subtraction) → same total as the OpenAI case for the same physical request
+    expect(cost).toBeCloseTo((400 * 15 + 100 * 75 + 600 * 1.5) / 1_000_000, 9);
+  });
+
+  it('matches anthropic provider name case-insensitively', () => {
+    const cost = calculateCost(
+      {
+        ...baseDetail,
+        source_type: 'Anthropic',
+        tokens: { input_tokens: 1, output_tokens: 0, reasoning_tokens: 0, cached_tokens: 100, total_tokens: 1 },
+      },
+      prices,
+    );
+    // 用 anthropic 公式：promptTokens=1，不会被减成 0
+    expect(cost).toBeGreaterThan(0);
   });
 });

--- a/web/src/utils/usage.ts
+++ b/web/src/utils/usage.ts
@@ -445,13 +445,24 @@ export function calculateCost(detail: UsageDetailRecord, modelPrices: Record<str
     toNumber(detail.tokens.cached_tokens),
     toNumber(detail.tokens.cache_tokens)
   );
-  const promptTokens = Math.max(inputTokens - cachedTokens, 0);
+  // Anthropic 的 input_tokens 已不含 cached（与 OpenAI/Gemini 风格相反），不能再减一次。
+  const promptTokens = isAnthropicStyleProvider(detail.source_type)
+    ? inputTokens
+    : Math.max(inputTokens - cachedTokens, 0);
 
   return (
     (promptTokens / 1_000_000) * pricing.prompt +
     (completionTokens / 1_000_000) * pricing.completion +
     (cachedTokens / 1_000_000) * pricing.cache
   );
+}
+
+// CPA 把 provider 原始口径直接落库；Anthropic 的 input_tokens 不含 cached，其它 provider 都含。
+// 计算成本/缓存率时需要按 source_type 区分公式。
+export function isAnthropicStyleProvider(sourceType: unknown): boolean {
+  if (typeof sourceType !== 'string') return false;
+  const value = sourceType.trim().toLowerCase();
+  return value === 'claude' || value === 'anthropic';
 }
 
 export function buildCandidateUsageSourceIds({ apiKey, prefix }: { apiKey?: string; prefix?: string }): string[] {


### PR DESCRIPTION
## Summary
- Follow-up to #73: keep this PR focused on supplemental coverage and cleanup for the request event cost column.
- Reuse the shared `calculateCost` helper in `RequestEventsDetailsCard` so the table display uses the same provider-aware accounting as the rest of the usage UI.
- Add component coverage for the per-event cost column when model pricing exists.

## Test plan
- [x] `npm --prefix ./web run typecheck`
- [x] `npm --prefix ./web run lint` (passes with the existing `UsagePage` hook dependency warning on this branch)
- [x] `npm --prefix ./web test`
- [x] `npm --prefix ./web run build`