### PR TITLE
docs: add compose env file example

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -85,6 +85,26 @@ networks:
     driver: bridge
 ```
 
+To manage Keeper settings with a `.env` file, replace `environment` in the `cpa-usage-keeper` service with `env_file`:
+
+```yaml
+    env_file:
+      - .env
+```
+
+Then create `.env` on the host in the same directory as `docker-compose.yml`, for example:
+
+```env
+TZ=Asia/Shanghai
+CPA_BASE_URL=http://cli-proxy-api:8317
+CPA_MANAGEMENT_KEY=replace-with-your-management-key
+REDIS_QUEUE_ADDR=cli-proxy-api:8317
+AUTH_ENABLED=true
+LOGIN_PASSWORD=replace-with-your-login-password
+```
+
+`env_file` paths are resolved relative to the `docker-compose.yml` directory; the `.env` above is injected into the Keeper container, equivalent to setting those environment variables for the container.
+
 Start:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -85,6 +85,26 @@ networks:
     driver: bridge
 ```
 
+如果想用 `.env` 文件管理 Keeper 配置，可以把上面 `cpa-usage-keeper` 的 `environment` 改成 `env_file`：
+
+```yaml
+    env_file:
+      - .env
+```
+
+然后在宿主机的 `docker-compose.yml` 同一目录创建 `.env` 文件，例如：
+
+```env
+TZ=Asia/Shanghai
+CPA_BASE_URL=http://cli-proxy-api:8317
+CPA_MANAGEMENT_KEY=replace-with-your-management-key
+REDIS_QUEUE_ADDR=cli-proxy-api:8317
+AUTH_ENABLED=true
+LOGIN_PASSWORD=replace-with-your-login-password
+```
+
+`env_file` 中的路径相对 `docker-compose.yml` 所在目录解析；上面的 `.env` 会被注入 Keeper 容器，效果等同于为容器设置这些环境变量。
+
 启动：
 
 ```bash


### PR DESCRIPTION
## Summary

- Add Docker Compose documentation for configuring Keeper with `env_file`
- Show where to place the host `.env` file and how it is injected into the container
- Keep Chinese and English README content aligned

## Validation

- Documentation-only change; tests were not run
