### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -41,7 +41,7 @@ body:
     attributes:
       label: Environment
       description: Version and deployment details.
-      placeholder: |
+      value: |
         CPA Usage Keeper version:
         CPA version:
         Deployment: Docker Compose / Docker / binary / systemd / source

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug.
+
+        Please remove sensitive information before submitting:
+        - CPA_MANAGEMENT_KEY
+        - API keys
+        - Login password
+        - Cookies / tokens
+        - Raw private logs or database files
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the problem clearly.
+      placeholder: "Example: The Usage Overview page shows no data for Today, but request events exist."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How to reproduce?
+      description: Steps, screenshots, or anything that helps reproduce the issue.
+      placeholder: |
+        1. Open ...
+        2. Select ...
+        3. See ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Version and deployment details.
+      placeholder: |
+        CPA Usage Keeper version:
+        CPA version:
+        Deployment: Docker Compose / Docker / binary / systemd / source
+        OS:
+        Browser, if this is a UI issue:
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste relevant logs or screenshots. Please redact secrets.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Feature Request
+description: Suggest an improvement or new feature
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem do you want to solve?
+      placeholder: "Example: I want to compare usage cost by API key over a custom time range."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: What would you like to happen?
+      placeholder: "Example: Add a cost comparison chart to the Analysis page."
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, mockups, examples, or related links.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -6,7 +6,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        Please do not include secrets such as CPA_MANAGEMENT_KEY, API keys, login passwords, cookies, or tokens.
+        Please remove sensitive information before submitting:
+        - CPA_MANAGEMENT_KEY
+        - API keys
+        - Login password
+        - Cookies / tokens
+        - Raw private logs or database files
 
   - type: textarea
     id: question
@@ -21,11 +26,12 @@ body:
     attributes:
       label: Environment
       description: Optional, but helpful for setup or deployment questions.
-      placeholder: |
+      value: |
         CPA Usage Keeper version:
         CPA version:
-        Deployment:
+        Deployment: Docker Compose / Docker / binary / systemd / source
         OS:
+        Browser, if this is a UI issue:
       render: text
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,35 @@
+name: Question / Help
+description: Ask a usage, setup, or deployment question
+title: "[Question] "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please do not include secrets such as CPA_MANAGEMENT_KEY, API keys, login passwords, cookies, or tokens.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      placeholder: "Example: How should I configure CPA Usage Keeper when CPA and Keeper run in separate Docker containers?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Optional, but helpful for setup or deployment questions.
+      placeholder: |
+        CPA Usage Keeper version:
+        CPA version:
+        Deployment:
+        OS:
+      render: text
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      placeholder: "Example: I followed the Docker Compose section in the README, but ..."


### PR DESCRIPTION
## Summary
- Add lightweight GitHub issue forms for bug reports, feature requests, and questions.
- Disable blank issues so new issues use one of the structured templates.
- Include short secret-redaction reminders for bug reports and questions.

## Test plan
- [x] `git diff --cached --check`
- [x] Reviewed staged issue template diff
- [x] Confirmed repository labels `bug`, `enhancement`, and `question` exist