### PR TITLE
fix: sync openai compatibility base url

### DIFF
--- a/internal/api/usage_events_test.go
+++ b/internal/api/usage_events_test.go
@@ -147,6 +147,37 @@ func TestUsageIdentityDisplayNameAddsProviderBaseURLQualifier(t *testing.T) {
 	}
 }
 
+func TestUsageIdentityDisplayNameKeepsOpenAICompatibilityName(t *testing.T) {
+	identity := entities.UsageIdentity{
+		Name:     "OpenRouter",
+		Prefix:   "openrouter",
+		BaseURL:  "https://openrouter.ai/api/v1",
+		AuthType: entities.UsageIdentityAuthTypeAIProvider,
+		Type:     "openai",
+		Provider: "OpenRouter",
+		Identity: "openrouter-auth-index",
+	}
+
+	if got := usageIdentityDisplayName(identity); got != "OpenRouter" {
+		t.Fatalf("expected openai compatibility displayName to keep name without qualifiers, got %q", got)
+	}
+}
+
+func TestUsageIdentityDisplayNameFallsBackWhenOpenAICompatibilityNameIsMissing(t *testing.T) {
+	identity := entities.UsageIdentity{
+		Prefix:   "openrouter",
+		BaseURL:  "https://openrouter.ai/api/v1",
+		AuthType: entities.UsageIdentityAuthTypeAIProvider,
+		Type:     "openai",
+		Provider: "openai",
+		Identity: "openrouter-auth-index",
+	}
+
+	if got := usageIdentityDisplayName(identity); got != "openrouter(openrouter.ai/api/v1)" {
+		t.Fatalf("expected unnamed openai compatibility displayName to fall back to provider qualifier rules, got %q", got)
+	}
+}
+
 func TestUsageIdentityDisplayNameUsesProviderWhenAuthFileNameIsMissing(t *testing.T) {
 	identity := entities.UsageIdentity{
 		AuthType: entities.UsageIdentityAuthTypeAuthFile,

--- a/internal/api/usage_identity_resolver.go
+++ b/internal/api/usage_identity_resolver.go
@@ -51,7 +51,7 @@ func usageIdentityDisplayName(item entities.UsageIdentity) string {
 		return provider
 	}
 
-	if strings.TrimSpace(item.Type) == "openai" && name != "" {
+	if strings.TrimSpace(item.Type) == "openai" && name != "" && name != "openai" && provider == name {
 		return name
 	}
 

--- a/internal/api/usage_identity_resolver.go
+++ b/internal/api/usage_identity_resolver.go
@@ -51,6 +51,10 @@ func usageIdentityDisplayName(item entities.UsageIdentity) string {
 		return provider
 	}
 
+	if strings.TrimSpace(item.Type) == "openai" && name != "" {
+		return name
+	}
+
 	prefix := strings.TrimSpace(item.Prefix)
 	baseURL := formatUsageIdentityBaseURLDisplay(item.BaseURL)
 	qualifiers := usageIdentityDisplayQualifiers(prefix, baseURL)

--- a/internal/cpa/dto/providerconfig/metadata.go
+++ b/internal/cpa/dto/providerconfig/metadata.go
@@ -40,6 +40,7 @@ func (p *ProviderKeyConfig) UnmarshalJSON(data []byte) error {
 type OpenAICompatibilityConfig struct {
 	Name          string
 	Prefix        string
+	BaseURL       string
 	APIKeyEntries []OpenAIApiKeyEntry
 }
 
@@ -50,6 +51,7 @@ func (c *OpenAICompatibilityConfig) UnmarshalJSON(data []byte) error {
 	}
 	c.Name = firstString(raw, "name", "id")
 	c.Prefix = firstString(raw, "prefix")
+	c.BaseURL = firstString(raw, "base-url", "base_url", "baseURL")
 	c.APIKeyEntries = nil
 	for _, key := range []string{"apiKeyEntries", "api-key-entries", "api-keys"} {
 		value, ok := raw[key]

--- a/internal/cpa/dto/providerconfig/metadata_test.go
+++ b/internal/cpa/dto/providerconfig/metadata_test.go
@@ -20,3 +20,19 @@ func TestProviderKeyConfigUnmarshalsBaseURLVariants(t *testing.T) {
 		})
 	}
 }
+
+func TestOpenAICompatibilityConfigUnmarshalsBaseURLVariants(t *testing.T) {
+	for _, field := range []string{"base-url", "base_url", "baseURL"} {
+		t.Run(field, func(t *testing.T) {
+			data := []byte(`{"name":"OpenRouter","prefix":"openrouter","` + field + `":"https://openrouter.ai/api/v1","api-key-entries":[{"apiKey":"provider-key","auth-index":"openrouter-auth"}]}`)
+
+			var cfg OpenAICompatibilityConfig
+			if err := json.Unmarshal(data, &cfg); err != nil {
+				t.Fatalf("unmarshal openai compatibility config: %v", err)
+			}
+			if cfg.BaseURL != "https://openrouter.ai/api/v1" {
+				t.Fatalf("BaseURL = %q, want %q", cfg.BaseURL, "https://openrouter.ai/api/v1")
+			}
+		})
+	}
+}

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -688,7 +688,7 @@ func flattenProviderMetadata(cfg providerconfig.ProviderMetadataConfig) []servic
 	for _, provider := range cfg.OpenAICompatibility {
 		displayName := firstNonEmpty(provider.Name, "openai")
 		for _, entry := range provider.APIKeyEntries {
-			appendItem(entry.APIKey, provider.Prefix, "openai", displayName, entry.AuthIndex, "")
+			appendItem(entry.APIKey, provider.Prefix, "openai", displayName, entry.AuthIndex, provider.BaseURL)
 		}
 	}
 

--- a/internal/service/sync_test.go
+++ b/internal/service/sync_test.go
@@ -964,6 +964,38 @@ func TestSyncMetadataStoresProviderBaseURLWithoutOverwritingNameOrProvider(t *te
 	}
 }
 
+func TestSyncMetadataStoresOpenAICompatibilityBaseURL(t *testing.T) {
+	db := openSyncTestDatabase(t)
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
+		BaseURL: "https://cpa.example.com",
+		MetadataFetcher: stubMetadataFetcher{providerConfig: providerconfig.ProviderMetadataConfig{
+			OpenAICompatibility: []providerconfig.OpenAICompatibilityConfig{
+				{
+					Name:    "OpenRouter",
+					Prefix:  "openrouter",
+					BaseURL: "https://openrouter.ai/api/v1",
+					APIKeyEntries: []providerconfig.OpenAIApiKeyEntry{
+						{APIKey: "openrouter-key", AuthIndex: "openrouter-auth"},
+					},
+				},
+			},
+		}},
+	})
+
+	if err := service.SyncMetadata(context.Background()); err != nil {
+		t.Fatalf("SyncMetadata returned error: %v", err)
+	}
+	items, err := repository.ListUsageIdentities(context.Background(), db)
+	if err != nil {
+		t.Fatalf("list usage identities: %v", err)
+	}
+	byIdentity := usageIdentitiesByIdentity(items)
+	identity := byIdentity["openrouter-auth"]
+	if identity.Name != "OpenRouter" || identity.Provider != "OpenRouter" || identity.Type != "openai" || identity.BaseURL != "https://openrouter.ai/api/v1" {
+		t.Fatalf("expected openai compatibility identity to keep name/provider/type and store base URL, got %+v", identity)
+	}
+}
+
 func TestSyncMetadataKeepsProviderIdentityWhenPrefixEqualsAPIKey(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	service := NewSyncServiceWithOptions(db, SyncServiceOptions{


### PR DESCRIPTION
## Summary
- follow up #74 by syncing provider-level OpenAICompatibility base URLs into usage identity metadata
- keep named OpenAICompatibility display names unchanged when returning API data
- add DTO, sync, and displayName coverage

## Related
- Follow-up to #74

## Test plan
- [x] go test ./internal/cpa/dto/providerconfig ./internal/service ./internal/api -count=1
- [x] go test ./internal/... -count=1