### PR TITLE
Fix usage and credentials table layouts

### DIFF
--- a/web/src/components/ui/Select.tsx
+++ b/web/src/components/ui/Select.tsx
@@ -31,6 +31,7 @@ interface SelectProps {
   ariaLabelledBy?: string;
   ariaDescribedBy?: string;
   fullWidth?: boolean;
+  dropdownMinWidth?: number;
   id?: string;
 }
 
@@ -41,13 +42,14 @@ const DROPDOWN_Z_INDEX = 2010;
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
-const resolveDropdownStyle = (element: HTMLElement): CSSProperties => {
+const resolveDropdownStyle = (element: HTMLElement, dropdownMinWidth?: number): CSSProperties => {
   const rect = element.getBoundingClientRect();
   const viewportWidth = window.innerWidth;
   const viewportHeight = window.innerHeight;
-  const width = Math.min(rect.width, Math.max(0, viewportWidth - VIEWPORT_MARGIN * 2));
+  const availableWidth = Math.max(0, viewportWidth - VIEWPORT_MARGIN * 2);
+  const width = Math.min(Math.max(rect.width, dropdownMinWidth ?? 0), availableWidth);
   const left = clamp(
-    rect.left,
+    rect.left - (width - rect.width) / 2,
     VIEWPORT_MARGIN,
     Math.max(VIEWPORT_MARGIN, viewportWidth - width - VIEWPORT_MARGIN)
   );
@@ -90,6 +92,7 @@ export function Select({
   ariaLabelledBy,
   ariaDescribedBy,
   fullWidth = true,
+  dropdownMinWidth,
   id,
 }: SelectProps) {
   const generatedId = useId();
@@ -116,8 +119,8 @@ export function Select({
 
   const updateDropdownStyle = useCallback(() => {
     if (!wrapRef.current) return;
-    setDropdownStyle(resolveDropdownStyle(wrapRef.current));
-  }, []);
+    setDropdownStyle(resolveDropdownStyle(wrapRef.current, dropdownMinWidth));
+  }, [dropdownMinWidth]);
 
   const scheduleDropdownStyleUpdate = useCallback(() => {
     if (typeof window === 'undefined') return;

--- a/web/src/components/usage/credentials/AiProviderCredentialsSection.tsx
+++ b/web/src/components/usage/credentials/AiProviderCredentialsSection.tsx
@@ -41,6 +41,7 @@ export function AiProviderCredentialsSection({ rows, total, page, totalPages, pa
             </>
           )}
           side={<AiProviderTrafficPanel row={row} />}
+          rowClassName={styles.aiProviderCredentialRow}
         />
       ))}
       <CredentialsPagination

--- a/web/src/components/usage/credentials/AuthFileCredentialsSection.tsx
+++ b/web/src/components/usage/credentials/AuthFileCredentialsSection.tsx
@@ -73,6 +73,7 @@ export function AuthFileCredentialsSection({ rows, total, page, totalPages, page
                 {row.cacheRate !== null && <MetricPill label={t('usage_stats.cache_rate')} value={<TonePercent value={row.cacheRate} tone={cacheRateTone(row.cacheRate)} />} />}
               </>
             )}
+            rowClassName={styles.authFileCredentialRow}
             side={(
               <div className={styles.credentialQuotaSideWithAction}>
                 <AuthFileQuotaPanel row={row} />

--- a/web/src/components/usage/credentials/CredentialSectionShell.tsx
+++ b/web/src/components/usage/credentials/CredentialSectionShell.tsx
@@ -17,6 +17,7 @@ interface CredentialRowShellProps {
   badges: ReactNode
   metrics: ReactNode
   side: ReactNode
+  rowClassName?: string
 }
 
 export function CredentialSectionShell({ eyebrow, title, subtitle, countLabel, actions, children }: CredentialSectionShellProps) {
@@ -38,10 +39,10 @@ export function CredentialSectionShell({ eyebrow, title, subtitle, countLabel, a
   )
 }
 
-export function CredentialRowShell({ title, subtitle, badges, metrics, side }: CredentialRowShellProps) {
+export function CredentialRowShell({ title, subtitle, badges, metrics, side, rowClassName }: CredentialRowShellProps) {
   // 统一三段式行结构：左侧身份信息、中间指标、右侧 quota/状态区域。
   return (
-    <article className={styles.credentialRow}>
+    <article className={`${styles.credentialRow} ${rowClassName ?? ''}`.trim()}>
       <div className={styles.credentialIdentityBlock}>
         <div className={styles.credentialNameRow}>
           <span className={styles.credentialDisplayName}>{title}</span>

--- a/web/src/components/usage/credentials/CredentialSections.module.scss
+++ b/web/src/components/usage/credentials/CredentialSections.module.scss
@@ -152,7 +152,6 @@
 
 .credentialRow {
   display: grid;
-  grid-template-columns: minmax(170px, 250px) minmax(394px, max-content) minmax(250px, 1fr);
   column-gap: 18px;
   row-gap: 12px;
   align-items: center;
@@ -168,12 +167,7 @@
     background: color-mix(in srgb, var(--primary-color) 5%, var(--bg-primary));
   }
 
-  @include tablet {
-    grid-template-columns: 1fr;
-  }
-
   @include mobile {
-    grid-template-columns: 1fr;
     padding: 16px 18px;
   }
 }
@@ -181,7 +175,30 @@
 .credentialIdentityBlock {
   min-width: 0;
   width: 100%;
-  max-width: 250px;
+}
+
+.authFileCredentialRow {
+  grid-template-columns: minmax(170px, 250px) minmax(394px, max-content) minmax(250px, 1fr);
+
+  .credentialIdentityBlock {
+    max-width: 250px;
+  }
+
+  @include tablet {
+    grid-template-columns: 1fr;
+  }
+}
+
+.aiProviderCredentialRow {
+  grid-template-columns: 300px minmax(394px, max-content) minmax(250px, 1fr);
+
+  .credentialIdentityBlock {
+    max-width: 300px;
+  }
+
+  @include tablet {
+    grid-template-columns: 1fr;
+  }
 }
 
 .credentialNameRow {
@@ -385,7 +402,7 @@
 
 .credentialQuotaSideWithAction {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 30px;
+  grid-template-columns: minmax(350px, 1fr) 30px;
   gap: 14px;
   align-items: center;
   width: 100%;
@@ -431,16 +448,12 @@
 
 .credentialQuotaBars {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(150px, 1fr));
   gap: 14px;
-
-  @include mobile {
-    grid-template-columns: 1fr;
-  }
 }
 
 .credentialQuotaBarBlock {
-  min-width: 195px;
+  min-width: 150px;
 }
 
 .credentialQuotaBarHeader,

--- a/web/src/components/usage/credentials/CredentialSections.styles.test.ts
+++ b/web/src/components/usage/credentials/CredentialSections.styles.test.ts
@@ -3,20 +3,28 @@ import { describe, expect, it } from 'vitest'
 
 const credentialStyles = readFileSync(new URL('./CredentialSections.module.scss', import.meta.url), 'utf8')
 const credentialShellSource = readFileSync(new URL('./CredentialSectionShell.tsx', import.meta.url), 'utf8')
+const aiProviderSectionSource = readFileSync(new URL('./AiProviderCredentialsSection.tsx', import.meta.url), 'utf8')
+const authFileSectionSource = readFileSync(new URL('./AuthFileCredentialsSection.tsx', import.meta.url), 'utf8')
 
 describe('Credential section styles', () => {
-  it('keeps Auth Files and AI Provider identity columns at the requested width', () => {
-    expect(credentialStyles).toMatch(/\.credentialRow\s*\{[\s\S]*?grid-template-columns:\s*minmax\(170px, 250px\) minmax\(394px, max-content\) minmax\(250px, 1fr\);/)
-    expect(credentialStyles).toMatch(/\.credentialIdentityBlock\s*\{[\s\S]*?max-width:\s*250px;/)
-    expect(credentialShellSource).toContain('<article className={styles.credentialRow}>')
+  it('keeps Auth Files and AI Provider row sizing separate', () => {
+    expect(credentialStyles).toMatch(/\.authFileCredentialRow\s*\{[\s\S]*?grid-template-columns:\s*minmax\(170px, 250px\) minmax\(394px, max-content\) minmax\(250px, 1fr\);/)
+    expect(credentialStyles).toMatch(/\.authFileCredentialRow\s*\{[\s\S]*?\.credentialIdentityBlock\s*\{[\s\S]*?max-width:\s*250px;/)
+    expect(credentialStyles).toMatch(/\.aiProviderCredentialRow\s*\{[\s\S]*?grid-template-columns:\s*300px minmax\(394px, max-content\) minmax\(250px, 1fr\);/)
+    expect(credentialStyles).toMatch(/\.aiProviderCredentialRow\s*\{[\s\S]*?\.credentialIdentityBlock\s*\{[\s\S]*?max-width:\s*300px;/)
+    expect(credentialShellSource).toContain('rowClassName?: string')
+    expect(aiProviderSectionSource).toContain('rowClassName={styles.aiProviderCredentialRow}')
+    expect(authFileSectionSource).toContain('rowClassName={styles.authFileCredentialRow}')
+    expect(authFileSectionSource).not.toContain('aiProviderCredentialRow')
   })
 
-  it('balances the Auth Files quota spacing without fixing the quota bar width', () => {
+  it('lets Auth Files quota bars wrap before their blocks overlap', () => {
     expect(credentialStyles).toMatch(/\.credentialRow\s*\{[\s\S]*?column-gap:\s*18px;/)
-    expect(credentialStyles).toMatch(/\.credentialQuotaSideWithAction\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) 30px;/)
+    expect(credentialStyles).toMatch(/\.credentialQuotaSideWithAction\s*\{[\s\S]*?grid-template-columns:\s*minmax\(350px, 1fr\) 30px;/)
     expect(credentialStyles).toMatch(/\.credentialQuotaSideWithAction\s*\{[\s\S]*?gap:\s*14px;/)
+    expect(credentialStyles).toMatch(/\.credentialQuotaBars\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2, minmax\(150px, 1fr\)\);/)
     expect(credentialStyles).toMatch(/\.credentialQuotaBars\s*\{[\s\S]*?gap:\s*14px;/)
-    expect(credentialStyles).toMatch(/\.credentialQuotaBarBlock\s*\{[\s\S]*?min-width:\s*195px;/)
+    expect(credentialStyles).toMatch(/\.credentialQuotaBarBlock\s*\{[\s\S]*?min-width:\s*150px;/)
     expect(credentialStyles).not.toContain('credentialQuotaSidePanel')
     expect(credentialStyles).not.toContain('credentialQuotaRow')
   })

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -442,14 +442,6 @@
     margin 340ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.usageFilterBarCollapsed {
-  max-height: 0;
-  margin-top: -12px;
-  opacity: 0;
-  pointer-events: none;
-  transform: translateY(-8px);
-}
-
 .usageFilterField {
   display: flex;
   flex-direction: column;
@@ -503,8 +495,8 @@
 }
 
 .apiKeySelectControl {
-  width: 150px;
-  flex: 0 0 150px;
+  width: 172px;
+  flex: 0 0 172px;
 
   :global(button) {
     height: 34px;
@@ -564,6 +556,13 @@
   transform: translateX(0);
 }
 
+.usageRefreshSlot {
+  display: flex;
+  justify-content: flex-end;
+  flex: 0 0 auto;
+  min-width: 0;
+}
+
 .usageFilterActions {
   display: flex;
   align-items: center;
@@ -601,25 +600,6 @@
     flex-wrap: wrap;
     width: 100%;
     border-radius: 24px;
-  }
-}
-
-.timeRangeGroupCollapsed {
-  max-width: 0;
-  min-height: 0;
-  padding-left: 0;
-  padding-right: 0;
-  border-width: 0;
-  opacity: 0;
-  pointer-events: none;
-  transform: translateX(8px);
-
-  @include mobile {
-    width: 0;
-    max-height: 0;
-    padding-top: 0;
-    padding-bottom: 0;
-    flex-basis: 0;
   }
 }
 
@@ -759,8 +739,12 @@
     transform: translateY(0);
   }
 
-  .usageFilterActions {
+  .usageRefreshSlot {
     margin-left: auto;
+  }
+
+  .usageFilterActions {
+    margin-left: 0;
   }
 
   .timeRangeGroup {
@@ -801,6 +785,7 @@
   .usageFilterField,
   .customRangeFieldGroup,
   .customRangeField,
+  .usageRefreshSlot,
   .usageFilterActions,
   .refreshSwitcher,
   .refreshPill {
@@ -812,11 +797,16 @@
   }
 
   .apiKeyFilterField,
-  .rangeFilterField,
-  .apiKeySelectControl,
-  .rangeSelectControl {
+  .rangeFilterField {
     flex-basis: 100%;
     width: 100%;
+  }
+
+  .apiKeySelectControl,
+  .rangeSelectControl {
+    width: 100%;
+    max-width: 100%;
+    flex: 1 1 auto;
   }
 
   .apiKeyFilterField,
@@ -842,6 +832,7 @@
     width: 100%;
   }
 
+  .usageRefreshSlot,
   .usageFilterActions {
     margin-left: 0;
   }

--- a/web/src/pages/UsagePage.styles.test.ts
+++ b/web/src/pages/UsagePage.styles.test.ts
@@ -6,11 +6,35 @@ const usagePageSource = readFileSync(new URL('./UsagePage.tsx', import.meta.url)
 const requestEventsSource = readFileSync(new URL('../components/usage/RequestEventsDetailsCard.tsx', import.meta.url), 'utf8')
 const priceSettingsSource = readFileSync(new URL('../components/usage/PriceSettingsCard.tsx', import.meta.url), 'utf8')
 const chartLineSelectorSource = readFileSync(new URL('../components/usage/ChartLineSelector.tsx', import.meta.url), 'utf8')
+const selectSource = readFileSync(new URL('../components/ui/Select.tsx', import.meta.url), 'utf8')
 
 describe('UsagePage toolbar styles', () => {
   it('keeps visible range controls content-sized in narrow layouts', () => {
     expect(usagePageStyles).toMatch(/\.timeRangeGroup\s*\{[\s\S]*?width:\s*fit-content;/)
     expect(usagePageStyles).toMatch(/\.timeRangeSelectControl\s*\{[\s\S]*?flex:\s*0 0 164px;/)
+  })
+
+  it('keeps refresh controls outside the query filter layout', () => {
+    expect(usagePageSource).toContain('{showRangeControls && (\n                  <div className={styles.usageFilterBar}>')
+    expect(usagePageSource).toContain('className={styles.usageRefreshSlot}')
+    expect(usagePageSource).not.toContain('styles.usageFilterBarCollapsed')
+    expect(usagePageStyles).toMatch(/\.usageRefreshSlot\s*\{[\s\S]*?flex:\s*0 0 auto;/)
+  })
+
+  it('widens only the API key dropdown menu without changing the trigger width', () => {
+    expect(selectSource).toContain('dropdownMinWidth?: number')
+    expect(selectSource).toContain('rect.left - (width - rect.width) / 2')
+    expect(usagePageSource).toContain('dropdownMinWidth={180}')
+  })
+
+  it('preserves the original desktop toolbar sizing while isolating refresh layout', () => {
+    expect(usagePageStyles).toMatch(/\.toolbarActionsRight\s*\{[\s\S]*?align-items:\s*center;/)
+    expect(usagePageStyles).toMatch(/\.usageFilterBar\s*\{[\s\S]*?align-items:\s*center;/)
+    expect(usagePageStyles).toMatch(/\.usageFilterBar\s*\{[\s\S]*?flex:\s*1 1 auto;/)
+    expect(usagePageStyles).toMatch(/\.apiKeySelectControl\s*\{[\s\S]*?width:\s*172px;/)
+    expect(usagePageStyles).toMatch(/\.apiKeySelectControl\s*\{[\s\S]*?flex:\s*0 0 172px;/)
+    expect(usagePageStyles).toMatch(/\.rangeSelectControl\s*\{[\s\S]*?width:\s*164px;/)
+    expect(usagePageStyles).toMatch(/\.rangeSelectControl\s*\{[\s\S]*?flex:\s*0 0 164px;/)
   })
 
   it('keeps custom range inputs hidden and disabled until the custom range is selected', () => {

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -1385,8 +1385,9 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
               </div>
 
               <div className={styles.toolbarActionsRight}>
-                <div className={`${styles.usageFilterBar} ${showRangeControls ? '' : styles.usageFilterBarCollapsed}`.trim()} aria-hidden={!showRangeControls}>
-                  <div className={styles.apiKeyFilterGroup}>
+                {showRangeControls && (
+                  <div className={styles.usageFilterBar}>
+                    <div className={styles.apiKeyFilterGroup}>
                     <label className={`${styles.usageFilterField} ${styles.apiKeyFilterField}`.trim()}>
                       <span className={styles.usageFilterLabel}>{t('usage_stats.api_key_filter')}</span>
                       <Select
@@ -1396,10 +1397,11 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                         className={styles.apiKeySelectControl}
                         ariaLabel={t('usage_stats.api_key_filter')}
                         fullWidth
+                        dropdownMinWidth={180}
                       />
                     </label>
                   </div>
-                  <div className={`${styles.timeRangeGroup} ${showRangeControls ? '' : styles.timeRangeGroupCollapsed}`.trim()}>
+                    <div className={styles.timeRangeGroup}>
                     <label className={`${styles.usageFilterField} ${styles.rangeFilterField}`.trim()}>
                       <span className={styles.usageFilterLabel}>{t('usage_stats.range_filter')}</span>
                       <Select
@@ -1466,34 +1468,37 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                       </label>
                     </div>
                   </div>
-                </div>
-                {showRangeControls && isCustomRange && customRangeHint && (
-                  <span className={styles.customRangeHint}>{customRangeHint}</span>
+                    {isCustomRange && customRangeHint && (
+                      <span className={styles.customRangeHint}>{customRangeHint}</span>
+                    )}
+                    {isCustomRange && customRangeError && (
+                      <span className={styles.customRangeError}>{customRangeError}</span>
+                    )}
+                  </div>
                 )}
-                {showRangeControls && isCustomRange && customRangeError && (
-                  <span className={styles.customRangeError}>{customRangeError}</span>
-                )}
-                <div className={styles.usageFilterActions}>
-                  <div className={styles.refreshSwitcher} role="group" aria-label={t('usage_stats.refresh')}>
-                    <button
-                      type="button"
-                      className={`${styles.refreshPill} ${styles.refreshPillActive} ${manualRefreshLoading ? styles.refreshPillLoading : ''}`.trim()}
-                      onClick={() => void handleManualRefresh().catch(() => {})}
-                      disabled={manualRefreshLoading}
-                      aria-busy={manualRefreshLoading}
-                    >
-                      {manualRefreshLoading ? (
-                        <span className={styles.refreshPillInner}>
-                          <LoadingSpinner size={12} className={styles.refreshSpinner} />
-                          <span>{t('common.loading')}</span>
-                        </span>
-                      ) : (
-                        <span className={styles.refreshPillInner}>
-                          <IconRefreshCw size={14} />
-                          <span>{t('usage_stats.refresh')}</span>
-                        </span>
-                      )}
-                    </button>
+                <div className={styles.usageRefreshSlot}>
+                  <div className={styles.usageFilterActions}>
+                    <div className={styles.refreshSwitcher} role="group" aria-label={t('usage_stats.refresh')}>
+                      <button
+                        type="button"
+                        className={`${styles.refreshPill} ${styles.refreshPillActive} ${manualRefreshLoading ? styles.refreshPillLoading : ''}`.trim()}
+                        onClick={() => void handleManualRefresh().catch(() => {})}
+                        disabled={manualRefreshLoading}
+                        aria-busy={manualRefreshLoading}
+                      >
+                        {manualRefreshLoading ? (
+                          <span className={styles.refreshPillInner}>
+                            <LoadingSpinner size={12} className={styles.refreshSpinner} />
+                            <span>{t('common.loading')}</span>
+                          </span>
+                        ) : (
+                          <span className={styles.refreshPillInner}>
+                            <IconRefreshCw size={14} />
+                            <span>{t('usage_stats.refresh')}</span>
+                          </span>
+                        )}
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Stabilize the Usage toolbar so hidden range controls do not cause tab-switch jitter while keeping refresh controls independent.
- Preserve API key select trigger styling while widening and centering the dropdown menu.
- Split Credentials row sizing between Auth Files and AI Provider, and adjust Auth Files quota bar spacing to reduce narrow-width overlap.

## Test plan
- [x] npm --prefix web test -- UsagePage.styles.test.ts
- [x] npm --prefix web test -- CredentialSections.styles.test.ts
- [x] npm --prefix web run typecheck
- [x] npm --prefix web run build
- [x] Backend health check returned 200 after restart