### PR TITLE
Fix auth file quota display

### DIFF
--- a/internal/quota/refresh.go
+++ b/internal/quota/refresh.go
@@ -286,7 +286,6 @@ func (s *Service) markRefreshTaskCompleted(taskID string, response CheckResponse
 	task.Status = RefreshTaskStatusCompleted
 	task.FinishedAt = now
 	task.CachedAt = now
-	task.ExpiresAt = now.Add(s.refreshTaskTTL)
 	task.Quota = &response
 }
 

--- a/internal/quota/refresh.go
+++ b/internal/quota/refresh.go
@@ -216,6 +216,7 @@ func (s *Service) ensureRefreshTask(authIndex string, source RefreshSource) (*Re
 		if task, ok := s.refreshTasks[taskID]; ok && task.isActive() {
 			return task, false
 		}
+		delete(s.refreshTasks, taskID)
 	}
 	task := &RefreshTaskRecord{
 		TaskID:    fmt.Sprintf("quota-refresh-%d", atomic.AddUint64(&s.refreshTaskSeq, 1)),

--- a/internal/quota/service_test.go
+++ b/internal/quota/service_test.go
@@ -63,6 +63,17 @@ func TestRefreshCreatesTaskPerAuthIndexAndCachesCompletedQuota(t *testing.T) {
 	if task.AuthIndex != "auth-1" || task.Quota == nil || task.Quota.ID != "auth-1" || len(task.Quota.Quota) != 1 {
 		t.Fatalf("expected completed task to expose cached quota, got %+v", task)
 	}
+	if task.ExpiresAt != nil {
+		t.Fatalf("expected completed quota cache to have no expiry, got %v", task.ExpiresAt)
+	}
+	service.cleanupExpiredRefreshTasks(time.Now().Add(defaultRefreshTaskTTL * 2))
+	cache, err := service.GetCachedQuota(context.Background(), CacheRequest{AuthIndexes: []string{"auth-1"}})
+	if err != nil {
+		t.Fatalf("GetCachedQuota returned error: %v", err)
+	}
+	if len(cache.Items) != 1 || cache.Items[0].ID != "auth-1" {
+		t.Fatalf("expected completed quota cache to survive cleanup, got %+v", cache)
+	}
 	if handler.callCount() != 1 {
 		t.Fatalf("expected one provider call, got %d", handler.callCount())
 	}

--- a/internal/quota/service_test.go
+++ b/internal/quota/service_test.go
@@ -79,6 +79,39 @@ func TestRefreshCreatesTaskPerAuthIndexAndCachesCompletedQuota(t *testing.T) {
 	}
 }
 
+func TestRefreshPrunesPreviousCompletedTaskForSameAuthIndex(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "auth-1", Provider: "claude", Type: "auth-file", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	handler := &refreshHandlerStub{output: ProviderOutput{Result: ClaudeResult{Usage: &ClaudeUsagePayload{FiveHour: &ClaudeUsageWindow{Utilization: 25}}}}}
+	service := NewServiceWithRegistry(db, NewProviderRegistry(map[string]ProviderHandler{"claude": handler}))
+
+	first, err := service.Refresh(context.Background(), RefreshRequest{AuthIndexes: []string{"auth-1"}, Source: RefreshSourceManual})
+	if err != nil {
+		t.Fatalf("first Refresh returned error: %v", err)
+	}
+	firstTask := waitForRefreshTask(t, service, first.Tasks[0].TaskID, RefreshTaskStatusCompleted)
+
+	handler.output = ProviderOutput{Result: ClaudeResult{Usage: &ClaudeUsagePayload{FiveHour: &ClaudeUsageWindow{Utilization: 60}}}}
+	second, err := service.Refresh(context.Background(), RefreshRequest{AuthIndexes: []string{"auth-1"}, Source: RefreshSourceManual})
+	if err != nil {
+		t.Fatalf("second Refresh returned error: %v", err)
+	}
+	secondTask := waitForRefreshTask(t, service, second.Tasks[0].TaskID, RefreshTaskStatusCompleted)
+	if firstTask.TaskID == secondTask.TaskID {
+		t.Fatalf("expected a new task id for the second refresh, got %s", secondTask.TaskID)
+	}
+	if _, err := service.GetRefreshTask(context.Background(), firstTask.TaskID); !errors.Is(err, ErrTaskNotFound) {
+		t.Fatalf("expected first task to be pruned, got error %v", err)
+	}
+	cache, err := service.GetCachedQuota(context.Background(), CacheRequest{AuthIndexes: []string{"auth-1"}})
+	if err != nil {
+		t.Fatalf("GetCachedQuota returned error: %v", err)
+	}
+	if len(cache.Items) != 1 || cache.Items[0].Quota[0].UsedPercent == nil || *cache.Items[0].Quota[0].UsedPercent != 60 {
+		t.Fatalf("expected cache to expose latest quota, got %+v", cache)
+	}
+}
+
 func TestRefreshRejectsInvalidEntriesAndIgnoresRunningTask(t *testing.T) {
 	db := openQuotaTestDatabase(t)
 	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "auth-1", Provider: "claude", Type: "auth-file", AuthType: entities.UsageIdentityAuthTypeAuthFile})

