### PR TITLE
Fix mobile date inputs and token chart values

### DIFF
--- a/web/src/components/usage/OverviewCharts.logic.test.ts
+++ b/web/src/components/usage/OverviewCharts.logic.test.ts
@@ -577,6 +577,8 @@ describe('overview chart data flow', () => {
     expect(series.dataByCategory.cached).toEqual([0, 600]);
     expect(series.dataByCategory.output).toEqual([0, 50]);
     expect(series.dataByCategory.reasoning).toEqual([0, 50]);
+    expect(series.tooltipDataByCategory.input).toEqual([0, 1000]);
+    expect(series.tooltipDataByCategory.output).toEqual([0, 100]);
     expect(series.totalTokens).toEqual([0, 1150]);
   });
 
@@ -779,9 +781,10 @@ describe('overview chart data flow', () => {
     expect(tickCallback?.call({} as never, 1_500_000, 0, [])).toBe('1.50M');
     expect(typeof tooltipLabel).toBe('function');
     expect(tooltipLabel?.({
-      dataset: { label: 'Input' },
-      parsed: { y: 2_500_000_000 },
-    } as never)).toBe('Input: 2.50B tokens');
+      dataset: { label: 'Input', tooltipData: [1_000_000_000] },
+      dataIndex: 0,
+      parsed: { y: 400_000_000 },
+    } as never)).toBe('Input: 1.00B tokens');
     expect(typeof tooltipFooter).toBe('function');
     expect(tooltipFooter?.([{ dataIndex: 0 }] as never)).toBe('Total: 1.15K tokens');
   });

--- a/web/src/components/usage/OverviewCharts.logic.test.ts
+++ b/web/src/components/usage/OverviewCharts.logic.test.ts
@@ -785,6 +785,11 @@ describe('overview chart data flow', () => {
       dataIndex: 0,
       parsed: { y: 400_000_000 },
     } as never)).toBe('Input: 1.00B tokens');
+    expect(tooltipLabel?.({
+      dataset: null,
+      dataIndex: 0,
+      parsed: { y: 125 },
+    } as never)).toBe('125 tokens');
     expect(typeof tooltipFooter).toBe('function');
     expect(tooltipFooter?.([{ dataIndex: 0 }] as never)).toBe('Total: 1.15K tokens');
   });

--- a/web/src/components/usage/OverviewCharts.logic.test.ts
+++ b/web/src/components/usage/OverviewCharts.logic.test.ts
@@ -545,6 +545,41 @@ describe('overview chart data flow', () => {
     expect(series.dataByCategory.output[24]).toBe(0);
   });
 
