### PR TITLE
Tune CPA ingest all-failed retry backoff

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -513,7 +513,6 @@ func testAppConfig(t *testing.T) config.Config {
 		CPABaseURL:              "https://cpa.example.com",
 		CPAManagementKey:        "secret",
 		RedisQueueIdleInterval:  time.Second,
-		RedisQueueErrorBackoff:  10 * time.Second,
 		MetadataSyncInterval:    30 * time.Second,
 		SQLitePath:              t.TempDir() + "/app.db",
 		BackupEnabled:           true,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,6 @@ const (
 	DefaultTimeZone                 = "Asia/Shanghai"
 	RedisQueueKeyDefault            = cpa.ManagementUsageQueueKey
 	RedisQueueBatchSizeDefault      = 10000
-	RedisQueueErrorBackoffDefault   = 10 * time.Second
 	MetadataSyncIntervalDefault     = 30 * time.Second
 	QuotaAutoRefreshIntervalDefault = 5 * time.Minute
 	QuotaAutoRefreshIntervalMin     = 60 * time.Second
@@ -63,8 +62,6 @@ type Config struct {
 	RedisQueueBatchSize int
 	// RedisQueueIdleInterval 是 Redis 队列为空时的下一次检查间隔。
 	RedisQueueIdleInterval time.Duration
-	// RedisQueueErrorBackoff 是 Redis 临时错误后的固定退避间隔。
-	RedisQueueErrorBackoff time.Duration
 	// MetadataSyncInterval 是 auth files 和 provider metadata 的固定刷新间隔。
 	MetadataSyncInterval time.Duration
 	// QuotaAutoRefreshEnabled 控制是否启动 Auth Files 限额自动刷新后台任务。
@@ -259,7 +256,6 @@ func Load(options LoadOptions) (*Config, error) {
 		RedisQueueKey:            RedisQueueKeyDefault,
 		RedisQueueBatchSize:      redisQueueBatchSize,
 		RedisQueueIdleInterval:   redisQueueIdleInterval,
-		RedisQueueErrorBackoff:   RedisQueueErrorBackoffDefault,
 		MetadataSyncInterval:     MetadataSyncIntervalDefault,
 		QuotaAutoRefreshEnabled:  quotaAutoRefreshEnabled,
 		QuotaAutoRefreshInterval: quotaAutoRefreshInterval,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -149,9 +149,6 @@ func TestLoadFromEnvAppliesDefaults(t *testing.T) {
 	if cfg.RedisQueueIdleInterval != time.Second {
 		t.Fatalf("expected default redis queue idle interval 1s, got %s", cfg.RedisQueueIdleInterval)
 	}
-	if cfg.RedisQueueErrorBackoff != RedisQueueErrorBackoffDefault {
-		t.Fatalf("expected default redis queue error backoff 10s, got %s", cfg.RedisQueueErrorBackoff)
-	}
 	if cfg.MetadataSyncInterval != MetadataSyncIntervalDefault {
 		t.Fatalf("expected default metadata sync interval 30s, got %s", cfg.MetadataSyncInterval)
 	}
@@ -571,18 +568,17 @@ func TestLoadFromEnvRejectsNonPositiveRedisQueueIdleInterval(t *testing.T) {
 	}
 }
 
-func TestLoadFromEnvIgnoresRemovedRedisPollerEnvOverrides(t *testing.T) {
+func TestLoadFromEnvIgnoresRemovedMetadataSyncIntervalOverride(t *testing.T) {
 	t.Setenv("CPA_BASE_URL", "http://127.0.0.1:"+cpa.ManagementRedisDefaultPort)
 	t.Setenv("CPA_MANAGEMENT_KEY", "secret")
-	t.Setenv("REDIS_QUEUE_ERROR_BACKOFF", "20s")
 	t.Setenv("REDIS_METADATA_SYNC_INTERVAL", "45s")
 
 	cfg, err := LoadFromEnv()
 	if err != nil {
 		t.Fatalf("LoadFromEnv returned error: %v", err)
 	}
-	if cfg.RedisQueueErrorBackoff != RedisQueueErrorBackoffDefault || cfg.MetadataSyncInterval != MetadataSyncIntervalDefault {
-		t.Fatalf("expected removed env overrides to be ignored, got error_backoff=%s metadata_interval=%s", cfg.RedisQueueErrorBackoff, cfg.MetadataSyncInterval)
+	if cfg.MetadataSyncInterval != MetadataSyncIntervalDefault {
+		t.Fatalf("expected removed env overrides to be ignored, got metadata_interval=%s", cfg.MetadataSyncInterval)
 	}
 }
 

--- a/internal/poller/redis_ingest_runner.go
+++ b/internal/poller/redis_ingest_runner.go
@@ -175,6 +175,12 @@ func (r *RedisIngestRunner) Run(ctx context.Context) error {
 			// http_pull 模式退出后重新探测，避免异常退出后永久停止。
 			continue
 		}
+		if errors.Is(httpErr, errRedisIngestInboxWrite) {
+			if !r.pauseAfterInboxWriteFailure(ctx, "http_inbox_write_failed", httpErr) {
+				return nil
+			}
+			continue
+		}
 		// 三条远端入口都失败时合并错误，状态和日志能同时看到完整失败链。
 		joined := errors.Join(subErr, redisErr, httpErr)
 		// 连续启动失败使用指数退避，避免 CPA 故障时高频刷错误。

--- a/internal/poller/redis_ingest_runner.go
+++ b/internal/poller/redis_ingest_runner.go
@@ -46,8 +46,10 @@ type RedisIngestRunner struct {
 	now func() time.Time
 	// sleep 允许测试替换等待逻辑，生产环境使用可被 context 打断的 timer。
 	sleep func(context.Context, time.Duration) bool
-	// failureBackoff 只在连续失败路径递增，任何成功拉取都会 reset。
+	// failureBackoff 只在普通连续失败路径递增，任何成功拉取都会 reset。
 	failureBackoff *RedisIngestBackoff
+	// startupAllFailedBackoff 只在启动探测三条入口全部失败时递增。
+	startupAllFailedBackoff *RedisIngestBackoff
 	// opMu 串行化远端拉取和 inbox 写入，避免同一 runner 内不同路径重复消费。
 	opMu sync.Mutex
 	// mu 保护状态字段，Status、日志记录和 runner goroutine 都会访问这些字段。
@@ -87,8 +89,10 @@ func NewRedisIngestRunner(sub UsageSubscriptionSource, redis UsagePullSource, ht
 		now: time.Now,
 		// 默认使用 context-aware sleep，保证关停时不会卡住。
 		sleep: sleepContext,
-		// 失败退避从配置初始值开始，最大值默认 30s。
+		// 普通失败退避保留原来的 1s 起步，不影响已有降级和单链路失败逻辑。
 		failureBackoff: NewRedisIngestBackoff(resolvePositiveDuration(cfg.HTTPBackoffInitial, time.Second), resolvePositiveDuration(cfg.HTTPBackoffMax, 30*time.Second)),
+		// 三入口全部失败时从 10s 起步独立退避，避免 CPA 整体不可用时高频重连。
+		startupAllFailedBackoff: NewRedisIngestBackoff(RedisIngestAllFailedRetryInitial, 30*time.Second),
 		// 新 runner 尚未完成启动探测，所以先标记 unknown/starting。
 		mode:     RedisIngestSyncModeUnknown,
 		subState: RedisIngestSubStateStarting,
@@ -115,6 +119,8 @@ func (r *RedisIngestRunner) Run(ctx context.Context) error {
 		// 启动优先尝试 Redis subscribe，只有订阅成功才进入最复杂的 subscribe 模式。
 		sub, subErr := r.subscribeSource.Subscribe(ctx)
 		if subErr == nil {
+			// 任一启动入口恢复后，下一次整体故障重新从 10s 开始。
+			r.startupAllFailedBackoff.Reset()
 			// 订阅连上后先进入 backfill 阶段，补订阅建立前可能遗漏的队列数据。
 			r.recordState(RedisIngestSyncModeSubscribe, RedisIngestSubStateSubscribeBackfill, "subscribe_connected", "", "")
 			// subscribe 模式内部会处理断线、降级轮询和固定间隔重连。
@@ -130,6 +136,8 @@ func (r *RedisIngestRunner) Run(ctx context.Context) error {
 		// 启动探测第二步：Redis LPOP 成功就把长期模式固定为 redis_pull。
 		redisCount, redisErr := r.serialPullAndWrite(ctx, RedisIngestSourceRedisPull, r.redisSource)
 		if redisErr == nil {
+			// 任一启动入口恢复后，下一次整体故障重新从 10s 开始。
+			r.startupAllFailedBackoff.Reset()
 			// 成功拉取说明远端恢复，清掉连续失败退避。
 			r.failureBackoff.Reset()
 			// 记录 redis_pull 长期模式，message_count 不进 status，避免状态字符串频繁变化。
@@ -153,6 +161,8 @@ func (r *RedisIngestRunner) Run(ctx context.Context) error {
 		// 启动探测第三步：HTTP 成功就把长期模式固定为 http_pull。
 		httpCount, httpErr := r.serialPullAndWrite(ctx, RedisIngestSourceHTTPPull, r.httpSource)
 		if httpErr == nil {
+			// 任一启动入口恢复后，下一次整体故障重新从 10s 开始。
+			r.startupAllFailedBackoff.Reset()
 			// HTTP 成功说明兜底链路可用，重置连续失败退避。
 			r.failureBackoff.Reset()
 			// 记录 http_pull 固定模式；该模式不再尝试 Redis/subscribe，符合启动选择规则。
@@ -168,7 +178,7 @@ func (r *RedisIngestRunner) Run(ctx context.Context) error {
 		// 三条远端入口都失败时合并错误，状态和日志能同时看到完整失败链。
 		joined := errors.Join(subErr, redisErr, httpErr)
 		// 连续启动失败使用指数退避，避免 CPA 故障时高频刷错误。
-		delay := r.failureBackoff.NextDelay()
+		delay := r.startupAllFailedBackoff.NextDelay()
 		// 记录最终启动失败，Status.LastError 展示合并后的失败原因。
 		r.recordError("startup_failed", joined)
 		// 下一次探测等待时间属于重复轮询细节，只放 debug，避免 error 日志成倍输出。
@@ -703,8 +713,12 @@ func (r *RedisIngestRunner) validate() error {
 		r.sleep = sleepContext
 	}
 	if r.failureBackoff == nil {
-		// backoff 缺失时恢复 1s 到 30s 的失败退避。
+		// backoff 缺失时恢复 1s 到 30s 的普通失败退避。
 		r.failureBackoff = NewRedisIngestBackoff(time.Second, 30*time.Second)
+	}
+	if r.startupAllFailedBackoff == nil {
+		// 三入口全部失败的退避独立恢复为 10s 到 30s。
+		r.startupAllFailedBackoff = NewRedisIngestBackoff(RedisIngestAllFailedRetryInitial, 30*time.Second)
 	}
 	return nil
 }

--- a/internal/poller/redis_ingest_runner_internal_test.go
+++ b/internal/poller/redis_ingest_runner_internal_test.go
@@ -63,6 +63,32 @@ func TestRedisIngestRunnerHTTPPullFailureKeepsOneSecondInitialBackoff(t *testing
 	}
 }
 
+func TestRedisIngestRunnerStartupHTTPInboxWriteFailureUsesOneSecondBackoff(t *testing.T) {
+	runner := NewRedisIngestRunner(
+		internalFailingSubscribeSource{err: errors.New("subscribe unavailable")},
+		internalFailingPullSource{err: errors.New("redis unavailable")},
+		internalStaticPullSource{messages: []string{`{"request_id":"http"}`}},
+		internalFailingInboxWriter{err: errors.New("sqlite locked")},
+		RedisIngestRunnerConfig{IdleInterval: time.Millisecond, BatchSize: 10},
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var delays []time.Duration
+	runner.sleep = func(_ context.Context, delay time.Duration) bool {
+		delays = append(delays, delay)
+		cancel()
+		return false
+	}
+
+	if err := runner.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	want := []time.Duration{time.Second}
+	if !reflect.DeepEqual(delays, want) {
+		t.Fatalf("unexpected http inbox write retry delays: got %v want %v", delays, want)
+	}
+}
+
 type internalFailingSubscribeSource struct {
 	err error
 }
@@ -91,8 +117,24 @@ func (s internalFailingPullSource) Pull(context.Context) ([]string, error) {
 	return nil, nil
 }
 
+type internalStaticPullSource struct {
+	messages []string
+}
+
+func (s internalStaticPullSource) Pull(context.Context) ([]string, error) {
+	return append([]string(nil), s.messages...), nil
+}
+
 type internalNoopInboxWriter struct{}
 
 func (internalNoopInboxWriter) Insert(context.Context, string, []string, time.Time) (int, error) {
 	return 0, nil
+}
+
+type internalFailingInboxWriter struct {
+	err error
+}
+
+func (w internalFailingInboxWriter) Insert(context.Context, string, []string, time.Time) (int, error) {
+	return 0, w.err
 }

--- a/internal/poller/redis_ingest_runner_internal_test.go
+++ b/internal/poller/redis_ingest_runner_internal_test.go
@@ -1,0 +1,98 @@
+package poller
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestRedisIngestRunnerStartupAllFailedBackoffIncreasesFromTenSeconds(t *testing.T) {
+	runner := NewRedisIngestRunner(
+		internalFailingSubscribeSource{err: errors.New("subscribe unavailable")},
+		internalFailingPullSource{err: errors.New("redis unavailable")},
+		internalFailingPullSource{err: errors.New("http unavailable")},
+		internalNoopInboxWriter{},
+		RedisIngestRunnerConfig{IdleInterval: time.Millisecond, BatchSize: 10, HTTPBackoffInitial: time.Second, HTTPBackoffMax: 30 * time.Second},
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var delays []time.Duration
+	runner.sleep = func(_ context.Context, delay time.Duration) bool {
+		delays = append(delays, delay)
+		if len(delays) == 3 {
+			cancel()
+			return false
+		}
+		return true
+	}
+
+	if err := runner.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	want := []time.Duration{10 * time.Second, 20 * time.Second, 30 * time.Second}
+	if !reflect.DeepEqual(delays, want) {
+		t.Fatalf("unexpected startup all-failed retry delays: got %v want %v", delays, want)
+	}
+}
+
+func TestRedisIngestRunnerHTTPPullFailureKeepsOneSecondInitialBackoff(t *testing.T) {
+	runner := NewRedisIngestRunner(
+		internalFailingSubscribeSource{},
+		internalFailingPullSource{},
+		internalFailingPullSource{err: errors.New("http unavailable")},
+		internalNoopInboxWriter{},
+		RedisIngestRunnerConfig{IdleInterval: time.Millisecond, BatchSize: 10},
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var delays []time.Duration
+	runner.sleep = func(_ context.Context, delay time.Duration) bool {
+		delays = append(delays, delay)
+		cancel()
+		return false
+	}
+
+	if err := runner.runHTTPPullMode(ctx); err != context.Canceled {
+		t.Fatalf("runHTTPPullMode returned %v, want context.Canceled", err)
+	}
+	want := []time.Duration{time.Second}
+	if !reflect.DeepEqual(delays, want) {
+		t.Fatalf("unexpected http pull failure retry delays: got %v want %v", delays, want)
+	}
+}
+
+type internalFailingSubscribeSource struct {
+	err error
+}
+
+func (s internalFailingSubscribeSource) Subscribe(context.Context) (UsageSubscription, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return internalNoopSubscription{}, nil
+}
+
+type internalNoopSubscription struct{}
+
+func (internalNoopSubscription) Receive(context.Context) (string, error) { return "", context.Canceled }
+
+func (internalNoopSubscription) Close() error { return nil }
+
+type internalFailingPullSource struct {
+	err error
+}
+
+func (s internalFailingPullSource) Pull(context.Context) ([]string, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return nil, nil
+}
+
+type internalNoopInboxWriter struct{}
+
+func (internalNoopInboxWriter) Insert(context.Context, string, []string, time.Time) (int, error) {
+	return 0, nil
+}

--- a/internal/poller/redis_ingest_state.go
+++ b/internal/poller/redis_ingest_state.go
@@ -49,8 +49,12 @@ const (
 	RedisIngestSourceHTTPPull = "http_pull:usage_queue"
 )
 
-// redisIngestRecoveryRetryInterval 控制 subscribe/Redis 恢复探测间隔。
-const redisIngestRecoveryRetryInterval = 30 * time.Second
+const (
+	// RedisIngestAllFailedRetryInitial 是三条远端入口全部失败后的最小重试间隔。
+	RedisIngestAllFailedRetryInitial = 10 * time.Second
+	// redisIngestRecoveryRetryInterval 控制 subscribe/Redis 恢复探测间隔。
+	redisIngestRecoveryRetryInterval = 30 * time.Second
+)
 
 // redisIngestSubscribeBatchWindow 控制订阅收到首条消息后最多聚合 1s 再写入 inbox。
 const redisIngestSubscribeBatchWindow = time.Second

--- a/internal/poller/test/redis_ingest_runner_test.go
+++ b/internal/poller/test/redis_ingest_runner_test.go
@@ -34,6 +34,35 @@ func TestRedisIngestRunnerStartupFallsBackToHTTPPull(t *testing.T) {
 	}
 }
 
+func TestRedisIngestRunnerStartupAllFailedUsesTenSecondInitialRetry(t *testing.T) {
+	logs := capturePollerLogs(t, logrus.DebugLevel)
+	runner := poller.NewRedisIngestRunner(
+		fakeSubscribeSource{err: errors.New("subscribe unavailable")},
+		&fakePullSource{err: errors.New("redis unavailable")},
+		&fakePullSource{err: errors.New("http unavailable")},
+		newFakeInboxWriter(),
+		poller.RedisIngestRunnerConfig{IdleInterval: 10 * time.Millisecond, BatchSize: 10},
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		_ = runner.Run(ctx)
+		close(done)
+	}()
+
+	output := waitForLogContains(t, logs, "redis ingest startup retry scheduled", "retry_after=10s")
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runner to stop")
+	}
+	if !strings.Contains(output, "startup_failed") {
+		t.Fatalf("expected startup failure before retry schedule, got logs: %s", output)
+	}
+}
+
 func TestRedisIngestRunnerSubscribeBackfillsBeforeReceiving(t *testing.T) {
 	writer := newFakeInboxWriter()
 	sub := &blockingSubscription{messages: make(chan string)}


### PR DESCRIPTION
## Summary

- Add an independent 10s initial retry backoff for startup probes where Redis subscribe, Redis queue pull, and HTTP queue pull all fail.
- Keep existing 1s initial backoff for ordinary single-path failures so fallback and degraded polling behavior do not change.
- Remove the unused Redis queue error backoff config field.

Closed #144 

## Validation

- `rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build go test ./internal/config ./internal/poller/... ./internal/app -count=1`
