### PR TITLE
Fix frontend usage table and credential details

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -24,18 +24,24 @@ It relies on [CLIProxyAPI (CPA)](https://github.com/router-for-me/CLIProxyAPI) a
 ## Project Structure
 
 ```text
-cmd/                 Application entrypoint
-internal/api/        HTTP routes and handlers
-internal/app/        App wiring and startup
-internal/auth/       In-memory session auth
-internal/backup/     SQLite database backup management
-internal/config/     Environment config loading
-internal/cpa/        CPA client and types
-internal/models/     GORM models
-internal/poller/     Background sync loop
-internal/repository/ SQLite access and aggregations
-internal/service/    Sync, usage, and pricing services
-web/                 React + TypeScript frontend
+cmd/server/              Application entrypoint
+internal/api/            HTTP routes and handlers
+internal/app/            App wiring and startup
+internal/auth/           In-memory session auth
+internal/backup/         SQLite database backup management
+internal/config/         Environment config loading
+internal/cpa/            CPA client and types
+internal/entities/       GORM data models
+internal/logging/        Logging setup and retention
+internal/poller/         Background queue consumption and metadata sync
+internal/quota/          Quota cache, refresh, and query services
+internal/redact/         Browser-facing field redaction
+internal/repository/     SQLite access and aggregations
+internal/service/        Usage, pricing, and identity services
+internal/timeutil/       Project timezone and time helpers
+internal/updatecheck/    GitHub Release update checks
+deploy/                  systemd, Docker, and deployment assets
+web/                     React + TypeScript frontend
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -24,18 +24,24 @@
 ## 项目结构
 
 ```text
-cmd/                 应用入口
-internal/api/        HTTP 路由与处理器
-internal/app/        应用装配与启动
-internal/auth/       内存 session 鉴权
-internal/backup/     SQLite 数据库备份管理
-internal/config/     环境配置加载
-internal/cpa/        CPA 客户端与类型定义
-internal/models/     GORM 模型
-internal/poller/     后台同步轮询
-internal/repository/ SQLite 访问与聚合逻辑
-internal/service/    同步、usage 与 pricing 服务
-web/                 React + TypeScript 前端
+cmd/server/              应用入口
+internal/api/            HTTP 路由与处理器
+internal/app/            应用装配与启动
+internal/auth/           内存 session 鉴权
+internal/backup/         SQLite 数据库备份管理
+internal/config/         环境配置加载
+internal/cpa/            CPA 客户端与类型定义
+internal/entities/       GORM 数据模型
+internal/logging/        日志初始化与保留策略
+internal/poller/         后台队列消费与 metadata 同步
+internal/quota/          quota 缓存、刷新与查询服务
+internal/redact/         前端展示字段脱敏
+internal/repository/     SQLite 访问与聚合逻辑
+internal/service/        usage、pricing 与身份数据服务
+internal/timeutil/       项目时区与时间工具
+internal/updatecheck/    GitHub Release 更新检查
+deploy/                  systemd、Docker 与部署资源
+web/                     React + TypeScript 前端
 ```
 
 ## 配置

--- a/internal/api/quota.go
+++ b/internal/api/quota.go
@@ -9,65 +9,19 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-const quotaRefreshMaxAuthIndexes = 20
-
-type quotaCheckRequest struct {
-	AuthIndex string `json:"auth_index"`
-}
-
-type quotaRefreshRequest struct {
+type quotaRequest struct {
 	AuthIndexes []string `json:"auth_indexes"`
-	Limit       int      `json:"limit"`
 }
 
 func registerQuotaRoutes(router gin.IRoutes, provider QuotaProvider) {
-	router.POST("/quota/check", func(c *gin.Context) {
-		if provider == nil {
-			writeInternalError(c, "quota provider is not configured", nil)
-			return
-		}
-
-		// 先解析并校验 auth_index，避免空值进入后端身份解析流程。
-		var request quotaCheckRequest
-		if err := c.ShouldBindJSON(&request); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "auth_index is required"})
-			return
-		}
-		request.AuthIndex = strings.TrimSpace(request.AuthIndex)
-		if request.AuthIndex == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "auth_index is required"})
-			return
-		}
-
-		// 统一把 service 层错误映射为前端可展示的 HTTP 状态和提示文案。
-		response, err := provider.Check(c.Request.Context(), quota.CheckRequest{AuthIndex: request.AuthIndex})
-		if err != nil {
-			switch {
-			case errors.Is(err, quota.ErrValidation):
-				c.JSON(http.StatusBadRequest, gin.H{"error": "auth_index is required"})
-			case errors.Is(err, quota.ErrNotFound):
-				c.JSON(http.StatusNotFound, gin.H{"error": "quota identity not found"})
-			case errors.Is(err, quota.ErrUnsupportedType):
-				c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "quota identity type is unsupported"})
-			case errors.Is(err, quota.ErrProviderInput):
-				c.JSON(http.StatusUnprocessableEntity, gin.H{"error": quotaProviderInputErrorMessage(err)})
-			default:
-				writeInternalError(c, "quota check failed", err)
-			}
-			return
-		}
-
-		c.JSON(http.StatusOK, response)
-	})
-
 	router.POST("/quota/cache", func(c *gin.Context) {
 		if provider == nil {
 			writeInternalError(c, "quota provider is not configured", nil)
 			return
 		}
 
-		// 缓存读取只校验查询列表，不套用刷新队列的 20 条上限。
-		var request quotaRefreshRequest
+		// 缓存读取只校验查询列表；列表返回多少 auth_index，就按相同数量读取缓存。
+		var request quotaRequest
 		if err := c.ShouldBindJSON(&request); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "auth_indexes are required"})
 			return
@@ -76,14 +30,8 @@ func registerQuotaRoutes(router gin.IRoutes, provider QuotaProvider) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "auth_indexes are required"})
 			return
 		}
-		if request.Limit <= 0 {
-			request.Limit = len(request.AuthIndexes)
-		}
 
-		response, err := provider.GetCachedQuota(c.Request.Context(), quota.CacheRequest{
-			AuthIndexes: request.AuthIndexes,
-			Limit:       request.Limit,
-		})
+		response, err := provider.GetCachedQuota(c.Request.Context(), quota.CacheRequest{AuthIndexes: request.AuthIndexes})
 		if err != nil {
 			switch {
 			case errors.Is(err, quota.ErrValidation):
@@ -103,8 +51,7 @@ func registerQuotaRoutes(router gin.IRoutes, provider QuotaProvider) {
 			return
 		}
 
-		// 手动刷新会真正触发 provider 请求，所以在入口层限制当前页最多 20 条。
-		var request quotaRefreshRequest
+		var request quotaRequest
 		if err := c.ShouldBindJSON(&request); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "auth_indexes are required"})
 			return
@@ -113,21 +60,9 @@ func registerQuotaRoutes(router gin.IRoutes, provider QuotaProvider) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "auth_indexes are required"})
 			return
 		}
-		if len(request.AuthIndexes) > quotaRefreshMaxAuthIndexes {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "auth_indexes must not exceed 20"})
-			return
-		}
-		if request.Limit <= 0 {
-			request.Limit = quotaRefreshMaxAuthIndexes
-		}
-		if request.Limit > quotaRefreshMaxAuthIndexes {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "limit must not exceed 20"})
-			return
-		}
 
 		response, err := provider.Refresh(c.Request.Context(), quota.RefreshRequest{
 			AuthIndexes: request.AuthIndexes,
-			Limit:       request.Limit,
 			Source:      quota.RefreshSourceManual,
 		})
 		if err != nil {
@@ -168,8 +103,4 @@ func registerQuotaRoutes(router gin.IRoutes, provider QuotaProvider) {
 
 		c.JSON(http.StatusOK, response)
 	})
-}
-
-func quotaProviderInputErrorMessage(err error) string {
-	return quota.ProviderInputErrorMessage(err, "quota provider input is invalid")
 }

--- a/internal/api/quota_test.go
+++ b/internal/api/quota_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -14,9 +13,6 @@ import (
 )
 
 type quotaProviderStub struct {
-	request         quota.CheckRequest
-	response        quota.CheckResponse
-	err             error
 	refreshRequest  quota.RefreshRequest
 	refreshResponse quota.RefreshResponse
 	refreshErr      error
@@ -26,14 +22,6 @@ type quotaProviderStub struct {
 	cacheRequest    quota.CacheRequest
 	cacheResponse   quota.CacheResponse
 	cacheErr        error
-}
-
-func (s *quotaProviderStub) Check(ctx context.Context, request quota.CheckRequest) (quota.CheckResponse, error) {
-	s.request = request
-	if s.err != nil {
-		return quota.CheckResponse{}, s.err
-	}
-	return s.response, nil
 }
 
 func (s *quotaProviderStub) Refresh(ctx context.Context, request quota.RefreshRequest) (quota.RefreshResponse, error) {
@@ -60,132 +48,13 @@ func (s *quotaProviderStub) GetCachedQuota(ctx context.Context, request quota.Ca
 	return s.cacheResponse, nil
 }
 
-func floatPtr(value float64) *float64 {
-	return &value
-}
-
-func TestQuotaCheckReturnsProviderResponse(t *testing.T) {
-	provider := &quotaProviderStub{response: quota.CheckResponse{
-		ID: "codex-auth",
-		Quota: []quota.QuotaRow{{
-			Key:       "rate_limit.primary_window",
-			Label:     "5h",
-			Scope:     "window",
-			Remaining: floatPtr(10),
-		}},
-	}}
-	router := NewRouter(nil, nil, nil, nil, AuthConfig{}, nil, "", OptionalProviders{Quota: provider})
-
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/quota/check", strings.NewReader(`{"auth_index":"codex-auth"}`))
-	req.Header.Set("Content-Type", "application/json")
-	resp := httptest.NewRecorder()
-	router.ServeHTTP(resp, req)
-
-	if resp.Code != http.StatusOK {
-		t.Fatalf("expected status 200, got %d body=%s", resp.Code, resp.Body.String())
-	}
-	if provider.request.AuthIndex != "codex-auth" {
-		t.Fatalf("expected auth_index to be forwarded, got %+v", provider.request)
-	}
-	body := resp.Body.String()
-	if !contains(body, `"id":"codex-auth"`) || !contains(body, `"quota":[`) || !contains(body, `"remaining":10`) || contains(body, `"auth_index"`) || contains(body, `"provider"`) || contains(body, `"type"`) || contains(body, `"result"`) || contains(body, `"planType"`) || contains(body, `"name"`) || contains(body, `"identity"`) || contains(body, `"account_id"`) || contains(body, `"project_id"`) {
-		t.Fatalf("unexpected response body: %s", body)
-	}
-}
-
-func TestQuotaCheckReturnsProviderSpecificResultShape(t *testing.T) {
-	provider := &quotaProviderStub{response: quota.CheckResponse{
-		ID: "gemini-auth",
-		Quota: []quota.QuotaRow{
-			{Key: "bucket.gemini-2.5-pro_vertex.PROMPT", Label: "gemini-2.5-pro_vertex", Scope: "model", Metric: "PROMPT", RemainingFraction: floatPtr(0.7), Remaining: floatPtr(42), ResetAt: "2026-05-09T12:00:00Z"},
-			{Key: "code_assist.current_tier.GOOGLE_ONE_AI", Label: "Code Assist Credit", Scope: "credits", Metric: "GOOGLE_ONE_AI", Remaining: floatPtr(10)},
-		},
-	}}
-	router := NewRouter(nil, nil, nil, nil, AuthConfig{}, nil, "", OptionalProviders{Quota: provider})
-
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/quota/check", strings.NewReader(`{"auth_index":"gemini-auth"}`))
-	req.Header.Set("Content-Type", "application/json")
-	resp := httptest.NewRecorder()
-	router.ServeHTTP(resp, req)
-
-	if resp.Code != http.StatusOK {
-		t.Fatalf("expected status 200, got %d body=%s", resp.Code, resp.Body.String())
-	}
-	body := resp.Body.String()
-	if !contains(body, `"id":"gemini-auth"`) || !contains(body, `"bucket.gemini-2.5-pro_vertex.PROMPT"`) || !contains(body, `"code_assist.current_tier.GOOGLE_ONE_AI"`) || contains(body, `"quota_items"`) || contains(body, `"limits"`) || contains(body, `"auth_index"`) || contains(body, `"provider"`) || contains(body, `"type"`) {
-		t.Fatalf("unexpected response body: %s", body)
-	}
-}
-
-func TestQuotaCheckRejectsMissingAuthIndex(t *testing.T) {
-	provider := &quotaProviderStub{}
-	router := NewRouter(nil, nil, nil, nil, AuthConfig{}, nil, "", OptionalProviders{Quota: provider})
-
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/quota/check", strings.NewReader(`{}`))
-	req.Header.Set("Content-Type", "application/json")
-	resp := httptest.NewRecorder()
-	router.ServeHTTP(resp, req)
-
-	if resp.Code != http.StatusBadRequest {
-		t.Fatalf("expected status 400, got %d body=%s", resp.Code, resp.Body.String())
-	}
-	if provider.request.AuthIndex != "" {
-		t.Fatalf("provider should not be called for missing auth_index, got %+v", provider.request)
-	}
-}
-
-func TestQuotaCheckMapsNotFoundTo404(t *testing.T) {
-	provider := &quotaProviderStub{err: quota.ErrNotFound}
-	router := NewRouter(nil, nil, nil, nil, AuthConfig{}, nil, "", OptionalProviders{Quota: provider})
-
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/quota/check", strings.NewReader(`{"auth_index":"missing-auth"}`))
-	req.Header.Set("Content-Type", "application/json")
-	resp := httptest.NewRecorder()
-	router.ServeHTTP(resp, req)
-
-	if resp.Code != http.StatusNotFound {
-		t.Fatalf("expected status 404, got %d body=%s", resp.Code, resp.Body.String())
-	}
-}
-
-func TestQuotaCheckMapsUnsupportedTypeTo422(t *testing.T) {
-	provider := &quotaProviderStub{err: quota.ErrUnsupportedType}
-	router := NewRouter(nil, nil, nil, nil, AuthConfig{}, nil, "", OptionalProviders{Quota: provider})
-
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/quota/check", strings.NewReader(`{"auth_index":"unknown-auth"}`))
-	req.Header.Set("Content-Type", "application/json")
-	resp := httptest.NewRecorder()
-	router.ServeHTTP(resp, req)
-
-	if resp.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("expected status 422, got %d body=%s", resp.Code, resp.Body.String())
-	}
-}
-
-func TestQuotaCheckMapsProviderInputTo422(t *testing.T) {
-	provider := &quotaProviderStub{err: errors.Join(quota.ErrProviderInput, errors.New("missing project_id parameter"))}
-	router := NewRouter(nil, nil, nil, nil, AuthConfig{}, nil, "", OptionalProviders{Quota: provider})
-
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/quota/check", strings.NewReader(`{"auth_index":"gemini-auth"}`))
-	req.Header.Set("Content-Type", "application/json")
-	resp := httptest.NewRecorder()
-	router.ServeHTTP(resp, req)
-
-	if resp.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("expected status 422, got %d body=%s", resp.Code, resp.Body.String())
-	}
-	if !contains(resp.Body.String(), "missing project_id parameter") {
-		t.Fatalf("expected provider input message in response, got %s", resp.Body.String())
-	}
-}
-
 func TestQuotaCacheReturnsCachedCurrentPageQuota(t *testing.T) {
 	provider := &quotaProviderStub{cacheResponse: quota.CacheResponse{
 		Items: []quota.CheckResponse{{ID: "auth-1", Quota: []quota.QuotaRow{{Key: "rate_limit.secondary_window", Label: "Weekly", PlanType: "plus"}}}},
 	}}
 	router := NewRouter(nil, nil, nil, nil, AuthConfig{}, nil, "", OptionalProviders{Quota: provider})
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/quota/cache", strings.NewReader(`{"auth_indexes":["auth-1","auth-2"],"limit":20}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/quota/cache", strings.NewReader(`{"auth_indexes":["auth-1","auth-2"]}`))
 	req.Header.Set("Content-Type", "application/json")
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -195,9 +64,6 @@ func TestQuotaCacheReturnsCachedCurrentPageQuota(t *testing.T) {
 	}
 	if got := strings.Join(provider.cacheRequest.AuthIndexes, ","); got != "auth-1,auth-2" {
 		t.Fatalf("expected auth indexes to be forwarded, got %+v", provider.cacheRequest.AuthIndexes)
-	}
-	if provider.cacheRequest.Limit != 20 {
-		t.Fatalf("expected outer cache limit 20, got %d", provider.cacheRequest.Limit)
 	}
 	body := resp.Body.String()
 	if !contains(body, `"items"`) || !contains(body, `"id":"auth-1"`) || !contains(body, `"label":"Weekly"`) || !contains(body, `"planType":"plus"`) {
@@ -212,7 +78,7 @@ func TestQuotaCacheAllowsMoreThanRefreshLimit(t *testing.T) {
 	for i := range authIndexes {
 		authIndexes[i] = "auth-" + strconv.Itoa(i+1)
 	}
-	bodyBytes, err := json.Marshal(map[string]any{"auth_indexes": authIndexes, "limit": 50})
+	bodyBytes, err := json.Marshal(map[string]any{"auth_indexes": authIndexes})
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)
 	}
@@ -225,8 +91,8 @@ func TestQuotaCacheAllowsMoreThanRefreshLimit(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d body=%s", resp.Code, resp.Body.String())
 	}
-	if provider.cacheRequest.Limit != 50 || len(provider.cacheRequest.AuthIndexes) != 21 {
-		t.Fatalf("expected cache request to bypass refresh limit, got %+v", provider.cacheRequest)
+	if len(provider.cacheRequest.AuthIndexes) != 21 {
+		t.Fatalf("expected cache request to use all requested auth indexes, got %+v", provider.cacheRequest)
 	}
 }
 
@@ -234,11 +100,11 @@ func TestQuotaRefreshCreatesTasksForCurrentPageAuthIndexes(t *testing.T) {
 	provider := &quotaProviderStub{refreshResponse: quota.RefreshResponse{
 		Tasks:    []quota.RefreshTaskID{{AuthIndex: "auth-1", TaskID: "task-1"}, {AuthIndex: "auth-2", TaskID: "task-2"}},
 		Accepted: 2,
-		Limit:    20,
+		Limit:    2,
 	}}
 	router := NewRouter(nil, nil, nil, nil, AuthConfig{}, nil, "", OptionalProviders{Quota: provider})
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/quota/refresh", strings.NewReader(`{"auth_indexes":["auth-1","auth-2"],"limit":20}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/quota/refresh", strings.NewReader(`{"auth_indexes":["auth-1","auth-2"]}`))
 	req.Header.Set("Content-Type", "application/json")
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -249,23 +115,20 @@ func TestQuotaRefreshCreatesTasksForCurrentPageAuthIndexes(t *testing.T) {
 	if got := strings.Join(provider.refreshRequest.AuthIndexes, ","); got != "auth-1,auth-2" {
 		t.Fatalf("expected auth indexes to be forwarded, got %+v", provider.refreshRequest.AuthIndexes)
 	}
-	if provider.refreshRequest.Limit != 20 {
-		t.Fatalf("expected outer refresh limit 20, got %d", provider.refreshRequest.Limit)
-	}
 	if provider.refreshRequest.Source != quota.RefreshSourceManual {
 		t.Fatalf("expected manual refresh source, got %q", provider.refreshRequest.Source)
 	}
 	body := resp.Body.String()
-	if !contains(body, `"tasks"`) || !contains(body, `"taskId":"task-1"`) || !contains(body, `"accepted":2`) || !contains(body, `"limit":20`) {
+	if !contains(body, `"tasks"`) || !contains(body, `"taskId":"task-1"`) || !contains(body, `"accepted":2`) || !contains(body, `"limit":2`) {
 		t.Fatalf("unexpected response body: %s", body)
 	}
 }
 
-func TestQuotaRefreshRejectsTooManyAuthIndexesAtOuterLayer(t *testing.T) {
-	provider := &quotaProviderStub{}
+func TestQuotaRefreshAllowsCurrentPageSizeWithoutOuterTwentyLimit(t *testing.T) {
+	provider := &quotaProviderStub{refreshResponse: quota.RefreshResponse{Accepted: 25, Limit: 25}}
 	router := NewRouter(nil, nil, nil, nil, AuthConfig{}, nil, "", OptionalProviders{Quota: provider})
-	authIndexes := make([]string, 0, 21)
-	for i := 0; i < 21; i++ {
+	authIndexes := make([]string, 0, 25)
+	for i := 0; i < 25; i++ {
 		authIndexes = append(authIndexes, `"auth"`)
 	}
 
@@ -274,11 +137,11 @@ func TestQuotaRefreshRejectsTooManyAuthIndexesAtOuterLayer(t *testing.T) {
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
 
-	if resp.Code != http.StatusBadRequest {
-		t.Fatalf("expected status 400, got %d body=%s", resp.Code, resp.Body.String())
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", resp.Code, resp.Body.String())
 	}
-	if provider.refreshRequest.AuthIndexes != nil {
-		t.Fatalf("provider should not be called for oversized refresh request, got %+v", provider.refreshRequest)
+	if len(provider.refreshRequest.AuthIndexes) != 25 {
+		t.Fatalf("expected refresh to forward all current-page auth indexes, got %+v", provider.refreshRequest)
 	}
 }
 
@@ -286,7 +149,7 @@ func TestQuotaRefreshRejectsEmptyAuthIndexes(t *testing.T) {
 	provider := &quotaProviderStub{}
 	router := NewRouter(nil, nil, nil, nil, AuthConfig{}, nil, "", OptionalProviders{Quota: provider})
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/quota/refresh", strings.NewReader(`{"auth_indexes":[],"limit":20}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/quota/refresh", strings.NewReader(`{"auth_indexes":[]}`))
 	req.Header.Set("Content-Type", "application/json")
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -354,19 +217,5 @@ func TestQuotaDoesNotExposeProviderSpecificEndpoints(t *testing.T) {
 		if resp.Code != http.StatusNotFound {
 			t.Fatalf("expected %s to return 404, got %d", path, resp.Code)
 		}
-	}
-}
-
-func TestQuotaCheckMapsWrappedErrors(t *testing.T) {
-	provider := &quotaProviderStub{err: errors.Join(quota.ErrNotFound, errors.New("missing"))}
-	router := NewRouter(nil, nil, nil, nil, AuthConfig{}, nil, "", OptionalProviders{Quota: provider})
-
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/quota/check", strings.NewReader(`{"auth_index":"missing-auth"}`))
-	req.Header.Set("Content-Type", "application/json")
-	resp := httptest.NewRecorder()
-	router.ServeHTTP(resp, req)
-
-	if resp.Code != http.StatusNotFound {
-		t.Fatalf("expected status 404, got %d body=%s", resp.Code, resp.Body.String())
 	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -51,7 +51,6 @@ type SyncRunner interface {
 }
 
 type QuotaProvider interface {
-	Check(context.Context, quota.CheckRequest) (quota.CheckResponse, error)
 	GetCachedQuota(context.Context, quota.CacheRequest) (quota.CacheResponse, error)
 	Refresh(context.Context, quota.RefreshRequest) (quota.RefreshResponse, error)
 	GetRefreshTask(context.Context, string) (quota.RefreshTaskResponse, error)

--- a/internal/quota/refresh.go
+++ b/internal/quota/refresh.go
@@ -34,7 +34,6 @@ const (
 
 type CacheRequest struct {
 	AuthIndexes []string `json:"auth_indexes"`
-	Limit       int      `json:"limit"`
 }
 
 type CacheResponse struct {
@@ -43,7 +42,6 @@ type CacheResponse struct {
 
 type RefreshRequest struct {
 	AuthIndexes []string      `json:"auth_indexes"`
-	Limit       int           `json:"limit"`
 	Source      RefreshSource `json:"source"`
 }
 
@@ -92,20 +90,16 @@ type RefreshTaskRecord struct {
 func (s *Service) GetCachedQuota(ctx context.Context, request CacheRequest) (CacheResponse, error) {
 	_ = ctx
 	// 缓存读取只返回已完成任务的结果，不触发新的 provider 请求。
-	limit := request.Limit
-	if limit <= 0 {
-		return CacheResponse{}, fmt.Errorf("%w: limit is required", ErrValidation)
+	if len(request.AuthIndexes) == 0 {
+		return CacheResponse{}, fmt.Errorf("%w: auth_indexes are required", ErrValidation)
 	}
-	response := CacheResponse{Items: make([]CheckResponse, 0, min(limit, len(request.AuthIndexes)))}
+	response := CacheResponse{Items: make([]CheckResponse, 0, len(request.AuthIndexes))}
 	s.cleanupExpiredRefreshTasks(time.Now())
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
 	// 按请求顺序去重并读取每个 auth_index 最近一次完成的任务缓存。
 	seen := make(map[string]struct{}, len(request.AuthIndexes))
 	for _, rawAuthIndex := range request.AuthIndexes {
-		if len(response.Items) >= limit {
-			break
-		}
 		authIndex := strings.TrimSpace(rawAuthIndex)
 		if authIndex == "" {
 			continue
@@ -130,9 +124,9 @@ func (s *Service) GetCachedQuota(ctx context.Context, request CacheRequest) (Cac
 
 func (s *Service) Refresh(ctx context.Context, request RefreshRequest) (RefreshResponse, error) {
 	// 刷新入口只负责校验、去重、建任务；实际 provider 调用交给后台 worker。
-	limit := request.Limit
+	limit := len(request.AuthIndexes)
 	if limit <= 0 {
-		return RefreshResponse{}, fmt.Errorf("%w: limit is required", ErrValidation)
+		return RefreshResponse{}, fmt.Errorf("%w: auth_indexes are required", ErrValidation)
 	}
 	response := RefreshResponse{Limit: limit}
 	seen := make(map[string]struct{}, len(request.AuthIndexes))

--- a/internal/quota/service_test.go
+++ b/internal/quota/service_test.go
@@ -51,7 +51,7 @@ func TestRefreshCreatesTaskPerAuthIndexAndCachesCompletedQuota(t *testing.T) {
 	handler := &refreshHandlerStub{output: ProviderOutput{Result: ClaudeResult{Usage: &ClaudeUsagePayload{FiveHour: &ClaudeUsageWindow{Utilization: 25}}}}}
 	service := NewServiceWithRegistry(db, NewProviderRegistry(map[string]ProviderHandler{"claude": handler}))
 
-	response, err := service.Refresh(context.Background(), RefreshRequest{AuthIndexes: []string{"auth-1"}, Limit: 20, Source: RefreshSourceManual})
+	response, err := service.Refresh(context.Background(), RefreshRequest{AuthIndexes: []string{"auth-1"}, Source: RefreshSourceManual})
 	if err != nil {
 		t.Fatalf("Refresh returned error: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestRefreshRejectsInvalidEntriesAndIgnoresRunningTask(t *testing.T) {
 	handler := &refreshHandlerStub{block: block, output: ProviderOutput{Result: ClaudeResult{Usage: &ClaudeUsagePayload{FiveHour: &ClaudeUsageWindow{Utilization: 25}}}}}
 	service := NewServiceWithRegistry(db, NewProviderRegistry(map[string]ProviderHandler{"claude": handler}))
 
-	response, err := service.Refresh(context.Background(), RefreshRequest{AuthIndexes: []string{"auth-1", "auth-1", "provider-1", "deleted-1", "missing"}, Limit: 20, Source: RefreshSourceManual})
+	response, err := service.Refresh(context.Background(), RefreshRequest{AuthIndexes: []string{"auth-1", "auth-1", "provider-1", "deleted-1", "missing"}, Source: RefreshSourceManual})
 	if err != nil {
 		t.Fatalf("Refresh returned error: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestRefreshRejectsInvalidEntriesAndIgnoresRunningTask(t *testing.T) {
 
 	firstTaskID := response.Tasks[0].TaskID
 	waitForRefreshTask(t, service, firstTaskID, RefreshTaskStatusRunning)
-	second, err := service.Refresh(context.Background(), RefreshRequest{AuthIndexes: []string{"auth-1"}, Limit: 20, Source: RefreshSourceManual})
+	second, err := service.Refresh(context.Background(), RefreshRequest{AuthIndexes: []string{"auth-1"}, Source: RefreshSourceManual})
 	if err != nil {
 		t.Fatalf("second Refresh returned error: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestRefreshTaskFailureReturnsFriendlyMessage(t *testing.T) {
 	handler := &refreshHandlerStub{err: errors.New("upstream exploded")}
 	service := NewServiceWithRegistry(db, NewProviderRegistry(map[string]ProviderHandler{"claude": handler}))
 
-	response, err := service.Refresh(context.Background(), RefreshRequest{AuthIndexes: []string{"auth-1"}, Limit: 20, Source: RefreshSourceManual})
+	response, err := service.Refresh(context.Background(), RefreshRequest{AuthIndexes: []string{"auth-1"}, Source: RefreshSourceManual})
 	if err != nil {
 		t.Fatalf("Refresh returned error: %v", err)
 	}

--- a/web/src/components/usage/RequestEventsDetailsCard.test.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.test.tsx
@@ -68,6 +68,33 @@ describe('RequestEventsDetailsCard pagination', () => {
     expect(html).toContain('disabled');
   });
 
+  it('formats timestamps with compact numeric date and time', () => {
+    const html = renderCard({
+      events: [{ ...events[0], timestamp: '2026-05-13T00:38:19+08:00' }],
+    });
+
+    expect(html).toContain('2026/05/13 00:38:19');
+    expect(html).not.toContain('5/13/2026, 12:38:19 AM');
+  });
+
+  it('renders cache rate after cached tokens with two decimal places', () => {
+    const html = renderCard({
+      events: [{ ...events[0], tokens: { ...events[0].tokens, input_tokens: 100, cached_tokens: 25 } }],
+    });
+
+    expect(html.indexOf('<th>Cached</th>')).toBeLessThan(html.indexOf('<th>Cache Rate</th>'));
+    expect(html.indexOf('<th>Cache Rate</th>')).toBeLessThan(html.indexOf('<th>Total Tokens</th>'));
+    expect(html).toContain('<td>25</td><td>25.00%</td><td>200</td>');
+  });
+
+  it('shows a dash for cache rate when input tokens are zero', () => {
+    const html = renderCard({
+      events: [{ ...events[0], tokens: { ...events[0].tokens, input_tokens: 0, cached_tokens: 25 } }],
+    });
+
+    expect(html).toContain('<td>0</td><td>60</td><td>20</td><td>25</td><td>-</td><td>200</td>');
+  });
+
   it('stacks source value above source tags', () => {
     const html = renderCard({
       events: [{ ...events[0], isDelete: true }],

--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -49,6 +49,7 @@ type RequestEventRow = {
   reasoningTokens: number;
   cachedTokens: number;
   totalTokens: number;
+  cacheRate: string;
   cost: number;
   hasPrice: boolean;
 };
@@ -78,6 +79,17 @@ const toNumber = (value: unknown): number => {
   const parsed = Number(value);
   if (!Number.isFinite(parsed)) return 0;
   return parsed;
+};
+
+const formatRequestEventTimestamp = (timestamp: string): string => {
+  const match = timestamp.match(/^(\d{4})-(\d{2})-(\d{2})[T\s](\d{2}):(\d{2}):(\d{2})/);
+  if (!match) return timestamp || '-';
+  return `${match[1]}/${match[2]}/${match[3]} ${match[4]}:${match[5]}:${match[6]}`;
+};
+
+const formatCacheRate = (cachedTokens: number, inputTokens: number): string => {
+  if (inputTokens <= 0) return '-';
+  return `${((cachedTokens / inputTokens) * 100).toFixed(2)}%`;
 };
 
 const encodeCsv = (value: string | number): string => {
@@ -120,7 +132,7 @@ export function RequestEventsDetailsCard({
   onSourceFilterChange,
   onResultFilterChange,
 }: RequestEventsDetailsCardProps) {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const latencyHint = t('usage_stats.latency_unit_hint', {
     field: LATENCY_SOURCE_FIELD,
     unit: t('usage_stats.duration_unit_ms'),
@@ -169,7 +181,7 @@ export function RequestEventsDetailsCard({
         id: event.id ? String(event.id) : `${timestamp}-${model}-${sourceRaw || source}-${authIndex}-${index}`,
         timestamp,
         timestampMs: Number.isNaN(timestampMs) ? 0 : timestampMs,
-        timestampLabel: date ? date.toLocaleString(i18n.language) : timestamp || '-',
+        timestampLabel: formatRequestEventTimestamp(timestamp),
         model,
         sourceRaw: sourceRaw || '-',
         source,
@@ -183,11 +195,12 @@ export function RequestEventsDetailsCard({
         reasoningTokens,
         cachedTokens,
         totalTokens,
+        cacheRate: formatCacheRate(cachedTokens, inputTokens),
         cost,
         hasPrice: Boolean(pricing),
       };
     });
-  }, [events, i18n.language, modelPrices]);
+  }, [events, modelPrices]);
 
   const hasLatencyData = useMemo(() => rows.some((row) => row.latencyMs !== null), [rows]);
 
@@ -419,8 +432,9 @@ export function RequestEventsDetailsCard({
                   {hasLatencyData && <th title={latencyHint}>{t('usage_stats.time')}</th>}
                   <th>{t('usage_stats.input_tokens')}</th>
                   <th>{t('usage_stats.output_tokens')}</th>
-                  <th>{t('usage_stats.reasoning_tokens')}</th>
+                  <th className={styles.requestEventsReasoningHeader}>{t('usage_stats.reasoning_tokens')}</th>
                   <th>{t('usage_stats.cached_tokens')}</th>
+                  <th>{t('usage_stats.cache_rate')}</th>
                   <th>{t('usage_stats.total_tokens')}</th>
                   <th>{t('usage_stats.total_cost')}</th>
                 </tr>
@@ -465,6 +479,7 @@ export function RequestEventsDetailsCard({
                     <td>{row.outputTokens.toLocaleString()}</td>
                     <td>{row.reasoningTokens.toLocaleString()}</td>
                     <td>{row.cachedTokens.toLocaleString()}</td>
+                    <td>{row.cacheRate}</td>
                     <td>{row.totalTokens.toLocaleString()}</td>
                     <td title={row.hasPrice ? undefined : t('usage_stats.cost_need_price')}>
                       {row.hasPrice ? formatUsd(row.cost) : '-'}

--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -142,7 +142,6 @@ export function RequestEventsDetailsCard({
     return events.map((event, index) => {
       const timestamp = event.timestamp;
       const timestampMs = Date.parse(timestamp);
-      const date = Number.isNaN(timestampMs) ? null : new Date(timestampMs);
       const sourceRaw = String(event.source_raw ?? '').trim() || String(event.source ?? '').trim();
       const authIndexRaw = event.auth_index as unknown;
       const authIndex =

--- a/web/src/components/usage/credentials/CredentialSectionShell.test.ts
+++ b/web/src/components/usage/credentials/CredentialSectionShell.test.ts
@@ -1,13 +1,19 @@
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import { CredentialsPagination, formatCredentialNumber } from './CredentialSectionShell'
+import { CredentialsPagination, formatCredentialNumber, formatCredentialPercent } from './CredentialSectionShell'
 
 describe('CredentialSectionShell formatting', () => {
   it('uses the shared compact K/M/B number format', () => {
     expect(formatCredentialNumber(950)).toBe('950')
     expect(formatCredentialNumber(12_345)).toBe('12.35K')
     expect(formatCredentialNumber(1_234_567)).toBe('1.23M')
+  })
+
+  it('formats credential rates with two decimal places', () => {
+    expect(formatCredentialPercent(2 / 3 * 100)).toBe('66.67%')
+    expect(formatCredentialPercent(75)).toBe('75.00%')
+    expect(formatCredentialPercent(null)).toBe('—')
   })
 
   it('renders only controls in the pagination footer', () => {

--- a/web/src/components/usage/credentials/CredentialSectionShell.tsx
+++ b/web/src/components/usage/credentials/CredentialSectionShell.tsx
@@ -159,7 +159,7 @@ export function formatCredentialPercent(value: number | null): string {
   if (value === null) {
     return '—'
   }
-  return `${Math.round(value)}%`
+  return `${value.toFixed(2)}%`
 }
 
 export function credentialToneClassName(prefix: string, tone: string): string {

--- a/web/src/components/usage/credentials/credentialViewModels.test.ts
+++ b/web/src/components/usage/credentials/credentialViewModels.test.ts
@@ -166,6 +166,22 @@ describe('credentialViewModels', () => {
     expect(rows[0].extraQuota.map((quota) => quota.label)).toEqual(['Code Assist Credit'])
   })
 
+  it('classifies quota bar colors at 50 and 20 percent remaining thresholds', () => {
+    const quotas = new Map<string, UsageQuotaRow[]>([
+      ['green-auth', [{ key: 'rate_limit.primary_window', label: '5h', remainingFraction: 0.5 }]],
+      ['yellow-auth', [{ key: 'rate_limit.primary_window', label: '5h', remainingFraction: 0.49 }]],
+      ['red-auth', [{ key: 'rate_limit.primary_window', label: '5h', remainingFraction: 0.19 }]],
+    ])
+
+    const rows = buildAuthFileCredentialRows([
+      identity({ identity: 'green-auth' }),
+      identity({ identity: 'yellow-auth' }),
+      identity({ identity: 'red-auth' }),
+    ], quotas)
+
+    expect(rows.map((row) => row.primaryQuota?.status)).toEqual(['ok', 'warning', 'danger'])
+  })
+
   it('uses quota window duration instead of raw key when classifying Codex windows', () => {
     const quotas = new Map<string, UsageQuotaRow[]>([
       ['auth-1', [

--- a/web/src/components/usage/credentials/credentialViewModels.ts
+++ b/web/src/components/usage/credentials/credentialViewModels.ts
@@ -247,10 +247,10 @@ function quotaStatus(row: UsageQuotaRow, percent: number | null, kind: DisplayQu
   if (remainingPercent === null) {
     return 'unknown'
   }
-  if (remainingPercent <= 10) {
+  if (remainingPercent < 20) {
     return 'danger'
   }
-  if (remainingPercent <= 25) {
+  if (remainingPercent < 50) {
     return 'warning'
   }
   return 'ok'

--- a/web/src/components/usage/credentials/useQuotaCache.ts
+++ b/web/src/components/usage/credentials/useQuotaCache.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react'
+import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import { ApiError, fetchUsageQuotaCache } from '@/lib/api'
 import type { UsageQuotaRow } from '@/lib/types'
 
@@ -16,11 +16,6 @@ export interface QuotaCacheState {
 export function useQuotaCache({ enabled, authIndexes, onAuthRequired }: UseQuotaCacheOptions): QuotaCacheState {
   const [quotaByAuthIndex, setQuotaByAuthIndex] = useState<Record<string, UsageQuotaRow[]>>({})
   const requestControllerRef = useRef<AbortController | null>(null)
-  const uncachedAuthIndexes = useMemo(
-    // 页面加载只读缓存；已经读过的 auth_index 不重复请求，避免分页切换时无效调用。
-    () => authIndexes.filter((authIndex) => quotaByAuthIndex[authIndex] === undefined),
-    [authIndexes, quotaByAuthIndex],
-  )
 
   useEffect(() => {
     if (!enabled) {
@@ -29,14 +24,14 @@ export function useQuotaCache({ enabled, authIndexes, onAuthRequired }: UseQuota
       return
     }
     requestControllerRef.current?.abort()
-    if (uncachedAuthIndexes.length === 0) {
+    if (authIndexes.length === 0) {
       return
     }
 
     const controller = new AbortController()
     requestControllerRef.current = controller
-    // 缓存接口不会刷新限额，只把后端已有的完成任务结果同步到当前页。
-    void fetchUsageQuotaCache(uncachedAuthIndexes, controller.signal).then((response) => {
+    // 缓存接口不会刷新限额；当前页有多少 auth_index 就查询多少缓存。
+    void fetchUsageQuotaCache(authIndexes, controller.signal).then((response) => {
       if (controller.signal.aborted || requestControllerRef.current !== controller) {
         return
       }
@@ -51,7 +46,7 @@ export function useQuotaCache({ enabled, authIndexes, onAuthRequired }: UseQuota
             changed = true
           }
         }
-        for (const authIndex of uncachedAuthIndexes) {
+        for (const authIndex of authIndexes) {
           if (!returnedAuthIndexes.has(authIndex) && next[authIndex] !== undefined) {
             delete next[authIndex]
             changed = true
@@ -75,7 +70,7 @@ export function useQuotaCache({ enabled, authIndexes, onAuthRequired }: UseQuota
     return () => {
       controller.abort()
     }
-  }, [enabled, onAuthRequired, uncachedAuthIndexes])
+  }, [enabled, onAuthRequired, authIndexes])
 
   return { quotaByAuthIndex, setQuotaByAuthIndex }
 }

--- a/web/src/components/usage/credentials/useQuotaRefreshTasks.ts
+++ b/web/src/components/usage/credentials/useQuotaRefreshTasks.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react'
 import { ApiError, fetchUsageQuotaRefreshTask, refreshUsageQuotas } from '@/lib/api'
 import type { UsageQuotaRow } from '@/lib/types'
-import { CREDENTIALS_PAGE_SIZE } from './credentialViewModels'
 
 export interface QuotaState {
   loading?: boolean
@@ -173,7 +172,7 @@ export function useQuotaRefreshTasks({ enabled, currentAuthIndexes, setQuotaByAu
   const refreshQuotaForCurrentAuthFilePage = useCallback(async () => {
     // 批量刷新只提交当前页且未在工作的条目，单行刷新中的任务不会重复入队。
     const refreshableAuthIndexes = currentAuthIndexes.filter((authIndex) => !isQuotaRefreshWorking(quotaStateByAuthIndex[authIndex]))
-    await startQuotaRefresh(refreshableAuthIndexes.slice(0, CREDENTIALS_PAGE_SIZE), 'batch')
+    await startQuotaRefresh(refreshableAuthIndexes, 'batch')
   }, [currentAuthIndexes, quotaStateByAuthIndex, startQuotaRefresh])
 
   const refreshQuotaForAuthIndex = useCallback(async (authIndex: string) => {

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fetchUsageQuotaCache, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchUsageIdentities, fetchUsageIdentitiesPage, fetchUsageQuotaCheck, fetchUsageQuotaRefreshTask, refreshUsageQuotas, triggerSync } from './api';
+import { fetchUsageQuotaCache, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchUsageIdentities, fetchUsageIdentitiesPage, fetchUsageQuotaRefreshTask, refreshUsageQuotas, triggerSync } from './api';
 
 describe('fetchUsageEvents', () => {
   afterEach(() => {
@@ -151,30 +151,6 @@ describe('fetchUsageEvents', () => {
     expect(init).toMatchObject({ credentials: 'include', signal });
   });
 
-  it('checks quota for a single auth index', async () => {
-    vi.stubGlobal('window', { __APP_BASE_PATH__: undefined });
-    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        id: 'auth-1',
-        quota: [{ key: 'rate_limit.primary_window', label: '5h', remaining: 12 }],
-      }),
-    } as Response);
-    const signal = new AbortController().signal;
-
-    const response = await fetchUsageQuotaCheck('auth-1', signal);
-
-    const [url, init] = fetchMock.mock.calls[0];
-    const parsed = new URL(String(url), 'http://localhost');
-
-    expect(response.id).toBe('auth-1');
-    expect(response.quota[0].remaining).toBe(12);
-    expect(parsed.pathname).toBe('/api/v1/quota/check');
-    expect(init).toMatchObject({ credentials: 'include', method: 'POST', signal });
-    expect(init?.headers).toEqual({ 'Content-Type': 'application/json' });
-    expect(init?.body).toBe(JSON.stringify({ auth_index: 'auth-1' }));
-  });
-
   it('loads cached quota for current page auth indexes without refreshing', async () => {
     vi.stubGlobal('window', { __APP_BASE_PATH__: undefined });
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
@@ -207,7 +183,7 @@ describe('fetchUsageEvents', () => {
         rejected: [],
         accepted: 1,
         skipped: 0,
-        limit: 20,
+        limit: 1,
       }),
     } as Response);
     const signal = new AbortController().signal;
@@ -218,11 +194,11 @@ describe('fetchUsageEvents', () => {
     const parsed = new URL(String(url), 'http://localhost');
 
     expect(response.tasks[0]).toEqual({ authIndex: 'auth-1', taskId: 'task-1' });
-    expect(response.limit).toBe(20);
+    expect(response.limit).toBe(1);
     expect(parsed.pathname).toBe('/api/v1/quota/refresh');
     expect(init).toMatchObject({ credentials: 'include', method: 'POST', signal });
     expect(init?.headers).toEqual({ 'Content-Type': 'application/json' });
-    expect(init?.body).toBe(JSON.stringify({ auth_indexes: ['auth-1'], limit: 20 }));
+    expect(init?.body).toBe(JSON.stringify({ auth_indexes: ['auth-1'] }));
   });
 
   it('loads quota refresh task status', async () => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { USAGE_QUOTA_REFRESH_LIMIT, type AuthSessionResponse, type PricingEntry, type PricingResponse, type StatusResponse, type UpdateCheckResponse, type UsageAnalysisResponse, type UsageEventModelFilterOptionsResponse, type UsageEventSourceFilterOptionsResponse, type UsedModelsResponse, type UsageIdentitiesPageResponse, type UsageIdentitiesResponse, type UsageEventsResponse, type UsageIdentityAuthType, type UsageOverviewResponse, type UsageQuotaCacheResponse, type UsageQuotaCheckResponse, type UsageQuotaRefreshResponse, type UsageQuotaRefreshTaskResponse } from './types'
+import { type AuthSessionResponse, type PricingEntry, type PricingResponse, type StatusResponse, type UpdateCheckResponse, type UsageAnalysisResponse, type UsageEventModelFilterOptionsResponse, type UsageEventSourceFilterOptionsResponse, type UsedModelsResponse, type UsageIdentitiesPageResponse, type UsageIdentitiesResponse, type UsageEventsResponse, type UsageIdentityAuthType, type UsageOverviewResponse, type UsageQuotaCacheResponse, type UsageQuotaRefreshResponse, type UsageQuotaRefreshTaskResponse } from './types'
 
 export class ApiError extends Error {
   status: number
@@ -181,21 +181,6 @@ export async function fetchUsageIdentitiesPage(signal?: AbortSignal, options?: F
   return response.json()
 }
 
-export async function fetchUsageQuotaCheck(authIndex: string, signal?: AbortSignal): Promise<UsageQuotaCheckResponse> {
-  const response = await apiFetch(apiPath('/quota/check'), {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ auth_index: authIndex }),
-    signal,
-  })
-  if (!response.ok) {
-    await parseApiError(response, `Failed to check usage quota: ${response.status}`)
-  }
-  return response.json()
-}
-
 export async function fetchUsageQuotaCache(authIndexes: string[], signal?: AbortSignal): Promise<UsageQuotaCacheResponse> {
   // cache 只读后端已有结果，不携带刷新 limit，避免把缓存读取误当队列提交。
   const response = await apiFetch(apiPath('/quota/cache'), {
@@ -213,13 +198,13 @@ export async function fetchUsageQuotaCache(authIndexes: string[], signal?: Abort
 }
 
 export async function refreshUsageQuotas(authIndexes: string[], signal?: AbortSignal): Promise<UsageQuotaRefreshResponse> {
-  // refresh 会创建后台任务，前端固定提交当前页上限，真正上限仍由后端入口校验。
+  // refresh 会创建后台任务，前端提交当前页所有 auth_index。
   const response = await apiFetch(apiPath('/quota/refresh'), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ auth_indexes: authIndexes, limit: USAGE_QUOTA_REFRESH_LIMIT }),
+    body: JSON.stringify({ auth_indexes: authIndexes }),
     signal,
   })
   if (!response.ok) {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,5 +1,3 @@
-export const USAGE_QUOTA_REFRESH_LIMIT = 20
-
 export interface AuthSessionResponse {
   authenticated: boolean
 }

--- a/web/src/pages/UsagePage.logic.test.ts
+++ b/web/src/pages/UsagePage.logic.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { buildCustomDateRangeQuery, getOverviewChartEndMs, getOverviewDisplayLoading, getOverviewHourWindowHours, getPreferredOverviewChartPeriod, getTimeRangeOptions, getUsageTabOptions, refreshPageData, sanitizeRequestEventFilters, scheduleOverviewAutoRefresh, shouldShowRangeControls, shouldShowUpdateCheckButton, getUpdateCheckToastDuration, syncCpaData } from './UsagePage';
+import { buildCustomDateRangeQuery, getOverviewChartEndMs, getOverviewDisplayLoading, getOverviewHourWindowHours, getPreferredOverviewChartPeriod, getTimeRangeOptions, getUsageTabOptions, refreshPageData, sanitizeRequestEventFilters, scheduleOverviewAutoRefresh, shouldAutoRefreshUsageTab, shouldShowRangeControls, shouldShowUpdateCheckButton, getUpdateCheckToastDuration, syncCpaData } from './UsagePage';
 import { ApiError } from '@/lib/api';
 import { filterUsageByWindow, type UsageFilterWindow } from '@/utils/usage';
 import type { StatusResponse, UsageSnapshot } from '@/lib/types';
@@ -203,6 +203,25 @@ describe('UsagePage Overview auto-refresh', () => {
     testDocument.dispatchEvent(new Event('visibilitychange'));
 
     expect(refreshOverview).not.toHaveBeenCalled();
+  });
+});
+
+describe('UsagePage active tab auto-refresh guard', () => {
+  it('allows Request Events auto-refresh only on the first page', () => {
+    expect(shouldAutoRefreshUsageTab({ activeTab: 'events', eventsPage: 1, authFilePage: 1, aiProviderPage: 1 })).toBe(true);
+    expect(shouldAutoRefreshUsageTab({ activeTab: 'events', eventsPage: 2, authFilePage: 1, aiProviderPage: 1 })).toBe(false);
+  });
+
+  it('allows Credentials auto-refresh only when both lists are on the first page', () => {
+    expect(shouldAutoRefreshUsageTab({ activeTab: 'credentials', eventsPage: 1, authFilePage: 1, aiProviderPage: 1 })).toBe(true);
+    expect(shouldAutoRefreshUsageTab({ activeTab: 'credentials', eventsPage: 1, authFilePage: 2, aiProviderPage: 1 })).toBe(false);
+    expect(shouldAutoRefreshUsageTab({ activeTab: 'credentials', eventsPage: 1, authFilePage: 1, aiProviderPage: 2 })).toBe(false);
+  });
+
+  it('keeps Overview auto-refresh enabled and does not auto-refresh other tabs', () => {
+    expect(shouldAutoRefreshUsageTab({ activeTab: 'overview', eventsPage: 2, authFilePage: 2, aiProviderPage: 2 })).toBe(true);
+    expect(shouldAutoRefreshUsageTab({ activeTab: 'analysis', eventsPage: 1, authFilePage: 1, aiProviderPage: 1 })).toBe(false);
+    expect(shouldAutoRefreshUsageTab({ activeTab: 'pricing', eventsPage: 1, authFilePage: 1, aiProviderPage: 1 })).toBe(false);
   });
 });
 

--- a/web/src/pages/UsagePage.logic.test.ts
+++ b/web/src/pages/UsagePage.logic.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { buildCustomDateRangeQuery, getOverviewChartEndMs, getOverviewDisplayLoading, getOverviewHourWindowHours, getPreferredOverviewChartPeriod, getTimeRangeOptions, getUsageTabOptions, refreshPageData, sanitizeRequestEventFilters, scheduleOverviewAutoRefresh, shouldAutoRefreshUsageTab, shouldShowRangeControls, shouldShowUpdateCheckButton, getUpdateCheckToastDuration, syncCpaData } from './UsagePage';
+import { buildCustomDateRangeQuery, getCustomDateRangeBounds, getOverviewChartEndMs, getOverviewDisplayLoading, getOverviewHourWindowHours, getPreferredOverviewChartPeriod, getTimeRangeOptions, getUsageTabOptions, isCustomDateWithinBounds, openDateInputPicker, refreshPageData, sanitizeRequestEventFilters, scheduleOverviewAutoRefresh, shouldAutoRefreshUsageTab, shouldShowRangeControls, shouldShowUpdateCheckButton, getUpdateCheckToastDuration, syncCpaData } from './UsagePage';
 import { ApiError } from '@/lib/api';
 import { filterUsageByWindow, type UsageFilterWindow } from '@/utils/usage';
 import type { StatusResponse, UsageSnapshot } from '@/lib/types';
@@ -315,6 +315,45 @@ describe('UsagePage Overview chart period preference', () => {
     expect(getPreferredOverviewChartPeriod({ windowMinutes: 24 * 60 })).toBe('hour');
     expect(getPreferredOverviewChartPeriod({ windowMinutes: (24 * 60) + 1 })).toBe('day');
     expect(getPreferredOverviewChartPeriod({ windowMinutes: 30 * 24 * 60 })).toBe('day');
+  });
+});
+
+describe('UsagePage custom date input bounds', () => {
+  it('limits selectable Custom dates to today through the first day of the previous month', () => {
+    expect(getCustomDateRangeBounds(Date.parse('2026-05-13T12:00:00.000Z'), 'UTC')).toEqual({
+      min: '2026-04-01',
+      max: '2026-05-13',
+    });
+  });
+
+  it('uses the project timezone when deriving Custom date bounds', () => {
+    expect(getCustomDateRangeBounds(Date.parse('2026-05-13T06:30:00.000Z'), 'America/Los_Angeles')).toEqual({
+      min: '2026-04-01',
+      max: '2026-05-12',
+    });
+  });
+
+  it('rejects tomorrow and dates before the first day of the previous month', () => {
+    const bounds = { min: '2026-04-01', max: '2026-05-13' };
+
+    expect(isCustomDateWithinBounds('2026-05-13', bounds)).toBe(true);
+    expect(isCustomDateWithinBounds('2026-04-01', bounds)).toBe(true);
+    expect(isCustomDateWithinBounds('2026-05-14', bounds)).toBe(false);
+    expect(isCustomDateWithinBounds('2026-03-31', bounds)).toBe(false);
+  });
+
+  it('opens the native date picker when the date field is activated', () => {
+    const showPicker = vi.fn();
+
+    openDateInputPicker({ showPicker } as unknown as HTMLInputElement);
+
+    expect(showPicker).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores browsers that reject programmatic date picker opening', () => {
+    const input = { showPicker: vi.fn(() => { throw new Error('not allowed') }) } as unknown as HTMLInputElement;
+
+    expect(() => openDateInputPicker(input)).not.toThrow();
   });
 });
 

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -1765,14 +1765,31 @@
 
 .requestEventsTableWrapper {
   overflow: auto;
-  max-height: 460px;
+  height: clamp(400px, 60vh, 600px);
   border: 1px solid var(--border-color);
   border-radius: $radius-md;
+
+  .table {
+    border-collapse: separate;
+    border-spacing: 0;
+  }
+
+  thead th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+  }
 }
 
 .requestEventsTimestamp {
   white-space: nowrap;
-  min-width: 160px;
+  width: 136px;
+  min-width: 136px;
+  font-variant-numeric: tabular-nums;
+}
+
+.requestEventsReasoningHeader {
+  white-space: nowrap;
 }
 
 .requestEventsSourceCell,

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -526,6 +526,15 @@
   margin: 0;
   padding: 6px 12px;
   font-size: 12px;
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+
+  &:out-of-range {
+    color: var(--text-tertiary);
+    background: color-mix(in srgb, var(--bg-secondary) 88%, var(--border-color));
+    border-color: color-mix(in srgb, var(--border-color) 72%, var(--text-tertiary));
+  }
 }
 
 .customRangeField .customRangeInput {

--- a/web/src/pages/UsagePage.styles.test.ts
+++ b/web/src/pages/UsagePage.styles.test.ts
@@ -32,6 +32,27 @@ describe('UsagePage toolbar styles', () => {
     expect(usagePageStyles).toMatch(/\.requestEventsPaginationFooter\s*\{[\s\S]*?padding:\s*0 #\{\$spacing-lg\};/)
   })
 
+  it('keeps Request Event Log headers visible while the table scrolls', () => {
+    expect(usagePageStyles).toMatch(/\.requestEventsTableWrapper\s*\{[\s\S]*?height:\s*clamp\(400px,\s*60vh,\s*600px\);/)
+    expect(usagePageStyles).toMatch(/\.requestEventsTableWrapper\s*\{[\s\S]*?overflow:\s*auto;/)
+    expect(usagePageStyles).toMatch(/\.requestEventsTableWrapper\s*\{[\s\S]*?thead\s+th\s*\{[\s\S]*?position:\s*sticky;/)
+    expect(usagePageStyles).toMatch(/\.requestEventsTableWrapper\s*\{[\s\S]*?thead\s+th\s*\{[\s\S]*?top:\s*0;/)
+    expect(usagePageStyles).toMatch(/\.requestEventsTableWrapper\s*\{[\s\S]*?thead\s+th\s*\{[\s\S]*?z-index:\s*2;/)
+    expect(usagePageStyles).toMatch(/\.requestEventsTableWrapper\s*\{[\s\S]*?\.table\s*\{[\s\S]*?border-collapse:\s*separate;/)
+  })
+
+  it('keeps the Request Event Log timestamp column compact', () => {
+    expect(usagePageStyles).toMatch(/\.requestEventsTimestamp\s*\{[\s\S]*?width:\s*136px;/)
+    expect(usagePageStyles).toMatch(/\.requestEventsTimestamp\s*\{[\s\S]*?min-width:\s*136px;/)
+    expect(usagePageStyles).toMatch(/\.requestEventsTimestamp\s*\{[\s\S]*?font-variant-numeric:\s*tabular-nums;/)
+  })
+
+  it('keeps the Request Event Log reasoning header on one line without fixing column width', () => {
+    expect(usagePageStyles).toMatch(/\.requestEventsReasoningHeader\s*\{[\s\S]*?white-space:\s*nowrap;/)
+    expect(usagePageStyles).not.toMatch(/\.requestEventsReasoningHeader\s*\{[^}]*width:/)
+    expect(requestEventsSource).toContain('<th className={styles.requestEventsReasoningHeader}>{t(\'usage_stats.reasoning_tokens\')}</th>')
+  })
+
   it('provides reusable pill controls for usage subpages', () => {
     expect(usagePageStyles).toMatch(/\.usagePillControl\s*\{[\s\S]*?border-radius:\s*999px;/)
     expect(usagePageStyles).toMatch(/\.usagePillAction\s*\{[\s\S]*?border-radius:\s*999px;/)

--- a/web/src/pages/UsagePage.styles.test.ts
+++ b/web/src/pages/UsagePage.styles.test.ts
@@ -18,6 +18,16 @@ describe('UsagePage toolbar styles', () => {
     expect(usagePageSource).not.toContain('aria-hidden={!isCustomRange}')
   })
 
+  it('keeps custom date inputs selectable through the native picker without pointer interception', () => {
+    expect(usagePageStyles).toMatch(/\.customRangeInput\s*\{[\s\S]*?user-select:\s*none;/)
+    expect(usagePageStyles).toMatch(/\.customRangeInput\s*\{[\s\S]*?-webkit-user-select:\s*none;/)
+    expect(usagePageSource).not.toContain('readOnly')
+    expect(usagePageSource).not.toContain('onPointerDown={handleCustomDateInputPointerDown}')
+    expect(usagePageSource).toContain('onClick={handleCustomDateInputActivate}')
+    expect(usagePageSource).toContain('onFocus={handleCustomDateInputActivate}')
+    expect(usagePageSource).toContain('onKeyDown={handleCustomDateInputKeyDown}')
+  })
+
   it('keeps chart line selects aligned with reusable pill controls', () => {
     expect(chartLineSelectorSource).toContain('className={styles.usagePillControl}')
   })

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -117,6 +117,23 @@ export const shouldShowUpdateCheckButton = (status: Pick<StatusResponse, 'update
 
 export const getUpdateCheckToastDuration = (kind: 'success' | 'info' | 'error') => (kind === 'error' ? 6_000 : 4_000);
 
+export const shouldAutoRefreshUsageTab = ({
+  activeTab,
+  eventsPage,
+  authFilePage,
+  aiProviderPage,
+}: {
+  activeTab: UsageTab;
+  eventsPage: number;
+  authFilePage: number;
+  aiProviderPage: number;
+}) => {
+  if (activeTab === 'overview') return true;
+  if (activeTab === 'events') return eventsPage === 1;
+  if (activeTab === 'credentials') return authFilePage === 1 && aiProviderPage === 1;
+  return false;
+};
+
 type RequestEventFilterState = {
   model: string;
   source: string;
@@ -856,6 +873,25 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     await loadUsage();
   }, [activeTab, loadAnalysis, loadEventFilterOptions, loadEvents, loadPricing, loadUsage, refreshCredentials]);
 
+  const refreshAutoRefreshTab = useCallback(async () => {
+    if (activeTab === 'events') {
+      await loadEvents();
+      return;
+    }
+    if (activeTab === 'credentials') {
+      await refreshCredentials();
+      return;
+    }
+    await loadUsage();
+  }, [activeTab, loadEvents, loadUsage, refreshCredentials]);
+
+  const autoRefreshEnabled = shouldAutoRefreshUsageTab({
+    activeTab,
+    eventsPage,
+    authFilePage: credentialsData.authFilePage,
+    aiProviderPage: credentialsData.aiProviderPage,
+  });
+
   const handleManualRefresh = useCallback(async () => {
     setManualRefreshLoading(true);
     try {
@@ -911,9 +947,9 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   }, [onAuthRequired, showUpdateCheckNotice, t]);
 
   useEffect(() => scheduleOverviewAutoRefresh({
-    enabled: isOverviewTab,
-    refreshOverview: loadUsage,
-  }), [isOverviewTab, loadUsage]);
+    enabled: autoRefreshEnabled,
+    refreshOverview: refreshAutoRefreshTab,
+  }), [autoRefreshEnabled, refreshAutoRefreshTab]);
 
   useHeaderRefresh(refreshActiveTab);
 

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { useState, useMemo, useCallback, useEffect, useRef, type KeyboardEvent, type SyntheticEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Chart as ChartJS,
@@ -269,6 +269,54 @@ const toDateInputValue = (timestamp: number): string => {
   if (Number.isNaN(date.getTime())) return '';
   const pad = (value: number) => String(value).padStart(2, '0');
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+};
+
+const toDateInputValueInTimezone = (timestamp: number, timezone?: string): string => {
+  if (!timezone) return toDateInputValue(timestamp);
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).formatToParts(new Date(timestamp));
+    const year = parts.find((part) => part.type === 'year')?.value;
+    const month = parts.find((part) => part.type === 'month')?.value;
+    const day = parts.find((part) => part.type === 'day')?.value;
+    if (!year || !month || !day) return toDateInputValue(timestamp);
+    return `${year}-${month}-${day}`;
+  } catch {
+    return toDateInputValue(timestamp);
+  }
+};
+
+const previousMonthStartDateInputValue = (value: string): string => {
+  const match = /^(\d{4})-(\d{2})-\d{2}$/.exec(value);
+  if (!match) return value;
+  const [, year, month] = match;
+  const date = new Date(Date.UTC(Number(year), Number(month) - 2, 1));
+  const pad = (nextValue: number) => String(nextValue).padStart(2, '0');
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-01`;
+};
+
+export const getCustomDateRangeBounds = (anchorMs = Date.now(), timezone?: string) => {
+  const max = toDateInputValueInTimezone(anchorMs, timezone);
+  return {
+    min: previousMonthStartDateInputValue(max),
+    max,
+  };
+};
+
+export const isCustomDateWithinBounds = (value: string, bounds: { min: string; max: string }) => (
+  value === '' || (value >= bounds.min && value <= bounds.max)
+);
+
+export const openDateInputPicker = (input: HTMLInputElement) => {
+  try {
+    input.showPicker?.();
+  } catch {
+    // 某些浏览器会拒绝非用户手势触发的 showPicker。
+  }
 };
 
 const parseCustomDateBoundary = (value: string, endOfDay: boolean): number | undefined => {
@@ -621,6 +669,15 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     windowMinutes: filterWindow.windowMinutes,
   });
   const isCustomRange = timeRange === 'custom';
+  const customDateRangeBounds = useMemo(() => getCustomDateRangeBounds(Date.now(), status?.timezone), [status?.timezone]);
+  const handleCustomDateInputKeyDown = useCallback((event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Tab') return;
+    event.preventDefault();
+    openDateInputPicker(event.currentTarget);
+  }, []);
+  const handleCustomDateInputActivate = useCallback((event: SyntheticEvent<HTMLInputElement>) => {
+    openDateInputPicker(event.currentTarget);
+  }, []);
 
   const handleChartLinesChange = useCallback((lines: string[]) => {
     setChartLines(normalizeChartLines(lines));
@@ -1249,12 +1306,20 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                               type="date"
                               className={`input ${styles.customRangeInput}`}
                               value={customTimeRange.start}
-                              onChange={(event) =>
+                              min={customDateRangeBounds.min}
+                              max={customDateRangeBounds.max}
+                              onClick={handleCustomDateInputActivate}
+                              onFocus={handleCustomDateInputActivate}
+                              onKeyDown={handleCustomDateInputKeyDown}
+                              onPaste={(event) => event.preventDefault()}
+                              onChange={(event) => {
+                                const nextValue = event.target.value;
+                                if (!isCustomDateWithinBounds(nextValue, customDateRangeBounds)) return;
                                 setCustomTimeRange((current) => ({
                                   ...current,
-                                  start: event.target.value
-                                }))
-                              }
+                                  start: nextValue
+                                }));
+                              }}
                               aria-label={t('usage_stats.custom_start')}
                             />
                           </label>
@@ -1265,12 +1330,20 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                               type="date"
                               className={`input ${styles.customRangeInput}`}
                               value={customTimeRange.end}
-                              onChange={(event) =>
+                              min={customDateRangeBounds.min}
+                              max={customDateRangeBounds.max}
+                              onClick={handleCustomDateInputActivate}
+                              onFocus={handleCustomDateInputActivate}
+                              onKeyDown={handleCustomDateInputKeyDown}
+                              onPaste={(event) => event.preventDefault()}
+                              onChange={(event) => {
+                                const nextValue = event.target.value;
+                                if (!isCustomDateWithinBounds(nextValue, customDateRangeBounds)) return;
                                 setCustomTimeRange((current) => ({
                                   ...current,
-                                  end: event.target.value
-                                }))
-                              }
+                                  end: nextValue
+                                }));
+                              }}
                               aria-label={t('usage_stats.custom_end')}
                             />
                           </label>


### PR DESCRIPTION
## Summary
- Improve Request Event Log readability with sticky headers, compact timestamps, adaptive table height, and cache rate display.
- Clean quota cache/refresh flows by removing stale `/quota/check` usage and list-size limits.
- Add active-tab auto-refresh, Custom date picker bounds, and two-decimal credential rate formatting.
- Refresh the Chinese and English README project structure sections to match current backend, frontend, and deployment directories.

## Test plan
- [x] npm --prefix web test -- RequestEventsDetailsCard.test.tsx UsagePage.logic.test.ts UsagePage.styles.test.ts credentialViewModels.test.ts CredentialSectionShell.test.ts AiProviderCredentialsSection.test.tsx AuthFileCredentialsSection.test.ts useCredentialsTabData.test.ts
- [x] npm --prefix web test -- CredentialSectionShell.test.ts AiProviderCredentialsSection.test.tsx AuthFileCredentialsSection.test.ts credentialViewModels.test.ts
- [x] npm --prefix web test -- UsagePage.logic.test.ts UsagePage.styles.test.ts
- [x] npm --prefix web run lint
- [x] npm --prefix web run typecheck
- [x] npm --prefix web run build
- [x] go test ./internal/api ./internal/quota
- [x] Manual test via backend-served frontend at /cpa/
- [x] README-only project structure update reviewed by diff