### PR TITLE
fix: correct Claude cache rate

### DIFF
--- a/web/src/components/usage/RequestEventsDetailsCard.test.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.test.tsx
@@ -87,6 +87,19 @@ describe('RequestEventsDetailsCard pagination', () => {
     expect(html).toContain('<td>25</td><td>25.00%</td><td>200</td>');
   });
 
+  it('uses Claude token semantics for cache rate', () => {
+    const html = renderCard({
+      events: [{
+        ...events[0],
+        source_type: 'claude',
+        tokens: { ...events[0].tokens, input_tokens: 400, cached_tokens: 600, total_tokens: 500 },
+      }],
+    });
+
+    expect(html).toContain('<td>600</td><td>60.00%</td><td>500</td>');
+    expect(html).not.toContain('150.00%');
+  });
+
   it('shows a dash for cache rate when input tokens are zero', () => {
     const html = renderCard({
       events: [{ ...events[0], tokens: { ...events[0].tokens, input_tokens: 0, cached_tokens: 25 } }],

--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -6,6 +6,7 @@ import { EmptyState } from '@/components/ui/EmptyState';
 import { Select } from '@/components/ui/Select';
 import type { UsageEvent, UsageSourceFilterOption } from '@/lib/types';
 import {
+  calculateCacheRate,
   calculateCost,
   formatDurationMs,
   formatUsd,
@@ -87,9 +88,9 @@ const formatRequestEventTimestamp = (timestamp: string): string => {
   return `${match[1]}/${match[2]}/${match[3]} ${match[4]}:${match[5]}:${match[6]}`;
 };
 
-const formatCacheRate = (cachedTokens: number, inputTokens: number): string => {
-  if (inputTokens <= 0) return '-';
-  return `${((cachedTokens / inputTokens) * 100).toFixed(2)}%`;
+const formatCacheRateForSource = (cachedTokens: number, inputTokens: number, sourceType?: string): string => {
+  const rate = calculateCacheRate({ inputTokens, cachedTokens, sourceType });
+  return rate === null ? '-' : `${rate.toFixed(2)}%`;
 };
 
 const encodeCsv = (value: string | number): string => {
@@ -194,7 +195,7 @@ export function RequestEventsDetailsCard({
         reasoningTokens,
         cachedTokens,
         totalTokens,
-        cacheRate: formatCacheRate(cachedTokens, inputTokens),
+        cacheRate: formatCacheRateForSource(cachedTokens, inputTokens, sourceType),
         cost,
         hasPrice: Boolean(pricing),
       };

--- a/web/src/components/usage/credentials/credentialViewModels.test.ts
+++ b/web/src/components/usage/credentials/credentialViewModels.test.ts
@@ -145,7 +145,7 @@ describe('credentialViewModels', () => {
       ]],
     ])
 
-    const rows = buildAuthFileCredentialRows([identity({ identity: 'auth-1', displayName: 'Claude Auth', total_requests: 10, success_count: 9, input_tokens: 1000, cached_tokens: 250, total_tokens: 1500 })], quotas)
+    const rows = buildAuthFileCredentialRows([identity({ identity: 'auth-1', displayName: 'Claude Auth', total_requests: 10, success_count: 9, input_tokens: 750, cached_tokens: 250, total_tokens: 1500 })], quotas)
 
     expect(rows[0].displayName).toBe('Claude Auth')
     expect(rows[0].typeLabel).toBe('claude')
@@ -164,6 +164,14 @@ describe('credentialViewModels', () => {
     expect(rows[0].secondaryQuota?.percentKind).toBe('used')
     expect(rows[0].secondaryQuota?.barPercent).toBe(60)
     expect(rows[0].extraQuota.map((quota) => quota.label)).toEqual(['Code Assist Credit'])
+  })
+
+  it('uses Claude token semantics for auth file cache rate', () => {
+    const rows = buildAuthFileCredentialRows([
+      identity({ identity: 'auth-claude', type: 'claude', input_tokens: 400, cached_tokens: 600 }),
+    ])
+
+    expect(rows[0].cacheRate).toBe(60)
   })
 
   it('classifies quota bar colors at 50 and 20 percent remaining thresholds', () => {

--- a/web/src/components/usage/credentials/credentialViewModels.ts
+++ b/web/src/components/usage/credentials/credentialViewModels.ts
@@ -1,4 +1,5 @@
 import type { UsageIdentity, UsageQuotaRow } from '@/lib/types'
+import { calculateCacheRate } from '@/utils/usage'
 
 export const CREDENTIALS_PAGE_SIZE = 10
 
@@ -347,11 +348,11 @@ function successRate(identity: UsageIdentity): number | null {
 }
 
 function cacheRate(identity: UsageIdentity): number | null {
-  const inputTokens = safeNumber(identity.input_tokens)
-  if (inputTokens <= 0) {
-    return null
-  }
-  return (safeNumber(identity.cached_tokens) / inputTokens) * 100
+  return calculateCacheRate({
+    inputTokens: identity.input_tokens,
+    cachedTokens: identity.cached_tokens,
+    sourceType: identity.type,
+  })
 }
 
 function firstNonEmpty(...values: Array<string | undefined>): string | undefined {

--- a/web/src/utils/usage.test.ts
+++ b/web/src/utils/usage.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { buildChartData, buildUsageFromDetails, calculateCost, filterUsageByWindow, filterUsageSnapshot, resolveUsageFilterWindow, sanitizeChartLines } from '@/utils/usage';
+import { buildChartData, buildUsageFromDetails, calculateCacheRate, calculateCost, filterUsageByWindow, filterUsageSnapshot, resolveUsageFilterWindow, sanitizeChartLines } from '@/utils/usage';
 import type { UsageSnapshot } from '@/lib/types';
 
 afterEach(() => {
@@ -256,5 +256,19 @@ describe('calculateCost', () => {
     );
     // 用 anthropic 公式：promptTokens=1，不会被减成 0
     expect(cost).toBeGreaterThan(0);
+  });
+});
+
+describe('calculateCacheRate', () => {
+  it('uses input tokens as the denominator for OpenAI-style providers', () => {
+    expect(calculateCacheRate({ inputTokens: 1000, cachedTokens: 250, sourceType: 'openai' })).toBe(25);
+  });
+
+  it('adds cached tokens to the denominator for Anthropic-style providers', () => {
+    expect(calculateCacheRate({ inputTokens: 400, cachedTokens: 600, sourceType: 'claude' })).toBe(60);
+  });
+
+  it('returns null when there is no cacheable input', () => {
+    expect(calculateCacheRate({ inputTokens: 0, cachedTokens: 0, sourceType: 'openai' })).toBeNull();
   });
 });

--- a/web/src/utils/usage.ts
+++ b/web/src/utils/usage.ts
@@ -484,6 +484,24 @@ export function calculateCost(detail: UsageDetailRecord, modelPrices: Record<str
   );
 }
 
+export function calculateCacheRate({
+  inputTokens,
+  cachedTokens,
+  sourceType,
+}: {
+  inputTokens: unknown;
+  cachedTokens: unknown;
+  sourceType?: unknown;
+}): number | null {
+  const input = Math.max(toNumber(inputTokens), 0);
+  const cached = Math.max(toNumber(cachedTokens), 0);
+  const denominator = isAnthropicStyleProvider(sourceType) ? input + cached : input;
+  if (denominator <= 0) {
+    return null;
+  }
+  return (cached / denominator) * 100;
+}
+
 // CPA 把 provider 原始口径直接落库；Anthropic 的 input_tokens 不含 cached，其它 provider 都含。
 // 计算成本/缓存率时需要按 source_type 区分公式。
 export function isAnthropicStyleProvider(sourceType: unknown): boolean {


### PR DESCRIPTION
## Summary
- add a shared cache-rate helper that honors Anthropic/Claude token semantics
- update request-event and credential cache-rate displays to use the helper
- add regressions for Claude cache-rate calculations

## Tests
- npm run test -- usage.test.ts RequestEventsDetailsCard.test.tsx credentialViewModels.test.ts
- npm run typecheck