### PR TITLE
Fix credentials request metric width

### DIFF
--- a/web/src/components/usage/credentials/CredentialSections.module.scss
+++ b/web/src/components/usage/credentials/CredentialSections.module.scss
@@ -393,7 +393,7 @@
 
 .credentialMetricGroup {
   display: grid;
-  grid-template-columns: max-content repeat(3, 95px);
+  grid-template-columns: minmax(109px, max-content) repeat(3, 95px);
   gap: 6px;
   align-items: center;
   justify-content: start;

--- a/web/src/components/usage/credentials/CredentialSections.module.scss
+++ b/web/src/components/usage/credentials/CredentialSections.module.scss
@@ -393,7 +393,7 @@
 
 .credentialMetricGroup {
   display: grid;
-  grid-template-columns: 109px repeat(3, 95px);
+  grid-template-columns: max-content repeat(3, 95px);
   gap: 6px;
   align-items: center;
   justify-content: start;

--- a/web/src/components/usage/credentials/CredentialSections.styles.test.ts
+++ b/web/src/components/usage/credentials/CredentialSections.styles.test.ts
@@ -40,7 +40,7 @@ describe('Credential section styles', () => {
   })
 
   it('lets the Total Requests metric grow without changing the other metric widths', () => {
-    expect(credentialStyles).toMatch(/\.credentialMetricGroup\s*\{[\s\S]*?grid-template-columns:\s*max-content repeat\(3, 95px\);/)
+    expect(credentialStyles).toMatch(/\.credentialMetricGroup\s*\{[\s\S]*?grid-template-columns:\s*minmax\(109px, max-content\) repeat\(3, 95px\);/)
     expect(credentialStyles).toMatch(/\.credentialRequestMetric\s*\{[\s\S]*?align-items:\s*center;/)
     expect(credentialStyles).toMatch(/\.credentialRequestMetric\s*\{[\s\S]*?white-space:\s*nowrap;/)
     expect(credentialStyles).toMatch(/\.credentialRequestBreakdown\s*\{[\s\S]*?display:\s*inline-flex;/)

--- a/web/src/components/usage/credentials/CredentialSections.styles.test.ts
+++ b/web/src/components/usage/credentials/CredentialSections.styles.test.ts
@@ -39,8 +39,10 @@ describe('Credential section styles', () => {
     expect(credentialStyles).toMatch(/@include mobile\s*\{[\s\S]*?\.credentialQuotaBarBlock\s*\{[\s\S]*?min-width:\s*0;/)
   })
 
-  it('keeps Total Requests success and failure counts horizontally aligned', () => {
+  it('lets the Total Requests metric grow without changing the other metric widths', () => {
+    expect(credentialStyles).toMatch(/\.credentialMetricGroup\s*\{[\s\S]*?grid-template-columns:\s*max-content repeat\(3, 95px\);/)
     expect(credentialStyles).toMatch(/\.credentialRequestMetric\s*\{[\s\S]*?align-items:\s*center;/)
+    expect(credentialStyles).toMatch(/\.credentialRequestMetric\s*\{[\s\S]*?white-space:\s*nowrap;/)
     expect(credentialStyles).toMatch(/\.credentialRequestBreakdown\s*\{[\s\S]*?display:\s*inline-flex;/)
     expect(credentialStyles).toMatch(/\.credentialRequestBreakdown\s*\{[\s\S]*?align-items:\s*center;/)
     expect(credentialStyles).toMatch(/\.credentialRequestBreakdown\s*\{[\s\S]*?line-height:\s*1;/)


### PR DESCRIPTION
## Summary
- Let the Credentials Total Requests metric pill size to its content instead of using the previous fixed 109px column.
- Keep the other credential metric widths unchanged and preserve existing quota bar layout.

## Test plan
- [x] `npm --prefix web test -- --run src/components/usage/credentials/CredentialSections.styles.test.ts`
- [x] `npm --prefix web run build`
- [x] Manual check with rebuilt frontend served by backend