### PR TITLE
Fix Analysis data and mobile layout issues

### DIFF
--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -317,12 +317,10 @@ func analysisHourlyStatsEnd(filter dto.UsageQueryFilter, fullEnd time.Time) time
 	if filter.StartTime == nil || filter.EndTime == nil {
 		return fullEnd
 	}
-	end := timeutil.NormalizeStorageTime(*filter.EndTime)
-	endHour := end.Truncate(time.Hour)
 	switch filter.Range {
 	case "4h", "8h", "12h", "24h":
-		if end.After(endHour) {
-			return endHour.Add(time.Hour)
+		if timeutil.NormalizeStorageTime(*filter.EndTime).After(fullEnd) {
+			return fullEnd.Add(time.Hour)
 		}
 		return fullEnd
 	case "today", "yesterday":

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -317,7 +317,16 @@ func analysisHourlyStatsEnd(filter dto.UsageQueryFilter, fullEnd time.Time) time
 	if filter.StartTime == nil || filter.EndTime == nil {
 		return fullEnd
 	}
-	if filter.Range != "today" && filter.Range != "yesterday" {
+	end := timeutil.NormalizeStorageTime(*filter.EndTime)
+	endHour := end.Truncate(time.Hour)
+	switch filter.Range {
+	case "4h", "8h", "12h", "24h":
+		if end.After(endHour) {
+			return endHour.Add(time.Hour)
+		}
+		return fullEnd
+	case "today", "yesterday":
+	default:
 		return fullEnd
 	}
 	start := timeutil.NormalizeStorageTime(*filter.StartTime).Truncate(time.Hour)

--- a/internal/repository/usage_test.go
+++ b/internal/repository/usage_test.go
@@ -331,6 +331,42 @@ func TestBuildAnalysisWithFilterKeepsHeatmapPairsSeparateWhenValuesContainDelimi
 	}
 }
 
+func TestBuildAnalysisWithFilterIncludesCurrentHourStatsInRollingHourlyRanges(t *testing.T) {
+	withRepositoryTestLocation(t, "Asia/Shanghai")
+	db := openUsageTestDatabase(t)
+	start := time.Date(2026, 5, 21, 5, 14, 21, 0, time.Local)
+	end := time.Date(2026, 5, 21, 9, 14, 21, 0, time.Local)
+	currentHour := time.Date(2026, 5, 21, 9, 0, 0, 0, time.Local)
+	if err := db.Create(&entities.CPAAPIKey{APIKey: "sk-target-key", DisplayKey: "sk-*********target"}).Error; err != nil {
+		t.Fatalf("insert CPA API key: %v", err)
+	}
+	if err := db.Create(&entities.UsageOverviewHourlyStat{
+		BucketStart:  currentHour,
+		APIGroupKey:  "sk-target-key",
+		Model:        "claude-sonnet",
+		RequestCount: 6,
+		InputTokens:  90,
+		OutputTokens: 10,
+		TotalTokens:  100,
+	}).Error; err != nil {
+		t.Fatalf("insert current hour stat: %v", err)
+	}
+	if err := db.Migrator().DropTable(&entities.UsageEvent{}); err != nil {
+		t.Fatalf("drop usage_events: %v", err)
+	}
+
+	analysis, err := BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{Range: "4h", StartTime: &start, EndTime: &end})
+	if err != nil {
+		t.Fatalf("BuildAnalysisWithFilter returned error: %v", err)
+	}
+	if len(analysis.TokenUsage) != 1 {
+		t.Fatalf("expected current hour bucket only, got %+v", analysis.TokenUsage)
+	}
+	if !analysis.TokenUsage[0].Bucket.Equal(currentHour) || analysis.TokenUsage[0].TotalTokens != 100 || analysis.TokenUsage[0].Requests != 6 {
+		t.Fatalf("expected current hour stat to be included, got %+v", analysis.TokenUsage[0])
+	}
+}
+
 func TestBuildAnalysisWithFilterFillsTodayAndYesterdayHourlyBucketsFromStats(t *testing.T) {
 	db := openUsageTestDatabase(t)
 	start := time.Date(2026, 5, 14, 0, 0, 0, 0, time.Local)
@@ -435,25 +471,29 @@ func TestBuildAnalysisWithFilterIncludesPartialCurrentDayInDailyRanges(t *testin
 		t.Fatalf("drop usage_events: %v", err)
 	}
 
-	analysis, err := BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{Range: "7d", StartTime: &start, EndTime: &end})
-	if err != nil {
-		t.Fatalf("BuildAnalysisWithFilter returned error: %v", err)
-	}
+	for _, rangeValue := range []string{"7d", "30d"} {
+		t.Run(rangeValue, func(t *testing.T) {
+			analysis, err := BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{Range: rangeValue, StartTime: &start, EndTime: &end})
+			if err != nil {
+				t.Fatalf("BuildAnalysisWithFilter returned error: %v", err)
+			}
 
-	if analysis.Granularity != "daily" {
-		t.Fatalf("expected daily granularity, got %q", analysis.Granularity)
-	}
-	if len(analysis.TokenUsage) != 2 {
-		t.Fatalf("expected yesterday and current-day buckets, got %+v", analysis.TokenUsage)
-	}
-	if !analysis.TokenUsage[0].Bucket.Equal(yesterday) || analysis.TokenUsage[0].TotalTokens != 30 || analysis.TokenUsage[0].Requests != 2 {
-		t.Fatalf("expected yesterday daily stats first, got %+v", analysis.TokenUsage[0])
-	}
-	if !analysis.TokenUsage[1].Bucket.Equal(time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC)) || analysis.TokenUsage[1].TotalTokens != 90 || analysis.TokenUsage[1].Requests != 4 {
-		t.Fatalf("expected current-day hourly stats to be folded into daily bucket, got %+v", analysis.TokenUsage[1])
-	}
-	if len(analysis.APIKeyComposition) != 1 || analysis.APIKeyComposition[0].TotalTokens != 120 || analysis.APIKeyComposition[0].Requests != 6 {
-		t.Fatalf("expected compositions to include daily and current-day hourly stats, got %+v", analysis.APIKeyComposition)
+			if analysis.Granularity != "daily" {
+				t.Fatalf("expected daily granularity, got %q", analysis.Granularity)
+			}
+			if len(analysis.TokenUsage) != 2 {
+				t.Fatalf("expected yesterday and current-day buckets, got %+v", analysis.TokenUsage)
+			}
+			if !analysis.TokenUsage[0].Bucket.Equal(yesterday) || analysis.TokenUsage[0].TotalTokens != 30 || analysis.TokenUsage[0].Requests != 2 {
+				t.Fatalf("expected yesterday daily stats first, got %+v", analysis.TokenUsage[0])
+			}
+			if !analysis.TokenUsage[1].Bucket.Equal(time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC)) || analysis.TokenUsage[1].TotalTokens != 90 || analysis.TokenUsage[1].Requests != 4 {
+				t.Fatalf("expected current-day hourly stats to be folded into daily bucket, got %+v", analysis.TokenUsage[1])
+			}
+			if len(analysis.APIKeyComposition) != 1 || analysis.APIKeyComposition[0].TotalTokens != 120 || analysis.APIKeyComposition[0].Requests != 6 {
+				t.Fatalf("expected compositions to include daily and current-day hourly stats, got %+v", analysis.APIKeyComposition)
+			}
+		})
 	}
 }
 

