### PR TITLE
fix: settings page scroll wheel blocked by overscroll-behavior

### DIFF
--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -1481,6 +1481,7 @@
   display: flex;
   flex-direction: column;
   height: 520px;
+  overflow: hidden;
   overflow: clip;
 
   @include mobile {

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -1481,7 +1481,7 @@
   display: flex;
   flex-direction: column;
   height: 520px;
-  overflow: hidden;
+  overflow: clip;
 
   @include mobile {
     height: 420px;
@@ -1493,7 +1493,6 @@
   min-height: 0;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
-  overscroll-behavior: contain;
 }
 
 .detailsNote {
@@ -1714,14 +1713,13 @@
   flex: 0 0 auto;
   flex-direction: column;
   gap: 12px;
-  height: var(--settings-list-scroll-height);
+  max-height: var(--settings-list-scroll-height);
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
   padding-right: 4px;
   padding-bottom: 4px;
   -webkit-overflow-scrolling: touch;
-  overscroll-behavior: contain;
 }
 
 .apiKeySettingsList {
@@ -1826,12 +1824,11 @@
   }
 
   .apiKeySettingsBody {
-    height: var(--settings-list-scroll-height);
+    max-height: var(--settings-list-scroll-height);
     min-height: 0;
     overflow-y: auto;
     overflow-x: hidden;
     -webkit-overflow-scrolling: touch;
-    overscroll-behavior: contain;
   }
 
   .apiKeySettingsList {
@@ -1889,11 +1886,10 @@
   flex-direction: column;
   gap: 6px;
   flex: 0 0 auto;
-  height: var(--settings-list-scroll-height);
+  max-height: var(--settings-list-scroll-height);
   min-height: 0;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
-  overscroll-behavior: contain;
 }
 
 .priceItem {


### PR DESCRIPTION
## Summary
- Remove `overscroll-behavior: contain` from settings scroll containers — was consuming wheel events at scroll boundaries even when content didn't overflow
- Change `height` to `max-height` on settings list containers so they shrink when content is short, preventing empty containers from intercepting wheel events
- Change `detailsFixedCard` overflow from `hidden` to `clip` to avoid creating an unnecessary scroll container

## Test Plan
- [x] Open settings page, scroll through API key list and price list with mouse wheel
- [x] Verify page-level scroll works when hovering over short/empty lists