--- a/web/src/components/usage/credentials/AuthFileCredentialsSection.test.ts
+++ b/web/src/components/usage/credentials/AuthFileCredentialsSection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { formatQuotaResetLabel, getQuotaRotationPhase } from './AuthFileCredentialsSection'
+import { formatQuotaResetLabel } from './AuthFileCredentialsSection'
 
 const formatLocalResetTime = (resetAt: string) => {
   const resetTime = new Date(resetAt)
@@ -10,22 +10,12 @@ const formatLocalResetTime = (resetAt: string) => {
   return `${month}/${day} ${hour}:${minute}`
 }
 
-describe('AuthFileCredentialsSection quota value rotation', () => {
-  it('uses a shared wall-clock five-second phase for every quota row', () => {
-    expect(getQuotaRotationPhase(0)).toBe('percent')
-    expect(getQuotaRotationPhase(4_999)).toBe('percent')
-    expect(getQuotaRotationPhase(5_000)).toBe('reset')
-    expect(getQuotaRotationPhase(9_999)).toBe('reset')
-    expect(getQuotaRotationPhase(10_000)).toBe('percent')
-  })
-})
-
 describe('AuthFileCredentialsSection quota reset formatting', () => {
   it('formats reset labels with days when remaining time exceeds 24 hours', () => {
     vi.setSystemTime(new Date('2026-05-10T10:00:00Z'))
     try {
       const resetAt = '2026-05-12T10:15:00Z'
-      expect(formatQuotaResetLabel(resetAt)).toBe(`2d0h15m(${formatLocalResetTime(resetAt)})`)
+      expect(formatQuotaResetLabel(resetAt)).toBe(`2d0h15m (${formatLocalResetTime(resetAt)})`)
     } finally {
       vi.useRealTimers()
     }
@@ -35,7 +25,7 @@ describe('AuthFileCredentialsSection quota reset formatting', () => {
     vi.setSystemTime(new Date('2026-05-10T10:00:00Z'))
     try {
       const resetAt = '2026-05-10T14:15:00Z'
-      expect(formatQuotaResetLabel(resetAt)).toBe(`4h15m(${formatLocalResetTime(resetAt)})`)
+      expect(formatQuotaResetLabel(resetAt)).toBe(`4h15m (${formatLocalResetTime(resetAt)})`)
     } finally {
       vi.useRealTimers()
     }

--- a/web/src/components/usage/credentials/AuthFileCredentialsSection.tsx
+++ b/web/src/components/usage/credentials/AuthFileCredentialsSection.tsx
@@ -171,9 +171,10 @@ export function formatQuotaResetLabel(resetAt: string): string {
 
 function QuotaBar({ quota }: { quota: DisplayQuota }) {
   // 条宽使用剩余额度百分比，颜色跟随剩余风险状态从绿到黄到红。
+  const { t } = useTranslation()
   const percent = quota.barPercent ?? 0
   const width = `${Math.max(0, Math.min(100, percent))}%`
-  const percentLabel = quota.barPercent === null ? '' : `${Math.round(quota.barPercent)}%`
+  const percentLabel = quota.barPercent === null ? '' : t('usage_stats.credentials_quota_percent_remaining', { percent: `${Math.round(quota.barPercent)}%` })
   const resetLabel = quota.resetText ? formatQuotaResetLabel(quota.resetText) : ''
 
   return (

--- a/web/src/components/usage/credentials/AuthFileCredentialsSection.tsx
+++ b/web/src/components/usage/credentials/AuthFileCredentialsSection.tsx
@@ -1,12 +1,9 @@
-import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { IconRefreshCw } from '@/components/ui/icons'
 import styles from './CredentialSections.module.scss'
 import type { AuthFileCredentialRow, DisplayQuota, PlanTypeTone } from './credentialViewModels'
 import { CredentialBadge, CredentialRowShell, CredentialSectionShell, CredentialsPagination, MetricPill, RequestMetric, TonePercent, cacheRateTone, capitalize, credentialToneClassName, formatCredentialNumber, successRateTone } from './CredentialSectionShell'
-
-type QuotaRotationPhase = 'percent' | 'reset'
 
 interface AuthFileCredentialsSectionProps {
   rows: AuthFileCredentialRow[]
@@ -25,7 +22,6 @@ interface AuthFileCredentialsSectionProps {
 
 export function AuthFileCredentialsSection({ rows, total, page, totalPages, pageSize, loading, quotaRefreshing, quotaRefreshError, onPageChange, onPageSizeChange, onRefreshQuota, onRefreshQuotaForAuthIndex }: AuthFileCredentialsSectionProps) {
   const { t } = useTranslation()
-  const quotaRotationPhase = useQuotaRotationPhase()
   const canRefresh = rows.some((row) => !isRowRefreshing(row) && !row.identity.is_deleted) && !quotaRefreshing
 
   return (
@@ -79,7 +75,7 @@ export function AuthFileCredentialsSection({ rows, total, page, totalPages, page
             )}
             side={(
               <div className={styles.credentialQuotaSideWithAction}>
-                <AuthFileQuotaPanel row={row} rotationPhase={quotaRotationPhase} />
+                <AuthFileQuotaPanel row={row} />
                 <button
                   type="button"
                   className={`${styles.credentialRowRefreshButton} ${rowRefreshing ? styles.credentialRowRefreshButtonLoading : ''}`.trim()}
@@ -117,7 +113,7 @@ function CredentialPlanBadge({ children, tone = 'neutral' }: { children: string;
   return <span className={`${styles.credentialPlanBadge} ${styles[`credentialPlanBadge${capitalize(tone)}`]}`.trim()}>{children}</span>
 }
 
-function AuthFileQuotaPanel({ row, rotationPhase }: { row: AuthFileCredentialRow; rotationPhase: QuotaRotationPhase }) {
+function AuthFileQuotaPanel({ row }: { row: AuthFileCredentialRow }) {
   const { t } = useTranslation()
 
   // 限额区域按加载、错误、刷新中、无缓存、可展示数据的顺序降级。
@@ -138,8 +134,8 @@ function AuthFileQuotaPanel({ row, rotationPhase }: { row: AuthFileCredentialRow
     <div className={styles.credentialQuotaPanel}>
       <div className={styles.credentialQuotaBars}>
         {/* 主/次窗口固定优先展示，额外窗口放到下方 chips，避免宽度被无限撑开。 */}
-        {row.primaryQuota && <QuotaBar quota={row.primaryQuota} rotationPhase={rotationPhase} />}
-        {row.secondaryQuota && <QuotaBar quota={row.secondaryQuota} rotationPhase={rotationPhase} />}
+        {row.primaryQuota && <QuotaBar quota={row.primaryQuota} />}
+        {row.secondaryQuota && <QuotaBar quota={row.secondaryQuota} />}
       </div>
       {row.extraQuota.length > 0 && (
         <div className={styles.credentialQuotaChips}>
@@ -155,39 +151,7 @@ function AuthFileQuotaPanel({ row, rotationPhase }: { row: AuthFileCredentialRow
   )
 }
 
-export function getQuotaRotationPhase(nowMs = Date.now()): QuotaRotationPhase {
-  return Math.floor(nowMs / 5_000) % 2 === 0 ? 'percent' : 'reset'
-}
-
-function useQuotaRotationPhase(): QuotaRotationPhase {
-  const [phase, setPhase] = useState(() => getQuotaRotationPhase())
-
-  useEffect(() => {
-    // 所有行都按同一个墙钟 5 秒边界更新，避免每条刷新完成后从自己的动画起点开始跑。
-    let intervalId: ReturnType<typeof setInterval> | undefined
-    const timeoutId = setTimeout(() => {
-      setPhase(getQuotaRotationPhase())
-      intervalId = setInterval(() => setPhase(getQuotaRotationPhase()), 5_000)
-    }, 5_000 - (Date.now() % 5_000))
-
-    return () => {
-      clearTimeout(timeoutId)
-      if (intervalId) {
-        clearInterval(intervalId)
-      }
-    }
-  }, [])
-
-  return phase
-}
-
-function quotaRotationClassName(phase: QuotaRotationPhase): string {
-  const phaseClass = phase === 'percent' ? styles.credentialQuotaRotatingValuePercent : styles.credentialQuotaRotatingValueReset
-  return `${styles.credentialQuotaRotatingValue} ${phaseClass}`
-}
-
 export function formatQuotaResetLabel(resetAt: string): string {
-  // 重置时间同时给相对剩余时长和绝对时间，供进度条右上角轮播展示。
   const resetTime = new Date(resetAt)
   const resetMs = resetTime.getTime()
   if (!Number.isFinite(resetMs)) {
@@ -202,33 +166,33 @@ export function formatQuotaResetLabel(resetAt: string): string {
   const hour = String(resetTime.getHours()).padStart(2, '0')
   const minute = String(resetTime.getMinutes()).padStart(2, '0')
   const duration = days > 0 ? `${days}d${hours}h${minutes}m` : `${hours}h${minutes}m`
-  return `${duration}(${month}/${day} ${hour}:${minute})`
+  return `${duration} (${month}/${day} ${hour}:${minute})`
 }
 
-function QuotaBar({ quota, rotationPhase }: { quota: DisplayQuota; rotationPhase: QuotaRotationPhase }) {
+function QuotaBar({ quota }: { quota: DisplayQuota }) {
   // 条宽使用剩余额度百分比，颜色跟随剩余风险状态从绿到黄到红。
-  const { t } = useTranslation()
   const percent = quota.barPercent ?? 0
   const width = `${Math.max(0, Math.min(100, percent))}%`
-  const percentLabel = quota.percent === null ? '' : t(`usage_stats.credentials_quota_percent_${quota.percentKind}`, { percent: `${Math.round(quota.percent)}%` })
+  const percentLabel = quota.barPercent === null ? '' : `${Math.round(quota.barPercent)}%`
   const resetLabel = quota.resetText ? formatQuotaResetLabel(quota.resetText) : ''
 
   return (
     <div className={styles.credentialQuotaBarBlock}>
       <div className={styles.credentialQuotaBarHeader}>
-        <span>{quota.label}</span>
-        {(percentLabel || resetLabel) && (
-          <strong className={percentLabel && resetLabel ? quotaRotationClassName(rotationPhase) : ''}>
-            {percentLabel && <span>{percentLabel}</span>}
-            {resetLabel && <span>{resetLabel}</span>}
-          </strong>
+        <span className={styles.credentialQuotaLabelGroup}>
+          <span>{quota.label}</span>
+        </span>
+        {percentLabel && (
+          <span className={styles.credentialQuotaValueGroup}>
+            <strong>{percentLabel}</strong>
+          </span>
         )}
       </div>
       <div className={styles.credentialQuotaTrack}>
         <span className={`${styles.credentialQuotaFill} ${credentialToneClassName('credentialQuotaFill', quota.status)}`.trim()} style={{ width }} />
       </div>
       <div className={styles.credentialQuotaMeta}>
-        {quota.remaining !== undefined && <span>{t('usage_stats.credentials_quota_remaining', { count: formatCredentialNumber(quota.remaining) })}</span>}
+        {resetLabel && <span>{resetLabel}</span>}
       </div>
     </div>
   )

--- a/web/src/components/usage/credentials/CredentialSections.module.scss
+++ b/web/src/components/usage/credentials/CredentialSections.module.scss
@@ -453,48 +453,57 @@
 }
 
 .credentialQuotaBarHeader {
+  align-items: center;
   margin-bottom: 6px;
+}
 
-  > span {
+.credentialQuotaValueGroup {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  min-width: 0;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+
+  strong {
+    color: var(--text-primary);
+    white-space: nowrap;
+  }
+
+  span {
+    color: var(--text-secondary);
+    font-weight: 600;
+    white-space: nowrap;
+  }
+}
+
+.credentialQuotaLabelGroup {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  overflow: hidden;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+
+  span {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-
-  strong {
-    display: inline-grid;
-    min-width: 0;
-    justify-items: end;
-    color: var(--text-primary);
-    font-variant-numeric: tabular-nums;
-  }
-}
-
-.credentialQuotaRotatingValue {
-  position: relative;
-  min-width: 104px;
-  min-height: 14px;
-  overflow: hidden;
-
-  span {
-    grid-area: 1 / 1;
-    white-space: nowrap;
-    opacity: 0;
-    transform: translateY(4px);
-    transition: opacity 0.18s ease, transform 0.18s ease;
-  }
-}
-
-.credentialQuotaRotatingValuePercent span:first-child,
-.credentialQuotaRotatingValueReset span + span {
-  opacity: 1;
-  transform: translateY(0);
 }
 
 .credentialQuotaMeta {
+  justify-content: flex-end;
   min-height: 13px;
   margin-top: 5px;
   color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+
+  span {
+    white-space: nowrap;
+  }
 }
 
 .credentialQuotaTrack {


### PR DESCRIPTION
## Summary
- Simplify Auth Files quota bars by removing the rotating quota text and showing the remaining percentage with reset timing below the bar.
- Keep completed quota cache entries available until a manual refresh overwrites them, instead of expiring cached quota data.
- Restore the remaining-label text next to the quota percentage.

## Test plan
- [x] go test ./internal/quota ./internal/api
- [x] cd web && npm test -- --run src/components/usage/credentials/AuthFileCredentialsSection.test.ts
- [x] cd web && npm run build

Closes #90