--- a/web/src/components/usage/credentials/CredentialSections.module.scss
+++ b/web/src/components/usage/credentials/CredentialSections.module.scss
@@ -790,6 +790,27 @@
   }
 }
 
+@include mobile {
+  .credentialPagination {
+    justify-content: flex-start;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: 0 14px;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .credentialPaginationControls {
+    width: max-content;
+    min-width: 100%;
+    flex: 0 0 auto;
+  }
+
+  .credentialPageSizeControl {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+}
+
 :global([data-theme='dark']) {
   .credentialPlanBadgeTeam {
     border-color: color-mix(in srgb, #86efac 46%, var(--border-color));

--- a/web/src/components/usage/credentials/CredentialSections.styles.test.ts
+++ b/web/src/components/usage/credentials/CredentialSections.styles.test.ts
@@ -56,6 +56,9 @@ describe('Credential section styles', () => {
     expect(credentialStyles).toMatch(/\.credentialPagination\s*\{[\s\S]*?box-sizing:\s*border-box;/)
     expect(credentialStyles).toMatch(/\.credentialPagination\s*\{[\s\S]*?align-items:\s*center;/)
     expect(credentialStyles).toMatch(/\.credentialPagination\s*\{[\s\S]*?padding:\s*0 22px;/)
+    expect(credentialStyles).toMatch(/@include mobile\s*\{[\s\S]*?\.credentialPagination\s*\{[\s\S]*?overflow-x:\s*auto;/)
+    expect(credentialStyles).toMatch(/@include mobile\s*\{[\s\S]*?\.credentialPaginationControls\s*\{[\s\S]*?width:\s*max-content;/)
+    expect(credentialStyles).toMatch(/@include mobile\s*\{[\s\S]*?\.credentialPageSizeControl\s*\{[\s\S]*?flex:\s*0 0 auto;/)
   })
 
   it('keeps plan and remaining-day badges readable in dark mode', () => {

--- a/web/src/pages/KeyOverviewPage.module.scss
+++ b/web/src/pages/KeyOverviewPage.module.scss
@@ -266,8 +266,10 @@
 .tabPillActive {
   background: var(--bg-primary);
   color: var(--text-primary);
-  border-color: rgba($primary-color, 0.4);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);
+  border-color: rgba($primary-color, 0.45);
+  box-shadow:
+    0 0 0 1px rgba($primary-color, 0.08) inset,
+    0 4px 12px rgba($primary-color, 0.14);
 }
 
 .toolbarActionsRight {

--- a/web/src/pages/KeyOverviewPage.styles.test.ts
+++ b/web/src/pages/KeyOverviewPage.styles.test.ts
@@ -28,4 +28,16 @@ describe('KeyOverviewPage layout', () => {
     expect(styles).toMatch(/\.rangeSelectControl\s*\{[\s\S]*?width:\s*164px;/)
     expect(styles).toMatch(/\.lastRefreshed\s*\{[\s\S]*?font-size:\s*11px;/)
   })
+
+  it('uses the same soft active tab shadow as the admin usage tabs', () => {
+    const activeTabBlock = styles.slice(
+      styles.indexOf('.tabPillActive {'),
+      styles.indexOf('.toolbarActionsRight')
+    )
+
+    expect(activeTabBlock).toMatch(/border-color:\s*rgba\(\$primary-color, 0\.45\);/)
+    expect(activeTabBlock).toContain('0 0 0 1px rgba($primary-color, 0.08) inset,')
+    expect(activeTabBlock).toContain('0 4px 12px rgba($primary-color, 0.14);')
+    expect(activeTabBlock).not.toContain('box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);')
+  })
 })

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -402,8 +402,10 @@
 .tabPillActive {
   background: var(--bg-primary);
   color: var(--text-primary);
-  border-color: rgba($primary-color, 0.4);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);
+  border-color: rgba($primary-color, 0.45);
+  box-shadow:
+    0 0 0 1px rgba($primary-color, 0.08) inset,
+    0 4px 12px rgba($primary-color, 0.14);
 }
 
 .toolbarActionsRight {

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -1566,13 +1566,15 @@
   gap: 18px;
 }
 
+.settingsSections {
+  --settings-list-scroll-height: 480px;
+}
+
 // Pricing Section (80%比例)
 .pricingFixedCard {
-  @include mobile {
-    height: auto;
-    min-height: 0;
-    overflow: visible;
-  }
+  height: auto;
+  min-height: 0;
+  overflow: visible;
 }
 
 .pricingSection {
@@ -1645,14 +1647,17 @@
 }
 
 .apiKeySettingsCard:global(.card) {
+  height: auto;
   min-height: auto;
+  overflow: visible;
 }
 
 .apiKeySettingsBody {
   display: flex;
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   flex-direction: column;
   gap: 12px;
+  height: var(--settings-list-scroll-height);
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
@@ -1764,7 +1769,7 @@
   }
 
   .apiKeySettingsBody {
-    height: 480px;
+    height: var(--settings-list-scroll-height);
     min-height: 0;
     overflow-y: auto;
     overflow-x: hidden;
@@ -1777,12 +1782,28 @@
   }
 
   .apiKeySettingsItem {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: stretch;
     padding: 12px;
     gap: 12px;
   }
 
   .apiKeySettingsForm {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .apiKeyAliasField {
+    width: 100%;
+
+    :global(.form-group) {
+      width: 100%;
+      min-width: 0;
+      margin-bottom: 0;
+    }
+  }
+
+  .apiKeyAliasInput {
+    max-width: 100%;
   }
 
   .apiKeySettingsActions,
@@ -1810,17 +1831,12 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  flex: 1 1 auto;
+  flex: 0 0 auto;
+  height: var(--settings-list-scroll-height);
   min-height: 0;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
-
-  .pricingFixedCard & {
-    @include mobile {
-      overflow: visible;
-    }
-  }
 }
 
 .priceItem {

--- a/web/src/pages/UsagePage.styles.test.ts
+++ b/web/src/pages/UsagePage.styles.test.ts
@@ -74,13 +74,58 @@ describe('UsagePage toolbar styles', () => {
 
   it('lets API Key Settings content scroll inside the card instead of being clipped', () => {
     expect(usagePageStyles).toMatch(/\.apiKeySettingsCard:global\(\.card\)\s*\{[\s\S]*?min-height:\s*auto;/)
-    expect(usagePageStyles).toMatch(/\.apiKeySettingsBody\s*\{[\s\S]*?flex:\s*1 1 auto;/)
+    expect(usagePageStyles).toMatch(/\.apiKeySettingsBody\s*\{[\s\S]*?flex:\s*0 0 auto;/)
+    expect(usagePageStyles).toMatch(/\.apiKeySettingsBody\s*\{[\s\S]*?height:\s*var\(--settings-list-scroll-height\);/)
     expect(usagePageStyles).toMatch(/\.apiKeySettingsBody\s*\{[\s\S]*?min-height:\s*0;/)
     expect(usagePageStyles).toMatch(/\.apiKeySettingsBody\s*\{[\s\S]*?overflow-y:\s*auto;/)
     expect(usagePageStyles).toMatch(/\.apiKeySettingsBody\s*\{[\s\S]*?padding-right:\s*4px;/)
-    expect(usagePageStyles).toMatch(/@include mobile\s*\{[\s\S]*?\.apiKeySettingsCard:global\(\.card\)\s*\{[\s\S]*?height:\s*auto;/)
-    expect(usagePageStyles).toMatch(/@include mobile\s*\{[\s\S]*?\.apiKeySettingsBody\s*\{[\s\S]*?height:\s*480px;/)
-    expect(usagePageStyles).toMatch(/@include mobile\s*\{[\s\S]*?\.apiKeySettingsList\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\);/)
+    const apiKeySettingsMobileBlock = usagePageStyles.slice(
+      usagePageStyles.indexOf('@include mobile {\n  .apiKeySettingsCard:global(.card)'),
+      usagePageStyles.indexOf('.pricesList')
+    )
+
+    expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeySettingsCard:global\(\.card\)\s*\{[\s\S]*?height:\s*auto;/)
+    expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeySettingsBody\s*\{[\s\S]*?height:\s*var\(--settings-list-scroll-height\);/)
+    expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeySettingsList\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\);/)
+    expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeySettingsItem\s*\{[^}]*grid-template-columns:\s*minmax\(0, 1fr\);/)
+    expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeySettingsItem\s*\{[^}]*align-items:\s*stretch;/)
+    expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeyAliasField\s*\{[\s\S]*?width:\s*100%;/)
+    expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeyAliasField\s*\{[\s\S]*?:global\(\.form-group\)\s*\{[\s\S]*?width:\s*100%;/)
+    expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeyAliasField\s*\{[\s\S]*?:global\(\.form-group\)\s*\{[\s\S]*?min-width:\s*0;/)
+    expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeyAliasField\s*\{[\s\S]*?:global\(\.form-group\)\s*\{[\s\S]*?margin-bottom:\s*0;/)
+    expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeyAliasInput\s*\{[\s\S]*?max-width:\s*100%;/)
+  })
+
+  it('keeps Model Pricing Settings list viewport aligned with API Key Settings without shrinking it behind the form', () => {
+    const settingsSectionsBlock = usagePageStyles.slice(
+      usagePageStyles.indexOf('.settingsSections {'),
+      usagePageStyles.indexOf('// Pricing Section')
+    )
+    const pricingBlock = usagePageStyles.slice(
+      usagePageStyles.indexOf('.pricingFixedCard {'),
+      usagePageStyles.indexOf('.priceForm')
+    )
+    const apiKeyBodyBlock = usagePageStyles.slice(
+      usagePageStyles.indexOf('.apiKeySettingsBody {'),
+      usagePageStyles.indexOf('.apiKeySettingsList')
+    )
+    const apiKeySettingsMobileBlock = usagePageStyles.slice(
+      usagePageStyles.indexOf('@include mobile {\n  .apiKeySettingsCard:global(.card)'),
+      usagePageStyles.indexOf('.pricesList')
+    )
+    const pricingGridBlock = usagePageStyles.slice(
+      usagePageStyles.indexOf('.pricesGrid {'),
+      usagePageStyles.indexOf('.priceItem')
+    )
+
+    expect(settingsSectionsBlock).toMatch(/--settings-list-scroll-height:\s*480px;/)
+    expect(pricingBlock).toMatch(/\.pricingFixedCard\s*\{[\s\S]*?height:\s*auto;/)
+    expect(pricingBlock).not.toMatch(/\.pricingSection\s*\{[\s\S]*?height:\s*480px;/)
+    expect(apiKeyBodyBlock).toMatch(/height:\s*var\(--settings-list-scroll-height\);/)
+    expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeySettingsBody\s*\{[\s\S]*?height:\s*var\(--settings-list-scroll-height\);/)
+    expect(pricingGridBlock).toMatch(/height:\s*var\(--settings-list-scroll-height\);/)
+    expect(pricingGridBlock).toMatch(/\.pricesGrid\s*\{[\s\S]*?overflow:\s*auto;/)
+    expect(pricingGridBlock).not.toMatch(/@include mobile\s*\{[\s\S]*?overflow:\s*visible;/)
   })
 
   it('keeps the Analysis chart presentation aligned with the reference design', () => {


### PR DESCRIPTION
## Summary
- Include current-hour hourly stats for rolling Analysis ranges (`4h`, `8h`, `12h`, `24h`) without falling back to raw events.
- Fix mobile Credentials footer controls so pagination and sorting remain reachable via horizontal scroll.
- Align Settings list scrolling for API Key Settings and Model Pricing Settings, and soften the active usage tab shadow.

Closes #130 

## Test plan
- [x] `go test ./internal/repository`
- [x] `npm --prefix web test -- UsagePage.styles.test.ts CredentialSections.styles.test.ts`
- [x] `npm --prefix web run build`
- [x] Manual local verification at `http://127.0.0.1:8080/cpa/`