### PR TITLE
Unify project timezone handling

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -17,6 +17,7 @@ import (
 	"cpa-usage-keeper/internal/poller"
 	"cpa-usage-keeper/internal/quota"
 	"cpa-usage-keeper/internal/service"
+	"cpa-usage-keeper/internal/timeutil"
 	"cpa-usage-keeper/internal/updatecheck"
 	"cpa-usage-keeper/internal/version"
 	"github.com/gin-gonic/gin"
@@ -310,7 +311,7 @@ func buildStatusResponse(status poller.Status) statusResponse {
 		LastStatus:         status.LastStatus,
 	}
 	if !status.LastRunAt.IsZero() {
-		lastRunAt := status.LastRunAt.UTC()
+		lastRunAt := timeutil.NormalizeStorageTime(status.LastRunAt)
 		response.LastRunAt = &lastRunAt
 	}
 	return response

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -88,6 +88,14 @@ func TestRouterDoesNotTrustForwardedClientIPByDefault(t *testing.T) {
 }
 
 func TestStatusReturnsPollerState(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	t.Cleanup(func() { time.Local = previousLocal })
+	time.Local = location
+
 	lastRunAt := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
 	router := NewRouter(nil, statusStub{status: poller.Status{
 		Running:     true,
@@ -106,7 +114,7 @@ func TestStatusReturnsPollerState(t *testing.T) {
 		t.Fatalf("expected status 200, got %d", resp.Code)
 	}
 	body := resp.Body.String()
-	if !(contains(body, `"running":true`) && contains(body, `"sync_running":false`) && contains(body, `"last_error":"boom"`) && contains(body, `"last_warning":"metadata unavailable"`) && contains(body, `"last_status":"completed_with_warnings"`) && contains(body, `"last_run_at":"2026-04-16T12:00:00Z"`)) {
+	if !(contains(body, `"running":true`) && contains(body, `"sync_running":false`) && contains(body, `"last_error":"boom"`) && contains(body, `"last_warning":"metadata unavailable"`) && contains(body, `"last_status":"completed_with_warnings"`) && contains(body, `"last_run_at":"2026-04-16T20:00:00+08:00"`)) {
 		t.Fatalf("unexpected response body: %s", body)
 	}
 }
@@ -186,6 +194,14 @@ func TestStatusHidesUpdateCheckForDevVersion(t *testing.T) {
 }
 
 func TestManualSyncTriggersSyncRunner(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	t.Cleanup(func() { time.Local = previousLocal })
+	time.Local = location
+
 	lastRunAt := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
 	syncer := &syncStatusStub{status: poller.Status{Running: true, LastRunAt: lastRunAt, LastStatus: "completed"}}
 	router := NewRouter(nil, syncer, nil, nil, AuthConfig{}, nil, "")
@@ -201,7 +217,7 @@ func TestManualSyncTriggersSyncRunner(t *testing.T) {
 		t.Fatalf("expected sync runner to be called once, got %d", syncer.calls)
 	}
 	body := resp.Body.String()
-	if !(contains(body, `"last_status":"completed"`) && contains(body, `"last_run_at":"2026-04-16T12:00:00Z"`)) {
+	if !(contains(body, `"last_status":"completed"`) && contains(body, `"last_run_at":"2026-04-16T20:00:00+08:00"`)) {
 		t.Fatalf("unexpected response body: %s", body)
 	}
 }

--- a/internal/api/usage_analysis.go
+++ b/internal/api/usage_analysis.go
@@ -7,6 +7,7 @@ import (
 	"cpa-usage-keeper/internal/redact"
 	"cpa-usage-keeper/internal/service"
 	servicedto "cpa-usage-keeper/internal/service/dto"
+	"cpa-usage-keeper/internal/timeutil"
 	"github.com/gin-gonic/gin"
 )
 
@@ -50,7 +51,7 @@ func registerUsageAnalysisRoute(router gin.IRoutes, usageProvider service.UsageP
 			return
 		}
 
-		filter, err := parseUsageFilterQuery(c.Request, time.Now().UTC())
+		filter, err := parseUsageFilterQuery(c.Request, timeutil.NormalizeStorageTime(time.Now()))
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return

--- a/internal/api/usage_events.go
+++ b/internal/api/usage_events.go
@@ -8,6 +8,7 @@ import (
 	"cpa-usage-keeper/internal/entities"
 	"cpa-usage-keeper/internal/service"
 	servicedto "cpa-usage-keeper/internal/service/dto"
+	"cpa-usage-keeper/internal/timeutil"
 
 	"github.com/gin-gonic/gin"
 )
@@ -82,7 +83,7 @@ func registerUsageEventsRoute(
 			return
 		}
 
-		filter, err := parseUsageFilterQuery(c.Request, time.Now().UTC())
+		filter, err := parseUsageFilterQuery(c.Request, timeutil.NormalizeStorageTime(time.Now()))
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
@@ -139,7 +140,7 @@ func buildUsageEventsPayload(rows []servicedto.UsageEventRecord, resolver usageI
 		source, isDelete := usageEventPublicSource(row, identity, matched)
 		payload = append(payload, usageEventPayload{
 			ID:         row.ID,
-			Timestamp:  row.Timestamp.UTC().Format(time.RFC3339),
+			Timestamp:  timeutil.FormatStorageTime(row.Timestamp),
 			Model:      row.Model,
 			Source:     source,
 			SourceType: identity.Type,

--- a/internal/api/usage_events_test.go
+++ b/internal/api/usage_events_test.go
@@ -53,6 +53,14 @@ func (s *usageEventsStub) GetUsageAnalysis(context.Context, servicedto.UsageFilt
 }
 
 func TestUsageEventsReturnsFilteredRows(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	t.Cleanup(func() { time.Local = previousLocal })
+	time.Local = location
+
 	provider := &usageEventsStub{events: []servicedto.UsageEventRecord{{
 		ID:              42,
 		Timestamp:       time.Date(2026, 4, 22, 11, 0, 0, 0, time.UTC),
@@ -96,6 +104,9 @@ func TestUsageEventsReturnsFilteredRows(t *testing.T) {
 	}
 	if !contains(body, `"auth_index":"2"`) {
 		t.Fatalf("expected auth index in response body: %s", body)
+	}
+	if !contains(body, `"timestamp":"2026-04-22T19:00:00+08:00"`) {
+		t.Fatalf("expected project timezone timestamp in response body: %s", body)
 	}
 	if provider.filterCalls != 1 {
 		t.Fatalf("expected ListUsageEvents to be called once, got %d", provider.filterCalls)

--- a/internal/api/usage_filter.go
+++ b/internal/api/usage_filter.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	servicedto "cpa-usage-keeper/internal/service/dto"
+	"cpa-usage-keeper/internal/timeutil"
 )
 
 var presetUsageRangeDurations = map[string]time.Duration{
@@ -99,10 +100,10 @@ func parseUsageFilterQuery(req *http.Request, anchor time.Time) (servicedto.Usag
 	case "all":
 		return filter, nil
 	case "today":
-		localAnchor := anchor.In(time.Local)
+		localAnchor := timeutil.NormalizeStorageTime(anchor)
 		localStart := time.Date(localAnchor.Year(), localAnchor.Month(), localAnchor.Day(), 0, 0, 0, 0, time.Local)
-		startTime := localStart.UTC()
-		endTime := localStart.AddDate(0, 0, 1).Add(-time.Nanosecond).UTC()
+		startTime := timeutil.NormalizeStorageTime(localStart)
+		endTime := timeutil.NormalizeStorageTime(localStart.AddDate(0, 0, 1).Add(-time.Nanosecond))
 		filter.StartTime = &startTime
 		filter.EndTime = &endTime
 		return filter, nil
@@ -120,8 +121,8 @@ func parseUsageFilterQuery(req *http.Request, anchor time.Time) (servicedto.Usag
 		if err != nil {
 			return servicedto.UsageFilter{}, fmt.Errorf("invalid end: %w", err)
 		}
-		startTime = startTime.UTC()
-		endTime = endTime.UTC()
+		startTime = timeutil.NormalizeStorageTime(startTime)
+		endTime = timeutil.NormalizeStorageTime(endTime)
 		if startTime.After(endTime) {
 			return servicedto.UsageFilter{}, fmt.Errorf("custom range start must be before end")
 		}
@@ -133,8 +134,8 @@ func parseUsageFilterQuery(req *http.Request, anchor time.Time) (servicedto.Usag
 		if !ok {
 			return servicedto.UsageFilter{}, fmt.Errorf("unsupported usage range %q", rangeValue)
 		}
-		endTime := anchor.UTC()
-		startTime := endTime.Add(-duration)
+		endTime := timeutil.NormalizeStorageTime(anchor)
+		startTime := timeutil.NormalizeStorageTime(endTime.Add(-duration))
 		filter.StartTime = &startTime
 		filter.EndTime = &endTime
 		return filter, nil

--- a/internal/api/usage_filter_test.go
+++ b/internal/api/usage_filter_test.go
@@ -61,13 +61,19 @@ func TestParseUsageFilterQueryTodayRangeUsesLocalDayBoundary(t *testing.T) {
 	if filter.StartTime == nil || filter.EndTime == nil {
 		t.Fatalf("expected today range to resolve concrete times, got %+v", filter)
 	}
-	expectedStart := time.Date(2026, 4, 22, 0, 0, 0, 0, location).UTC()
-	expectedEnd := time.Date(2026, 4, 23, 0, 0, 0, 0, location).Add(-time.Nanosecond).UTC()
+	expectedStart := time.Date(2026, 4, 22, 0, 0, 0, 0, location)
+	expectedEnd := time.Date(2026, 4, 23, 0, 0, 0, 0, location).Add(-time.Nanosecond)
 	if !filter.StartTime.Equal(expectedStart) {
 		t.Fatalf("expected today start %s, got %s", expectedStart, *filter.StartTime)
 	}
+	if filter.StartTime.Location().String() != location.String() {
+		t.Fatalf("expected today start to keep project timezone, got %s", filter.StartTime.Location())
+	}
 	if !filter.EndTime.Equal(expectedEnd) {
 		t.Fatalf("expected today end %s, got %s", expectedEnd, *filter.EndTime)
+	}
+	if filter.EndTime.Location().String() != location.String() {
+		t.Fatalf("expected today end to keep project timezone, got %s", filter.EndTime.Location())
 	}
 }
 
@@ -90,13 +96,19 @@ func TestParseUsageFilterQueryTodayRangeUsesLocalDSTBoundary(t *testing.T) {
 	if filter.StartTime == nil || filter.EndTime == nil {
 		t.Fatalf("expected today range to resolve concrete times, got %+v", filter)
 	}
-	expectedStart := time.Date(2026, 3, 8, 0, 0, 0, 0, location).UTC()
-	expectedEnd := time.Date(2026, 3, 9, 0, 0, 0, 0, location).Add(-time.Nanosecond).UTC()
+	expectedStart := time.Date(2026, 3, 8, 0, 0, 0, 0, location)
+	expectedEnd := time.Date(2026, 3, 9, 0, 0, 0, 0, location).Add(-time.Nanosecond)
 	if !filter.StartTime.Equal(expectedStart) {
 		t.Fatalf("expected DST today start %s, got %s", expectedStart, *filter.StartTime)
 	}
+	if filter.StartTime.Location().String() != location.String() {
+		t.Fatalf("expected DST today start to keep project timezone, got %s", filter.StartTime.Location())
+	}
 	if !filter.EndTime.Equal(expectedEnd) {
 		t.Fatalf("expected DST today end %s, got %s", expectedEnd, *filter.EndTime)
+	}
+	if filter.EndTime.Location().String() != location.String() {
+		t.Fatalf("expected DST today end to keep project timezone, got %s", filter.EndTime.Location())
 	}
 }
 
@@ -136,13 +148,19 @@ func TestParseUsageFilterQueryCustomDateRangeUsesLocalDayBoundary(t *testing.T) 
 	if filter.StartTime == nil || filter.EndTime == nil {
 		t.Fatalf("expected custom date range bounds, got %+v", filter)
 	}
-	expectedStart := time.Date(2026, 4, 20, 0, 0, 0, 0, location).UTC()
-	expectedEnd := time.Date(2026, 4, 22, 0, 0, 0, 0, location).Add(-time.Nanosecond).UTC()
+	expectedStart := time.Date(2026, 4, 20, 0, 0, 0, 0, location)
+	expectedEnd := time.Date(2026, 4, 22, 0, 0, 0, 0, location).Add(-time.Nanosecond)
 	if !filter.StartTime.Equal(expectedStart) {
 		t.Fatalf("expected custom date start %s, got %s", expectedStart, *filter.StartTime)
 	}
+	if filter.StartTime.Location().String() != location.String() {
+		t.Fatalf("expected custom date start to keep project timezone, got %s", filter.StartTime.Location())
+	}
 	if !filter.EndTime.Equal(expectedEnd) {
 		t.Fatalf("expected custom date end %s, got %s", expectedEnd, *filter.EndTime)
+	}
+	if filter.EndTime.Location().String() != location.String() {
+		t.Fatalf("expected custom date end to keep project timezone, got %s", filter.EndTime.Location())
 	}
 }
 

--- a/internal/api/usage_overview.go
+++ b/internal/api/usage_overview.go
@@ -8,6 +8,7 @@ import (
 	repodto "cpa-usage-keeper/internal/repository/dto"
 	"cpa-usage-keeper/internal/service"
 	servicedto "cpa-usage-keeper/internal/service/dto"
+	"cpa-usage-keeper/internal/timeutil"
 	"github.com/gin-gonic/gin"
 )
 
@@ -123,7 +124,7 @@ func registerUsageOverviewRoute(router gin.IRoutes, usageProvider service.UsageP
 			return
 		}
 
-		filter, err := parseUsageFilterQuery(c.Request, time.Now().UTC())
+		filter, err := parseUsageFilterQuery(c.Request, timeutil.NormalizeStorageTime(time.Now()))
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return

--- a/internal/api/usage_overview_test.go
+++ b/internal/api/usage_overview_test.go
@@ -72,8 +72,8 @@ func TestUsageOverviewResponseIncludesResolvedRangeAndTimezone(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", resp.Code)
 	}
-	expectedStart := time.Date(2026, 4, 20, 0, 0, 0, 0, location).UTC().Format(time.RFC3339Nano)
-	expectedEnd := time.Date(2026, 4, 22, 0, 0, 0, 0, location).Add(-time.Nanosecond).UTC().Format(time.RFC3339Nano)
+	expectedStart := time.Date(2026, 4, 20, 0, 0, 0, 0, location).Format(time.RFC3339Nano)
+	expectedEnd := time.Date(2026, 4, 22, 0, 0, 0, 0, location).Add(-time.Nanosecond).Format(time.RFC3339Nano)
 	body := resp.Body.String()
 	if !contains(body, `"timezone":"Asia/Shanghai"`) || !contains(body, `"range_start":"`+expectedStart+`"`) || !contains(body, `"range_end":"`+expectedEnd+`"`) {
 		t.Fatalf("expected overview response to include resolved range and timezone, got %s", body)

--- a/internal/entities/model_price_setting.go
+++ b/internal/entities/model_price_setting.go
@@ -9,6 +9,6 @@ type ModelPriceSetting struct {
 	PromptPricePer1M     float64
 	CompletionPricePer1M float64
 	CachePricePer1M      float64
-	CreatedAt            time.Time
-	UpdatedAt            time.Time
+	CreatedAt            time.Time `gorm:"serializer:storageTime"`
+	UpdatedAt            time.Time `gorm:"serializer:storageTime"`
 }

--- a/internal/entities/redis_usage_inbox.go
+++ b/internal/entities/redis_usage_inbox.go
@@ -12,8 +12,8 @@ type RedisUsageInbox struct {
 	AttemptCount  int    `gorm:"not null;default:0"`
 	LastError     string
 	UsageEventKey string     `gorm:"index:idx_redis_usage_inboxes_status_usage_event_key,priority:2"`
-	PoppedAt      time.Time  `gorm:"not null"`
-	ProcessedAt   *time.Time `gorm:"index:idx_redis_usage_inboxes_status_processed_at,priority:2"`
-	CreatedAt     time.Time
-	UpdatedAt     time.Time `gorm:"index:idx_redis_usage_inboxes_status_updated_at,priority:2"`
+	PoppedAt      time.Time  `gorm:"serializer:storageTime;not null"`
+	ProcessedAt   *time.Time `gorm:"serializer:storageTime;index:idx_redis_usage_inboxes_status_processed_at,priority:2"`
+	CreatedAt     time.Time  `gorm:"serializer:storageTime"`
+	UpdatedAt     time.Time  `gorm:"serializer:storageTime;index:idx_redis_usage_inboxes_status_updated_at,priority:2"`
 }

--- a/internal/entities/usage_event.go
+++ b/internal/entities/usage_event.go
@@ -13,7 +13,7 @@ type UsageEvent struct {
 	RequestID       string    `gorm:"column:request_id"`
 	Model           string    `gorm:"index:idx_usage_events_model;index:idx_usage_events_trim_model,expression:TRIM(model)"`
 	ModelAlias      *string   `gorm:"column:model_alias"`
-	Timestamp       time.Time `gorm:"index:idx_usage_events_timestamp_id,sort:desc,priority:1"`
+	Timestamp       time.Time `gorm:"serializer:storageTime;index:idx_usage_events_timestamp_id,sort:desc,priority:1"`
 	Source          string    `gorm:"index:idx_usage_events_trim_source,expression:TRIM(source);index:idx_usage_events_auth_type_source_id,priority:2"`
 	AuthIndex       string    `gorm:"index:idx_usage_events_trim_auth_index,expression:TRIM(auth_index);index:idx_usage_events_auth_type_auth_index_id,priority:2"`
 	Failed          bool      `gorm:"index:idx_usage_events_failed"`
@@ -23,5 +23,5 @@ type UsageEvent struct {
 	ReasoningTokens int64
 	CachedTokens    int64
 	TotalTokens     int64
-	CreatedAt       time.Time
+	CreatedAt       time.Time `gorm:"serializer:storageTime"`
 }

--- a/internal/entities/usage_identity.go
+++ b/internal/entities/usage_identity.go
@@ -25,8 +25,8 @@ type UsageIdentity struct {
 	AccountID    *string
 	ProjectID    *string
 
-	ActiveStart *time.Time
-	ActiveUntil *time.Time
+	ActiveStart *time.Time `gorm:"serializer:storageTime"`
+	ActiveUntil *time.Time `gorm:"serializer:storageTime"`
 	PlanType    *string
 
 	TotalRequests   int64
@@ -39,12 +39,12 @@ type UsageIdentity struct {
 	TotalTokens     int64
 
 	LastAggregatedUsageEventID uint
-	FirstUsedAt                *time.Time
-	LastUsedAt                 *time.Time
-	StatsUpdatedAt             *time.Time
+	FirstUsedAt                *time.Time `gorm:"serializer:storageTime"`
+	LastUsedAt                 *time.Time `gorm:"serializer:storageTime"`
+	StatsUpdatedAt             *time.Time `gorm:"serializer:storageTime"`
 
 	IsDeleted bool
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	DeletedAt *time.Time
+	CreatedAt time.Time  `gorm:"serializer:storageTime"`
+	UpdatedAt time.Time  `gorm:"serializer:storageTime"`
+	DeletedAt *time.Time `gorm:"serializer:storageTime"`
 }

--- a/internal/poller/redis_drain.go
+++ b/internal/poller/redis_drain.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	servicedto "cpa-usage-keeper/internal/service/dto"
+	"cpa-usage-keeper/internal/timeutil"
 	"github.com/sirupsen/logrus"
 )
 
@@ -206,7 +207,7 @@ func (d *RedisDrain) runRedisProcess(ctx context.Context) (*servicedto.RedisBatc
 func (d *RedisDrain) recordPullResult(result *servicedto.RedisInboxPullResult, err error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	d.lastRunAt = d.now().UTC()
+	d.lastRunAt = timeutil.NormalizeStorageTime(d.now())
 	status := ""
 	if result != nil {
 		status = result.Status
@@ -225,7 +226,7 @@ func (d *RedisDrain) recordPullResult(result *servicedto.RedisInboxPullResult, e
 func (d *RedisDrain) recordResult(result *servicedto.RedisBatchSyncResult, err error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	d.lastRunAt = d.now().UTC()
+	d.lastRunAt = timeutil.NormalizeStorageTime(d.now())
 	status := ""
 	if result != nil {
 		status = result.Status

--- a/internal/quota/normalize.go
+++ b/internal/quota/normalize.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"cpa-usage-keeper/internal/timeutil"
 )
 
 func NormalizeQuotaRows(output ProviderOutput) []QuotaRow {
@@ -173,7 +175,7 @@ func appendCodexWindowQuotaRow(rows []QuotaRow, key string, label string, scope 
 		row.Window = &QuotaWindow{Seconds: intPtr(window.LimitWindowSeconds)}
 	}
 	if window.ResetAt != 0 {
-		row.ResetAt = time.Unix(window.ResetAt, 0).UTC().Format(time.RFC3339)
+		row.ResetAt = timeutil.FormatStorageTime(time.Unix(window.ResetAt, 0))
 	}
 	return append(rows, row)
 }

--- a/internal/quota/refresh.go
+++ b/internal/quota/refresh.go
@@ -10,6 +10,7 @@ import (
 
 	"cpa-usage-keeper/internal/entities"
 	"cpa-usage-keeper/internal/repository"
+	"cpa-usage-keeper/internal/timeutil"
 
 	"gorm.io/gorm"
 )
@@ -214,7 +215,7 @@ func (s *Service) validateRefreshAuthIndex(ctx context.Context, authIndex string
 
 func (s *Service) ensureRefreshTask(authIndex string, source RefreshSource) (*RefreshTaskRecord, bool) {
 	// 同一个 auth_index 已经 queued/running 时复用现有任务，避免重复打到上游接口。
-	now := time.Now().UTC()
+	now := timeutil.NormalizeStorageTime(time.Now())
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
 	if taskID, ok := s.refreshTaskIDsByAuth[authIndex]; ok {
@@ -268,7 +269,7 @@ func refreshTaskErrorMessage(err error) string {
 }
 
 func (s *Service) markRefreshTaskRunning(taskID string) (string, bool) {
-	now := time.Now().UTC()
+	now := timeutil.NormalizeStorageTime(time.Now())
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
 	task, ok := s.refreshTasks[taskID]
@@ -281,7 +282,7 @@ func (s *Service) markRefreshTaskRunning(taskID string) (string, bool) {
 }
 
 func (s *Service) markRefreshTaskCompleted(taskID string, response CheckResponse) {
-	now := time.Now().UTC()
+	now := timeutil.NormalizeStorageTime(time.Now())
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
 	task, ok := s.refreshTasks[taskID]
@@ -296,7 +297,7 @@ func (s *Service) markRefreshTaskCompleted(taskID string, response CheckResponse
 }
 
 func (s *Service) markRefreshTaskFailed(taskID string, message string) {
-	now := time.Now().UTC()
+	now := timeutil.NormalizeStorageTime(time.Now())
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
 	task, ok := s.refreshTasks[taskID]

--- a/internal/quota/test/normalizer_test.go
+++ b/internal/quota/test/normalizer_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"cpa-usage-keeper/internal/quota"
+	"cpa-usage-keeper/internal/timeutil"
 )
 
 func TestNormalizeClaudeQuotaRows(t *testing.T) {
@@ -42,6 +43,14 @@ func TestNormalizeClaudeQuotaRows(t *testing.T) {
 }
 
 func TestNormalizeCodexQuotaRows(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	t.Cleanup(func() { time.Local = previousLocal })
+	time.Local = location
+
 	allowed := true
 	limitReached := false
 	resetAt := int64(1760000000)
@@ -83,7 +92,7 @@ func TestNormalizeCodexQuotaRows(t *testing.T) {
 	assertFloatField(t, primary.UsedPercent, 25, "primary usedPercent")
 	assertIntField(t, primary.Window.Seconds, 18000, "primary window seconds")
 	assertIntField(t, primary.ResetAfterSeconds, 1200, "primary resetAfterSeconds")
-	if primary.ResetAt != time.Unix(resetAt, 0).UTC().Format(time.RFC3339) {
+	if primary.ResetAt != timeutil.FormatStorageTime(time.Unix(resetAt, 0)) {
 		t.Fatalf("unexpected primary resetAt: %#v", primary)
 	}
 	assertBoolField(t, primary.Allowed, true, "primary allowed")

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -11,6 +11,7 @@ import (
 	"cpa-usage-keeper/internal/config"
 	"cpa-usage-keeper/internal/entities"
 	"cpa-usage-keeper/internal/repository/migration"
+	"cpa-usage-keeper/internal/timeutil"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -22,7 +23,8 @@ func OpenDatabase(cfg config.Config) (*gorm.DB, error) {
 		return nil, err
 	}
 	dsn := sqliteDSN(cfg.SQLitePath)
-	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	// GORM 自动时间也先落到项目 TZ，再由 storageTime serializer 输出统一字符串。
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{NowFunc: func() time.Time { return timeutil.NormalizeStorageTime(time.Now()) }})
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite database %s: %w", filepath.Clean(cfg.SQLitePath), err)
 	}
@@ -113,6 +115,9 @@ func InsertUsageEvents(db *gorm.DB, events []entities.UsageEvent) (int, int, err
 	for start := 0; start < len(events); start += insertBatchSize(entities.UsageEvent{}) {
 		end := min(start+insertBatchSize(entities.UsageEvent{}), len(events))
 		batch := events[start:end]
+		for index := range batch {
+			batch[index].Timestamp = timeutil.NormalizeStorageTime(batch[index].Timestamp)
+		}
 
 		// 每批仍按 event_key 去重，保持原有重复事件忽略语义。
 		result := db.Clauses(clause.OnConflict{

--- a/internal/repository/db_test.go
+++ b/internal/repository/db_test.go
@@ -52,8 +52,8 @@ func TestOpenDatabaseCreatesFreshDatabaseFromCurrentSchemaWithoutRunningMigratio
 	if err := db.Table("schema_migrations").Count(&count).Error; err != nil {
 		t.Fatalf("count schema migrations: %v", err)
 	}
-	if count != 18 {
-		t.Fatalf("expected fresh database to mark 18 migrations applied, got %d", count)
+	if count != 19 {
+		t.Fatalf("expected fresh database to mark 19 migrations applied, got %d", count)
 	}
 	if strings.Contains(logs.String(), "schema migration started") {
 		t.Fatalf("expected fresh database creation not to run version migrations, got logs:\n%s", logs.String())
@@ -185,6 +185,82 @@ func TestInsertUsageEventsPersistsModelAlias(t *testing.T) {
 	}
 }
 
+func TestDatabaseTimeFieldsUseProjectTimezoneRFC3339Nano(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	time.Local = location
+	t.Cleanup(func() { time.Local = previousLocal })
+	db := openTestDatabase(t)
+
+	storageTime := time.Date(2026, 5, 12, 21, 59, 18, 353569620, location)
+	if _, _, err := InsertUsageEvents(db, []entities.UsageEvent{{
+		EventKey:    "event-storage-time",
+		APIGroupKey: "provider-a",
+		Model:       "claude-sonnet",
+		Timestamp:   storageTime,
+		AuthType:    "oauth",
+		AuthIndex:   "auth-1",
+		TotalTokens: 1,
+	}}); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+	if _, err := UpsertModelPriceSetting(db, dto.ModelPriceSettingInput{Model: "claude-sonnet", PromptPricePer1M: 1}); err != nil {
+		t.Fatalf("UpsertModelPriceSetting returned error: %v", err)
+	}
+	inboxRows, err := InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{QueueKey: "queue", RawMessage: `{"request_id":"event-storage-time"}`, PoppedAt: storageTime}})
+	if err != nil {
+		t.Fatalf("InsertRedisUsageInboxMessages returned error: %v", err)
+	}
+	if err := MarkRedisUsageInboxProcessed(db, inboxRows[0].ID, "event-storage-time", storageTime); err != nil {
+		t.Fatalf("MarkRedisUsageInboxProcessed returned error: %v", err)
+	}
+	activeStart := storageTime
+	activeUntil := storageTime.Add(time.Hour)
+	if err := ReplaceUsageIdentitiesForAuthType(t.Context(), db, []entities.UsageIdentity{{
+		Name:        "Auth 1",
+		Identity:    "auth-1",
+		ActiveStart: &activeStart,
+		ActiveUntil: &activeUntil,
+	}}, entities.UsageIdentityAuthTypeAuthFile, storageTime); err != nil {
+		t.Fatalf("ReplaceUsageIdentitiesForAuthType returned error: %v", err)
+	}
+	if err := AggregateUsageIdentityStats(t.Context(), db, storageTime); err != nil {
+		t.Fatalf("AggregateUsageIdentityStats returned error: %v", err)
+	}
+	if err := ReplaceUsageIdentitiesForAuthType(t.Context(), db, nil, entities.UsageIdentityAuthTypeAuthFile, storageTime); err != nil {
+		t.Fatalf("ReplaceUsageIdentitiesForAuthType delete returned error: %v", err)
+	}
+
+	for _, check := range []struct {
+		table string
+		field string
+		where string
+	}{
+		{table: "usage_events", field: "timestamp", where: "event_key = 'event-storage-time'"},
+		{table: "usage_events", field: "created_at", where: "event_key = 'event-storage-time'"},
+		{table: "model_price_settings", field: "created_at", where: "model = 'claude-sonnet'"},
+		{table: "model_price_settings", field: "updated_at", where: "model = 'claude-sonnet'"},
+		{table: "redis_usage_inboxes", field: "popped_at", where: "usage_event_key = 'event-storage-time'"},
+		{table: "redis_usage_inboxes", field: "processed_at", where: "usage_event_key = 'event-storage-time'"},
+		{table: "redis_usage_inboxes", field: "created_at", where: "usage_event_key = 'event-storage-time'"},
+		{table: "redis_usage_inboxes", field: "updated_at", where: "usage_event_key = 'event-storage-time'"},
+		{table: "usage_identities", field: "active_start", where: "identity = 'auth-1'"},
+		{table: "usage_identities", field: "active_until", where: "identity = 'auth-1'"},
+		{table: "usage_identities", field: "first_used_at", where: "identity = 'auth-1'"},
+		{table: "usage_identities", field: "last_used_at", where: "identity = 'auth-1'"},
+		{table: "usage_identities", field: "stats_updated_at", where: "identity = 'auth-1'"},
+		{table: "usage_identities", field: "created_at", where: "identity = 'auth-1'"},
+		{table: "usage_identities", field: "updated_at", where: "identity = 'auth-1'"},
+		{table: "usage_identities", field: "deleted_at", where: "identity = 'auth-1'"},
+		{table: "schema_migrations", field: "applied_at", where: "version = '20260503_add_usage_event_redis_fields'"},
+	} {
+		assertProjectTimezoneStorageValue(t, rawSQLiteTimeValue(t, db, check.table, check.field, check.where), check.table+"."+check.field)
+	}
+}
+
 func TestCleanupStorageCleansRedisInboxAndVacuums(t *testing.T) {
 	previousLocal := time.Local
 	location, err := time.LoadLocation("Asia/Shanghai")
@@ -234,6 +310,28 @@ func openTestDatabase(t *testing.T) *gorm.DB {
 	}
 	closeTestDatabase(t, db)
 	return db
+}
+
+func rawSQLiteTimeValue(t *testing.T, db *gorm.DB, table string, field string, where string) string {
+	t.Helper()
+	var value string
+	if err := db.Raw(fmt.Sprintf("SELECT %s FROM %s WHERE %s LIMIT 1", field, table, where)).Scan(&value).Error; err != nil {
+		t.Fatalf("read raw time value %s.%s: %v", table, field, err)
+	}
+	if strings.TrimSpace(value) == "" {
+		t.Fatalf("expected raw time value for %s.%s", table, field)
+	}
+	return value
+}
+
+func assertProjectTimezoneStorageValue(t *testing.T, value string, field string) {
+	t.Helper()
+	if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
+		t.Fatalf("expected %s to use RFC3339Nano storage format, got %q: %v", field, value, err)
+	}
+	if !strings.Contains(value, "T") || !strings.Contains(value, "+08:00") || strings.Contains(value, "Z") || strings.Contains(value, "+00:00") {
+		t.Fatalf("expected %s to use project timezone offset storage format, got %q", field, value)
+	}
 }
 
 func closeTestDatabase(t *testing.T, db *gorm.DB) {

--- a/internal/repository/db_test.go
+++ b/internal/repository/db_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"bytes"
+	"context"
 	"cpa-usage-keeper/internal/repository/dto"
 	"fmt"
 	"path/filepath"
@@ -219,7 +220,7 @@ func TestDatabaseTimeFieldsUseProjectTimezoneRFC3339Nano(t *testing.T) {
 	}
 	activeStart := storageTime
 	activeUntil := storageTime.Add(time.Hour)
-	if err := ReplaceUsageIdentitiesForAuthType(t.Context(), db, []entities.UsageIdentity{{
+	if err := ReplaceUsageIdentitiesForAuthType(context.Background(), db, []entities.UsageIdentity{{
 		Name:        "Auth 1",
 		Identity:    "auth-1",
 		ActiveStart: &activeStart,
@@ -227,10 +228,10 @@ func TestDatabaseTimeFieldsUseProjectTimezoneRFC3339Nano(t *testing.T) {
 	}}, entities.UsageIdentityAuthTypeAuthFile, storageTime); err != nil {
 		t.Fatalf("ReplaceUsageIdentitiesForAuthType returned error: %v", err)
 	}
-	if err := AggregateUsageIdentityStats(t.Context(), db, storageTime); err != nil {
+	if err := AggregateUsageIdentityStats(context.Background(), db, storageTime); err != nil {
 		t.Fatalf("AggregateUsageIdentityStats returned error: %v", err)
 	}
-	if err := ReplaceUsageIdentitiesForAuthType(t.Context(), db, nil, entities.UsageIdentityAuthTypeAuthFile, storageTime); err != nil {
+	if err := ReplaceUsageIdentitiesForAuthType(context.Background(), db, nil, entities.UsageIdentityAuthTypeAuthFile, storageTime); err != nil {
 		t.Fatalf("ReplaceUsageIdentitiesForAuthType delete returned error: %v", err)
 	}
 

--- a/internal/repository/migration/20260504_usage_identities_metadata.go
+++ b/internal/repository/migration/20260504_usage_identities_metadata.go
@@ -5,11 +5,12 @@ import (
 	"time"
 
 	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/timeutil"
 	"gorm.io/gorm"
 )
 
 func migrateUsageIdentitiesMetadataMigration(tx *gorm.DB) error {
-	now := time.Now().UTC()
+	now := timeutil.NormalizeStorageTime(time.Now())
 	if tx.Migrator().HasTable("auth_files") {
 		isDeletedSelect, deletedAtSelect := legacyDeletedStateSelect(tx, "auth_files")
 		if err := tx.Exec(`

--- a/internal/repository/migration/20260504_usage_identity_stats.go
+++ b/internal/repository/migration/20260504_usage_identity_stats.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/timeutil"
 	"gorm.io/gorm"
 )
 
@@ -42,7 +43,7 @@ func backfillUsageIdentityStatsMigration(tx *gorm.DB) error {
 			"last_aggregated_usage_event_id": stats.MaxUsageEventID,
 		}
 		if stats.TotalRequests > 0 {
-			now := time.Now().UTC()
+			now := timeutil.NormalizeStorageTime(time.Now())
 			updates["stats_updated_at"] = now
 		}
 		if err := tx.Model(&entities.UsageIdentity{}).Where("id = ?", identity.ID).Updates(updates).Error; err != nil {

--- a/internal/repository/migration/20260505_ai_provider_auth_index.go
+++ b/internal/repository/migration/20260505_ai_provider_auth_index.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/timeutil"
 	"gorm.io/gorm"
 )
 
@@ -154,7 +155,7 @@ func backfillAIProviderUsageIdentityStatsByAuthIndex(tx *gorm.DB) error {
 		}
 		var statsUpdatedAt *time.Time
 		if stats.TotalRequests > 0 {
-			now := time.Now().UTC()
+			now := timeutil.NormalizeStorageTime(time.Now())
 			statsUpdatedAt = &now
 		}
 		if err := tx.Exec(`

--- a/internal/repository/migration/20260512_storage_time_project_tz.go
+++ b/internal/repository/migration/20260512_storage_time_project_tz.go
@@ -1,0 +1,90 @@
+package migration
+
+import (
+	"fmt"
+	"strings"
+
+	"cpa-usage-keeper/internal/timeutil"
+	"gorm.io/gorm"
+)
+
+type storageTimeColumn struct {
+	table string
+	field string
+}
+
+func normalizeStorageTimesToProjectTZMigration(tx *gorm.DB) error {
+	// 最后一段迁移统一收口所有历史时间字段，前置迁移保留原顺序和原逻辑。
+	columns := []storageTimeColumn{
+		{table: "usage_events", field: "timestamp"},
+		{table: "usage_events", field: "created_at"},
+		{table: "redis_usage_inboxes", field: "popped_at"},
+		{table: "redis_usage_inboxes", field: "processed_at"},
+		{table: "redis_usage_inboxes", field: "created_at"},
+		{table: "redis_usage_inboxes", field: "updated_at"},
+		{table: "usage_identities", field: "active_start"},
+		{table: "usage_identities", field: "active_until"},
+		{table: "usage_identities", field: "first_used_at"},
+		{table: "usage_identities", field: "last_used_at"},
+		{table: "usage_identities", field: "stats_updated_at"},
+		{table: "usage_identities", field: "created_at"},
+		{table: "usage_identities", field: "updated_at"},
+		{table: "usage_identities", field: "deleted_at"},
+		{table: "model_price_settings", field: "created_at"},
+		{table: "model_price_settings", field: "updated_at"},
+		{table: "schema_migrations", field: "applied_at"},
+	}
+	for _, column := range columns {
+		if err := normalizeStorageTimeColumn(tx, column); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func storageTimeColumnExists(tx *gorm.DB, column storageTimeColumn) (bool, error) {
+	// 旧库可能缺少较新的列，迁移按实际 schema 跳过不存在的字段。
+	var rows []struct {
+		Name string
+	}
+	if err := tx.Raw(fmt.Sprintf("PRAGMA table_info(%s)", column.table)).Scan(&rows).Error; err != nil {
+		return false, fmt.Errorf("inspect %s columns: %w", column.table, err)
+	}
+	for _, row := range rows {
+		if row.Name == column.field {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func normalizeStorageTimeColumn(tx *gorm.DB, column storageTimeColumn) error {
+	exists, err := storageTimeColumnExists(tx, column)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	var rows []struct {
+		ID    int64
+		Value *string
+	}
+	// CAST 成 TEXT，避免 SQLite driver 把无时区 DATETIME 提前按 UTC 转成 time.Time。
+	if err := tx.Raw(fmt.Sprintf("SELECT rowid AS id, CAST(%s AS TEXT) AS value FROM %s WHERE %s IS NOT NULL", column.field, column.table, column.field)).Scan(&rows).Error; err != nil {
+		return fmt.Errorf("list %s.%s storage times: %w", column.table, column.field, err)
+	}
+	for _, row := range rows {
+		if row.Value == nil || strings.TrimSpace(*row.Value) == "" {
+			continue
+		}
+		parsed, err := timeutil.ParseStorageTime(*row.Value)
+		if err != nil {
+			return fmt.Errorf("parse %s.%s row %v value %q: %w", column.table, column.field, row.ID, *row.Value, err)
+		}
+		if err := tx.Exec(fmt.Sprintf("UPDATE %s SET %s = ? WHERE rowid = ?", column.table, column.field), timeutil.FormatStorageTime(parsed), row.ID).Error; err != nil {
+			return fmt.Errorf("update %s.%s row %v: %w", column.table, column.field, row.ID, err)
+		}
+	}
+	return nil
+}

--- a/internal/repository/migration/migration.go
+++ b/internal/repository/migration/migration.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"cpa-usage-keeper/internal/timeutil"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
@@ -27,11 +28,12 @@ const (
 	migrationUpdateUsageIdentityQuotaFields         = "20260509_update_usage_identity_quota_fields"
 	migrationRemoveUsageIdentityQuotaFields         = "20260510_remove_usage_identity_quota_fields"
 	migrationAddUsageIdentityBaseURL                = "20260511_add_usage_identity_base_url"
+	migrationNormalizeStorageTimesToProjectTZ       = "20260512_normalize_storage_times_to_project_tz"
 )
 
 type schemaMigration struct {
 	Version   string    `gorm:"primaryKey;column:version"`
-	AppliedAt time.Time `gorm:"not null;column:applied_at"`
+	AppliedAt time.Time `gorm:"serializer:storageTime;not null;column:applied_at"`
 }
 
 func (schemaMigration) TableName() string {
@@ -61,7 +63,7 @@ func MarkAllAsApplied(db *gorm.DB) error {
 		return err
 	}
 	return db.Transaction(func(tx *gorm.DB) error {
-		now := time.Now().UTC()
+		now := timeutil.NormalizeStorageTime(time.Now())
 		for _, migration := range orderedMigrations() {
 			if err := tx.Exec("INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)", migration.version, now).Error; err != nil {
 				return fmt.Errorf("mark schema migration %s applied: %w", migration.version, err)
@@ -98,6 +100,7 @@ func orderedMigrations() []databaseMigration {
 		{version: migrationUpdateUsageIdentityQuotaFields, run: updateUsageIdentityQuotaFieldsMigration},
 		{version: migrationRemoveUsageIdentityQuotaFields, run: removeUsageIdentityQuotaFieldsMigration},
 		{version: migrationAddUsageIdentityBaseURL, run: addUsageIdentityBaseURLMigration},
+		{version: migrationNormalizeStorageTimesToProjectTZ, run: normalizeStorageTimesToProjectTZMigration},
 	}
 }
 
@@ -118,7 +121,7 @@ func runSchemaMigration(db *gorm.DB, migration databaseMigration) error {
 			logger.WithError(err).Error("schema migration failed")
 			return fmt.Errorf("run schema migration %s: %w", migration.version, err)
 		}
-		if err := tx.Create(&schemaMigration{Version: migration.version, AppliedAt: time.Now().UTC()}).Error; err != nil {
+		if err := tx.Create(&schemaMigration{Version: migration.version, AppliedAt: timeutil.NormalizeStorageTime(time.Now())}).Error; err != nil {
 			logger.WithError(err).Error("schema migration failed")
 			return fmt.Errorf("record schema migration %s: %w", migration.version, err)
 		}

--- a/internal/repository/migration/migration_test.go
+++ b/internal/repository/migration/migration_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"cpa-usage-keeper/internal/entities"
 	"github.com/sirupsen/logrus"
@@ -36,6 +37,7 @@ func TestOrderedMigrationsPreservesExecutionOrder(t *testing.T) {
 		"20260509_update_usage_identity_quota_fields",
 		"20260510_remove_usage_identity_quota_fields",
 		"20260511_add_usage_identity_base_url",
+		"20260512_normalize_storage_times_to_project_tz",
 	}
 	if len(got) != len(want) {
 		t.Fatalf("expected ordered migrations %v, got %v", want, got)
@@ -89,6 +91,7 @@ func TestOpenDatabaseRunsSchemaMigrationsAndAddsUsageEventRedisFields(t *testing
 		"20260509_update_usage_identity_quota_fields",
 		"20260510_remove_usage_identity_quota_fields",
 		"20260511_add_usage_identity_base_url",
+		"20260512_normalize_storage_times_to_project_tz",
 	}
 	if len(versions) != len(expected) {
 		t.Fatalf("expected migration versions %v, got %v", expected, versions)
@@ -98,6 +101,71 @@ func TestOpenDatabaseRunsSchemaMigrationsAndAddsUsageEventRedisFields(t *testing
 			t.Fatalf("expected migration versions %v, got %v", expected, versions)
 		}
 	}
+}
+
+func TestRunNormalizesLegacyStorageTimesToProjectTimezone(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	time.Local = location
+	t.Cleanup(func() { time.Local = previousLocal })
+
+	db, err := gorm.Open(sqlite.Open(testSQLiteDSN(filepath.Join(t.TempDir(), "legacy-times.db"))), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	defer closeOpenedDatabase(t, db)
+	if err := db.Exec("CREATE TABLE schema_migrations (version TEXT PRIMARY KEY, applied_at DATETIME NOT NULL)").Error; err != nil {
+		t.Fatalf("create schema_migrations: %v", err)
+	}
+	if err := db.Exec("CREATE TABLE usage_events (id INTEGER PRIMARY KEY AUTOINCREMENT, event_key TEXT, model TEXT, timestamp DATETIME, created_at DATETIME)").Error; err != nil {
+		t.Fatalf("create usage_events: %v", err)
+	}
+	if err := db.Exec("CREATE TABLE redis_usage_inboxes (id INTEGER PRIMARY KEY AUTOINCREMENT, popped_at DATETIME NOT NULL, processed_at DATETIME, created_at DATETIME, updated_at DATETIME)").Error; err != nil {
+		t.Fatalf("create redis_usage_inboxes: %v", err)
+	}
+	if err := db.Exec("CREATE TABLE usage_identities (id INTEGER PRIMARY KEY AUTOINCREMENT, identity TEXT, active_start DATETIME, active_until DATETIME, first_used_at DATETIME, last_used_at DATETIME, stats_updated_at DATETIME, created_at DATETIME, updated_at DATETIME, deleted_at DATETIME)").Error; err != nil {
+		t.Fatalf("create usage_identities: %v", err)
+	}
+	if err := db.Exec("CREATE TABLE model_price_settings (id INTEGER PRIMARY KEY AUTOINCREMENT, model TEXT, created_at DATETIME, updated_at DATETIME)").Error; err != nil {
+		t.Fatalf("create model_price_settings: %v", err)
+	}
+	for _, migration := range orderedMigrations() {
+		if migration.version == migrationNormalizeStorageTimesToProjectTZ {
+			continue
+		}
+		if err := db.Exec("INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)", migration.version, "2026-05-12 13:47:39.744240399+00:00").Error; err != nil {
+			t.Fatalf("seed schema_migrations %s: %v", migration.version, err)
+		}
+	}
+	if err := db.Exec("INSERT INTO usage_events (event_key, model, timestamp, created_at) VALUES (?, ?, ?, ?)", "event-1", "claude-sonnet", "2026-05-12 13:47:39.744240399+00:00", "2026-05-12T13:47:39.744240399Z").Error; err != nil {
+		t.Fatalf("seed usage_events: %v", err)
+	}
+	if err := db.Exec("INSERT INTO redis_usage_inboxes (popped_at, processed_at, created_at, updated_at) VALUES (?, ?, ?, ?)", "2026-05-12T21:47:39.744240399+08:00", "2026-05-12 13:47:39.744240399", "2026-05-12T13:47:39.744240399", "2026-05-12 13:47:39").Error; err != nil {
+		t.Fatalf("seed redis_usage_inboxes: %v", err)
+	}
+	if err := db.Exec("INSERT INTO usage_identities (identity, active_start, active_until, first_used_at, last_used_at, stats_updated_at, created_at, updated_at, deleted_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", "auth-1", "2026-05-12 13:47:39.744240399", "2026-05-12T13:47:39.744240399", "2026-05-12T13:47:39.744240399Z", "2026-05-12 13:47:39.744240399+00:00", "2026-05-12T21:47:39.744240399+08:00", "2026-05-12 13:47:39", "2026-05-12T13:47:39", nil).Error; err != nil {
+		t.Fatalf("seed usage_identities: %v", err)
+	}
+	if err := db.Exec("INSERT INTO model_price_settings (model, created_at, updated_at) VALUES (?, ?, ?)", "claude-sonnet", "2026-05-12T13:47:39.744240399Z", "2026-05-12 13:47:39.744240399").Error; err != nil {
+		t.Fatalf("seed model_price_settings: %v", err)
+	}
+
+	if err := Run(db); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	assertRawMigrationTime(t, db, "usage_events", "timestamp", "id = 1", "2026-05-12T21:47:39.744240399+08:00")
+	assertRawMigrationTime(t, db, "usage_events", "created_at", "id = 1", "2026-05-12T21:47:39.744240399+08:00")
+	assertRawMigrationTime(t, db, "redis_usage_inboxes", "popped_at", "id = 1", "2026-05-12T21:47:39.744240399+08:00")
+	assertRawMigrationTime(t, db, "redis_usage_inboxes", "processed_at", "id = 1", "2026-05-12T13:47:39.744240399+08:00")
+	assertRawMigrationTime(t, db, "usage_identities", "active_start", "id = 1", "2026-05-12T13:47:39.744240399+08:00")
+	assertRawMigrationTime(t, db, "usage_identities", "first_used_at", "id = 1", "2026-05-12T21:47:39.744240399+08:00")
+	assertRawMigrationTime(t, db, "usage_identities", "deleted_at", "id = 1", "")
+	assertRawMigrationTime(t, db, "model_price_settings", "updated_at", "id = 1", "2026-05-12T13:47:39.744240399+08:00")
+	assertRawMigrationTime(t, db, "schema_migrations", "applied_at", "version = '20260511_add_usage_identity_base_url'", "2026-05-12T21:47:39.744240399+08:00")
 }
 
 func TestOpenDatabaseMigrationsAreIdempotent(t *testing.T) {
@@ -144,6 +212,26 @@ func TestOpenDatabaseLogsSchemaMigrations(t *testing.T) {
 		if !strings.Contains(content, want) {
 			t.Fatalf("expected migration logs to contain %q, got:\n%s", want, content)
 		}
+	}
+}
+
+func assertRawMigrationTime(t *testing.T, db *gorm.DB, table string, field string, where string, want string) {
+	t.Helper()
+	var got *string
+	if err := db.Raw(fmt.Sprintf("SELECT %s FROM %s WHERE %s LIMIT 1", field, table, where)).Scan(&got).Error; err != nil {
+		t.Fatalf("read %s.%s: %v", table, field, err)
+	}
+	if want == "" {
+		if got != nil {
+			t.Fatalf("expected %s.%s to stay NULL, got %q", table, field, *got)
+		}
+		return
+	}
+	if got == nil || *got != want {
+		if got == nil {
+			t.Fatalf("expected %s.%s = %q, got NULL", table, field, want)
+		}
+		t.Fatalf("expected %s.%s = %q, got %q", table, field, want, *got)
 	}
 }
 

--- a/internal/repository/redis_usage_inbox.go
+++ b/internal/repository/redis_usage_inbox.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/timeutil"
 	"gorm.io/gorm"
 )
 
@@ -38,7 +39,7 @@ func InsertRedisUsageInboxMessages(db *gorm.DB, inputs []dto.RedisInboxInsert) (
 			RawMessage:   input.RawMessage,
 			Status:       RedisUsageInboxStatusPending,
 			AttemptCount: 0,
-			PoppedAt:     input.PoppedAt.UTC(),
+			PoppedAt:     timeutil.NormalizeStorageTime(input.PoppedAt),
 		})
 	}
 
@@ -55,7 +56,7 @@ func MarkRedisUsageInboxProcessed(db *gorm.DB, id uint, eventKey string, process
 	return db.Model(&entities.RedisUsageInbox{}).Where("id = ?", id).Updates(map[string]any{
 		"status":          RedisUsageInboxStatusProcessed,
 		"usage_event_key": eventKey,
-		"processed_at":    processedAt.UTC(),
+		"processed_at":    timeutil.FormatStorageTime(processedAt),
 		"last_error":      "",
 	}).Error
 }
@@ -108,8 +109,8 @@ func ListPendingRedisUsageInbox(db *gorm.DB, limit int) ([]entities.RedisUsageIn
 func CleanupRedisUsageInbox(db *gorm.DB, now time.Time) (dto.RedisUsageInboxCleanupResult, error) {
 	localNow := now.In(time.Local)
 	localDayStart := time.Date(localNow.Year(), localNow.Month(), localNow.Day(), 0, 0, 0, 0, time.Local)
-	processedCutoff := localDayStart.UTC()
-	failedCutoff := now.UTC().AddDate(0, 0, -7)
+	processedCutoff := timeutil.FormatStorageTime(localDayStart)
+	failedCutoff := timeutil.FormatStorageTime(now.AddDate(0, 0, -7))
 	result := dto.RedisUsageInboxCleanupResult{}
 
 	processedDelete := db.Where("status = ? AND processed_at IS NOT NULL AND processed_at < ?", RedisUsageInboxStatusProcessed, processedCutoff).Delete(&entities.RedisUsageInbox{})

--- a/internal/repository/redis_usage_inbox_test.go
+++ b/internal/repository/redis_usage_inbox_test.go
@@ -262,10 +262,10 @@ func TestCleanupRedisUsageInboxRemovesOldProcessedAndFailedRows(t *testing.T) {
 	}
 	oldProcessedAt := time.Date(2026, 4, 26, 15, 59, 59, 0, time.UTC)
 	todayProcessedAt := time.Date(2026, 4, 26, 16, 0, 0, 0, time.UTC)
-	if err := db.Model(&entities.RedisUsageInbox{}).Where("id = ?", rows[0].ID).Updates(map[string]any{"status": RedisUsageInboxStatusProcessed, "processed_at": oldProcessedAt}).Error; err != nil {
+	if err := MarkRedisUsageInboxProcessed(db, rows[0].ID, "processed-old", oldProcessedAt); err != nil {
 		t.Fatalf("seed old processed row: %v", err)
 	}
-	if err := db.Model(&entities.RedisUsageInbox{}).Where("id = ?", rows[1].ID).Updates(map[string]any{"status": RedisUsageInboxStatusProcessed, "processed_at": todayProcessedAt}).Error; err != nil {
+	if err := MarkRedisUsageInboxProcessed(db, rows[1].ID, "processed-today", todayProcessedAt); err != nil {
 		t.Fatalf("seed today processed row: %v", err)
 	}
 	if err := db.Model(&entities.RedisUsageInbox{}).Where("id = ?", rows[2].ID).Updates(map[string]any{"status": RedisUsageInboxStatusProcessFailed, "updated_at": now.AddDate(0, 0, -8)}).Error; err != nil {

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -8,6 +8,7 @@ import (
 
 	"cpa-usage-keeper/internal/entities"
 	"cpa-usage-keeper/internal/repository/dto"
+	"cpa-usage-keeper/internal/timeutil"
 	"gorm.io/gorm"
 )
 
@@ -67,7 +68,7 @@ func ListUsageEventsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (*dto.U
 	for _, event := range events {
 		rows = append(rows, dto.UsageEventRecord{
 			ID:              event.ID,
-			Timestamp:       event.Timestamp.UTC(),
+			Timestamp:       timeutil.NormalizeStorageTime(event.Timestamp),
 			APIGroupKey:     strings.TrimSpace(event.APIGroupKey),
 			Model:           strings.TrimSpace(event.Model),
 			AuthType:        strings.TrimSpace(event.AuthType),
@@ -119,11 +120,12 @@ func queryUsageEvents(db *gorm.DB) *gorm.DB {
 }
 
 func applyUsageQueryWindow(query *gorm.DB, filter dto.UsageQueryFilter) *gorm.DB {
+	// 查询参数和落库 timestamp 使用同一格式，避免 SQLite TEXT 范围比较失真。
 	if filter.StartTime != nil {
-		query = query.Where("timestamp >= ?", filter.StartTime.UTC())
+		query = query.Where("timestamp >= ?", timeutil.FormatStorageTime(*filter.StartTime))
 	}
 	if filter.EndTime != nil {
-		query = query.Where("timestamp <= ?", filter.EndTime.UTC())
+		query = query.Where("timestamp <= ?", timeutil.FormatStorageTime(*filter.EndTime))
 	}
 	return query
 }
@@ -406,7 +408,7 @@ func applyUsageEventToSnapshot(snapshot *dto.StatisticsSnapshot, event entities.
 	modelSnapshot := apiSnapshot.Models[modelName]
 	if includeDetails {
 		detail := dto.RequestDetail{
-			Timestamp: event.Timestamp.UTC(),
+			Timestamp: timeutil.NormalizeStorageTime(event.Timestamp),
 			LatencyMS: event.LatencyMS,
 			Source:    strings.TrimSpace(event.Source),
 			AuthIndex: strings.TrimSpace(event.AuthIndex),
@@ -437,8 +439,9 @@ func applyUsageEventToSnapshot(snapshot *dto.StatisticsSnapshot, event entities.
 		snapshot.SuccessCount++
 	}
 
-	dayKey := event.Timestamp.In(time.Local).Format("2006-01-02")
-	hourKey := event.Timestamp.UTC().Format("2006-01-02T15:00:00Z")
+	eventTime := timeutil.NormalizeStorageTime(event.Timestamp)
+	dayKey := eventTime.Format("2006-01-02")
+	hourKey := timeutil.FormatStorageTime(eventTime.Truncate(time.Hour))
 	snapshot.RequestsByDay[dayKey]++
 	snapshot.RequestsByHour[hourKey]++
 	snapshot.TokensByDay[dayKey] += event.TotalTokens
@@ -525,15 +528,15 @@ func applyUsageEventToOverview(overview *dto.UsageOverviewRecord, event entities
 	cost := calculateUsageEventCost(event, pricing)
 	overview.Summary.TotalCost += cost
 
-	bucketKey, bucketMinutes := usageOverviewBucket(event.Timestamp.UTC(), bucketByDay)
+	bucketKey, bucketMinutes := usageOverviewBucket(timeutil.NormalizeStorageTime(event.Timestamp), bucketByDay)
 	applyUsageEventToOverviewSeries(&overview.Series, event, cost, bucketKey, bucketMinutes)
 
-	hourKey, hourMinutes := usageOverviewBucket(event.Timestamp.UTC(), false)
-	if latestHourlyStart == nil || !event.Timestamp.UTC().Before(*latestHourlyStart) {
+	hourKey, hourMinutes := usageOverviewBucket(timeutil.NormalizeStorageTime(event.Timestamp), false)
+	if latestHourlyStart == nil || !timeutil.NormalizeStorageTime(event.Timestamp).Before(*latestHourlyStart) {
 		applyUsageEventToOverviewSeries(&overview.HourlySeries, event, cost, hourKey, hourMinutes)
 	}
 
-	dayKey, dayMinutes := usageOverviewBucket(event.Timestamp.UTC(), true)
+	dayKey, dayMinutes := usageOverviewBucket(timeutil.NormalizeStorageTime(event.Timestamp), true)
 	applyUsageEventToOverviewSeries(&overview.DailySeries, event, cost, dayKey, dayMinutes)
 	updateUsageOverviewHealthBlock(overview.Health.BlockDetails, event)
 }
@@ -599,8 +602,8 @@ func computeWindowMinutes(filter dto.UsageQueryFilter) int64 {
 	if filter.StartTime == nil || filter.EndTime == nil {
 		return 0
 	}
-	start := filter.StartTime.UTC()
-	end := filter.EndTime.UTC()
+	start := timeutil.NormalizeStorageTime(*filter.StartTime)
+	end := timeutil.NormalizeStorageTime(*filter.EndTime)
 	if end.Before(start) {
 		return 0
 	}
@@ -623,16 +626,16 @@ func shouldBucketUsageOverviewByDay(filter dto.UsageQueryFilter, windowMinutes i
 
 func usageOverviewBucket(timestamp time.Time, byDay bool) (string, int64) {
 	if byDay {
-		return timestamp.In(time.Local).Format("2006-01-02"), 24 * 60
+		return timeutil.NormalizeStorageTime(timestamp).Format("2006-01-02"), 24 * 60
 	}
-	return timestamp.UTC().Format("2006-01-02T15:00:00Z"), 60
+	return timeutil.FormatStorageTime(timeutil.NormalizeStorageTime(timestamp).Truncate(time.Hour)), 60
 }
 
 func latestHourlySeriesStart(filter dto.UsageQueryFilter) *time.Time {
 	if filter.EndTime == nil {
 		return nil
 	}
-	currentHour := filter.EndTime.UTC().Truncate(time.Hour)
+	currentHour := timeutil.NormalizeStorageTime(*filter.EndTime).Truncate(time.Hour)
 	start := currentHour.Add(-23 * time.Hour)
 	return &start
 }
@@ -686,9 +689,9 @@ func isUsageOverviewShortHealthRange(value string) bool {
 }
 
 func usageOverviewHealthWindow(filter dto.UsageQueryFilter, totalBlocks int, span time.Duration) (time.Time, time.Time) {
-	end := time.Now().UTC()
+	end := timeutil.NormalizeStorageTime(time.Now())
 	if filter.EndTime != nil {
-		end = filter.EndTime.UTC()
+		end = timeutil.NormalizeStorageTime(*filter.EndTime)
 	}
 	if isUsageOverviewShortHealthRange(filter.Range) {
 		return end.Add(-usageOverviewHealthPresetWindow), end
@@ -699,7 +702,7 @@ func usageOverviewHealthWindow(filter dto.UsageQueryFilter, totalBlocks int, spa
 }
 
 func updateUsageOverviewHealthBlock(blocks []dto.UsageOverviewHealthBlockRecord, event entities.UsageEvent) {
-	timestamp := event.Timestamp.UTC()
+	timestamp := timeutil.NormalizeStorageTime(event.Timestamp)
 	for index := range blocks {
 		block := &blocks[index]
 		if timestamp.Before(block.StartTime) || !timestamp.Before(block.EndTime) {

--- a/internal/repository/usage_events_test.go
+++ b/internal/repository/usage_events_test.go
@@ -43,6 +43,37 @@ func TestListUsageEventsWithFilterAppliesTimeBoundsAndPagination(t *testing.T) {
 	}
 }
 
+func TestListUsageEventsWithFilterFindsProjectTimezoneStorageTimestamp(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	time.Local = location
+	t.Cleanup(func() { time.Local = previousLocal })
+
+	db, err := OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "usage-events-project-tz.db")})
+	if err != nil {
+		t.Fatalf("OpenDatabase returned error: %v", err)
+	}
+	closeTestDatabase(t, db)
+
+	eventTime := time.Date(2026, 5, 12, 21, 59, 18, 353569620, location)
+	if _, _, err := InsertUsageEvents(db, []entities.UsageEvent{{EventKey: "event-project-tz", Model: "claude-sonnet", Timestamp: eventTime, TotalTokens: 10}}); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+
+	start := time.Date(2026, 5, 12, 13, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 12, 14, 0, 0, 0, time.UTC)
+	page, err := ListUsageEventsWithFilter(db, dto.UsageQueryFilter{StartTime: &start, EndTime: &end, Page: 1, PageSize: 20})
+	if err != nil {
+		t.Fatalf("ListUsageEventsWithFilter returned error: %v", err)
+	}
+	if page.TotalCount != 1 || len(page.Events) != 1 || page.Events[0].Model != "claude-sonnet" {
+		t.Fatalf("expected project timezone timestamp to match UTC query window, got %+v", page)
+	}
+}
+
 func TestListUsageEventsWithFilterPagesByTimestampAndID(t *testing.T) {
 	db, err := OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "usage-events-pages.db")})
 	if err != nil {

--- a/internal/repository/usage_filter_test.go
+++ b/internal/repository/usage_filter_test.go
@@ -24,6 +24,8 @@ func withRepositoryTestLocation(t *testing.T, name string) {
 }
 
 func TestBuildUsageSnapshotWithFilterAppliesTimeBounds(t *testing.T) {
+	withRepositoryTestLocation(t, "Asia/Shanghai")
+
 	db, err := OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "usage-filter.db")})
 	if err != nil {
 		t.Fatalf("OpenDatabase returned error: %v", err)
@@ -55,15 +57,17 @@ func TestBuildUsageSnapshotWithFilterAppliesTimeBounds(t *testing.T) {
 	if len(snapshot.APIs) != 1 {
 		t.Fatalf("expected one API in filtered snapshot, got %+v", snapshot.APIs)
 	}
-	if snapshot.RequestsByHour["2026-04-16T10:00:00Z"] != 1 {
-		t.Fatalf("expected only 10:00 bucket to remain, got %+v", snapshot.RequestsByHour)
+	if snapshot.RequestsByHour["2026-04-16T18:00:00+08:00"] != 1 {
+		t.Fatalf("expected only 18:00 project-time bucket to remain, got %+v", snapshot.RequestsByHour)
 	}
-	if _, ok := snapshot.RequestsByHour["2026-04-16T09:00:00Z"]; ok {
-		t.Fatalf("expected 09:00 bucket to be filtered out, got %+v", snapshot.RequestsByHour)
+	if _, ok := snapshot.RequestsByHour["2026-04-16T17:00:00+08:00"]; ok {
+		t.Fatalf("expected 17:00 project-time bucket to be filtered out, got %+v", snapshot.RequestsByHour)
 	}
 }
 
 func TestBuildUsageOverviewWithFilterComputesSummaryAndSeries(t *testing.T) {
+	withRepositoryTestLocation(t, "Asia/Shanghai")
+
 	db, err := OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "usage-overview.db")})
 	if err != nil {
 		t.Fatalf("OpenDatabase returned error: %v", err)
@@ -163,40 +167,43 @@ func TestBuildUsageOverviewWithFilterComputesSummaryAndSeries(t *testing.T) {
 	if overview.Health.Rows != 7 || overview.Health.Columns != 96 || overview.Health.BucketSeconds != 15*60 {
 		t.Fatalf("unexpected service health grid metadata: %+v", overview.Health)
 	}
-	if overview.Health.WindowStart != time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC) ||
-		overview.Health.WindowEnd != time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC) {
+	location := time.Local
+	if overview.Health.WindowStart != time.Date(2026, 4, 11, 8, 0, 0, 0, location) ||
+		overview.Health.WindowEnd != time.Date(2026, 4, 18, 8, 0, 0, 0, location) {
 		t.Fatalf("unexpected service health window: %+v", overview.Health)
 	}
 	if len(overview.Health.BlockDetails) != overview.Health.Rows*overview.Health.Columns {
 		t.Fatalf("expected full service health grid, got %d blocks", len(overview.Health.BlockDetails))
 	}
 	firstBlock := overview.Health.BlockDetails[0]
-	if firstBlock.StartTime != time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC) ||
-		firstBlock.EndTime != time.Date(2026, 4, 11, 0, 15, 0, 0, time.UTC) ||
+	if firstBlock.StartTime != time.Date(2026, 4, 11, 8, 0, 0, 0, location) ||
+		firstBlock.EndTime != time.Date(2026, 4, 11, 8, 15, 0, 0, location) ||
 		firstBlock.Success != 0 || firstBlock.Failure != 0 || firstBlock.Rate != -1 {
 		t.Fatalf("unexpected first health block: %+v", firstBlock)
 	}
 	populatedBlock := overview.Health.BlockDetails[517]
-	if populatedBlock.StartTime != time.Date(2026, 4, 16, 9, 15, 0, 0, time.UTC) ||
-		populatedBlock.EndTime != time.Date(2026, 4, 16, 9, 30, 0, 0, time.UTC) ||
+	if populatedBlock.StartTime != time.Date(2026, 4, 16, 17, 15, 0, 0, location) ||
+		populatedBlock.EndTime != time.Date(2026, 4, 16, 17, 30, 0, 0, location) ||
 		populatedBlock.Success != 1 || populatedBlock.Failure != 0 || populatedBlock.Rate != 1 {
 		t.Fatalf("unexpected populated health block: %+v", populatedBlock)
 	}
 	failedBlock := overview.Health.BlockDetails[523]
-	if failedBlock.StartTime != time.Date(2026, 4, 16, 10, 45, 0, 0, time.UTC) ||
-		failedBlock.EndTime != time.Date(2026, 4, 16, 11, 0, 0, 0, time.UTC) ||
+	if failedBlock.StartTime != time.Date(2026, 4, 16, 18, 45, 0, 0, location) ||
+		failedBlock.EndTime != time.Date(2026, 4, 16, 19, 0, 0, 0, location) ||
 		failedBlock.Success != 0 || failedBlock.Failure != 1 || failedBlock.Rate != 0 {
 		t.Fatalf("unexpected failed health block: %+v", failedBlock)
 	}
 	latestPopulatedBlock := overview.Health.BlockDetails[620]
-	if latestPopulatedBlock.StartTime != time.Date(2026, 4, 17, 11, 0, 0, 0, time.UTC) ||
-		latestPopulatedBlock.EndTime != time.Date(2026, 4, 17, 11, 15, 0, 0, time.UTC) ||
+	if latestPopulatedBlock.StartTime != time.Date(2026, 4, 17, 19, 0, 0, 0, location) ||
+		latestPopulatedBlock.EndTime != time.Date(2026, 4, 17, 19, 15, 0, 0, location) ||
 		latestPopulatedBlock.Success != 1 || latestPopulatedBlock.Failure != 0 || latestPopulatedBlock.Rate != 1 {
 		t.Fatalf("unexpected latest populated health block: %+v", latestPopulatedBlock)
 	}
 }
 
 func TestBuildUsageOverviewFromEventsBuildsSnapshotAndOverviewInOnePass(t *testing.T) {
+	withRepositoryTestLocation(t, "Asia/Shanghai")
+
 	events := []entities.UsageEvent{
 		{
 			EventKey: "event-1", APIGroupKey: "provider-a", Model: "claude-sonnet",
@@ -255,13 +262,13 @@ func TestBuildUsageOverviewFromEventsBuildsSnapshotAndOverviewInOnePass(t *testi
 	if overview.Summary.CostAvailable {
 		t.Fatalf("expected cost to be unavailable when any event model with billable tokens is unpriced, got %+v", overview.Summary)
 	}
-	if overview.Series.Requests["2026-04-16T09:00:00Z"] != 1 || overview.Series.Requests["2026-04-16T10:00:00Z"] != 1 {
+	if overview.Series.Requests["2026-04-16T17:00:00+08:00"] != 1 || overview.Series.Requests["2026-04-16T18:00:00+08:00"] != 1 {
 		t.Fatalf("unexpected hourly request series: %+v", overview.Series.Requests)
 	}
-	if overview.HourlySeries.Models["claude-sonnet"].Requests["2026-04-16T09:00:00Z"] != 1 {
+	if overview.HourlySeries.Models["claude-sonnet"].Requests["2026-04-16T17:00:00+08:00"] != 1 {
 		t.Fatalf("expected claude-sonnet hourly model series, got %+v", overview.HourlySeries.Models)
 	}
-	if overview.HourlySeries.Models["unknown"].Tokens["2026-04-16T10:00:00Z"] != 3150 {
+	if overview.HourlySeries.Models["unknown"].Tokens["2026-04-16T18:00:00+08:00"] != 3150 {
 		t.Fatalf("expected unknown hourly model token series, got %+v", overview.HourlySeries.Models)
 	}
 	if overview.DailySeries.Models["claude-sonnet"].Requests["2026-04-16"] != 1 {
@@ -473,6 +480,8 @@ func TestBuildUsageOverviewWithFilterReturnsUnavailableCostWithoutPricing(t *tes
 }
 
 func TestBuildUsageOverviewWithFilterUsesExactPresetWindowMinutes(t *testing.T) {
+	withRepositoryTestLocation(t, "Asia/Shanghai")
+
 	db, err := OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "usage-overview-preset-window.db")})
 	if err != nil {
 		t.Fatalf("OpenDatabase returned error: %v", err)
@@ -493,7 +502,7 @@ func TestBuildUsageOverviewWithFilterUsesExactPresetWindowMinutes(t *testing.T) 
 			start:           time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC),
 			end:             time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC),
 			expectMinutes:   1440,
-			expectBucketKey: "2026-04-17T12:00:00Z",
+			expectBucketKey: "2026-04-17T20:00:00+08:00",
 		},
 		{
 			name:            "7d uses daily buckets with 10080 minute window",
@@ -575,16 +584,16 @@ func TestBuildUsageOverviewWithFilterBuildsLatestHourlySeriesForLongRanges(t *te
 	if len(overview.Series.Requests) != 2 || overview.Series.Requests["2026-04-17"] != 1 || overview.Series.Requests["2026-04-24"] != 2 {
 		t.Fatalf("expected main overview series to remain daily for 7d, got %+v", overview.Series.Requests)
 	}
-	if _, ok := overview.HourlySeries.Requests["2026-04-17T08:00:00Z"]; ok {
+	if _, ok := overview.HourlySeries.Requests["2026-04-17T16:00:00+08:00"]; ok {
 		t.Fatalf("expected latest hourly series to exclude buckets before the latest 24 hours, got %+v", overview.HourlySeries.Requests)
 	}
-	if overview.HourlySeries.Requests["2026-04-23T22:00:00Z"] != 1 || overview.HourlySeries.Requests["2026-04-23T23:00:00Z"] != 1 {
+	if overview.HourlySeries.Requests["2026-04-24T06:00:00+08:00"] != 1 || overview.HourlySeries.Requests["2026-04-24T07:00:00+08:00"] != 1 {
 		t.Fatalf("unexpected latest hourly request series: %+v", overview.HourlySeries.Requests)
 	}
-	if overview.HourlySeries.Cost["2026-04-23T22:00:00Z"] != 1.999993 || overview.HourlySeries.Cost["2026-04-23T23:00:00Z"] != 2.999983 {
+	if overview.HourlySeries.Cost["2026-04-24T06:00:00+08:00"] != 1.999993 || overview.HourlySeries.Cost["2026-04-24T07:00:00+08:00"] != 2.999983 {
 		t.Fatalf("unexpected latest hourly cost series: %+v", overview.HourlySeries.Cost)
 	}
-	if overview.HourlySeries.InputTokens["2026-04-23T22:00:00Z"] != 2_000_000 || overview.HourlySeries.OutputTokens["2026-04-23T23:00:00Z"] != 13 {
+	if overview.HourlySeries.InputTokens["2026-04-24T06:00:00+08:00"] != 2_000_000 || overview.HourlySeries.OutputTokens["2026-04-24T07:00:00+08:00"] != 13 {
 		t.Fatalf("unexpected latest hourly token category series: %+v", overview.HourlySeries)
 	}
 	if overview.DailySeries.Requests["2026-04-17"] != 1 || overview.DailySeries.Requests["2026-04-24"] != 2 {

--- a/internal/repository/usage_identities.go
+++ b/internal/repository/usage_identities.go
@@ -8,6 +8,7 @@ import (
 
 	"cpa-usage-keeper/internal/entities"
 	"cpa-usage-keeper/internal/repository/dto"
+	"cpa-usage-keeper/internal/timeutil"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -194,9 +195,9 @@ func AggregateUsageIdentityStats(ctx context.Context, db *gorm.DB, now time.Time
 				"reasoning_tokens":               identity.ReasoningTokens + delta.ReasoningTokens,
 				"cached_tokens":                  identity.CachedTokens + delta.CachedTokens,
 				"total_tokens":                   identity.TotalTokens + delta.TotalTokens,
-				"first_used_at":                  firstUsedAt,
-				"last_used_at":                   lastUsedAt,
-				"stats_updated_at":               now,
+				"first_used_at":                  formatStorageTimePtr(firstUsedAt),
+				"last_used_at":                   formatStorageTimePtr(lastUsedAt),
+				"stats_updated_at":               timeutil.FormatStorageTime(now),
 				"last_aggregated_usage_event_id": delta.MaxUsageEventID,
 			}
 			if err := tx.Model(&entities.UsageIdentity{}).Where("id = ?", identity.ID).Updates(updates).Error; err != nil {
@@ -300,11 +301,28 @@ func normalizeUsageIdentities(identities []entities.UsageIdentity, authType enti
 		identity.ProjectID = trimOptionalString(identity.ProjectID)
 		identity.PlanType = trimOptionalString(identity.PlanType)
 		identity.IsDeleted = false
+		identity.ActiveStart = normalizeStorageTimePtr(identity.ActiveStart)
+		identity.ActiveUntil = normalizeStorageTimePtr(identity.ActiveUntil)
 		identity.DeletedAt = nil
 		normalized = append(normalized, identity)
 	}
 
 	return normalized, incomingIdentities
+}
+
+func normalizeStorageTimePtr(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	normalized := timeutil.NormalizeStorageTime(*value)
+	return &normalized
+}
+
+func formatStorageTimePtr(value *time.Time) any {
+	if value == nil {
+		return nil
+	}
+	return timeutil.FormatStorageTime(*value)
 }
 
 func trimOptionalString(value *string) *string {
@@ -365,7 +383,7 @@ func markStaleUsageIdentitiesDeleted(tx *gorm.DB, query *gorm.DB, incomingIdenti
 		end := min(start+insertBatchSize(entities.UsageIdentity{}), len(staleIDs))
 		if err := tx.Model(&entities.UsageIdentity{}).
 			Where("id IN ?", staleIDs[start:end]).
-			Updates(map[string]any{"is_deleted": true, "deleted_at": now}).Error; err != nil {
+			Updates(map[string]any{"is_deleted": true, "deleted_at": timeutil.FormatStorageTime(now)}).Error; err != nil {
 			return fmt.Errorf("%s: %w", context, err)
 		}
 	}

--- a/internal/repository/usage_test.go
+++ b/internal/repository/usage_test.go
@@ -26,6 +26,8 @@ func TestBuildUsageSnapshotReturnsEmptyStructureWithoutEvents(t *testing.T) {
 }
 
 func TestBuildUsageSnapshotAggregatesEvents(t *testing.T) {
+	withRepositoryTestLocation(t, "Asia/Shanghai")
+
 	db := openUsageTestDatabase(t)
 	events := []entities.UsageEvent{
 		{EventKey: "event-1", APIGroupKey: "provider-a", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 16, 9, 0, 0, 0, time.UTC), Source: "codex-a", AuthIndex: "1", Failed: false, LatencyMS: 100, InputTokens: 10, OutputTokens: 20, ReasoningTokens: 5, CachedTokens: 0, TotalTokens: 35},
@@ -46,7 +48,7 @@ func TestBuildUsageSnapshotAggregatesEvents(t *testing.T) {
 	if snapshot.RequestsByDay["2026-04-16"] != 2 || snapshot.RequestsByDay["2026-04-17"] != 1 {
 		t.Fatalf("unexpected requests by day: %+v", snapshot.RequestsByDay)
 	}
-	if snapshot.TokensByHour["2026-04-16T09:00:00Z"] != 35 || snapshot.TokensByHour["2026-04-17T10:00:00Z"] != 185 {
+	if snapshot.TokensByHour["2026-04-16T17:00:00+08:00"] != 35 || snapshot.TokensByHour["2026-04-17T18:00:00+08:00"] != 185 {
 		t.Fatalf("unexpected tokens by hour: %+v", snapshot.TokensByHour)
 	}
 	providerA := snapshot.APIs["provider-a"]

--- a/internal/service/flatten.go
+++ b/internal/service/flatten.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"cpa-usage-keeper/internal/repository/dto"
+	"cpa-usage-keeper/internal/timeutil"
 )
 
 func BuildEventKey(apiGroupKey, model string, timestamp time.Time, source, authIndex string, failed bool, tokens dto.TokenStats) string {
@@ -16,7 +17,7 @@ func BuildEventKey(apiGroupKey, model string, timestamp time.Time, source, authI
 		"%s|%s|%s|%s|%s|%t|%d|%d|%d|%d|%d",
 		strings.TrimSpace(apiGroupKey),
 		strings.TrimSpace(model),
-		timestamp.UTC().Format(time.RFC3339Nano),
+		timeutil.FormatStorageTime(timestamp),
 		strings.TrimSpace(source),
 		strings.TrimSpace(authIndex),
 		failed,

--- a/internal/service/flatten_test.go
+++ b/internal/service/flatten_test.go
@@ -1,10 +1,15 @@
 package service
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"cpa-usage-keeper/internal/repository/dto"
+	"cpa-usage-keeper/internal/timeutil"
 )
 
 func TestBuildEventKeyIsStable(t *testing.T) {
@@ -16,5 +21,39 @@ func TestBuildEventKeyIsStable(t *testing.T) {
 
 	if key1 != key2 {
 		t.Fatalf("expected stable event key, got %s and %s", key1, key2)
+	}
+}
+
+func TestBuildEventKeyUsesStorageTimeFormat(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	t.Cleanup(func() { time.Local = previousLocal })
+	time.Local = location
+
+	timestamp := time.Date(2026, 4, 16, 12, 0, 0, 123, time.UTC)
+	tokens := dto.TokenStats{InputTokens: 1, OutputTokens: 2, ReasoningTokens: 3, CachedTokens: 4, TotalTokens: 10}
+
+	payload := fmt.Sprintf(
+		"%s|%s|%s|%s|%s|%t|%d|%d|%d|%d|%d",
+		strings.TrimSpace("provider-a"),
+		strings.TrimSpace("claude-sonnet"),
+		timeutil.FormatStorageTime(timestamp),
+		strings.TrimSpace("source-a"),
+		strings.TrimSpace("0"),
+		false,
+		tokens.InputTokens,
+		tokens.OutputTokens,
+		tokens.ReasoningTokens,
+		tokens.CachedTokens,
+		tokens.TotalTokens,
+	)
+	sum := sha256.Sum256([]byte(payload))
+	expected := hex.EncodeToString(sum[:])
+
+	if key := BuildEventKey("provider-a", "claude-sonnet", timestamp, "source-a", "0", false, tokens); key != expected {
+		t.Fatalf("expected storage-time event key %s, got %s", expected, key)
 	}
 }

--- a/internal/service/redis_usage.go
+++ b/internal/service/redis_usage.go
@@ -9,6 +9,7 @@ import (
 
 	"cpa-usage-keeper/internal/entities"
 	"cpa-usage-keeper/internal/repository/dto"
+	"cpa-usage-keeper/internal/timeutil"
 )
 
 type RedisQueue interface {
@@ -63,9 +64,9 @@ func (d queuedUsageDetail) toUsageEvent(fetchedAt time.Time) entities.UsageEvent
 	tokens := normalizeTokens(d.Tokens)
 	apiGroupKey := firstNonEmpty(d.APIKey, d.Provider, d.Endpoint, "unknown")
 	model := firstNonEmpty(d.Model, "unknown")
-	timestamp := d.Timestamp.UTC()
+	timestamp := timeutil.NormalizeStorageTime(d.Timestamp)
 	if timestamp.IsZero() {
-		timestamp = fetchedAt.UTC()
+		timestamp = timeutil.NormalizeStorageTime(fetchedAt)
 	}
 	source := strings.TrimSpace(d.Source)
 	authIndex := strings.TrimSpace(d.AuthIndex)

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -10,6 +10,7 @@ import (
 	"cpa-usage-keeper/internal/cpa"
 	"cpa-usage-keeper/internal/entities"
 	"cpa-usage-keeper/internal/repository"
+	"cpa-usage-keeper/internal/timeutil"
 
 	"cpa-usage-keeper/internal/cpa/dto/authfiles"
 	"cpa-usage-keeper/internal/cpa/dto/providerconfig"
@@ -141,7 +142,7 @@ func (s *SyncService) SyncMetadata(ctx context.Context) error {
 		return err
 	}
 	logrus.Debug("metadata sync started")
-	fetchedAt := s.now().UTC()
+	fetchedAt := timeutil.NormalizeStorageTime(s.now())
 	authFilesResult, authFilesErr := s.metadataFetcher.FetchAuthFiles(ctx)
 	providerConfig, fetchedProviderTypes, providerMetadataErr := fetchProviderMetadata(ctx, s.metadataFetcher)
 	authSyncErr := syncAuthFiles(ctx, s.db, authFilesResult, authFilesErr, fetchedAt)
@@ -176,7 +177,7 @@ func (s *SyncService) PullRedisUsageInbox(ctx context.Context) (*servicedto.Redi
 		return nil, fmt.Errorf("sync service redis queue is nil")
 	}
 
-	fetchedAt := s.now().UTC()
+	fetchedAt := timeutil.NormalizeStorageTime(s.now())
 	messages, err := s.redisQueue.PopUsage(ctx)
 	if err != nil {
 		return &servicedto.RedisInboxPullResult{Status: "failed"}, fmt.Errorf("fetch redis usage: %w", err)
@@ -206,7 +207,7 @@ func (s *SyncService) ProcessRedisUsageInbox(ctx context.Context) (*servicedto.R
 	if err := s.validate(syncMetadataOptional); err != nil {
 		return nil, err
 	}
-	fetchedAt := s.now().UTC()
+	fetchedAt := timeutil.NormalizeStorageTime(s.now())
 	processableRows, err := repository.ListProcessableRedisUsageInbox(s.db, redisInboxProcessLimit)
 	if err != nil {
 		return &servicedto.RedisBatchSyncResult{Status: "failed"}, fmt.Errorf("list processable redis usage inbox: %w", err)
@@ -345,7 +346,7 @@ func alignUsageEventKeysWithExistingCanonicalEvents(db *gorm.DB, events []entiti
 	canonicalEventKeys := make(map[string]string, len(events))
 	consumedCanonicalKeys := make(map[string]struct{}, len(events))
 	for i := range events {
-		events[i].Timestamp = events[i].Timestamp.UTC()
+		events[i].Timestamp = timeutil.NormalizeStorageTime(events[i].Timestamp)
 		canonicalKey := canonicalUsageEventKey(events[i])
 		incomingKey := strings.TrimSpace(events[i].EventKey)
 		if strings.TrimSpace(events[i].RequestID) != "" {

--- a/internal/service/usage_filter_test.go
+++ b/internal/service/usage_filter_test.go
@@ -40,6 +40,14 @@ func TestUsageServiceGetUsageWithFilterDelegatesToFilteredSnapshot(t *testing.T)
 }
 
 func TestUsageServiceGetUsageOverviewDelegatesToFilteredOverview(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	t.Cleanup(func() { time.Local = previousLocal })
+	time.Local = location
+
 	db, err := repository.OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "usage-service-overview.db")})
 	if err != nil {
 		t.Fatalf("OpenDatabase returned error: %v", err)
@@ -73,10 +81,10 @@ func TestUsageServiceGetUsageOverviewDelegatesToFilteredOverview(t *testing.T) {
 	if overview.Summary.WindowMinutes != 1440 {
 		t.Fatalf("expected 24h overview to use exact 1440 minute window, got %+v", overview.Summary)
 	}
-	if overview.Series.Requests["2026-04-16T09:00:00Z"] != 1 || overview.Series.Requests["2026-04-16T10:00:00Z"] != 1 {
+	if overview.Series.Requests["2026-04-16T17:00:00+08:00"] != 1 || overview.Series.Requests["2026-04-16T18:00:00+08:00"] != 1 {
 		t.Fatalf("expected hourly request series values, got %+v", overview.Series)
 	}
-	if math.Abs(overview.Series.Cost["2026-04-16T09:00:00Z"]-0.01023) > 0.000000001 || math.Abs(overview.Series.Cost["2026-04-16T10:00:00Z"]-0.00525) > 0.000000001 {
+	if math.Abs(overview.Series.Cost["2026-04-16T17:00:00+08:00"]-0.01023) > 0.000000001 || math.Abs(overview.Series.Cost["2026-04-16T18:00:00+08:00"]-0.00525) > 0.000000001 {
 		t.Fatalf("expected hourly cost series values, got %+v", overview.Series)
 	}
 }

--- a/internal/timeutil/storage.go
+++ b/internal/timeutil/storage.go
@@ -1,0 +1,50 @@
+package timeutil
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+func NormalizeStorageTime(t time.Time) time.Time {
+	return t.In(time.Local)
+}
+
+func FormatStorageTime(t time.Time) string {
+	return NormalizeStorageTime(t).Format(time.RFC3339Nano)
+}
+
+// 旧库带 offset 的值按原 offset 解析；不带 offset 的值按项目 TZ 本地时间解析。
+func ParseStorageTime(value string) (time.Time, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return time.Time{}, fmt.Errorf("storage time is empty")
+	}
+
+	// 先处理带明确时区的格式，保留原始 instant 后再交给格式化阶段转项目 TZ。
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05-07:00",
+	} {
+		parsed, err := time.Parse(layout, trimmed)
+		if err == nil {
+			return parsed, nil
+		}
+	}
+
+	// 无时区旧值代表项目本地时间，不能当 UTC 迁移。
+	for _, layout := range []string{
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02 15:04:05",
+		"2006-01-02T15:04:05",
+	} {
+		parsed, err := time.ParseInLocation(layout, trimmed, time.Local)
+		if err == nil {
+			return parsed, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("parse storage time %q", value)
+}

--- a/internal/timeutil/storage_serializer.go
+++ b/internal/timeutil/storage_serializer.go
@@ -1,0 +1,63 @@
+package timeutil
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"reflect"
+	"time"
+
+	"gorm.io/gorm/schema"
+)
+
+func init() {
+	schema.RegisterSerializer("storageTime", StorageTimeSerializer{})
+}
+
+type StorageTimeSerializer struct{}
+
+// GORM 读库时统一把历史格式和新格式还原成项目 TZ 下的 time.Time。
+func (StorageTimeSerializer) Scan(ctx context.Context, field *schema.Field, dst reflect.Value, dbValue any) error {
+	if dbValue == nil {
+		return field.Set(ctx, dst, nil)
+	}
+	var raw string
+	switch value := dbValue.(type) {
+	case time.Time:
+		return field.Set(ctx, dst, NormalizeStorageTime(value))
+	case string:
+		raw = value
+	case []byte:
+		raw = string(value)
+	default:
+		return fmt.Errorf("scan storage time from %T", dbValue)
+	}
+	parsed, err := ParseStorageTime(raw)
+	if err != nil {
+		return err
+	}
+	return field.Set(ctx, dst, NormalizeStorageTime(parsed))
+}
+
+// GORM 写库时统一输出 RFC3339Nano + 项目 TZ offset，避免 SQLite TEXT 混格式比较。
+func (StorageTimeSerializer) Value(ctx context.Context, field *schema.Field, dst reflect.Value, fieldValue any) (any, error) {
+	if fieldValue == nil {
+		return nil, nil
+	}
+	switch value := fieldValue.(type) {
+	case time.Time:
+		if value.IsZero() {
+			return nil, nil
+		}
+		return FormatStorageTime(value), nil
+	case *time.Time:
+		if value == nil || value.IsZero() {
+			return nil, nil
+		}
+		return FormatStorageTime(*value), nil
+	case driver.Valuer:
+		return value.Value()
+	default:
+		return fieldValue, nil
+	}
+}

--- a/internal/timeutil/storage_test.go
+++ b/internal/timeutil/storage_test.go
@@ -1,0 +1,72 @@
+package timeutil
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatStorageTimeUsesProjectTimezoneOffset(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	time.Local = location
+	t.Cleanup(func() { time.Local = previousLocal })
+
+	input := time.Date(2026, 5, 12, 13, 59, 18, 353569620, time.UTC)
+
+	got := FormatStorageTime(input)
+
+	if got != "2026-05-12T21:59:18.35356962+08:00" {
+		t.Fatalf("expected Asia/Shanghai RFC3339Nano storage time, got %q", got)
+	}
+}
+
+func TestParseStorageTimeUsesEmbeddedOffsetWhenPresent(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	time.Local = location
+	t.Cleanup(func() { time.Local = previousLocal })
+
+	for _, input := range []string{
+		"2026-05-12 13:47:39.744240399+00:00",
+		"2026-05-12T13:47:39.744240399Z",
+	} {
+		parsed, err := ParseStorageTime(input)
+		if err != nil {
+			t.Fatalf("ParseStorageTime(%q) returned error: %v", input, err)
+		}
+		got := FormatStorageTime(parsed)
+		if got != "2026-05-12T21:47:39.744240399+08:00" {
+			t.Fatalf("expected %q to convert from embedded offset, got %q", input, got)
+		}
+	}
+}
+
+func TestParseStorageTimeUsesProjectTimezoneForNaiveValues(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	time.Local = location
+	t.Cleanup(func() { time.Local = previousLocal })
+
+	for _, input := range []string{
+		"2026-05-12 13:47:39.744240399",
+		"2026-05-12T13:47:39.744240399",
+	} {
+		parsed, err := ParseStorageTime(input)
+		if err != nil {
+			t.Fatalf("ParseStorageTime(%q) returned error: %v", input, err)
+		}
+		got := FormatStorageTime(parsed)
+		if got != "2026-05-12T13:47:39.744240399+08:00" {
+			t.Fatalf("expected %q to be interpreted in project timezone, got %q", input, got)
+		}
+	}
+}

--- a/web/src/components/usage/CostTrendChart.test.ts
+++ b/web/src/components/usage/CostTrendChart.test.ts
@@ -171,6 +171,31 @@ describe('buildOverviewCostTrendSeries', () => {
     expect(result.hasData).toBe(true);
   });
 
+  it('keeps short-range hour view aligned to project timezone backend buckets', () => {
+    const result = buildOverviewCostTrendSeries({
+      usage: {
+        ...usageWithBackendCost,
+        hourly_series: {
+          ...usageWithBackendCost.hourly_series!,
+          cost: {
+            '2026-04-24T02:00:00+08:00': 1.47,
+            '2026-04-24T03:00:00+08:00': 0,
+            '2026-04-24T04:00:00+08:00': 0,
+            '2026-04-24T05:00:00+08:00': 0,
+            '2026-04-24T06:00:00+08:00': 0,
+          },
+        },
+      },
+      period: 'hour',
+      hourWindowHours: 4,
+      endMs: Date.parse('2026-04-24T06:16:00+08:00'),
+    });
+
+    expect(result.labels).toHaveLength(5);
+    expect(result.data).toEqual([1.47, 0, 0, 0, 0]);
+    expect(result.hasData).toBe(true);
+  });
+
   it('keeps short-range hour view aligned to backend partial-hour buckets', () => {
     const result = buildOverviewCostTrendSeries({
       usage: {

--- a/web/src/components/usage/CostTrendChart.tsx
+++ b/web/src/components/usage/CostTrendChart.tsx
@@ -27,8 +27,38 @@ interface OverviewCostTrendSeries {
   costAvailable: boolean;
 }
 
+const HOUR_MS = 60 * 60 * 1000;
+const HOUR_BUCKET_PATTERN = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+
+const parseHourBucketOffsetMinutes = (key?: string): number => {
+  const match = key?.match(HOUR_BUCKET_PATTERN);
+  const offset = match?.[7];
+  if (!offset || offset === 'Z') return 0;
+  const sign = offset[0] === '-' ? -1 : 1;
+  const hours = Number(offset.slice(1, 3));
+  const minutes = Number(offset.slice(4, 6));
+  return sign * ((hours * 60) + minutes);
+};
+
+const startOfOffsetHourMs = (timestampMs: number, offsetMinutes: number): number => {
+  const shiftedMs = timestampMs + offsetMinutes * 60 * 1000;
+  return Math.floor(shiftedMs / HOUR_MS) * HOUR_MS - offsetMinutes * 60 * 1000;
+};
+
+const formatHourBucketKey = (timestampMs: number, referenceKey?: string): string => {
+  const offsetMinutes = parseHourBucketOffsetMinutes(referenceKey);
+  const shifted = new Date(timestampMs + offsetMinutes * 60 * 1000);
+  const pad = (value: number) => String(value).padStart(2, '0');
+  const offset = offsetMinutes === 0
+    ? 'Z'
+    : `${offsetMinutes < 0 ? '-' : '+'}${pad(Math.floor(Math.abs(offsetMinutes) / 60))}:${pad(Math.abs(offsetMinutes) % 60)}`;
+  return `${shifted.getUTCFullYear()}-${pad(shifted.getUTCMonth() + 1)}-${pad(shifted.getUTCDate())}T${pad(shifted.getUTCHours())}:00:00${offset}`;
+};
+
 const formatHourLabel = (key: string, isFinalBucket = false): string => {
   if (isFinalBucket) return '24:00';
+  const match = key.match(HOUR_BUCKET_PATTERN);
+  if (match) return `${match[4]}:${match[5]}`;
   const date = new Date(key);
   if (Number.isNaN(date.getTime())) return key;
   return `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
@@ -49,11 +79,9 @@ const resolveHourBucketCount = (hourWindowHours?: number, includeFinalBucket = f
   return includeFinalBucket ? resolvedHours + 1 : resolvedHours >= 24 ? 24 : resolvedHours + 1;
 };
 
-const toUtcHourMs = (value: string | number): number => {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return NaN;
-  date.setUTCMinutes(0, 0, 0);
-  return date.getTime();
+const toOffsetHourMs = (value: string | number): number => {
+  const timestampMs = typeof value === 'number' ? value : Date.parse(value);
+  return Number.isNaN(timestampMs) ? NaN : startOfOffsetHourMs(timestampMs, parseHourBucketOffsetMinutes(String(value)));
 };
 
 export function buildOverviewCostTrendSeries({
@@ -87,16 +115,16 @@ export function buildOverviewCostTrendSeries({
 
   if (period === 'hour') {
     const bucketCount = resolveHourBucketCount(hourWindowHours, includeFinalHourBucket);
-    const anchorMs = Number.isFinite(endMs) && endMs ? endMs : (hourlyEntries.length ? Date.parse(hourlyEntries[hourlyEntries.length - 1][0]) : Date.now());
-    const currentHour = new Date(anchorMs);
-    currentHour.setUTCMinutes(0, 0, 0);
+    const referenceKey = hourlyEntries[hourlyEntries.length - 1]?.[0];
+    const offsetMinutes = parseHourBucketOffsetMinutes(referenceKey);
+    const anchorMs = Number.isFinite(endMs) && endMs ? endMs : (referenceKey ? Date.parse(referenceKey) : Date.now());
     const hourMs = 60 * 60 * 1000;
-    const earliestMs = currentHour.getTime() - ((bucketCount - 1) * hourMs);
+    const earliestMs = startOfOffsetHourMs(anchorMs, offsetMinutes) - ((bucketCount - 1) * hourMs);
     const labels = Array.from({ length: bucketCount }, (_, index) => {
       const bucketMs = earliestMs + (index * hourMs);
-      return formatHourLabel(new Date(bucketMs).toISOString(), includeFinalHourBucket && index === bucketCount - 1);
+      return formatHourLabel(formatHourBucketKey(bucketMs, referenceKey), includeFinalHourBucket && index === bucketCount - 1);
     });
-    const valueByHour = new Map(hourlyEntries.map(([label, value]) => [toUtcHourMs(label), Number(value ?? 0)]));
+    const valueByHour = new Map(hourlyEntries.map(([label, value]) => [toOffsetHourMs(label), Number(value ?? 0)]));
     const data = Array.from({ length: bucketCount }, (_, index) => {
       const bucketMs = earliestMs + (index * hourMs);
       return valueByHour.get(bucketMs) ?? 0;

--- a/web/src/components/usage/OverviewCharts.logic.test.ts
+++ b/web/src/components/usage/OverviewCharts.logic.test.ts
@@ -377,6 +377,40 @@ describe('overview chart data flow', () => {
     expect(tokens.datasets[0]?.data[24]).toBe(0);
   });
 
+  it('keeps short-range overview hour charts aligned to project timezone backend buckets', () => {
+    const chartUsage = {
+      ...overviewUsage.usage,
+      requests_by_hour: {
+        '2026-04-24T02:00:00+08:00': 34,
+        '2026-04-24T03:00:00+08:00': 41,
+        '2026-04-24T04:00:00+08:00': 9,
+        '2026-04-24T05:00:00+08:00': 16,
+        '2026-04-24T06:00:00+08:00': 93,
+      },
+      tokens_by_hour: {
+        '2026-04-24T02:00:00+08:00': 3664982,
+        '2026-04-24T03:00:00+08:00': 5003310,
+        '2026-04-24T04:00:00+08:00': 1362696,
+        '2026-04-24T05:00:00+08:00': 2583370,
+        '2026-04-24T06:00:00+08:00': 6477989,
+      },
+    };
+
+    const requests = buildChartData(chartUsage, 'hour', 'requests', ['all'], {
+      hourWindowHours: 4,
+      endMs: Date.parse('2026-04-24T06:16:00+08:00'),
+    });
+    const tokens = buildChartData(chartUsage, 'hour', 'tokens', ['all'], {
+      hourWindowHours: 4,
+      endMs: Date.parse('2026-04-24T06:16:00+08:00'),
+    });
+
+    expect(requests.labels).toHaveLength(5);
+    expect(requests.datasets[0]?.data).toEqual([34, 41, 9, 16, 93]);
+    expect(tokens.labels).toHaveLength(5);
+    expect(tokens.datasets[0]?.data[0]).toBe(3664982);
+  });
+
   it('keeps short-range overview hour charts aligned to backend partial-hour buckets', () => {
     const chartUsage = {
       ...overviewUsage.usage,
@@ -494,6 +528,30 @@ describe('overview chart data flow', () => {
     expect(series.dataByCategory.input.slice(0, 23)).toEqual(Array(23).fill(0));
     expect(series.dataByCategory.input[23]).toBe(100);
     expect(series.dataByCategory.output[23]).toBe(50);
+  });
+
+  it('aligns token breakdown sub-day hour buckets with project timezone backend buckets', () => {
+    const series = buildTokenBreakdownChartSeries({
+      usage: {
+        ...overviewUsage,
+        hourly_series: {
+          ...overviewUsage.hourly_series!,
+          input_tokens: {
+            '2026-04-24T02:00:00+08:00': 100,
+            '2026-04-24T04:00:00+08:00': 200,
+          },
+          output_tokens: {},
+          cached_tokens: {},
+          reasoning_tokens: {},
+        },
+      },
+      period: 'hour',
+      hourWindowHours: 4,
+      endMs: Date.parse('2026-04-24T04:16:00+08:00'),
+    });
+
+    expect(series.labels).toHaveLength(5);
+    expect(series.dataByCategory.input).toEqual([0, 0, 100, 0, 200]);
   });
 
   it('aligns token breakdown sub-day hour buckets with request and token trends', () => {

--- a/web/src/components/usage/TokenBreakdownChart.tsx
+++ b/web/src/components/usage/TokenBreakdownChart.tsx
@@ -18,6 +18,7 @@ const TOKEN_COLORS: Record<TokenCategory, { border: string; bg: string }> = {
 
 const CATEGORIES: TokenCategory[] = ['input', 'output', 'cached', 'reasoning'];
 const HOUR_MS = 60 * 60 * 1000;
+const HOUR_BUCKET_PATTERN = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
 
 type TokenBreakdownChartPeriod = 'hour' | 'day';
 
@@ -44,11 +45,36 @@ const resolveHourBucketCount = (hourWindowHours?: number, includeFinalBucket = f
   return includeFinalBucket ? resolvedHours + 1 : resolvedHours >= 24 ? 24 : resolvedHours + 1;
 };
 
-const formatHourBucketKey = (timestampMs: number): string => `${new Date(timestampMs).toISOString().slice(0, 13)}:00:00Z`;
+const parseHourBucketOffsetMinutes = (key?: string): number => {
+  const match = key?.match(HOUR_BUCKET_PATTERN);
+  const offset = match?.[7];
+  if (!offset || offset === 'Z') return 0;
+  const sign = offset[0] === '-' ? -1 : 1;
+  const hours = Number(offset.slice(1, 3));
+  const minutes = Number(offset.slice(4, 6));
+  return sign * ((hours * 60) + minutes);
+};
+
+const startOfOffsetHourMs = (timestampMs: number, offsetMinutes: number): number => {
+  const shiftedMs = timestampMs + offsetMinutes * 60 * 1000;
+  return Math.floor(shiftedMs / HOUR_MS) * HOUR_MS - offsetMinutes * 60 * 1000;
+};
+
+const formatHourBucketKey = (timestampMs: number, referenceKey?: string): string => {
+  const offsetMinutes = parseHourBucketOffsetMinutes(referenceKey);
+  const shifted = new Date(timestampMs + offsetMinutes * 60 * 1000);
+  const pad = (value: number) => String(value).padStart(2, '0');
+  const offset = offsetMinutes === 0
+    ? 'Z'
+    : `${offsetMinutes < 0 ? '-' : '+'}${pad(Math.floor(Math.abs(offsetMinutes) / 60))}:${pad(Math.abs(offsetMinutes) % 60)}`;
+  return `${shifted.getUTCFullYear()}-${pad(shifted.getUTCMonth() + 1)}-${pad(shifted.getUTCDate())}T${pad(shifted.getUTCHours())}:00:00${offset}`;
+};
 
 const formatChartLabel = (label: string, period: TokenBreakdownChartPeriod, isFinalBucket = false) => {
   if (period !== 'hour') return label;
   if (isFinalBucket) return '24:00';
+  const match = label.match(HOUR_BUCKET_PATTERN);
+  if (match) return `${match[4]}:${match[5]}`;
   const date = new Date(label);
   if (Number.isNaN(date.getTime())) return label;
   return `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
@@ -59,17 +85,19 @@ const getTokenSource = (usage: UsageOverviewPayload | null, period: TokenBreakdo
 );
 
 const buildHourlyLabels = (source: TokenSeriesSource | undefined, hourWindowHours?: number, endMs?: number, includeFinalBucket = false) => {
-  const labels = Object.keys(source?.input_tokens ?? {}).sort((a, b) => a.localeCompare(b));
+  const labels = Array.from(new Set(CATEGORIES.flatMap((category) => Object.keys(source?.[`${category}_tokens`] ?? {}))))
+    .sort((a, b) => a.localeCompare(b));
   if (labels.length === 0) return [];
 
   const bucketCount = resolveHourBucketCount(hourWindowHours, includeFinalBucket);
-  const latestLabelMs = Date.parse(labels[labels.length - 1]);
+  const referenceKey = labels[labels.length - 1];
+  const offsetMinutes = parseHourBucketOffsetMinutes(referenceKey);
+  const latestLabelMs = Date.parse(referenceKey);
   const requestedEndMs = Number.isFinite(endMs) && endMs && endMs > 0 ? endMs : latestLabelMs;
-  const currentHour = new Date(requestedEndMs);
-  currentHour.setUTCMinutes(0, 0, 0);
-  const earliestTime = currentHour.getTime() - ((bucketCount - 1) * HOUR_MS);
+  const currentHourMs = startOfOffsetHourMs(requestedEndMs, offsetMinutes);
+  const earliestTime = currentHourMs - ((bucketCount - 1) * HOUR_MS);
 
-  return Array.from({ length: bucketCount }, (_, index) => formatHourBucketKey(earliestTime + index * HOUR_MS));
+  return Array.from({ length: bucketCount }, (_, index) => formatHourBucketKey(earliestTime + index * HOUR_MS, referenceKey));
 };
 
 export const buildTokenBreakdownChartSeries = ({

--- a/web/src/lib/usage.ts
+++ b/web/src/lib/usage.ts
@@ -34,6 +34,33 @@ function formatLocalDayKey(date: Date): string {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
 }
 
+const HOUR_BUCKET_PATTERN = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})$/
+
+function parseHourBucketOffsetMinutes(key?: string): number {
+  const match = key?.match(HOUR_BUCKET_PATTERN)
+  const offset = match?.[7]
+  if (!offset || offset === 'Z') return 0
+  const sign = offset[0] === '-' ? -1 : 1
+  const hours = Number(offset.slice(1, 3))
+  const minutes = Number(offset.slice(4, 6))
+  return sign * ((hours * 60) + minutes)
+}
+
+function formatHourBucketKey(timestampMs: number, referenceKey?: string): string {
+  const offsetMinutes = parseHourBucketOffsetMinutes(referenceKey)
+  const shifted = new Date(timestampMs + offsetMinutes * 60 * 1000)
+  const pad = (value: number) => String(value).padStart(2, '0')
+  const offset = offsetMinutes === 0
+    ? 'Z'
+    : `${offsetMinutes < 0 ? '-' : '+'}${pad(Math.floor(Math.abs(offsetMinutes) / 60))}:${pad(Math.abs(offsetMinutes) % 60)}`
+  return `${shifted.getUTCFullYear()}-${pad(shifted.getUTCMonth() + 1)}-${pad(shifted.getUTCDate())}T${pad(shifted.getUTCHours())}:00:00${offset}`
+}
+
+function startOfHourKey(timestamp: string): string {
+  const timestampMs = Date.parse(timestamp)
+  return Number.isNaN(timestampMs) ? '' : formatHourBucketKey(timestampMs, timestamp)
+}
+
 function calculateEventCost(event: UsageEventWithNames, priceMap: Map<string, PricingEntry>): number {
   const pricing = priceMap.get(event.modelName)
   if (!pricing) return 0
@@ -152,7 +179,7 @@ export function filterUsageSnapshot(usage: UsageSnapshot, range: UsageTimeRange)
 
     const time = new Date(event.timestamp)
     const dayKey = formatLocalDayKey(time)
-    const hourKey = `${time.toISOString().slice(0, 13)}:00:00Z`
+    const hourKey = startOfHourKey(event.timestamp)
     filtered.requests_by_day[dayKey] = (filtered.requests_by_day[dayKey] ?? 0) + 1
     filtered.requests_by_hour[hourKey] = (filtered.requests_by_hour[hourKey] ?? 0) + 1
     filtered.tokens_by_day[dayKey] = (filtered.tokens_by_day[dayKey] ?? 0) + event.tokens.total_tokens
@@ -341,7 +368,7 @@ export function buildSeriesTrends(usage: UsageSnapshot, dimension: UsageSeriesDi
   const grouped = new Map<string, Record<string, number>>()
   for (const event of collectUsageEvents(usage)) {
     const key = dimension === 'api' ? event.apiName : event.modelName
-    const hourKey = `${new Date(event.timestamp).toISOString().slice(0, 13)}:00:00Z`
+    const hourKey = startOfHourKey(event.timestamp)
     const bucket = grouped.get(key) ?? {}
     bucket[hourKey] = (bucket[hourKey] ?? 0) + (metric === 'requests' ? 1 : event.tokens.total_tokens)
     grouped.set(key, bucket)
@@ -366,7 +393,7 @@ export function buildCostTrendPoints(usage: UsageSnapshot, pricing: PricingEntry
   const priceMap = getPriceMap(pricing)
   const buckets: Record<string, number> = {}
   for (const event of collectUsageEvents(usage)) {
-    const hourKey = `${new Date(event.timestamp).toISOString().slice(0, 13)}:00:00Z`
+    const hourKey = startOfHourKey(event.timestamp)
     buckets[hourKey] = (buckets[hourKey] ?? 0) + calculateEventCost(event, priceMap)
   }
   return buildTrendPoints(buckets)

--- a/web/src/utils/usage.ts
+++ b/web/src/utils/usage.ts
@@ -146,14 +146,42 @@ const startOfDayKey = (timestamp: string): string => {
   return Number.isNaN(date.getTime()) ? '' : formatLocalDayKey(date);
 };
 
-const formatHourBucketKey = (timestampMs: number): string => `${new Date(timestampMs).toISOString().slice(0, 13)}:00:00Z`;
+const HOUR_BUCKET_PATTERN = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+
+const parseHourBucketOffsetMinutes = (key?: string): number => {
+  const match = key?.match(HOUR_BUCKET_PATTERN);
+  const offset = match?.[7];
+  if (!offset || offset === 'Z') return 0;
+  const sign = offset[0] === '-' ? -1 : 1;
+  const hours = Number(offset.slice(1, 3));
+  const minutes = Number(offset.slice(4, 6));
+  return sign * ((hours * 60) + minutes);
+};
+
+const startOfOffsetHourMs = (timestampMs: number, offsetMinutes: number): number => {
+  const hourMs = 60 * 60 * 1000;
+  const shiftedMs = timestampMs + offsetMinutes * 60 * 1000;
+  return Math.floor(shiftedMs / hourMs) * hourMs - offsetMinutes * 60 * 1000;
+};
+
+const formatHourBucketKey = (timestampMs: number, referenceKey?: string): string => {
+  const offsetMinutes = parseHourBucketOffsetMinutes(referenceKey);
+  const shifted = new Date(timestampMs + offsetMinutes * 60 * 1000);
+  const pad = (value: number) => String(value).padStart(2, '0');
+  const offset = offsetMinutes === 0
+    ? 'Z'
+    : `${offsetMinutes < 0 ? '-' : '+'}${pad(Math.floor(Math.abs(offsetMinutes) / 60))}:${pad(Math.abs(offsetMinutes) % 60)}`;
+  return `${shifted.getUTCFullYear()}-${pad(shifted.getUTCMonth() + 1)}-${pad(shifted.getUTCDate())}T${pad(shifted.getUTCHours())}:00:00${offset}`;
+};
 
 const startOfHourKey = (timestamp: string): string => {
   const date = new Date(timestamp);
-  return Number.isNaN(date.getTime()) ? '' : formatHourBucketKey(date.getTime());
+  return Number.isNaN(date.getTime()) ? '' : formatHourBucketKey(date.getTime(), timestamp);
 };
 
 const formatHourLabel = (key: string): string => {
+  const match = key.match(HOUR_BUCKET_PATTERN);
+  if (match) return `${match[2]}-${match[3]} ${match[4]}:${match[5]}`;
   const date = new Date(key);
   if (Number.isNaN(date.getTime())) return key;
   const md = `${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
@@ -173,18 +201,17 @@ const normalizeHourWindow = (hourWindowHours?: number): number => {
 const resolveHourlyChartWindowHours = (hourWindowHours?: number): number =>
   normalizeHourWindow(hourWindowHours);
 
-const buildHourlyWindow = (hourWindowHours?: number, endMs?: number, includeFinalBucket = false) => {
+const buildHourlyWindow = (hourWindowHours?: number, endMs?: number, includeFinalBucket = false, referenceKey?: string) => {
   const resolvedHourWindow = resolveHourlyChartWindowHours(hourWindowHours);
   const bucketCount = includeFinalBucket ? resolvedHourWindow + 1 : resolvedHourWindow >= 24 ? 24 : resolvedHourWindow + 1;
   const hourMs = 60 * 60 * 1000;
-  const currentHour = new Date(Number.isFinite(endMs) && endMs && endMs > 0 ? endMs : Date.now());
-  currentHour.setUTCMinutes(0, 0, 0);
-  const earliestTime = currentHour.getTime() - ((bucketCount - 1) * hourMs);
+  const requestedEndMs = Number.isFinite(endMs) && endMs && endMs > 0 ? endMs : Date.now();
+  const earliestTime = startOfOffsetHourMs(requestedEndMs, parseHourBucketOffsetMinutes(referenceKey)) - ((bucketCount - 1) * hourMs);
   const labels = Array.from({ length: bucketCount }, (_, index) => {
     if (includeFinalBucket) {
       return `${String(index).padStart(2, '0')}:00`;
     }
-    return formatHourLabel(formatHourBucketKey(earliestTime + index * hourMs));
+    return formatHourLabel(formatHourBucketKey(earliestTime + index * hourMs, referenceKey));
   });
   return {
     hourMs,
@@ -559,10 +586,11 @@ export function buildChartData(
     }
     const hourWindow = period === 'hour'
       ? (() => {
-        const endMs = options.endMs ?? Date.parse(rawBucketKeys[rawBucketKeys.length - 1]);
-        const { earliestTime, hourMs, labels } = buildHourlyWindow(options.hourWindowHours, endMs, options.includeFinalHourBucket);
+        const referenceKey = rawBucketKeys[rawBucketKeys.length - 1];
+        const endMs = options.endMs ?? Date.parse(referenceKey);
+        const { earliestTime, hourMs, labels } = buildHourlyWindow(options.hourWindowHours, endMs, options.includeFinalHourBucket, referenceKey);
         return {
-          bucketKeys: labels.map((_, index) => formatHourBucketKey(earliestTime + index * hourMs)),
+          bucketKeys: labels.map((_, index) => formatHourBucketKey(earliestTime + index * hourMs, referenceKey)),
           labels,
         };
       })()
@@ -613,18 +641,17 @@ export function buildChartData(
 
   if (period === 'hour') {
     const hourEndMs = resolveHourlyChartEndMs(details, options.hourWindowHours, options.endMs);
-    const { labels, earliestTime, lastBucketTime, hourMs } = buildHourlyWindow(options.hourWindowHours, hourEndMs, options.includeFinalHourBucket);
-    const bucketKeys = labels.map((_, index) => formatHourBucketKey(earliestTime + index * hourMs));
+    const referenceKey = details.find((detail) => (detail.__timestampMs ?? 0) === hourEndMs)?.timestamp ?? details[0]?.timestamp;
+    const { labels, earliestTime, lastBucketTime, hourMs } = buildHourlyWindow(options.hourWindowHours, hourEndMs, options.includeFinalHourBucket, referenceKey);
+    const bucketKeys = labels.map((_, index) => formatHourBucketKey(earliestTime + index * hourMs, referenceKey));
     bucketKeys.forEach((key) => orderedKeys.add(key));
 
     details.forEach((detail) => {
       const timestamp = detail.__timestampMs ?? 0;
       if (!Number.isFinite(timestamp) || timestamp <= 0) return;
-      const normalized = new Date(timestamp);
-      normalized.setUTCMinutes(0, 0, 0);
-      const bucketStart = normalized.getTime();
+      const bucketStart = startOfOffsetHourMs(timestamp, parseHourBucketOffsetMinutes(detail.timestamp));
       if (bucketStart < earliestTime || bucketStart > lastBucketTime) return;
-      const key = new Date(bucketStart).toISOString();
+      const key = formatHourBucketKey(bucketStart, detail.timestamp);
       const lineKey = lines.includes(detail.__modelName ?? '')
         ? detail.__modelName ?? 'all'
         : lines.includes(detail.__apiName ?? '')
@@ -706,7 +733,8 @@ function buildTokenBreakdownSeries(usage: UsagePayload | null, period: 'hour' | 
 
   if (period === 'hour') {
     const hourEndMs = resolveHourlyChartEndMs(details, hourWindowHours, endMs);
-    const { labels, earliestTime, lastBucketTime, hourMs } = buildHourlyWindow(hourWindowHours, hourEndMs, includeFinalBucket);
+    const referenceKey = details.find((detail) => (detail.__timestampMs ?? 0) === hourEndMs)?.timestamp ?? details[0]?.timestamp;
+    const { labels, earliestTime, lastBucketTime, hourMs } = buildHourlyWindow(hourWindowHours, hourEndMs, includeFinalBucket, referenceKey);
     const dataByCategory = {
       input: new Array(labels.length).fill(0),
       output: new Array(labels.length).fill(0),
@@ -717,9 +745,7 @@ function buildTokenBreakdownSeries(usage: UsagePayload | null, period: 'hour' | 
     details.forEach((detail) => {
       const timestamp = detail.__timestampMs ?? 0;
       if (!Number.isFinite(timestamp) || timestamp <= 0) return;
-      const normalized = new Date(timestamp);
-      normalized.setUTCMinutes(0, 0, 0);
-      const bucketStart = normalized.getTime();
+      const bucketStart = startOfOffsetHourMs(timestamp, parseHourBucketOffsetMinutes(detail.timestamp));
       if (bucketStart < earliestTime || bucketStart > lastBucketTime) return;
       const bucketIndex = Math.floor((bucketStart - earliestTime) / hourMs);
       if (bucketIndex < 0 || bucketIndex >= labels.length) return;
@@ -758,16 +784,15 @@ function buildCostSeries(usage: UsagePayload | null, modelPrices: Record<string,
 
   if (period === 'hour') {
     const hourEndMs = resolveHourlyChartEndMs(details, hourWindowHours, endMs);
-    const { labels, earliestTime, lastBucketTime, hourMs } = buildHourlyWindow(hourWindowHours, hourEndMs, includeFinalBucket);
+    const referenceKey = details.find((detail) => (detail.__timestampMs ?? 0) === hourEndMs)?.timestamp ?? details[0]?.timestamp;
+    const { labels, earliestTime, lastBucketTime, hourMs } = buildHourlyWindow(hourWindowHours, hourEndMs, includeFinalBucket, referenceKey);
     const data = new Array(labels.length).fill(0);
     let hasData = false;
 
     details.forEach((detail) => {
       const timestamp = detail.__timestampMs ?? 0;
       if (!Number.isFinite(timestamp) || timestamp <= 0) return;
-      const normalized = new Date(timestamp);
-      normalized.setUTCMinutes(0, 0, 0);
-      const bucketStart = normalized.getTime();
+      const bucketStart = startOfOffsetHourMs(timestamp, parseHourBucketOffsetMinutes(detail.timestamp));
       if (bucketStart < earliestTime || bucketStart > lastBucketTime) return;
       const bucketIndex = Math.floor((bucketStart - earliestTime) / hourMs);
       if (bucketIndex < 0 || bucketIndex >= labels.length) return;


### PR DESCRIPTION
## Summary
- Normalize stored timestamps to the configured project timezone with RFC3339Nano + offset formatting, including a final migration for legacy rows.
- Use the same project-timezone contract across repository queries, service/API boundaries, poller/quota timestamps, and event-key generation.
- Align frontend overview, token breakdown, and cost trend charts with backend hour buckets that include the project timezone offset.

## Test plan
- [x] go test ./... -count=1
- [x] npm --prefix web test -- --run
- [x] npm --prefix web run build
- [x] Restarted backend/frontend with .env and verified overview/events return Asia/Shanghai +08:00 timestamps on the swapped database