### PR TITLE
Disable quota auto refresh by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,9 +66,9 @@ TLS_SKIP_VERIFY=false
 # 5. Auth Files 限额刷新 / Auth Files quota refresh
 # =============================================================================
 
-# 是否启用 Auth Files 限额自动刷新定时任务；仅在后台页面可见并持续心跳时执行。关闭时仍可手动刷新限额并计算 token/cost。必填：否。默认值：true。
-# Whether to enable the scheduled Auth Files quota auto-refresh task; it runs only while a backend page is visible and sending heartbeats. Manual quota refresh and token/cost calculation still work when disabled. Required: no. Default: true.
-QUOTA_AUTO_REFRESH_ENABLED=true
+# 是否启用 Auth Files 限额自动刷新定时任务；仅在后台页面可见并持续心跳时执行。关闭时仍可手动刷新限额并计算 token/cost。必填：否。默认值：false。
+# Whether to enable the scheduled Auth Files quota auto-refresh task; it runs only while a backend page is visible and sending heartbeats. Manual quota refresh and token/cost calculation still work when disabled. Required: no. Default: false.
+QUOTA_AUTO_REFRESH_ENABLED=false
 
 # Auth Files 限额自动刷新的定时任务间隔，最低 60s，仅在 QUOTA_AUTO_REFRESH_ENABLED=true 且后台页面活跃时生效。必填：否。默认值：5m。
 # Scheduled Auth Files quota auto-refresh interval, minimum 60s, only used when QUOTA_AUTO_REFRESH_ENABLED=true and a backend page is active. Required: no. Default: 5m.

--- a/README.en.md
+++ b/README.en.md
@@ -225,7 +225,7 @@ For first-time deployments, start with "Minimum required" and "Web access and re
 
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
-| `QUOTA_AUTO_REFRESH_ENABLED` | No | `true` | Enable Auth Files quota auto-refresh; it runs only while a backend page is visible and sending heartbeats |
+| `QUOTA_AUTO_REFRESH_ENABLED` | No | `false` | Enable Auth Files quota auto-refresh; it runs only while a backend page is visible and sending heartbeats |
 | `QUOTA_AUTO_REFRESH_INTERVAL` | No | `5m` | Auth Files quota auto-refresh interval, minimum `60s`, active only while a backend page is active |
 | `QUOTA_REFRESH_WORKER_LIMIT` | No | `10` | Maximum Auth Files quota refresh concurrency, capped at `100` |
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ cp .env.example .env
 
 | 变量 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- |
-| `QUOTA_AUTO_REFRESH_ENABLED` | 否 | `true` | 是否启用 Auth Files 限额自动刷新；仅在后台页面可见并持续心跳时执行 |
+| `QUOTA_AUTO_REFRESH_ENABLED` | 否 | `false` | 是否启用 Auth Files 限额自动刷新；仅在后台页面可见并持续心跳时执行 |
 | `QUOTA_AUTO_REFRESH_INTERVAL` | 否 | `5m` | Auth Files 限额自动刷新间隔，最低 `60s`，仅在后台页面活跃时生效 |
 | `QUOTA_REFRESH_WORKER_LIMIT` | 否 | `10` | Auth Files 限额刷新队列最大并发数，最大 `100` |
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -39,7 +39,7 @@ func TestAppCloseClosesDatabase(t *testing.T) {
 	}
 }
 
-func TestNewWithConfigBuildsQuotaAutoRefreshByDefault(t *testing.T) {
+func TestNewWithConfigBuildsQuotaAutoRefreshWhenEnabled(t *testing.T) {
 	app, err := NewWithConfig(testAppConfig(t))
 	if err != nil {
 		t.Fatalf("NewWithConfig returned error: %v", err)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -46,7 +46,7 @@ func TestNewWithConfigBuildsQuotaAutoRefreshWhenEnabled(t *testing.T) {
 	}
 	defer app.Close()
 	if app.QuotaAutoRefresh == nil {
-		t.Fatal("expected quota auto refresh runner by default")
+		t.Fatal("expected quota auto refresh runner when enabled")
 	}
 	if app.QuotaService == nil {
 		t.Fatal("expected quota service to remain available for manual refresh")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,7 +149,7 @@ func Load(options LoadOptions) (*Config, error) {
 		return nil, fmt.Errorf("REDIS_QUEUE_IDLE_INTERVAL must be positive")
 	}
 
-	quotaAutoRefreshEnabled, err := getBool("QUOTA_AUTO_REFRESH_ENABLED", true)
+	quotaAutoRefreshEnabled, err := getBool("QUOTA_AUTO_REFRESH_ENABLED", false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -158,8 +158,8 @@ func TestLoadFromEnvAppliesDefaults(t *testing.T) {
 	if cfg.QuotaRefreshWorkerLimit != 10 {
 		t.Fatalf("expected default quota refresh worker limit 10, got %d", cfg.QuotaRefreshWorkerLimit)
 	}
-	if !cfg.QuotaAutoRefreshEnabled {
-		t.Fatal("expected quota auto refresh to be enabled by default")
+	if cfg.QuotaAutoRefreshEnabled {
+		t.Fatal("expected quota auto refresh to be disabled by default")
 	}
 	if cfg.QuotaAutoRefreshInterval != 5*time.Minute {
 		t.Fatalf("expected default quota auto refresh interval 5m, got %s", cfg.QuotaAutoRefreshInterval)


### PR DESCRIPTION
## Summary
- default QUOTA_AUTO_REFRESH_ENABLED to false in backend config
- update .env.example and README defaults
- keep explicit enable/disable test coverage aligned with the new default

Related to #152

## Tests
- go test ./cmd/... ./internal/...