### PR TITLE
Improve credential quota and priority display

### DIFF
--- a/internal/quota/normalize.go
+++ b/internal/quota/normalize.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	quotaWindowFiveHourSeconds int64 = 5 * 60 * 60
-	quotaWindowSevenDaySeconds int64 = 7 * 24 * 60 * 60
+	quotaWindowFiveHourSeconds  int64 = 5 * 60 * 60
+	quotaWindowSevenDaySeconds  int64 = 7 * 24 * 60 * 60
+	quotaWindowThirtyDaySeconds int64 = 30 * 24 * 60 * 60
 )
 
 func NormalizeQuotaRows(output ProviderOutput) []QuotaRow {
@@ -104,7 +105,7 @@ func appendClaudeWindowQuotaRow(rows []QuotaRow, key string, label string, scope
 }
 
 func normalizeCodexQuotaRows(result CodexResult) []QuotaRow {
-	// Codex 根据 limit_window_seconds 明确区分 5h/Weekly；未知窗口只标记 Window，不猜测。
+	// Codex 根据 limit_window_seconds 明确区分 5h/Weekly/Monthly；未知窗口回退到 primary/secondary 角色。
 	if result.Usage == nil {
 		return nil
 	}
@@ -138,33 +139,70 @@ func appendCodexWindowQuotaRows(rows []QuotaRow, keyPrefix string, primaryLabel 
 	return rows
 }
 
-func codexWindowLabel(label string, seconds int64) string {
+func codexWindowLabel(key string, label string, seconds int64) string {
 	switch seconds {
-	case 18000:
-		if strings.Contains(label, "Weekly") {
-			return strings.Replace(label, "Weekly", "5h", 1)
-		}
-		return label
-	case 604800:
-		if strings.Contains(label, "5h") {
-			return strings.Replace(label, "5h", "Weekly", 1)
-		}
-		return label
+	case quotaWindowFiveHourSeconds:
+		return codexKnownWindowLabel(label, "5h")
+	case quotaWindowSevenDaySeconds:
+		return codexKnownWindowLabel(label, "Weekly")
+	case quotaWindowThirtyDaySeconds:
+		return codexKnownWindowLabel(label, "Monthly")
 	}
-	return codexUnknownWindowLabel(label)
+	return codexRoleWindowLabel(key, label)
 }
 
-func codexUnknownWindowLabel(label string) string {
-	if label == "5h" || label == "Weekly" {
-		return "Window"
+func codexKnownWindowLabel(label string, replacement string) string {
+	if label == "5h" || label == "Weekly" || label == "Monthly" || label == "Window" {
+		return replacement
 	}
-	if strings.Contains(label, "5h") {
-		return strings.Replace(label, "5h", "Window", 1)
-	}
-	if strings.Contains(label, "Weekly") {
-		return strings.Replace(label, "Weekly", "Window", 1)
+	for _, candidate := range []string{"5h", "Weekly", "Monthly", "Window"} {
+		if strings.Contains(label, candidate) {
+			return strings.Replace(label, candidate, replacement, 1)
+		}
 	}
 	return label
+}
+
+func codexRoleWindowLabel(key string, label string) string {
+	role := codexWindowRole(key)
+	if role == "" {
+		return label
+	}
+	fallback := codexPrefixedWindowRole(key, role)
+	if label == "" || label == "5h" || label == "Weekly" || label == "Monthly" || label == "Window" {
+		return fallback
+	}
+	for _, candidate := range []string{"5h", "Weekly", "Monthly", "Window"} {
+		if strings.Contains(label, candidate) {
+			return strings.Replace(label, candidate, role, 1)
+		}
+	}
+	return fallback
+}
+
+func codexWindowRole(key string) string {
+	if strings.HasSuffix(key, ".primary_window") {
+		return "Primary"
+	}
+	if strings.HasSuffix(key, ".secondary_window") {
+		return "Secondary"
+	}
+	return ""
+}
+
+func codexPrefixedWindowRole(key string, role string) string {
+	if strings.HasPrefix(key, "code_review_rate_limit.") {
+		return "Code Review " + role
+	}
+	if strings.HasPrefix(key, "additional_rate_limits.") {
+		name := strings.TrimPrefix(key, "additional_rate_limits.")
+		name = strings.TrimSuffix(name, ".primary_window")
+		name = strings.TrimSuffix(name, ".secondary_window")
+		if name != "" {
+			return name + " " + role
+		}
+	}
+	return role
 }
 
 func appendCodexWindowQuotaRow(rows []QuotaRow, key string, label string, scope string, metric string, info *CodexRateLimitInfo, window *CodexUsageWindow) []QuotaRow {
@@ -172,7 +210,7 @@ func appendCodexWindowQuotaRow(rows []QuotaRow, key string, label string, scope 
 	if window == nil {
 		return rows
 	}
-	label = codexWindowLabel(label, window.LimitWindowSeconds)
+	label = codexWindowLabel(key, label, window.LimitWindowSeconds)
 	row := QuotaRow{
 		Key:          key,
 		Label:        label,

--- a/internal/quota/test/normalizer_test.go
+++ b/internal/quota/test/normalizer_test.go
@@ -129,16 +129,58 @@ func TestNormalizeCodexPrimaryWindowUsesWindowSecondsForWeeklyLabel(t *testing.T
 	}
 }
 
-func TestNormalizeCodexUnknownWindowDoesNotGuessFiveHourOrWeekly(t *testing.T) {
+func TestNormalizeCodexPrimaryWindowUsesWindowSecondsForMonthlyLabel(t *testing.T) {
 	rows := quota.NormalizeQuotaRows(quota.ProviderOutput{Provider: "codex", Result: quota.CodexResult{Usage: &quota.CodexUsagePayload{
 		RateLimit: &quota.CodexRateLimitInfo{
-			PrimaryWindow: &quota.CodexUsageWindow{UsedPercent: 10, LimitWindowSeconds: 3600},
+			PrimaryWindow: &quota.CodexUsageWindow{UsedPercent: 10, LimitWindowSeconds: 2592000},
 		},
+		CodeReviewRateLimit: &quota.CodexRateLimitInfo{
+			PrimaryWindow: &quota.CodexUsageWindow{UsedPercent: 25, LimitWindowSeconds: 2592000},
+		},
+		AdditionalRateLimits: []quota.CodexAdditionalRateLimit{{
+			LimitName: "codex-spark",
+			RateLimit: &quota.CodexRateLimitInfo{
+				PrimaryWindow: &quota.CodexUsageWindow{UsedPercent: 40, LimitWindowSeconds: 2592000},
+			},
+		}},
 	}}})
 
 	primary := findQuotaRow(t, rows, "rate_limit.primary_window")
-	assertQuotaText(t, primary, "Window", "window", "")
+	assertQuotaText(t, primary, "Monthly", "window", "")
+	assertIntField(t, primary.Window.Seconds, 2592000, "primary monthly window seconds")
+	codeReview := findQuotaRow(t, rows, "code_review_rate_limit.primary_window")
+	assertQuotaText(t, codeReview, "Code Review Monthly", "code_review", "")
+	additional := findQuotaRow(t, rows, "additional_rate_limits.codex-spark.primary_window")
+	assertQuotaText(t, additional, "codex-spark Monthly", "additional", "codex-spark")
+}
+
+func TestNormalizeCodexUnknownWindowKeepsRoleLabelWithoutGenericWindow(t *testing.T) {
+	rows := quota.NormalizeQuotaRows(quota.ProviderOutput{Provider: "codex", Result: quota.CodexResult{Usage: &quota.CodexUsagePayload{
+		RateLimit: &quota.CodexRateLimitInfo{
+			PrimaryWindow:   &quota.CodexUsageWindow{UsedPercent: 10, LimitWindowSeconds: 3600},
+			SecondaryWindow: &quota.CodexUsageWindow{UsedPercent: 20, LimitWindowSeconds: 7200},
+		},
+		CodeReviewRateLimit: &quota.CodexRateLimitInfo{
+			PrimaryWindow: &quota.CodexUsageWindow{UsedPercent: 30, LimitWindowSeconds: 3600},
+		},
+		AdditionalRateLimits: []quota.CodexAdditionalRateLimit{{
+			LimitName: "GPT-5.3-Codex-Spark",
+			RateLimit: &quota.CodexRateLimitInfo{
+				SecondaryWindow: &quota.CodexUsageWindow{UsedPercent: 40, LimitWindowSeconds: 7200},
+			},
+		}},
+	}}})
+
+	primary := findQuotaRow(t, rows, "rate_limit.primary_window")
+	assertQuotaText(t, primary, "Primary", "window", "")
 	assertIntField(t, primary.Window.Seconds, 3600, "primary unknown window seconds")
+	secondary := findQuotaRow(t, rows, "rate_limit.secondary_window")
+	assertQuotaText(t, secondary, "Secondary", "window", "")
+	assertIntField(t, secondary.Window.Seconds, 7200, "secondary unknown window seconds")
+	codeReview := findQuotaRow(t, rows, "code_review_rate_limit.primary_window")
+	assertQuotaText(t, codeReview, "Code Review Primary", "code_review", "")
+	additional := findQuotaRow(t, rows, "additional_rate_limits.GPT-5.3-Codex-Spark.secondary_window")
+	assertQuotaText(t, additional, "GPT-5.3-Codex-Spark Secondary", "additional", "GPT-5.3-Codex-Spark")
 }
 
 func TestNormalizeGeminiCLIQuotaRows(t *testing.T) {

--- a/internal/quota/test/service_test.go
+++ b/internal/quota/test/service_test.go
@@ -58,7 +58,7 @@ func TestServiceIgnoresProviderOnlyIdentity(t *testing.T) {
 func TestServiceDispatchesAuthFileIdentityByProviderBeforeType(t *testing.T) {
 	db := openQuotaTestDB(t)
 	seedUsageIdentity(t, db, entities.UsageIdentity{AuthType: entities.UsageIdentityAuthTypeAuthFile, Identity: "codex-auth", Provider: "codex", Type: "unknown", Name: "auth file"})
-	handler := &recordingProviderHandler{output: quota.ProviderOutput{Provider: "codex", Result: quota.CodexResult{Usage: &quota.CodexUsagePayload{RateLimit: &quota.CodexRateLimitInfo{PrimaryWindow: &quota.CodexUsageWindow{UsedPercent: 25}}}}}}
+	handler := &recordingProviderHandler{output: quota.ProviderOutput{Provider: "codex", Result: quota.CodexResult{Usage: &quota.CodexUsagePayload{RateLimit: &quota.CodexRateLimitInfo{PrimaryWindow: &quota.CodexUsageWindow{UsedPercent: 25, LimitWindowSeconds: 18000}}}}}}
 	service := quota.NewServiceWithRegistry(db, quota.NewProviderRegistry(map[string]quota.ProviderHandler{"codex": handler}))
 
 	response, err := service.Check(context.Background(), quota.CheckRequest{AuthIndex: "codex-auth"})

--- a/internal/repository/usage_identities.go
+++ b/internal/repository/usage_identities.go
@@ -150,7 +150,7 @@ func ListActiveUsageIdentitiesPage(ctx context.Context, db *gorm.DB, request Lis
 		return nil, 0, nil, fmt.Errorf("count active usage identities page: %w", err)
 	}
 	var identities []entities.UsageIdentity
-	if err := applyUsageIdentityPageSort(query.Select(usageIdentityReadColumns), request.Sort).Offset((page - 1) * pageSize).Limit(pageSize).Find(&identities).Error; err != nil {
+	if err := applyUsageIdentityPageSort(query.Select(usageIdentityReadColumns), request.Sort, request.AuthType).Offset((page - 1) * pageSize).Limit(pageSize).Find(&identities).Error; err != nil {
 		return nil, 0, nil, fmt.Errorf("list active usage identities page: %w", err)
 	}
 	return identities, total, typeCounts, nil
@@ -201,10 +201,15 @@ func applyUsageIdentityTypesFilter(query *gorm.DB, types []string) *gorm.DB {
 	}
 }
 
-func applyUsageIdentityPageSort(query *gorm.DB, sort string) *gorm.DB {
+func applyUsageIdentityPageSort(query *gorm.DB, sort string, authType *entities.UsageIdentityAuthType) *gorm.DB {
 	switch sort {
 	case UsageIdentityPageSortPriority:
-		return query.Order("priority IS NULL ASC").Order("priority DESC").Order("id ASC")
+		// Auth Files 的 priority 同分需要稳定按名称排列；AI Provider 只保留同步顺序兜底。
+		query = query.Order("priority IS NULL ASC").Order("priority DESC")
+		if authType != nil && *authType == entities.UsageIdentityAuthTypeAuthFile {
+			query = query.Order("LOWER(name) ASC")
+		}
+		return query.Order("id ASC")
 	case UsageIdentityPageSortTotalTokens:
 		return query.Order("total_tokens DESC").Order("id ASC")
 	default:

--- a/internal/repository/usage_identities_test.go
+++ b/internal/repository/usage_identities_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -821,6 +822,9 @@ func TestUsageIdentityListActivePageFiltersEnabledAuthFilesAndOrdersByPriority(t
 	enabled := false
 	rows := []entities.UsageIdentity{
 		{Identity: "default", Name: "Default", AuthType: entities.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Type: "claude", Provider: "Claude", Priority: nil, Disabled: nil, TotalRequests: 40, TotalTokens: 400, CreatedAt: now, UpdatedAt: now},
+		{Identity: "priority-5-zeta", Name: "Zeta", AuthType: entities.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Type: "claude", Provider: "Claude", Priority: intPtr(5), Disabled: &enabled, TotalRequests: 25, TotalTokens: 250, CreatedAt: now, UpdatedAt: now},
+		{Identity: "priority-5-alpha", Name: "Alpha", AuthType: entities.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Type: "claude", Provider: "Claude", Priority: intPtr(5), Disabled: &enabled, TotalRequests: 22, TotalTokens: 220, CreatedAt: now, UpdatedAt: now},
+		{Identity: "priority-5-beta-lower", Name: "beta", AuthType: entities.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Type: "claude", Provider: "Claude", Priority: intPtr(5), Disabled: &enabled, TotalRequests: 21, TotalTokens: 210, CreatedAt: now, UpdatedAt: now},
 		{Identity: "priority-1", Name: "Priority 1", AuthType: entities.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Type: "claude", Provider: "Claude", Priority: intPtr(1), Disabled: &enabled, TotalRequests: 10, TotalTokens: 100, CreatedAt: now, UpdatedAt: now},
 		{Identity: "priority-5", Name: "Priority 5", AuthType: entities.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Type: "claude", Provider: "Claude", Priority: intPtr(5), Disabled: &enabled, TotalRequests: 20, TotalTokens: 200, CreatedAt: now, UpdatedAt: now},
 		{Identity: "disabled", Name: "Disabled", AuthType: entities.UsageIdentityAuthTypeAuthFile, AuthTypeName: "oauth", Type: "claude", Provider: "Claude", Priority: intPtr(0), Disabled: &disabled, TotalRequests: 99, TotalTokens: 999, CreatedAt: now, UpdatedAt: now},
@@ -835,11 +839,11 @@ func TestUsageIdentityListActivePageFiltersEnabledAuthFilesAndOrdersByPriority(t
 	if err != nil {
 		t.Fatalf("list page: %v", err)
 	}
-	if total != 3 {
-		t.Fatalf("expected total 3, got %d", total)
+	if total != 6 {
+		t.Fatalf("expected total 6, got %d", total)
 	}
-	if got := []string{items[0].Identity, items[1].Identity, items[2].Identity}; !reflect.DeepEqual(got, []string{"priority-5", "priority-1", "default"}) {
-		t.Fatalf("expected enabled auth files sorted by priority desc with missing priority last, got %v", got)
+	if got := []string{items[0].Identity, items[1].Identity, items[2].Identity, items[3].Identity, items[4].Identity, items[5].Identity}; !reflect.DeepEqual(got, []string{"priority-5-alpha", "priority-5-beta-lower", "priority-5", "priority-5-zeta", "priority-1", "default"}) {
+		t.Fatalf("expected enabled auth files sorted by priority desc, name asc case-insensitively, then missing priority last, got %v", got)
 	}
 }
 
@@ -873,6 +877,55 @@ func TestUsageIdentityListActivePageOrdersByTotalTokensDesc(t *testing.T) {
 	}
 	if got := []string{items[0].Identity, items[1].Identity, items[2].Identity}; !reflect.DeepEqual(got, []string{"high", "middle", "low"}) {
 		t.Fatalf("expected page sorted by total tokens desc, got %v", got)
+	}
+}
+
+func TestUsageIdentityListActivePageOrdersAIProvidersByPriorityWithoutNameTieBreak(t *testing.T) {
+	db := openTestDatabase(t)
+	now := time.Date(2026, 5, 11, 12, 30, 0, 0, time.UTC)
+	rows := []entities.UsageIdentity{
+		{Identity: "priority-5-zeta", Name: "Zeta", AuthType: entities.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Type: "openai", Provider: "OpenAI", Priority: intPtr(5), CreatedAt: now, UpdatedAt: now},
+		{Identity: "priority-5-alpha", Name: "Alpha", AuthType: entities.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Type: "openai", Provider: "OpenAI", Priority: intPtr(5), CreatedAt: now, UpdatedAt: now},
+		{Identity: "priority-1", Name: "Priority 1", AuthType: entities.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Type: "openai", Provider: "OpenAI", Priority: intPtr(1), CreatedAt: now, UpdatedAt: now},
+		{Identity: "default", Name: "Default", AuthType: entities.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Type: "openai", Provider: "OpenAI", Priority: nil, CreatedAt: now, UpdatedAt: now},
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("seed usage identities: %v", err)
+	}
+	authType := entities.UsageIdentityAuthTypeAIProvider
+
+	items, total, _, err := ListActiveUsageIdentitiesPage(context.Background(), db, ListUsageIdentitiesPageRequest{AuthType: &authType, Sort: UsageIdentityPageSortPriority, Page: 1, PageSize: 10})
+	if err != nil {
+		t.Fatalf("list page: %v", err)
+	}
+	if total != 4 {
+		t.Fatalf("expected total 4, got %d", total)
+	}
+	if got := []string{items[0].Identity, items[1].Identity, items[2].Identity, items[3].Identity}; !reflect.DeepEqual(got, []string{"priority-5-zeta", "priority-5-alpha", "priority-1", "default"}) {
+		t.Fatalf("expected AI providers sorted by priority desc and id asc without name tie-break, got %v", got)
+	}
+}
+
+func TestUsageIdentityPrioritySortUsesPortableNullAndNameOrdering(t *testing.T) {
+	db := openTestDatabase(t).Session(&gorm.Session{DryRun: true})
+	authType := entities.UsageIdentityAuthTypeAuthFile
+	var rows []entities.UsageIdentity
+
+	statement := applyUsageIdentityPageSort(db.Model(&entities.UsageIdentity{}), UsageIdentityPageSortPriority, &authType).Find(&rows).Statement
+	sql := statement.SQL.String()
+
+	for _, expected := range []string{
+		"priority IS NULL ASC",
+		"priority DESC",
+		"LOWER(name) ASC",
+		"id ASC",
+	} {
+		if !strings.Contains(sql, expected) {
+			t.Fatalf("expected priority sort SQL to include %q, got %s", expected, sql)
+		}
+	}
+	if strings.Contains(sql, "COLLATE NOCASE") {
+		t.Fatalf("expected priority sort SQL to avoid sqlite-specific COLLATE NOCASE, got %s", sql)
 	}
 }
 

--- a/web/src/components/usage/credentials/AiProviderCredentialsSection.test.tsx
+++ b/web/src/components/usage/credentials/AiProviderCredentialsSection.test.tsx
@@ -39,6 +39,7 @@ describe('AiProviderCredentialsSection', () => {
       providerLabel: 'anthropic',
       typeLabel: 'claude',
       authTypeLabel: 'apikey',
+      priorityLabel: 'P5',
       totalRequests: 0,
       successCount: 0,
       failureCount: 0,
@@ -52,7 +53,18 @@ describe('AiProviderCredentialsSection', () => {
     } as AiProviderCredentialRow & Record<string, unknown>
 
     const html = renderToStaticMarkup(
-      <AiProviderCredentialsSection rows={[row]} total={1} page={1} totalPages={1} loading={false} onPageChange={() => undefined} />,
+      <AiProviderCredentialsSection
+        rows={[row]}
+        total={1}
+        page={1}
+        totalPages={1}
+        pageSize={10}
+        sort="priority"
+        loading={false}
+        onPageChange={() => undefined}
+        onPageSizeChange={() => undefined}
+        onSortChange={() => undefined}
+      />,
     )
 
     expect(html.match(/usage_stats\.total_requests/g)).toHaveLength(1)
@@ -60,6 +72,8 @@ describe('AiProviderCredentialsSection', () => {
     expect(html.match(/usage_stats\.total_tokens/g)).toHaveLength(1)
     expect(html.match(/usage_stats\.cache_rate/g)).toHaveLength(1)
     expect(html).toContain('claude')
+    expect(html).toContain('P5')
+    expect(html).toContain('usage_stats.credentials_sort_priority')
     expect(html).not.toContain('Team')
     expect(html).not.toContain('25d')
     expect(html).not.toContain('5h')

--- a/web/src/components/usage/credentials/AiProviderCredentialsSection.tsx
+++ b/web/src/components/usage/credentials/AiProviderCredentialsSection.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import styles from './CredentialSections.module.scss'
 import type { AiProviderCredentialRow } from './credentialViewModels'
 import type { UsageIdentityPageSort } from '@/lib/api'
-import { CredentialBadge, CredentialRowShell, CredentialSectionShell, CredentialsPagination, MetricPill, RequestMetric, TonePercent, cacheRateTone, formatCredentialNumber, successRateTone } from './CredentialSectionShell'
+import { CredentialBadge, CredentialPriorityBadge, CredentialRowShell, CredentialSectionShell, CredentialsPagination, MetricPill, RequestMetric, TonePercent, cacheRateTone, formatCredentialNumber, successRateTone } from './CredentialSectionShell'
 
 interface AiProviderCredentialsSectionProps {
   rows: AiProviderCredentialRow[]
@@ -33,7 +33,12 @@ export function AiProviderCredentialsSection({ rows, total, page, totalPages, pa
         <CredentialRowShell
           key={row.identity.id || row.identity.identity}
           title={row.displayName}
-          subtitle={<CredentialBadge>{row.typeLabel}</CredentialBadge>}
+          subtitle={(
+            <span className={styles.credentialIdentityBadges}>
+              <CredentialBadge>{row.typeLabel}</CredentialBadge>
+              {row.priorityLabel && <CredentialPriorityBadge>{row.priorityLabel}</CredentialPriorityBadge>}
+            </span>
+          )}
           badges={null}
           metrics={(
             <>
@@ -55,6 +60,7 @@ export function AiProviderCredentialsSection({ rows, total, page, totalPages, pa
         sortValue={sort}
         sortLabel={t('usage_stats.credentials_sort_label')}
         sortOptions={[
+          { value: 'priority', label: t('usage_stats.credentials_sort_priority') },
           { value: 'total_requests', label: t('usage_stats.credentials_sort_total_requests') },
           { value: 'total_tokens', label: t('usage_stats.credentials_sort_total_tokens') },
         ]}

--- a/web/src/components/usage/credentials/AuthFileCredentialsSection.tsx
+++ b/web/src/components/usage/credentials/AuthFileCredentialsSection.tsx
@@ -6,7 +6,7 @@ import quotaTokenIcon from '@/assets/icons/quota-token.svg'
 import styles from './CredentialSections.module.scss'
 import type { AuthFileCredentialRow, DisplayQuota, PlanTypeTone } from './credentialViewModels'
 import type { UsageIdentityPageSort } from '@/lib/api'
-import { CredentialBadge, CredentialRowShell, CredentialSectionShell, CredentialsPagination, MetricPill, RequestMetric, TonePercent, cacheRateTone, capitalize, credentialToneClassName, formatCredentialNumber, successRateTone } from './CredentialSectionShell'
+import { CredentialBadge, CredentialPriorityBadge, CredentialRowShell, CredentialSectionShell, CredentialsPagination, MetricPill, RequestMetric, TonePercent, cacheRateTone, capitalize, credentialToneClassName, formatCredentialNumber, successRateTone } from './CredentialSectionShell'
 
 type Translate = (key: string, options?: Record<string, string>) => string
 
@@ -77,6 +77,7 @@ export function AuthFileCredentialsSection({ rows, total, page, totalPages, page
                 <CredentialBadge>{row.typeLabel}</CredentialBadge>
                 {row.planTypeLabel && <CredentialPlanBadge tone={row.planTypeTone}>{row.planTypeLabel}</CredentialPlanBadge>}
                 {row.remainingDaysLabel && <span className={styles.credentialRemainingDaysBadge}>{row.remainingDaysLabel}</span>}
+                {row.priorityLabel && <CredentialPriorityBadge>{row.priorityLabel}</CredentialPriorityBadge>}
               </span>
             )}
             badges={null}
@@ -151,27 +152,16 @@ function AuthFileQuotaPanel({ row }: { row: AuthFileCredentialRow }) {
   if (row.refreshStatus === 'queued' || row.refreshStatus === 'running') {
     return <div className={styles.credentialQuotaRefreshStatus}>{t(`usage_stats.credentials_refresh_status_${row.refreshStatus}`)}</div>
   }
-  if (!row.primaryQuota && !row.secondaryQuota && row.extraQuota.length === 0) {
+  if (row.displayQuotas.length === 0) {
     return <div className={styles.credentialQuotaState}>{t('usage_stats.credentials_quota_unavailable')}</div>
   }
 
   return (
     <div className={styles.credentialQuotaPanel}>
       <div className={styles.credentialQuotaBars}>
-        {/* 主/次窗口固定优先展示，额外窗口放到下方 chips，避免宽度被无限撑开。 */}
-        {row.primaryQuota && <QuotaBar quota={row.primaryQuota} />}
-        {row.secondaryQuota && <QuotaBar quota={row.secondaryQuota} />}
+        {/* 每个可计算进度的 quota 都独占一个稳定块；不可进度化 quota 在 view model 中已过滤。 */}
+        {row.displayQuotas.map((quota) => <QuotaBar key={quota.key} quota={quota} />)}
       </div>
-      {row.extraQuota.length > 0 && (
-        <div className={styles.credentialQuotaChips}>
-          {row.extraQuota.map((quota) => (
-            <span key={quota.key} className={styles.credentialQuotaChip}>
-              <span>{quota.label}</span>
-              {quota.remaining !== undefined && <strong>{formatCredentialNumber(quota.remaining)}</strong>}
-            </span>
-          ))}
-        </div>
-      )}
     </div>
   )
 }

--- a/web/src/components/usage/credentials/CredentialSectionShell.tsx
+++ b/web/src/components/usage/credentials/CredentialSectionShell.tsx
@@ -62,6 +62,10 @@ export function CredentialBadge({ children, tone = 'neutral' }: { children: Reac
   return <span className={`${styles.credentialBadge} ${styles[`credentialBadge${capitalize(tone)}`]}`.trim()}>{children}</span>
 }
 
+export function CredentialPriorityBadge({ children }: { children: ReactNode }) {
+  return <span className={styles.credentialPriorityBadge}>{children}</span>
+}
+
 export function MetricPill({ label, value }: { label: string; value: ReactNode }) {
   return (
     <span className={styles.credentialMetricPill}>

--- a/web/src/components/usage/credentials/CredentialSections.module.scss
+++ b/web/src/components/usage/credentials/CredentialSections.module.scss
@@ -448,6 +448,23 @@
   color: #b91c1c;
 }
 
+.credentialPriorityBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  min-height: 18px;
+  padding: 2px 6px;
+  border-radius: $radius-full;
+  border: 1px solid color-mix(in srgb, var(--primary-color) 34%, var(--border-color));
+  background: color-mix(in srgb, var(--primary-color) 10%, var(--bg-primary));
+  color: color-mix(in srgb, var(--text-primary) 82%, var(--primary-color));
+  font-size: 10px;
+  font-weight: 900;
+  line-height: 1.3;
+  font-variant-numeric: tabular-nums;
+}
+
 .credentialRemainingDaysBadge,
 .credentialPlanBadge {
   display: inline-flex;
@@ -639,7 +656,7 @@
   }
 
   .credentialQuotaBars {
-    grid-template-columns: repeat(auto-fit, minmax(min(100%, 120px), 1fr));
+    grid-template-columns: minmax(0, 1fr);
     gap: 10px;
   }
 
@@ -772,36 +789,6 @@
 
 .credentialQuotaFillUnknown {
   background: var(--text-tertiary);
-}
-
-.credentialQuotaChips {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-
-.credentialQuotaChip {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  max-width: 180px;
-  padding: 4px 8px;
-  border-radius: $radius-full;
-  border: 1px solid var(--border-color);
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
-  font-size: 11px;
-
-  span {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  strong {
-    color: var(--text-primary);
-    font-variant-numeric: tabular-nums;
-  }
 }
 
 .credentialQuotaState,

--- a/web/src/components/usage/credentials/CredentialSections.styles.test.ts
+++ b/web/src/components/usage/credentials/CredentialSections.styles.test.ts
@@ -29,14 +29,24 @@ describe('Credential section styles', () => {
     expect(credentialStyles).toMatch(/\.credentialQuotaBars\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2, minmax\(150px, 1fr\)\);/)
     expect(credentialStyles).toMatch(/\.credentialQuotaBars\s*\{[\s\S]*?gap:\s*14px;/)
     expect(credentialStyles).toMatch(/\.credentialQuotaBarBlock\s*\{[\s\S]*?min-width:\s*150px;/)
+    expect(credentialStyles).not.toContain('credentialQuotaChips')
+    expect(credentialStyles).not.toContain('credentialQuotaChip')
     expect(credentialStyles).not.toContain('credentialQuotaSidePanel')
     expect(credentialStyles).not.toContain('credentialQuotaRow')
   })
 
   it('keeps Auth Files quota actions inside the mobile card boundary', () => {
     expect(credentialStyles).toMatch(/@include mobile\s*\{[\s\S]*?\.credentialQuotaSideWithAction\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) auto;/)
-    expect(credentialStyles).toMatch(/@include mobile\s*\{[\s\S]*?\.credentialQuotaBars\s*\{[\s\S]*?grid-template-columns:\s*repeat\(auto-fit, minmax\(min\(100%, 120px\), 1fr\)\);/)
+    expect(credentialStyles).toMatch(/@include mobile\s*\{[\s\S]*?\.credentialQuotaBars\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\);/)
     expect(credentialStyles).toMatch(/@include mobile\s*\{[\s\S]*?\.credentialQuotaBarBlock\s*\{[\s\S]*?min-width:\s*0;/)
+  })
+
+  it('renders compact priority badges without lengthening credential names', () => {
+    expect(credentialStyles).toMatch(/\.credentialPriorityBadge\s*\{[\s\S]*?min-width:\s*22px;/)
+    expect(credentialShellSource).toContain('CredentialPriorityBadge')
+    expect(authFileSectionSource).toContain('row.priorityLabel')
+    expect(authFileSectionSource).toMatch(/row\.planTypeLabel[\s\S]*?row\.remainingDaysLabel[\s\S]*?row\.priorityLabel/)
+    expect(aiProviderSectionSource).toContain('row.priorityLabel')
   })
 
   it('keeps Total Requests fixed and wraps the breakdown only when it overflows', () => {

--- a/web/src/components/usage/credentials/credentialViewModels.test.ts
+++ b/web/src/components/usage/credentials/credentialViewModels.test.ts
@@ -18,6 +18,7 @@ function identity(overrides: Partial<UsageIdentity>): UsageIdentity {
     identity: overrides.identity ?? 'auth-1',
     type: overrides.type ?? 'claude',
     provider: overrides.provider ?? 'claude',
+    priority: overrides.priority,
     plan_type: overrides.plan_type,
     total_requests: overrides.total_requests ?? 0,
     success_count: overrides.success_count ?? 0,
@@ -136,11 +137,12 @@ describe('credentialViewModels', () => {
     expect(thirdPage.items.map((item) => item.identity)).toEqual(['auth-21', 'auth-22', 'auth-23', 'auth-24', 'auth-25'])
   })
 
-  it('builds auth file rows with primary secondary and extra quota display data', () => {
+  it('builds auth file rows with displayable quota bars and ignores quota without progress', () => {
     const quotas = new Map<string, UsageQuotaRow[]>([
       ['auth-1', [
         { key: 'rate_limit.primary_window', label: '5h', remainingFraction: 0.72, remaining: 72, resetAt: '2026-05-09T12:00:00Z', window_usage_tokens: 1_500_000, window_usage_cost: 12.34 },
         { key: 'rate_limit.secondary_window', label: 'Weekly', used: 40, limit: 100 },
+        { key: 'rate_limit.gpt_codex_spark_5h', label: 'GPT-5.3-Codex-Spark 5h', usedPercent: 83 },
         { key: 'code_assist.current_tier.GOOGLE_ONE_AI', label: 'Code Assist Credit', remaining: 10 },
       ]],
     ])
@@ -154,17 +156,25 @@ describe('credentialViewModels', () => {
     expect(rows[0].failureCount).toBe(0)
     expect(rows[0].totalTokens).toBe(1500)
     expect(rows[0].cacheRate).toBe(25)
-    expect(rows[0].primaryQuota?.label).toBe('5h')
-    expect(rows[0].primaryQuota?.percent).toBe(72)
-    expect(rows[0].primaryQuota?.percentKind).toBe('remaining')
-    expect(rows[0].primaryQuota?.barPercent).toBe(72)
-    expect(rows[0].primaryQuota?.status).toBe('ok')
-    expect(rows[0].primaryQuota?.windowUsage).toEqual({ tokens: '1.50M', cost: '$12.34' })
-    expect(rows[0].secondaryQuota?.label).toBe('Weekly')
-    expect(rows[0].secondaryQuota?.percent).toBe(40)
-    expect(rows[0].secondaryQuota?.percentKind).toBe('used')
-    expect(rows[0].secondaryQuota?.barPercent).toBe(60)
-    expect(rows[0].extraQuota.map((quota) => quota.label)).toEqual(['Code Assist Credit'])
+    expect(rows[0].displayQuotas.map((quota) => quota.label)).toEqual(['5h', 'Weekly', 'GPT-5.3-Codex-Spark 5h'])
+    expect(rows[0].displayQuotas[0]).toMatchObject({
+      percent: 72,
+      percentKind: 'remaining',
+      barPercent: 72,
+      status: 'ok',
+      windowUsage: { tokens: '1.50M', cost: '$12.34' },
+    })
+    expect(rows[0].displayQuotas[1]).toMatchObject({
+      percent: 40,
+      percentKind: 'used',
+      barPercent: 60,
+    })
+    expect(rows[0].displayQuotas[2]).toMatchObject({
+      percent: 83,
+      percentKind: 'used',
+      barPercent: 17,
+      status: 'danger',
+    })
   })
 
   it('formats zero quota window cost with two decimals', () => {
@@ -176,7 +186,7 @@ describe('credentialViewModels', () => {
 
     const rows = buildAuthFileCredentialRows([identity({ identity: 'auth-1' })], quotas)
 
-    expect(rows[0].primaryQuota?.windowUsage).toEqual({ tokens: '0', cost: '$0.00' })
+    expect(rows[0].displayQuotas[0].windowUsage).toEqual({ tokens: '0', cost: '$0.00' })
   })
 
   it('uses normalized input token semantics for auth file cache rate', () => {
@@ -200,7 +210,7 @@ describe('credentialViewModels', () => {
       identity({ identity: 'red-auth' }),
     ], quotas)
 
-    expect(rows.map((row) => row.primaryQuota?.status)).toEqual(['ok', 'warning', 'danger'])
+    expect(rows.map((row) => row.displayQuotas[0]?.status)).toEqual(['ok', 'warning', 'danger'])
   })
 
   it('uses quota window duration instead of raw key when classifying Codex windows', () => {
@@ -212,23 +222,65 @@ describe('credentialViewModels', () => {
 
     const rows = buildAuthFileCredentialRows([identity({ identity: 'auth-1' })], quotas)
 
-    expect(rows[0].primaryQuota).toBeUndefined()
-    expect(rows[0].secondaryQuota?.label).toBe('Weekly')
-    expect(rows[0].secondaryQuota?.barPercent).toBe(90)
+    expect(rows[0].displayQuotas[0]?.label).toBe('Weekly')
+    expect(rows[0].displayQuotas[0]?.barPercent).toBe(90)
   })
 
-  it('does not classify unknown Codex windows as 5h or weekly', () => {
+  it('uses monthly quota labels for 30 day Codex windows', () => {
     const quotas = new Map<string, UsageQuotaRow[]>([
       ['auth-1', [
-        { key: 'rate_limit.primary_window', label: '5h', usedPercent: 10, window: { seconds: 3600 } },
+        { key: 'rate_limit.primary_window', label: '5h', usedPercent: 20, window: { seconds: 2592000 } },
+        { key: 'code_review_rate_limit.primary_window', label: 'Code Review Weekly', usedPercent: 40, window: { seconds: 2592000 } },
+        { key: 'additional_rate_limits.GPT-5.3-Codex-Spark.primary_window', label: 'GPT-5.3-Codex-Spark 5h', usedPercent: 60, window: { seconds: 2592000 } },
       ]],
     ])
 
     const rows = buildAuthFileCredentialRows([identity({ identity: 'auth-1' })], quotas)
 
-    expect(rows[0].primaryQuota).toBeUndefined()
-    expect(rows[0].secondaryQuota).toBeUndefined()
-    expect(rows[0].extraQuota[0].label).toBe('Window')
+    expect(rows[0].displayQuotas.map((quota) => quota.label)).toEqual(['Monthly', 'Code Review Monthly', 'GPT-5.3-Codex-Spark Monthly'])
+    expect(rows[0].displayQuotas.map((quota) => quota.barPercent)).toEqual([80, 60, 40])
+  })
+
+  it('keeps unknown Codex windows displayable without showing a generic Window quota', () => {
+    const quotas = new Map<string, UsageQuotaRow[]>([
+      ['auth-1', [
+        { key: 'rate_limit.primary_window', label: 'Window', usedPercent: 10, window: { seconds: 3600 } },
+        { key: 'additional_rate_limits.GPT-5.3-Codex-Spark.primary_window', label: 'GPT-5.3-Codex-Spark 5h', usedPercent: 83, window: { seconds: 3600 } },
+      ]],
+    ])
+
+    const rows = buildAuthFileCredentialRows([identity({ identity: 'auth-1' })], quotas)
+
+    expect(rows[0].displayQuotas.map((quota) => quota.label)).toEqual(['Primary', 'GPT-5.3-Codex-Spark Primary'])
+    expect(rows[0].displayQuotas.map((quota) => quota.barPercent)).toEqual([90, 17])
+  })
+
+  it('maps legacy generic Window quota labels by Codex window role even without seconds', () => {
+    const quotas = new Map<string, UsageQuotaRow[]>([
+      ['auth-1', [
+        { key: 'rate_limit.primary_window', label: 'Window', usedPercent: 10 },
+        { key: 'code_review_rate_limit.secondary_window', label: 'Code Review Window', usedPercent: 30 },
+      ]],
+    ])
+
+    const rows = buildAuthFileCredentialRows([identity({ identity: 'auth-1' })], quotas)
+
+    expect(rows[0].displayQuotas.map((quota) => quota.label)).toEqual(['Primary', 'Code Review Secondary'])
+    expect(rows[0].displayQuotas.map((quota) => quota.barPercent)).toEqual([90, 70])
+  })
+
+  it('builds compact priority labels for auth files and AI providers', () => {
+    const authFileRows = buildAuthFileCredentialRows([
+      identity({ identity: 'priority-auth', priority: 5 }),
+      identity({ identity: 'zero-priority-auth', priority: 0 }),
+      identity({ identity: 'default-auth' }),
+    ])
+    const aiProviderRows = buildAiProviderCredentialRows([
+      identity({ auth_type: 2, identity: 'priority-provider', priority: 7 }),
+    ])
+
+    expect(authFileRows.map((row) => row.priorityLabel)).toEqual(['P5', 'P0', undefined])
+    expect(aiProviderRows[0].priorityLabel).toBe('P7')
   })
 
   it('builds AI provider rows without quota data', () => {
@@ -244,6 +296,6 @@ describe('credentialViewModels', () => {
     expect(rows[0].successRate).toBe(75)
     expect(rows[0].totalTokens).toBe(0)
     expect(rows[0].cacheRate).toBeNull()
-    expect('primaryQuota' in rows[0]).toBe(false)
+    expect('displayQuotas' in rows[0]).toBe(false)
   })
 })

--- a/web/src/components/usage/credentials/credentialViewModels.ts
+++ b/web/src/components/usage/credentials/credentialViewModels.ts
@@ -33,6 +33,7 @@ export interface AuthFileCredentialRow {
   providerLabel: string
   typeLabel: string
   authTypeLabel: string
+  priorityLabel?: string
   planTypeLabel?: string
   planTypeTone?: PlanTypeTone
   remainingDaysLabel?: string
@@ -46,9 +47,7 @@ export interface AuthFileCredentialRow {
   quotaLoading: boolean
   quotaError?: string
   refreshStatus?: 'queued' | 'running' | 'completed' | 'failed'
-  primaryQuota?: DisplayQuota
-  secondaryQuota?: DisplayQuota
-  extraQuota: DisplayQuota[]
+  displayQuotas: DisplayQuota[]
 }
 
 export interface AiProviderCredentialRow {
@@ -58,6 +57,7 @@ export interface AiProviderCredentialRow {
   providerLabel: string
   typeLabel: string
   authTypeLabel: string
+  priorityLabel?: string
   totalRequests: number
   successCount: number
   failureCount: number
@@ -122,12 +122,8 @@ export function buildAuthFileCredentialRows(
   return identities.map((identity) => {
     const quota = quotas.get(identity.identity) ?? []
     const state = quotaStates.get(identity.identity)
-    const displayQuotas = quota.map(toDisplayQuota)
+    const displayQuotas = quota.map(toDisplayQuota).filter(isDisplayableQuota)
     const planType = firstNonEmpty(...quota.map((row) => row.planType), identity.plan_type)
-    // 先挑 5h 主窗口，再挑 Weekly 次窗口，其余限额保留到 chips 中展示。
-    const primaryQuota = displayQuotas.find(isPrimaryQuota)
-    const secondaryQuota = displayQuotas.find((item) => item !== primaryQuota && isSecondaryQuota(item))
-    const extraQuota = displayQuotas.filter((item) => item !== primaryQuota && item !== secondaryQuota)
 
     return {
       identity,
@@ -136,6 +132,7 @@ export function buildAuthFileCredentialRows(
       providerLabel: credentialProviderLabel(identity),
       typeLabel: credentialTypeLabel(identity),
       authTypeLabel: credentialAuthTypeLabel(identity),
+      priorityLabel: credentialPriorityLabel(identity.priority),
       planTypeLabel: credentialPlanTypeLabel(planType),
       planTypeTone: credentialPlanTypeTone(planType),
       remainingDaysLabel: remainingDaysLabel(identity.active_until),
@@ -149,9 +146,7 @@ export function buildAuthFileCredentialRows(
       quotaLoading: state?.quotaLoading ?? false,
       quotaError: state?.quotaError,
       refreshStatus: state?.refreshStatus,
-      primaryQuota,
-      secondaryQuota,
-      extraQuota,
+      displayQuotas,
     }
   })
 }
@@ -164,6 +159,7 @@ export function buildAiProviderCredentialRows(identities: UsageIdentity[]): AiPr
     providerLabel: credentialProviderLabel(identity),
     typeLabel: credentialTypeLabel(identity),
     authTypeLabel: credentialAuthTypeLabel(identity),
+    priorityLabel: credentialPriorityLabel(identity.priority),
     totalRequests: safeNumber(identity.total_requests),
     successCount: safeNumber(identity.success_count),
     failureCount: safeNumber(identity.failure_count),
@@ -175,7 +171,7 @@ export function buildAiProviderCredentialRows(identities: UsageIdentity[]): AiPr
   }))
 }
 
-function toDisplayQuota(row: UsageQuotaRow): DisplayQuota {
+function toDisplayQuota(row: UsageQuotaRow): DisplayQuota | undefined {
   // 后端 quota row 可能是 used、remaining 或 remainingFraction，这里统一成展示进度。
   const used = finiteNumber(row.used)
   const limit = finiteNumber(row.limit)
@@ -184,6 +180,9 @@ function toDisplayQuota(row: UsageQuotaRow): DisplayQuota {
 
   const windowSeconds = finiteNumber(row.window?.seconds)
   const label = quotaLabel(row, windowSeconds)
+  if (!label) {
+    return undefined
+  }
 
   return {
     key: row.key,
@@ -223,32 +222,89 @@ function formatQuotaWindowCost(cost: number): string {
   }).format(cost || 0).replace(/^US\$/, '$')
 }
 
-function quotaLabel(row: UsageQuotaRow, windowSeconds?: number): string {
-  // 对已知窗口按秒数纠正标签；未知窗口不猜 5h/Weekly，避免误导用户。
+function quotaLabel(row: UsageQuotaRow, windowSeconds?: number): string | undefined {
+  // 对已知窗口按秒数纠正标签；未知窗口不展示 Window 占位，避免误导用户。
   const label = row.label || row.metric || row.scope || row.key
-  if (windowSeconds === 604800 && label.includes('5h')) {
-    return label.replace('5h', 'Weekly')
+  if (windowSeconds === 18000) {
+    return knownWindowLabel(label, '5h')
   }
-  if (windowSeconds === 18000 && label.includes('Weekly')) {
-    return label.replace('Weekly', '5h')
+  if (windowSeconds === 604800) {
+    return knownWindowLabel(label, 'Weekly')
   }
-  if (windowSeconds !== undefined && windowSeconds !== 18000 && windowSeconds !== 604800) {
-    return unknownWindowLabel(label)
+  if (windowSeconds === 2592000) {
+    return knownWindowLabel(label, 'Monthly')
+  }
+  if (windowSeconds !== undefined) {
+    return unknownWindowLabel(row, label)
+  }
+  if (genericWindowLabel(label)) {
+    return unknownWindowLabel(row, label)
   }
   return label
 }
 
-function unknownWindowLabel(label: string): string {
-  if (label === '5h' || label === 'Weekly') {
-    return 'Window'
+function knownWindowLabel(label: string, replacement: string): string {
+  if (label === '5h' || label === 'Weekly' || label === 'Monthly' || label === 'Window') {
+    return replacement
   }
-  if (label.includes('5h')) {
-    return label.replace('5h', 'Window')
-  }
-  if (label.includes('Weekly')) {
-    return label.replace('Weekly', 'Window')
+  for (const candidate of ['5h', 'Weekly', 'Monthly', 'Window']) {
+    if (label.includes(candidate)) {
+      return label.replace(candidate, replacement)
+    }
   }
   return label
+}
+
+function genericWindowLabel(label: string): boolean {
+  return /\bWindow\b/.test(label)
+}
+
+function unknownWindowLabel(row: UsageQuotaRow, label: string): string | undefined {
+  const role = quotaWindowRole(row.key)
+  if (!role) {
+    return genericWindowLabel(label) ? undefined : label
+  }
+  for (const candidate of ['5h', 'Weekly', 'Monthly', 'Window']) {
+    if (label === candidate) {
+      return role
+    }
+    if (label.includes(candidate)) {
+      return label.replace(candidate, role)
+    }
+  }
+  return quotaRoleLabel(row)
+}
+
+function quotaRoleLabel(row: UsageQuotaRow): string | undefined {
+  const role = quotaWindowRole(row.key)
+  if (!role) {
+    return undefined
+  }
+  const prefix = quotaWindowRolePrefix(row)
+  return prefix ? `${prefix} ${role}` : role
+}
+
+function quotaWindowRole(key: string): string | undefined {
+  if (key.endsWith('.primary_window')) {
+    return 'Primary'
+  }
+  if (key.endsWith('.secondary_window')) {
+    return 'Secondary'
+  }
+  return undefined
+}
+
+function quotaWindowRolePrefix(row: UsageQuotaRow): string {
+  if (row.key.startsWith('code_review_rate_limit.')) {
+    return 'Code Review'
+  }
+  if (!row.key.startsWith('additional_rate_limits.')) {
+    return ''
+  }
+  const keyName = row.key
+    .replace(/^additional_rate_limits\./, '')
+    .replace(/\.(primary|secondary)_window$/, '')
+  return firstNonEmpty(row.metric, keyName) ?? ''
 }
 
 function quotaPercent(row: UsageQuotaRow, used?: number, limit?: number): { percent: number | null; kind: DisplayQuota['percentKind'] } {
@@ -292,20 +348,8 @@ function quotaBarPercent(percent: number | null, kind: DisplayQuota['percentKind
   return kind === 'used' ? clampPercent(100 - percent) : percent
 }
 
-function isPrimaryQuota(quota: DisplayQuota): boolean {
-  if (quota.windowSeconds !== undefined) {
-    return quota.windowSeconds === 18000
-  }
-  const haystack = `${quota.key} ${quota.label}`.toLowerCase()
-  return haystack.includes('5h') || haystack.includes('five_hour')
-}
-
-function isSecondaryQuota(quota: DisplayQuota): boolean {
-  if (quota.windowSeconds !== undefined) {
-    return quota.windowSeconds === 604800
-  }
-  const haystack = `${quota.key} ${quota.label}`.toLowerCase()
-  return haystack.includes('weekly') || haystack.includes('seven_day')
+function isDisplayableQuota(quota: DisplayQuota | undefined): quota is DisplayQuota {
+  return quota !== undefined && quota.barPercent !== null
 }
 
 function credentialDisplayName(identity: UsageIdentity): string {
@@ -322,6 +366,13 @@ function credentialTypeLabel(identity: UsageIdentity): string {
 
 function credentialAuthTypeLabel(identity: UsageIdentity): string {
   return firstNonEmpty(identity.auth_type_name) ?? (identity.auth_type === 1 ? 'Auth file' : 'AI provider')
+}
+
+function credentialPriorityLabel(priority: number | undefined): string | undefined {
+  if (typeof priority !== 'number' || !Number.isFinite(priority)) {
+    return undefined
+  }
+  return `P${priority}`
 }
 
 function credentialPlanTypeLabel(planType?: string): string | undefined {


### PR DESCRIPTION
## Summary

- Show all progress-capable Auth Files quota rows as responsive progress bars, including Codex monthly windows and additional Codex limits.
- Replace generic Codex `Window` labels with `Monthly`, `Primary`, or `Secondary` labels based on the window data and row key.
- Add compact priority badges and priority sorting for Auth Files and AI Provider rows, with Auth Files name tie-breaks sorted case-insensitively.

## Tests

- `go test ./internal/quota/... ./internal/repository -count=1`
- `npm --prefix ./web run test -- --run src/components/usage/credentials`
- `npm --prefix ./web run typecheck`
- `npm --prefix ./web run lint`
- `npm --prefix ./web run build`
- `git diff --check`

Closes #172
Related #136 