+  it('subtracts cached tokens from overview token breakdown input series', () => {
+    const series = buildTokenBreakdownChartSeries({
+      usage: {
+        ...overviewUsage,
+        hourly_series: {
+          ...overviewUsage.hourly_series!,
+          input_tokens: {
+            '2026-04-23T00:00:00Z': 1000,
+          },
+          output_tokens: {
+            '2026-04-23T00:00:00Z': 100,
+          },
+          tokens: {
+            '2026-04-23T00:00:00Z': 1150,
+          },
+          cached_tokens: {
+            '2026-04-23T00:00:00Z': 600,
+          },
+          reasoning_tokens: {
+            '2026-04-23T00:00:00Z': 50,
+          },
+        },
+      },
+      period: 'hour',
+      hourWindowHours: 1,
+      endMs: Date.parse('2026-04-23T00:16:00Z'),
+    });
+
+    expect(series.dataByCategory.input).toEqual([0, 400]);
+    expect(series.dataByCategory.cached).toEqual([0, 600]);
+    expect(series.dataByCategory.output).toEqual([0, 50]);
+    expect(series.dataByCategory.reasoning).toEqual([0, 50]);
+    expect(series.totalTokens).toEqual([0, 1150]);
+  });
+
   it('keeps today token breakdown hour buckets aligned to full-day boundary buckets', () => {
     const series = buildTokenBreakdownChartSeries({
       usage: {
@@ -730,10 +765,13 @@ describe('overview chart data flow', () => {
       isDark: false,
       isMobile: false,
       stacked: true,
+      totalTokens: [1150],
+      totalLabel: 'Total',
     });
 
     const tickCallback = options.scales?.y?.ticks?.callback;
     const tooltipLabel = options.plugins?.tooltip?.callbacks?.label;
+    const tooltipFooter = options.plugins?.tooltip?.callbacks?.footer;
 
     expect(options.scales?.y?.stacked).toBe(true);
     expect(options.scales?.x?.stacked).toBe(true);
@@ -744,6 +782,8 @@ describe('overview chart data flow', () => {
       dataset: { label: 'Input' },
       parsed: { y: 2_500_000_000 },
     } as never)).toBe('Input: 2.50B tokens');
+    expect(typeof tooltipFooter).toBe('function');
+    expect(tooltipFooter?.([{ dataIndex: 0 }] as never)).toBe('Total: 1.15K tokens');
   });
 
   it('keeps mobile hourly overview chart data points visible without changing desktop point size', () => {

--- a/web/src/components/usage/TokenBreakdownChart.tsx
+++ b/web/src/components/usage/TokenBreakdownChart.tsx
@@ -26,6 +26,7 @@ type TokenSeriesSource = NonNullable<UsageOverviewPayload['series']>;
 export type TokenBreakdownChartSeries = {
   labels: string[];
   dataByCategory: Record<TokenCategory, number[]>;
+  tooltipDataByCategory: Record<TokenCategory, number[]>;
   totalTokens: number[];
 };
 
@@ -84,6 +85,12 @@ const getTokenSource = (usage: UsageOverviewPayload | null, period: TokenBreakdo
   period === 'hour' ? (usage?.hourly_series ?? usage?.series) : (usage?.daily_series ?? usage?.series)
 );
 
+const getTooltipTokenValue = (dataset: unknown, dataIndex: number | undefined, fallback: unknown): number => {
+  const tooltipData = (dataset as { tooltipData?: unknown[] }).tooltipData;
+  const tooltipValue = typeof dataIndex === 'number' ? tooltipData?.[dataIndex] : undefined;
+  return Number(tooltipValue ?? fallback ?? 0);
+};
+
 const buildHourlyLabels = (source: TokenSeriesSource | undefined, hourWindowHours?: number, endMs?: number, includeFinalBucket = false) => {
   const labels = Array.from(new Set(CATEGORIES.flatMap((category) => Object.keys(source?.[`${category}_tokens`] ?? {}))))
     .sort((a, b) => a.localeCompare(b));
@@ -123,6 +130,12 @@ export const buildTokenBreakdownChartSeries = ({
         outputTokens: source?.output_tokens?.[label],
         reasoningTokens: source?.reasoning_tokens?.[label],
       })),
+      cached: labels.map((label) => Number(source?.cached_tokens?.[label] ?? 0)),
+      reasoning: labels.map((label) => Number(source?.reasoning_tokens?.[label] ?? 0)),
+    },
+    tooltipDataByCategory: {
+      input: labels.map((label) => Number(source?.input_tokens?.[label] ?? 0)),
+      output: labels.map((label) => Number(source?.output_tokens?.[label] ?? 0)),
       cached: labels.map((label) => Number(source?.cached_tokens?.[label] ?? 0)),
       reasoning: labels.map((label) => Number(source?.reasoning_tokens?.[label] ?? 0)),
     },
@@ -168,7 +181,8 @@ export const buildTokenBreakdownChartOptions = ({
         callbacks: {
           label: (context) => {
             const label = context.dataset.label ? `${context.dataset.label}: ` : '';
-            return `${label}${formatCompactTokenValue(Number(context.parsed.y ?? 0), true)}`;
+            const value = getTooltipTokenValue(context.dataset, context.dataIndex, context.parsed.y);
+            return `${label}${formatCompactTokenValue(value, true)}`;
           },
           footer: (items) => {
             const dataIndex = items[0]?.dataIndex ?? -1;
@@ -231,6 +245,7 @@ export function TokenBreakdownChart({
         backgroundColor: TOKEN_COLORS[cat].bg,
         pointBackgroundColor: TOKEN_COLORS[cat].border,
         pointBorderColor: TOKEN_COLORS[cat].border,
+        tooltipData: series.tooltipDataByCategory[cat],
         fill: true,
         tension: 0.35
       }))

--- a/web/src/components/usage/TokenBreakdownChart.tsx
+++ b/web/src/components/usage/TokenBreakdownChart.tsx
@@ -85,8 +85,17 @@ const getTokenSource = (usage: UsageOverviewPayload | null, period: TokenBreakdo
   period === 'hour' ? (usage?.hourly_series ?? usage?.series) : (usage?.daily_series ?? usage?.series)
 );
 
+const getDatasetLabelPrefix = (dataset: unknown): string => {
+  const label = dataset && typeof dataset === 'object'
+    ? (dataset as { label?: unknown }).label
+    : undefined;
+  return typeof label === 'string' && label ? `${label}: ` : '';
+};
+
 const getTooltipTokenValue = (dataset: unknown, dataIndex: number | undefined, fallback: unknown): number => {
-  const tooltipData = (dataset as { tooltipData?: unknown[] }).tooltipData;
+  const tooltipData = dataset && typeof dataset === 'object'
+    ? (dataset as { tooltipData?: unknown[] }).tooltipData
+    : undefined;
   const tooltipValue = typeof dataIndex === 'number' ? tooltipData?.[dataIndex] : undefined;
   return Number(tooltipValue ?? fallback ?? 0);
 };
@@ -180,7 +189,7 @@ export const buildTokenBreakdownChartOptions = ({
         ...baseOptions.plugins?.tooltip,
         callbacks: {
           label: (context) => {
-            const label = context.dataset.label ? `${context.dataset.label}: ` : '';
+            const label = getDatasetLabelPrefix(context.dataset);
             const value = getTooltipTokenValue(context.dataset, context.dataIndex, context.parsed.y);
             return `${label}${formatCompactTokenValue(value, true)}`;
           },

--- a/web/src/components/usage/TokenBreakdownChart.tsx
+++ b/web/src/components/usage/TokenBreakdownChart.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Line } from 'react-chartjs-2';
 import type { ChartOptions } from 'chart.js';
 import { Card } from '@/components/ui/Card';
-import { formatCompactTokenValue, type TokenCategory } from '@/utils/usage';
+import { calculateDisplayInputTokens, calculateDisplayOutputTokens, formatCompactTokenValue, type TokenCategory } from '@/utils/usage';
 import { buildChartOptions, getHourChartMinWidth } from '@/utils/usage/chartConfig';
 import type { UsageOverviewPayload } from './hooks/useUsageData';
 import styles from '@/pages/UsagePage.module.scss';
@@ -26,6 +26,7 @@ type TokenSeriesSource = NonNullable<UsageOverviewPayload['series']>;
 export type TokenBreakdownChartSeries = {
   labels: string[];
   dataByCategory: Record<TokenCategory, number[]>;
+  totalTokens: number[];
 };
 
 export type BuildTokenBreakdownChartSeriesOptions = {
@@ -114,11 +115,18 @@ export const buildTokenBreakdownChartSeries = ({
   return {
     labels: labels.map((label, index) => formatChartLabel(label, period, includeFinalHourBucket && index === labels.length - 1)),
     dataByCategory: {
-      input: labels.map((label) => Number(source?.input_tokens?.[label] ?? 0)),
-      output: labels.map((label) => Number(source?.output_tokens?.[label] ?? 0)),
+      input: labels.map((label) => calculateDisplayInputTokens({
+        inputTokens: source?.input_tokens?.[label],
+        cachedTokens: source?.cached_tokens?.[label],
+      })),
+      output: labels.map((label) => calculateDisplayOutputTokens({
+        outputTokens: source?.output_tokens?.[label],
+        reasoningTokens: source?.reasoning_tokens?.[label],
+      })),
       cached: labels.map((label) => Number(source?.cached_tokens?.[label] ?? 0)),
       reasoning: labels.map((label) => Number(source?.reasoning_tokens?.[label] ?? 0)),
     },
+    totalTokens: labels.map((label) => Number(source?.tokens?.[label] ?? 0)),
   };
 };
 
@@ -139,12 +147,16 @@ export const buildTokenBreakdownChartOptions = ({
   isDark,
   isMobile,
   stacked = false,
+  totalTokens = [],
+  totalLabel = 'Total',
 }: {
   period: TokenBreakdownChartPeriod;
   labels: string[];
   isDark: boolean;
   isMobile: boolean;
   stacked?: boolean;
+  totalTokens?: number[];
+  totalLabel?: string;
 }): ChartOptions<'line'> => {
   const baseOptions = buildChartOptions({ period, labels, isDark, isMobile });
   return {
@@ -157,6 +169,11 @@ export const buildTokenBreakdownChartOptions = ({
           label: (context) => {
             const label = context.dataset.label ? `${context.dataset.label}: ` : '';
             return `${label}${formatCompactTokenValue(Number(context.parsed.y ?? 0), true)}`;
+          },
+          footer: (items) => {
+            const dataIndex = items[0]?.dataIndex ?? -1;
+            if (dataIndex < 0) return '';
+            return `${totalLabel}: ${formatCompactTokenValue(Number(totalTokens[dataIndex] ?? 0), true)}`;
           },
         },
       },
@@ -225,6 +242,8 @@ export function TokenBreakdownChart({
       isDark,
       isMobile,
       stacked: true,
+      totalTokens: series.totalTokens,
+      totalLabel: t('usage_stats.total_tokens'),
     });
 
     return { chartData: data, chartOptions: options };

--- a/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
@@ -67,6 +67,18 @@ describe('AnalysisPanel token chart data', () => {
     expect(datasets.find((dataset) => dataset.label === 'usage_stats.cached_tokens')?.data).toEqual([600]);
     expect(datasets.find((dataset) => dataset.label === 'usage_stats.output_tokens')?.data).toEqual([50]);
     expect(datasets.find((dataset) => dataset.label === 'usage_stats.reasoning_tokens')?.data).toEqual([50]);
+    const tooltipLabel = chartCapture.barOptions?.plugins?.tooltip?.callbacks?.label;
+    expect(typeof tooltipLabel).toBe('function');
+    expect(tooltipLabel?.({
+      dataset: { label: 'usage_stats.input_tokens', tooltipData: [1000] },
+      dataIndex: 0,
+      parsed: { y: 400 },
+    } as never)).toBe('usage_stats.input_tokens: 1.00K');
+    expect(tooltipLabel?.({
+      dataset: { label: 'usage_stats.output_tokens', tooltipData: [100] },
+      dataIndex: 0,
+      parsed: { y: 50 },
+    } as never)).toBe('usage_stats.output_tokens: 100');
     const tooltipFooter = chartCapture.barOptions?.plugins?.tooltip?.callbacks?.footer;
     expect(typeof tooltipFooter).toBe('function');
     expect(tooltipFooter?.([{ dataIndex: 0 }] as never)).toBe('usage_stats.total_tokens: 1.15K');

--- a/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
@@ -79,6 +79,11 @@ describe('AnalysisPanel token chart data', () => {
       dataIndex: 0,
       parsed: { y: 50 },
     } as never)).toBe('usage_stats.output_tokens: 100');
+    expect(tooltipLabel?.({
+      dataset: null,
+      dataIndex: 0,
+      parsed: { y: 125 },
+    } as never)).toBe('125');
     const tooltipFooter = chartCapture.barOptions?.plugins?.tooltip?.callbacks?.footer;
     expect(typeof tooltipFooter).toBe('function');
     expect(tooltipFooter?.([{ dataIndex: 0 }] as never)).toBe('usage_stats.total_tokens: 1.15K');

--- a/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import type { ChartData, ChartOptions } from 'chart.js';
+import type { AnalysisResponse } from '@/lib/types';
+
+const chartCapture = vi.hoisted(() => ({
+  barData: null as ChartData<'bar', number[], string> | null,
+  barOptions: null as ChartOptions<'bar'> | null,
+}));
+
+vi.mock('react-chartjs-2', () => ({
+  Bar: (props: { data: ChartData<'bar', number[], string>; options: ChartOptions<'bar'> }) => {
+    chartCapture.barData = props.data;
+    chartCapture.barOptions = props.options;
+    return React.createElement('div');
+  },
+  Doughnut: () => React.createElement('div'),
+}));
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: () => {},
+  },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+import { AnalysisPanel } from './AnalysisPanel';
+
+const emptyAnalysis: AnalysisResponse = {
+  granularity: 'hourly',
+  timezone: 'UTC',
+  token_usage: [],
+  api_key_composition: [],
+  model_composition: [],
+  auth_files_composition: [],
+  ai_provider_composition: [],
+  heatmap: {
+    api_keys: [],
+    models: [],
+    cells: [],
+  },
+};
+
+describe('AnalysisPanel token chart data', () => {
+  it('subtracts cached and reasoning tokens from displayed token series while keeping total tooltip values', () => {
+    const analysis: AnalysisResponse = {
+      ...emptyAnalysis,
+      token_usage: [{
+        bucket: '2026-05-28T01:00:00Z',
+        input_tokens: 1000,
+        output_tokens: 100,
+        cached_tokens: 600,
+        reasoning_tokens: 50,
+        total_tokens: 1150,
+        requests: 3,
+      }],
+    };
+
+    renderToStaticMarkup(<AnalysisPanel analysis={analysis} loading={false} isDark={false} isMobile={false} />);
+
+    const datasets = chartCapture.barData?.datasets ?? [];
+    expect(datasets.find((dataset) => dataset.label === 'usage_stats.input_tokens')?.data).toEqual([400]);
+    expect(datasets.find((dataset) => dataset.label === 'usage_stats.cached_tokens')?.data).toEqual([600]);
+    expect(datasets.find((dataset) => dataset.label === 'usage_stats.output_tokens')?.data).toEqual([50]);
+    expect(datasets.find((dataset) => dataset.label === 'usage_stats.reasoning_tokens')?.data).toEqual([50]);
+    const tooltipFooter = chartCapture.barOptions?.plugins?.tooltip?.callbacks?.footer;
+    expect(typeof tooltipFooter).toBe('function');
+    expect(tooltipFooter?.([{ dataIndex: 0 }] as never)).toBe('usage_stats.total_tokens: 1.15K');
+  });
+});

--- a/web/src/components/usage/analysis/AnalysisPanel.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.tsx
@@ -17,6 +17,8 @@ type ChartRow = {
   label: string;
   input: number;
   output: number;
+  rawInput: number;
+  rawOutput: number;
   cached: number;
   reasoning: number;
   total: number;
@@ -41,6 +43,10 @@ type LegendItem = {
 type GradientColor = {
   base: string;
   light: string;
+};
+
+type TokenTooltipDataset = ChartData<'bar', number[], string>['datasets'][number] & {
+  tooltipData?: number[];
 };
 
 const CHART_COLORS: GradientColor[] = [
@@ -94,6 +100,12 @@ const getChartTheme = (isDark: boolean): ChartTheme => ({
 const toNumber = (value: unknown) => {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const getTooltipTokenValue = (dataset: unknown, dataIndex: number | undefined, fallback: unknown): number => {
+  const tooltipData = (dataset as { tooltipData?: unknown[] }).tooltipData;
+  const tooltipValue = typeof dataIndex === 'number' ? tooltipData?.[dataIndex] : undefined;
+  return toNumber(tooltipValue ?? fallback);
 };
 
 const createChartGradient = (ctx: CanvasRenderingContext2D, chartArea: { top: number; bottom: number }, color: GradientColor) => {
@@ -160,6 +172,8 @@ function buildTokenUsageRows(buckets: AnalysisTokenUsageBucket[], granularity: A
       outputTokens: bucket.output_tokens,
       reasoningTokens: bucket.reasoning_tokens,
     }),
+    rawInput: toNumber(bucket.input_tokens),
+    rawOutput: toNumber(bucket.output_tokens),
     cached: toNumber(bucket.cached_tokens),
     reasoning: toNumber(bucket.reasoning_tokens),
     total: toNumber(bucket.total_tokens),
@@ -219,7 +233,8 @@ function buildAnalysisTokenChartOptions({ chartTheme, isMobile, totalTokens, tot
         callbacks: {
           label: (context) => {
             const label = context.dataset.label ? `${context.dataset.label}: ` : '';
-            return `${label}${formatCompactNumber(Number(context.parsed.y ?? 0))}`;
+            const value = getTooltipTokenValue(context.dataset, context.dataIndex, context.parsed.y);
+            return `${label}${formatCompactNumber(value)}`;
           },
           footer: (items) => {
             const dataIndex = items[0]?.dataIndex ?? -1;
@@ -262,10 +277,10 @@ function buildAnalysisTokenChartData(rows: ChartRow[], labels: TokenLabels): Cha
   return {
     labels: rows.map((row) => row.label),
     datasets: [
-      { label: labels.input, data: rows.map((row) => row.input), backgroundColor: (context) => toGradientFill(context, tokenColors.input), borderColor: tokenColors.input.base, stack: 'tokens', yAxisID: 'tokens' },
-      { label: labels.output, data: rows.map((row) => row.output), backgroundColor: (context) => toGradientFill(context, tokenColors.output), borderColor: tokenColors.output.base, stack: 'tokens', yAxisID: 'tokens' },
-      { label: labels.cached, data: rows.map((row) => row.cached), backgroundColor: (context) => toGradientFill(context, tokenColors.cached), borderColor: tokenColors.cached.base, stack: 'tokens', yAxisID: 'tokens' },
-      { label: labels.reasoning, data: rows.map((row) => row.reasoning), backgroundColor: (context) => toGradientFill(context, tokenColors.reasoning), borderColor: tokenColors.reasoning.base, stack: 'tokens', yAxisID: 'tokens' },
+      { label: labels.input, data: rows.map((row) => row.input), tooltipData: rows.map((row) => row.rawInput), backgroundColor: (context) => toGradientFill(context, tokenColors.input), borderColor: tokenColors.input.base, stack: 'tokens', yAxisID: 'tokens' } as TokenTooltipDataset,
+      { label: labels.output, data: rows.map((row) => row.output), tooltipData: rows.map((row) => row.rawOutput), backgroundColor: (context) => toGradientFill(context, tokenColors.output), borderColor: tokenColors.output.base, stack: 'tokens', yAxisID: 'tokens' } as TokenTooltipDataset,
+      { label: labels.cached, data: rows.map((row) => row.cached), tooltipData: rows.map((row) => row.cached), backgroundColor: (context) => toGradientFill(context, tokenColors.cached), borderColor: tokenColors.cached.base, stack: 'tokens', yAxisID: 'tokens' } as TokenTooltipDataset,
+      { label: labels.reasoning, data: rows.map((row) => row.reasoning), tooltipData: rows.map((row) => row.reasoning), backgroundColor: (context) => toGradientFill(context, tokenColors.reasoning), borderColor: tokenColors.reasoning.base, stack: 'tokens', yAxisID: 'tokens' } as TokenTooltipDataset,
       {
         type: 'line',
         label: labels.requests,

--- a/web/src/components/usage/analysis/AnalysisPanel.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.tsx
@@ -102,8 +102,17 @@ const toNumber = (value: unknown) => {
   return Number.isFinite(parsed) ? parsed : 0;
 };
 
+const getDatasetLabelPrefix = (dataset: unknown): string => {
+  const label = dataset && typeof dataset === 'object'
+    ? (dataset as { label?: unknown }).label
+    : undefined;
+  return typeof label === 'string' && label ? `${label}: ` : '';
+};
+
 const getTooltipTokenValue = (dataset: unknown, dataIndex: number | undefined, fallback: unknown): number => {
-  const tooltipData = (dataset as { tooltipData?: unknown[] }).tooltipData;
+  const tooltipData = dataset && typeof dataset === 'object'
+    ? (dataset as { tooltipData?: unknown[] }).tooltipData
+    : undefined;
   const tooltipValue = typeof dataIndex === 'number' ? tooltipData?.[dataIndex] : undefined;
   return toNumber(tooltipValue ?? fallback);
 };
@@ -232,7 +241,7 @@ function buildAnalysisTokenChartOptions({ chartTheme, isMobile, totalTokens, tot
         usePointStyle: true,
         callbacks: {
           label: (context) => {
-            const label = context.dataset.label ? `${context.dataset.label}: ` : '';
+            const label = getDatasetLabelPrefix(context.dataset);
             const value = getTooltipTokenValue(context.dataset, context.dataIndex, context.parsed.y);
             return `${label}${formatCompactNumber(value)}`;
           },

--- a/web/src/components/usage/analysis/AnalysisPanel.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { Chart, ChartData, ChartOptions, Plugin, TooltipModel } from 'chart.js';
 import { Bar, Doughnut } from 'react-chartjs-2';
 import type { AnalysisCompositionItem, AnalysisHeatmapCell, AnalysisResponse, AnalysisTokenUsageBucket } from '@/lib/types';
-import { formatCompactNumber } from '@/utils/usage';
+import { calculateDisplayInputTokens, calculateDisplayOutputTokens, formatCompactNumber } from '@/utils/usage';
 import styles from './AnalysisPanel.module.scss';
 
 interface AnalysisPanelProps {
@@ -19,6 +19,7 @@ type ChartRow = {
   output: number;
   cached: number;
   reasoning: number;
+  total: number;
   requests: number;
 };
 
@@ -64,6 +65,7 @@ type TokenLabels = {
   output: string;
   cached: string;
   reasoning: string;
+  total: string;
   requests: string;
 };
 
@@ -150,10 +152,17 @@ const formatBucketLabel = (bucket: string, granularity: AnalysisResponse['granul
 function buildTokenUsageRows(buckets: AnalysisTokenUsageBucket[], granularity: AnalysisResponse['granularity']): ChartRow[] {
   return buckets.map((bucket) => ({
     label: formatBucketLabel(bucket.bucket, granularity),
-    input: toNumber(bucket.input_tokens),
-    output: toNumber(bucket.output_tokens),
+    input: calculateDisplayInputTokens({
+      inputTokens: bucket.input_tokens,
+      cachedTokens: bucket.cached_tokens,
+    }),
+    output: calculateDisplayOutputTokens({
+      outputTokens: bucket.output_tokens,
+      reasoningTokens: bucket.reasoning_tokens,
+    }),
     cached: toNumber(bucket.cached_tokens),
     reasoning: toNumber(bucket.reasoning_tokens),
+    total: toNumber(bucket.total_tokens),
     requests: toNumber(bucket.requests),
   }));
 }
@@ -191,7 +200,7 @@ function buildTokenLegendItems(labels: TokenLabels): LegendItem[] {
   ];
 }
 
-function buildAnalysisTokenChartOptions({ chartTheme, isMobile }: { chartTheme: ChartTheme; isMobile: boolean }): ChartOptions<'bar'> {
+function buildAnalysisTokenChartOptions({ chartTheme, isMobile, totalTokens, totalLabel }: { chartTheme: ChartTheme; isMobile: boolean; totalTokens: number[]; totalLabel: string }): ChartOptions<'bar'> {
   return {
     responsive: true,
     maintainAspectRatio: false,
@@ -211,6 +220,11 @@ function buildAnalysisTokenChartOptions({ chartTheme, isMobile }: { chartTheme: 
           label: (context) => {
             const label = context.dataset.label ? `${context.dataset.label}: ` : '';
             return `${label}${formatCompactNumber(Number(context.parsed.y ?? 0))}`;
+          },
+          footer: (items) => {
+            const dataIndex = items[0]?.dataIndex ?? -1;
+            if (dataIndex < 0) return '';
+            return `${totalLabel}: ${formatCompactNumber(Number(totalTokens[dataIndex] ?? 0))}`;
           },
         },
       },
@@ -379,11 +393,17 @@ function TokenUsageChart({ rows, loading, isDark, isMobile }: { rows: ChartRow[]
     output: t('usage_stats.output_tokens'),
     cached: t('usage_stats.cached_tokens'),
     reasoning: t('usage_stats.reasoning_tokens'),
+    total: t('usage_stats.total_tokens'),
     requests: t('usage_stats.requests_count'),
   }), [t]);
   const chartTheme = useMemo(() => getChartTheme(isDark), [isDark]);
   const chartData = useMemo(() => buildAnalysisTokenChartData(rows, tokenLabels), [rows, tokenLabels]);
-  const chartOptions = useMemo(() => buildAnalysisTokenChartOptions({ chartTheme, isMobile }), [chartTheme, isMobile]);
+  const chartOptions = useMemo(() => buildAnalysisTokenChartOptions({
+    chartTheme,
+    isMobile,
+    totalTokens: rows.map((row) => row.total),
+    totalLabel: tokenLabels.total,
+  }), [chartTheme, isMobile, rows, tokenLabels.total]);
   const legendItems = useMemo(() => buildTokenLegendItems(tokenLabels), [tokenLabels]);
   return (
     <section className={`${styles.analysisCard} ${styles.tokenUsageCard}`}>

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -754,6 +754,14 @@
   border-radius: 9999px;
 }
 
+.customRangeInputShell {
+  display: contents;
+}
+
+.customRangeInputDisplay {
+  display: none;
+}
+
 .customRangeSeparator {
   display: inline-flex;
   align-items: center;
@@ -788,6 +796,8 @@
   .usageFilterBar {
     width: 100%;
     justify-content: flex-start;
+    max-height: none;
+    overflow: visible;
   }
 
   .apiKeyFilterField {
@@ -802,13 +812,15 @@
 
   .customRangeFieldGroup {
     flex: 1 1 100%;
+    flex-basis: 100%;
+    width: 100%;
     max-height: 0;
     transform: translateY(-4px);
   }
 
   .customRangeFieldGroupOpen {
     max-width: 100%;
-    max-height: 96px;
+    max-height: 180px;
     transform: translateY(0);
   }
 
@@ -821,8 +833,10 @@
   }
 
   .timeRangeGroup {
+    width: 100%;
     max-width: 100%;
     border-radius: 24px;
+    box-sizing: border-box;
   }
 
   .customRangeInline {
@@ -870,6 +884,8 @@
   }
 
   .usageFilterBar {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
     gap: 8px;
   }
 
@@ -877,6 +893,7 @@
   .rangeFilterField {
     flex-basis: 100%;
     width: 100%;
+    box-sizing: border-box;
   }
 
   .apiKeySelectControl,
@@ -889,24 +906,82 @@
   .apiKeyFilterField,
   .rangeFilterField {
     align-items: stretch;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 8px;
   }
 
   .customRangeFieldGroup {
-    flex-direction: column;
-    align-items: stretch;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
     max-height: 0;
   }
 
+  .customRangeField {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    min-inline-size: 0;
+    max-width: 100%;
+    max-inline-size: 100%;
+  }
+
   .customRangeFieldGroupOpen {
-    max-height: 160px;
+    max-height: 180px;
   }
 
   .customRangeSeparator {
     display: none;
   }
 
-  .customRangeInput {
+  // 移动端用外壳显示日期，避免 iOS 原生 date input 的绘制宽度撑出容器。
+  .customRangeInputShell {
+    position: relative;
+    display: block;
     width: 100%;
+    min-width: 0;
+    height: 34px;
+    overflow: hidden;
+    border: 1px solid var(--border-color);
+    border-radius: 9999px;
+    background-color: var(--bg-secondary);
+    transition: border-color 150ms ease, box-shadow 150ms ease;
+
+    &:focus-within {
+      border-color: var(--primary-color);
+      box-shadow: 0 0 0 3px rgba($primary-color, 0.18);
+    }
+  }
+
+  .customRangeInputDisplay {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+    padding: 6px 12px;
+    color: var(--text-primary);
+    font-size: 12px;
+    line-height: 1;
+    pointer-events: none;
+  }
+
+  .customRangeInput {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    border: 0;
+    min-width: 0;
+    min-inline-size: 0;
+    max-width: 100%;
+    max-inline-size: 100%;
+    display: block;
+    opacity: 0;
   }
 
   .usageRefreshSlot,

--- a/web/src/pages/UsagePage.styles.test.ts
+++ b/web/src/pages/UsagePage.styles.test.ts
@@ -342,9 +342,45 @@ describe('UsagePage toolbar styles', () => {
     expect(usagePageStyles).toMatch(/\.customRangeInput\s*\{[\s\S]*?-webkit-user-select:\s*none;/)
     expect(usagePageSource).not.toContain('readOnly')
     expect(usagePageSource).not.toContain('onPointerDown={handleCustomDateInputPointerDown}')
+    expect(usagePageSource).toContain('className={styles.customRangeInputShell}')
+    expect(usagePageSource).toContain('className={styles.customRangeInputDisplay}')
     expect(usagePageSource).toContain('onClick={handleCustomDateInputActivate}')
     expect(usagePageSource).toContain('onFocus={handleCustomDateInputActivate}')
     expect(usagePageSource).toContain('onKeyDown={handleCustomDateInputKeyDown}')
+  })
+
+  it('keeps mobile custom date fields inside the toolbar before the refresh action', () => {
+    const narrowToolbarStart = usagePageStyles.indexOf('@media (max-width: #{$breakpoint-tablet})')
+    const mobileToolbarStart = usagePageStyles.indexOf('@include mobile {\n  .tabPill', narrowToolbarStart)
+    const narrowToolbarBlock = usagePageStyles.slice(
+      narrowToolbarStart,
+      mobileToolbarStart
+    )
+    const mobileToolbarBlock = usagePageStyles.slice(
+      mobileToolbarStart,
+      usagePageStyles.indexOf('@media (prefers-reduced-motion: reduce)')
+    )
+
+    expect(narrowToolbarBlock).toMatch(/\.usageFilterBar\s*\{[\s\S]*?max-height:\s*none;/)
+    expect(narrowToolbarBlock).toMatch(/\.usageFilterBar\s*\{[\s\S]*?overflow:\s*visible;/)
+    expect(narrowToolbarBlock).toMatch(/\.timeRangeGroup\s*\{[\s\S]*?width:\s*100%;/)
+    expect(narrowToolbarBlock).toMatch(/\.customRangeFieldGroup\s*\{[\s\S]*?width:\s*100%;/)
+    expect(narrowToolbarBlock).toMatch(/\.customRangeFieldGroupOpen\s*\{[\s\S]*?max-height:\s*180px;/)
+    expect(mobileToolbarBlock).toMatch(/\.usageFilterBar\s*\{[\s\S]*?display:\s*grid;/)
+    expect(mobileToolbarBlock).toMatch(/\.usageFilterBar\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\);/)
+    expect(mobileToolbarBlock).toMatch(/\.rangeFilterField\s*\{[\s\S]*?grid-template-columns:\s*auto minmax\(0, 1fr\);/)
+    expect(mobileToolbarBlock).toMatch(/\.customRangeFieldGroup\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\);/)
+    expect(mobileToolbarBlock).toMatch(/\.customRangeField\s*\{[\s\S]*?grid-template-columns:\s*auto minmax\(0, 1fr\);/)
+    expect(mobileToolbarBlock).toMatch(/\.customRangeField\s*\{[\s\S]*?min-width:\s*0;/)
+    expect(mobileToolbarBlock).toMatch(/\.customRangeField\s*\{[\s\S]*?max-width:\s*100%;/)
+    expect(mobileToolbarBlock).toMatch(/\.customRangeInputShell\s*\{[\s\S]*?position:\s*relative;/)
+    expect(mobileToolbarBlock).toMatch(/\.customRangeInputShell\s*\{[\s\S]*?overflow:\s*hidden;/)
+    expect(mobileToolbarBlock).toMatch(/\.customRangeInputDisplay\s*\{[\s\S]*?display:\s*flex;/)
+    expect(mobileToolbarBlock).toMatch(/\.customRangeInput\s*\{[\s\S]*?position:\s*absolute;/)
+    expect(mobileToolbarBlock).toMatch(/\.customRangeInput\s*\{[\s\S]*?min-width:\s*0;/)
+    expect(mobileToolbarBlock).toMatch(/\.customRangeInput\s*\{[\s\S]*?max-width:\s*100%;/)
+    expect(mobileToolbarBlock).toMatch(/\.customRangeInput\s*\{[\s\S]*?display:\s*block;/)
+    expect(mobileToolbarBlock).toMatch(/\.customRangeInput\s*\{[\s\S]*?opacity:\s*0;/)
   })
 
   it('keeps Overview chart period controls hidden because period selection is automatic', () => {

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -1556,52 +1556,62 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                     >
                       <label className={styles.customRangeField}>
                         <span className={styles.customRangeFieldLabel}>{t('usage_stats.custom_start')}</span>
-                        <input
-                          type="date"
-                          className={`input ${styles.customRangeInput}`}
-                          value={customTimeRange.start}
-                          min={customDateRangeBounds.min}
-                          max={customDateRangeBounds.max}
-                          disabled={!isCustomRange}
-                          onClick={handleCustomDateInputActivate}
-                          onFocus={handleCustomDateInputActivate}
-                          onKeyDown={handleCustomDateInputKeyDown}
-                          onPaste={(event) => event.preventDefault()}
-                          onChange={(event) => {
-                            const nextValue = event.target.value;
-                            if (!isCustomDateWithinBounds(nextValue, customDateRangeBounds)) return;
-                            setCustomTimeRange((current) => ({
-                              ...current,
-                              start: nextValue
-                            }));
-                          }}
-                          aria-label={t('usage_stats.custom_start')}
-                        />
+                        <span className={styles.customRangeInputShell}>
+                          <input
+                            type="date"
+                            className={`input ${styles.customRangeInput}`}
+                            value={customTimeRange.start}
+                            min={customDateRangeBounds.min}
+                            max={customDateRangeBounds.max}
+                            disabled={!isCustomRange}
+                            onClick={handleCustomDateInputActivate}
+                            onFocus={handleCustomDateInputActivate}
+                            onKeyDown={handleCustomDateInputKeyDown}
+                            onPaste={(event) => event.preventDefault()}
+                            onChange={(event) => {
+                              const nextValue = event.target.value;
+                              if (!isCustomDateWithinBounds(nextValue, customDateRangeBounds)) return;
+                              setCustomTimeRange((current) => ({
+                                ...current,
+                                start: nextValue
+                              }));
+                            }}
+                            aria-label={t('usage_stats.custom_start')}
+                          />
+                          <span className={styles.customRangeInputDisplay} aria-hidden="true">
+                            {customTimeRange.start || 'YYYY-MM-DD'}
+                          </span>
+                        </span>
                       </label>
                       <span className={styles.customRangeSeparator} aria-hidden="true">—</span>
                       <label className={styles.customRangeField}>
                         <span className={styles.customRangeFieldLabel}>{t('usage_stats.custom_end')}</span>
-                        <input
-                          type="date"
-                          className={`input ${styles.customRangeInput}`}
-                          value={customTimeRange.end}
-                          min={customDateRangeBounds.min}
-                          max={customDateRangeBounds.max}
-                          disabled={!isCustomRange}
-                          onClick={handleCustomDateInputActivate}
-                          onFocus={handleCustomDateInputActivate}
-                          onKeyDown={handleCustomDateInputKeyDown}
-                          onPaste={(event) => event.preventDefault()}
-                          onChange={(event) => {
-                            const nextValue = event.target.value;
-                            if (!isCustomDateWithinBounds(nextValue, customDateRangeBounds)) return;
-                            setCustomTimeRange((current) => ({
-                              ...current,
-                              end: nextValue
-                            }));
-                          }}
-                          aria-label={t('usage_stats.custom_end')}
-                        />
+                        <span className={styles.customRangeInputShell}>
+                          <input
+                            type="date"
+                            className={`input ${styles.customRangeInput}`}
+                            value={customTimeRange.end}
+                            min={customDateRangeBounds.min}
+                            max={customDateRangeBounds.max}
+                            disabled={!isCustomRange}
+                            onClick={handleCustomDateInputActivate}
+                            onFocus={handleCustomDateInputActivate}
+                            onKeyDown={handleCustomDateInputKeyDown}
+                            onPaste={(event) => event.preventDefault()}
+                            onChange={(event) => {
+                              const nextValue = event.target.value;
+                              if (!isCustomDateWithinBounds(nextValue, customDateRangeBounds)) return;
+                              setCustomTimeRange((current) => ({
+                                ...current,
+                                end: nextValue
+                              }));
+                            }}
+                            aria-label={t('usage_stats.custom_end')}
+                          />
+                          <span className={styles.customRangeInputDisplay} aria-hidden="true">
+                            {customTimeRange.end || 'YYYY-MM-DD'}
+                          </span>
+                        </span>
                       </label>
                     </div>
                   </div>

--- a/web/src/utils/usage.ts
+++ b/web/src/utils/usage.ts
@@ -136,6 +136,14 @@ const toNumber = (value: unknown): number => {
   return Number.isFinite(parsed) ? parsed : 0;
 };
 
+export function calculateDisplayInputTokens({ inputTokens, cachedTokens }: { inputTokens: unknown; cachedTokens: unknown }): number {
+  return Math.max(Math.max(toNumber(inputTokens), 0) - Math.max(toNumber(cachedTokens), 0), 0);
+}
+
+export function calculateDisplayOutputTokens({ outputTokens, reasoningTokens }: { outputTokens: unknown; reasoningTokens: unknown }): number {
+  return Math.max(Math.max(toNumber(outputTokens), 0) - Math.max(toNumber(reasoningTokens), 0), 0);
+}
+
 const formatLocalDayKey = (date: Date): string => {
   const pad = (value: number) => String(value).padStart(2, '0');
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;


### PR DESCRIPTION
## Summary

- Keep custom mobile date range inputs inside the viewport without changing the desktop layout.
- Correct token chart display values so cached tokens are not counted inside input tokens, and reasoning tokens are not counted inside output tokens.
- Keep chart tooltips clear by showing backend raw input/output values and adding a Total footer.

Closed #137 

## Validation

- `npm --prefix ./web run test`
- `npm --prefix ./web run typecheck`
- `npm --prefix ./web run build`
