### PR TITLE
Recover Redis queue fallback after cached mode failure

### DIFF
--- a/internal/cpa/redis_queue_client.go
+++ b/internal/cpa/redis_queue_client.go
@@ -97,7 +97,11 @@ func (c *RedisQueueClient) PopUsage(ctx context.Context) ([]string, error) {
 
 	switch c.syncMode {
 	case redisQueueSyncModeRedis:
-		return c.popUsageOverRedis(ctx)
+		messages, err := c.popUsageOverRedis(ctx)
+		if err == nil {
+			return messages, nil
+		}
+		return c.popUsageOverHTTPFallback(ctx, err)
 	case redisQueueSyncModeHTTP:
 		return c.popUsageOverHTTP(ctx)
 	}
@@ -108,14 +112,18 @@ func (c *RedisQueueClient) PopUsage(ctx context.Context) ([]string, error) {
 		logrus.WithField("message_count", len(messages)).Info("usage queue sync used redis protocol")
 		return messages, nil
 	}
-	logrus.WithField("redis_error", err.Error()).Error("usage queue sync failed to used redis protocol")
+	return c.popUsageOverHTTPFallback(ctx, err)
+}
+
+func (c *RedisQueueClient) popUsageOverHTTPFallback(ctx context.Context, redisErr error) ([]string, error) {
+	logrus.WithField("redis_error", redisErr.Error()).Error("usage queue sync failed to used redis protocol")
 	if !c.canFallbackToHTTP() {
-		return nil, fmt.Errorf("usage queue sync failed: %w; http usage queue fallback not possible", err)
+		return nil, fmt.Errorf("usage queue sync failed: %w; http usage queue fallback not possible", redisErr)
 	}
 
 	messages, fallbackErr := c.popUsageOverHTTP(ctx)
 	if fallbackErr != nil {
-		return nil, fmt.Errorf("usage queue sync failed: %w; http usage queue fallback failed: %w", err, fallbackErr)
+		return nil, fmt.Errorf("usage queue sync failed: %w; http usage queue fallback failed: %w", redisErr, fallbackErr)
 	}
 	c.syncMode = redisQueueSyncModeHTTP
 	logrus.WithField("message_count", len(messages)).Info("usage queue sync used http protocol")

--- a/internal/cpa/redis_queue_client_test.go
+++ b/internal/cpa/redis_queue_client_test.go
@@ -162,6 +162,65 @@ func TestRedisQueueClientCachesRedisModeAfterFirstSuccessfulPop(t *testing.T) {
 	}
 }
 
+func TestRedisQueueClientFallsBackToHTTPWhenCachedRedisModeFails(t *testing.T) {
+	logs := captureRedisQueueClientInfoLogs(t)
+	var redisCalls atomic.Int32
+	redisServer := newRedisQueueMultiTestServer(t, 2, func(t *testing.T, conn net.Conn) {
+		call := redisCalls.Add(1)
+		reader := bufio.NewReader(conn)
+		readRESPCommand(t, reader)
+		if call == 1 {
+			fmt.Fprint(conn, "+OK\r\n")
+			readRESPCommand(t, reader)
+			fmt.Fprint(conn, "*1\r\n$7\r\n{\"r\":1}\r\n")
+			return
+		}
+		fmt.Fprint(conn, "-ERR RESP AUTH disabled; use mTLS\r\n")
+	})
+	var httpCalls atomic.Int32
+	httpServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		httpCalls.Add(1)
+		if got := r.Header.Get("Authorization"); got != "Bearer secret" {
+			t.Fatalf("expected management Authorization header, got %q", got)
+		}
+		_, _ = w.Write([]byte(`[{"h":2}]`))
+	}))
+	defer httpServer.Close()
+
+	client := NewRedisQueueClientWithOptions(RedisQueueOptions{
+		BaseURL:       httpServer.URL,
+		RedisAddr:     redisServer.Addr,
+		ManagementKey: "secret",
+		Timeout:       time.Second,
+		QueueKey:      ManagementUsageQueueKey,
+		BatchSize:     1,
+	})
+	client.httpClient.httpClient = httpServer.Client()
+
+	firstMessages, err := client.PopUsage(ctxWithTimeout(t))
+	if err != nil {
+		t.Fatalf("first PopUsage returned error: %v", err)
+	}
+	if len(firstMessages) != 1 || firstMessages[0] != `{"r":1}` {
+		t.Fatalf("unexpected first messages: %#v", firstMessages)
+	}
+
+	secondMessages, err := client.PopUsage(ctxWithTimeout(t))
+	if err != nil {
+		t.Fatalf("second PopUsage returned error: %v", err)
+	}
+	if len(secondMessages) != 1 || secondMessages[0] != `{"h":2}` {
+		t.Fatalf("unexpected second messages: %#v", secondMessages)
+	}
+	if httpCalls.Load() != 1 {
+		t.Fatalf("expected cached redis failure to fall back to one http call, got %d", httpCalls.Load())
+	}
+	content := logs.String()
+	if !strings.Contains(content, `msg="usage queue sync used http protocol"`) {
+		t.Fatalf("expected http fallback log, got %q", content)
+	}
+}
+
 func TestRedisQueueClientPrefersRedisBeforeHTTPFallback(t *testing.T) {
 	redisServer := newRedisQueueTestServer(t, func(t *testing.T, conn net.Conn) {
 		reader := bufio.NewReader(conn)


### PR DESCRIPTION
## Summary
- reuse the HTTP usage queue fallback when a cached Redis sync mode later fails
- add a regression test that reproduces Redis AUTH/mTLS rejection after an earlier Redis success

## Root cause
After the first successful Redis usage queue pop, the client cached `redis` mode. Later Redis failures returned directly from the cached path and skipped the existing HTTP fallback, so collectors could stay broken until process restart if the CPA management queue behavior changed.

## Validation
- `go test ./internal/cpa -run TestRedisQueueClientFallsBackToHTTPWhenCachedRedisModeFails -count=1`
- `go test ./internal/cpa -count=1`
- `go test ./... -count=1`
