### PR TITLE
Fix quota refresh api-call payload

### DIFF
--- a/internal/cpa/client_test.go
+++ b/internal/cpa/client_test.go
@@ -152,9 +152,16 @@ func TestCallManagementAPIPostsWrappedRequest(t *testing.T) {
 		if !ok || header["Chatgpt-Account-Id"] != "acct_123" {
 			t.Fatalf("unexpected api-call header body: %#v", body["header"])
 		}
-		data, ok := body["data"].(map[string]any)
-		if !ok || data["project"] != "project-123" {
-			t.Fatalf("unexpected api-call data body: %#v", body["data"])
+		data, ok := body["data"].(string)
+		if !ok {
+			t.Fatalf("expected api-call data to be JSON string, got %#v", body["data"])
+		}
+		var decodedData map[string]string
+		if err := json.Unmarshal([]byte(data), &decodedData); err != nil {
+			t.Fatalf("decode api-call data string: %v", err)
+		}
+		if decodedData["project"] != "project-123" {
+			t.Fatalf("unexpected api-call data body: %#v", decodedData)
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/cpa/dto/apicall/api_call.go
+++ b/internal/cpa/dto/apicall/api_call.go
@@ -11,25 +11,11 @@ type Request struct {
 }
 
 func (r Request) MarshalJSON() ([]byte, error) {
-	type alias struct {
-		AuthIndex string            `json:"authIndex"`
-		Method    string            `json:"method"`
-		URL       string            `json:"url"`
-		Header    map[string]string `json:"header,omitempty"`
-		Data      any               `json:"data,omitempty"`
-	}
-	encoded := alias{
-		AuthIndex: r.AuthIndex,
-		Method:    r.Method,
-		URL:       r.URL,
-		Header:    r.Header,
-	}
+	type alias Request
+	encoded := alias(r)
 	if r.Data != nil {
-		switch data := r.Data.(type) {
-		case string:
-			encoded.Data = data
-		default:
-			dataBytes, err := json.Marshal(data)
+		if _, ok := r.Data.(string); !ok {
+			dataBytes, err := json.Marshal(r.Data)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/cpa/dto/apicall/api_call.go
+++ b/internal/cpa/dto/apicall/api_call.go
@@ -10,6 +10,35 @@ type Request struct {
 	Data      any               `json:"data,omitempty"`
 }
 
+func (r Request) MarshalJSON() ([]byte, error) {
+	type alias struct {
+		AuthIndex string            `json:"authIndex"`
+		Method    string            `json:"method"`
+		URL       string            `json:"url"`
+		Header    map[string]string `json:"header,omitempty"`
+		Data      any               `json:"data,omitempty"`
+	}
+	encoded := alias{
+		AuthIndex: r.AuthIndex,
+		Method:    r.Method,
+		URL:       r.URL,
+		Header:    r.Header,
+	}
+	if r.Data != nil {
+		switch data := r.Data.(type) {
+		case string:
+			encoded.Data = data
+		default:
+			dataBytes, err := json.Marshal(data)
+			if err != nil {
+				return nil, err
+			}
+			encoded.Data = string(dataBytes)
+		}
+	}
+	return json.Marshal(encoded)
+}
+
 type Response struct {
 	StatusCode int             `json:"statusCode"`
 	BodyText   string          `json:"bodyText"`


### PR DESCRIPTION
## Summary
- Encode CPA management api-call `data` as a JSON string so Keeper matches the payload shape used by CPAMC
- Keep quota providers building structured request bodies while preserving existing `authIndex`, `header`, and provider-specific fields.
- Cover the wire payload shape with a CPA client test so Antigravity and Gemini CLI quota refresh requests stay compatible.

## Test plan
- [x] go test ./...

Closes #99