### PR TITLE
Add executor type to usage events

### DIFF
--- a/internal/api/usage_events.go
+++ b/internal/api/usage_events.go
@@ -40,6 +40,7 @@ type usageEventPayload struct {
 	APIKey          string                 `json:"api_key,omitempty"`
 	Model           string                 `json:"model"`
 	ReasoningEffort string                 `json:"reasoning_effort,omitempty"`
+	ExecutorType    string                 `json:"executor_type,omitempty"`
 	Endpoint        string                 `json:"endpoint,omitempty"`
 	Source          string                 `json:"source"`
 	SourceRaw       string                 `json:"source_raw,omitempty"`
@@ -164,6 +165,7 @@ func buildUsageEventsPayload(rows []servicedto.UsageEventRecord, resolver usageI
 			APIKey:          usageEventAPIKeyLabel(row.APIGroupKey, apiKeyInfos),
 			Model:           row.Model,
 			ReasoningEffort: strings.TrimSpace(row.ReasoningEffort),
+			ExecutorType:    strings.TrimSpace(row.ExecutorType),
 			Endpoint:        strings.TrimSpace(row.Endpoint),
 			Source:          source,
 			SourceType:      identity.Type,

--- a/internal/api/usage_events_test.go
+++ b/internal/api/usage_events_test.go
@@ -61,6 +61,7 @@ func TestUsageEventsReturnsFilteredRows(t *testing.T) {
 		Timestamp:           time.Date(2026, 4, 22, 11, 0, 0, 0, time.UTC),
 		Model:               "claude-sonnet",
 		ReasoningEffort:     "medium",
+		ExecutorType:        "responses",
 		Endpoint:            "POST /v1/responses",
 		AuthType:            "apikey",
 		Provider:            "OpenAI Mirror",
@@ -122,6 +123,9 @@ func TestUsageEventsReturnsFilteredRows(t *testing.T) {
 	}
 	if !contains(body, `"ttft_ms":45`) {
 		t.Fatalf("expected ttft_ms in response body: %s", body)
+	}
+	if !contains(body, `"executor_type":"responses"`) {
+		t.Fatalf("expected executor_type in response body: %s", body)
 	}
 	if !contains(body, `"cost_usd":0.1234`) || !contains(body, `"cost_available":true`) || !contains(body, `"pricing_style":"claude"`) {
 		t.Fatalf("expected backend cost fields in response body: %s", body)

--- a/internal/entities/usage_event.go
+++ b/internal/entities/usage_event.go
@@ -15,6 +15,7 @@ type UsageEvent struct {
 	ModelAlias          *string   `gorm:"column:model_alias"`
 	ReasoningEffort     string    `gorm:"column:reasoning_effort;not null;default:''"`
 	ServiceTier         string    `gorm:"column:service_tier;not null;default:''"`
+	ExecutorType        string    `gorm:"column:executor_type;not null;default:''"`
 	Timestamp           time.Time `gorm:"serializer:storageTime;index:idx_usage_events_timestamp_id,sort:desc,priority:1"`
 	Source              string
 	AuthIndex           string `gorm:"index:idx_usage_events_auth_index;index:idx_usage_events_auth_type_auth_index_id,priority:2"`

--- a/internal/repository/db_test.go
+++ b/internal/repository/db_test.go
@@ -54,8 +54,8 @@ func TestOpenDatabaseCreatesFreshDatabaseFromCurrentSchemaWithoutRunningMigratio
 	if err := db.Table("schema_migrations").Count(&count).Error; err != nil {
 		t.Fatalf("count schema migrations: %v", err)
 	}
-	if count != 32 {
-		t.Fatalf("expected fresh database to mark 32 migrations applied, got %d", count)
+	if count != 33 {
+		t.Fatalf("expected fresh database to mark 33 migrations applied, got %d", count)
 	}
 	if strings.Contains(logs.String(), "schema migration started") {
 		t.Fatalf("expected fresh database creation not to run version migrations, got logs:\n%s", logs.String())
@@ -291,6 +291,38 @@ func TestInsertUsageEventsPersistsServiceTier(t *testing.T) {
 	}
 	if got.ServiceTier != "standard" {
 		t.Fatalf("expected service_tier to persist, got %q", got.ServiceTier)
+	}
+}
+
+func TestInsertUsageEventsPersistsExecutorType(t *testing.T) {
+	db := openTestDatabase(t)
+	events := []entities.UsageEvent{{
+		EventKey:     "event-executor-type",
+		APIGroupKey:  "provider-a",
+		Model:        "claude-sonnet",
+		ExecutorType: "responses",
+		Timestamp:    time.Date(2026, 6, 2, 8, 0, 0, 0, time.UTC),
+		Source:       "source-a",
+		AuthIndex:    "auth-1",
+		TotalTokens:  10,
+	}}
+
+	inserted, deduped, err := InsertUsageEvents(db, events)
+	if err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+	if inserted != 1 || deduped != 0 {
+		t.Fatalf("expected inserted=1 deduped=0, got inserted=%d deduped=%d", inserted, deduped)
+	}
+
+	var got struct {
+		ExecutorType string `gorm:"column:executor_type"`
+	}
+	if err := db.Table("usage_events").Select("executor_type").Where("event_key = ?", "event-executor-type").First(&got).Error; err != nil {
+		t.Fatalf("load usage event executor_type: %v", err)
+	}
+	if got.ExecutorType != "responses" {
+		t.Fatalf("expected executor_type to persist, got %q", got.ExecutorType)
 	}
 }
 

--- a/internal/repository/dto/usage_events.go
+++ b/internal/repository/dto/usage_events.go
@@ -24,6 +24,7 @@ type UsageEventRecord struct {
 	APIGroupKey         string
 	Model               string
 	ReasoningEffort     string
+	ExecutorType        string
 	Endpoint            string
 	AuthType            string
 	Provider            string

--- a/internal/repository/migration/20260602_usage_event_executor_type.go
+++ b/internal/repository/migration/20260602_usage_event_executor_type.go
@@ -1,0 +1,22 @@
+package migration
+
+import (
+	"fmt"
+
+	"cpa-usage-keeper/internal/entities"
+
+	"gorm.io/gorm"
+)
+
+func addUsageEventExecutorTypeMigration(tx *gorm.DB) error {
+	if !tx.Migrator().HasTable(&entities.UsageEvent{}) {
+		return nil
+	}
+	if tx.Migrator().HasColumn(&entities.UsageEvent{}, "executor_type") {
+		return nil
+	}
+	if err := tx.Exec("ALTER TABLE usage_events ADD COLUMN executor_type TEXT NOT NULL DEFAULT ''").Error; err != nil {
+		return fmt.Errorf("add usage_events.executor_type column: %w", err)
+	}
+	return nil
+}

--- a/internal/repository/migration/20260602_usage_event_executor_type.go
+++ b/internal/repository/migration/20260602_usage_event_executor_type.go
@@ -15,7 +15,7 @@ func addUsageEventExecutorTypeMigration(tx *gorm.DB) error {
 	if tx.Migrator().HasColumn(&entities.UsageEvent{}, "executor_type") {
 		return nil
 	}
-	if err := tx.Exec("ALTER TABLE usage_events ADD COLUMN executor_type TEXT NOT NULL DEFAULT ''").Error; err != nil {
+	if err := tx.Migrator().AddColumn(&entities.UsageEvent{}, "ExecutorType"); err != nil {
 		return fmt.Errorf("add usage_events.executor_type column: %w", err)
 	}
 	return nil

--- a/internal/repository/migration/20260602_usage_event_executor_type_test.go
+++ b/internal/repository/migration/20260602_usage_event_executor_type_test.go
@@ -1,0 +1,52 @@
+package migration
+
+import (
+	"path/filepath"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestAddUsageEventExecutorTypeMigrationAddsColumn(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(testSQLiteDSN(filepath.Join(t.TempDir(), "legacy.db"))), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	defer closeOpenedDatabase(t, db)
+
+	if err := db.Exec(`CREATE TABLE usage_events (
+		id integer PRIMARY KEY,
+		event_key text,
+		model text,
+		timestamp datetime,
+		source text,
+		auth_index text,
+		total_tokens integer
+	)`).Error; err != nil {
+		t.Fatalf("create legacy usage_events table: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO usage_events (id, event_key, model, timestamp, source, auth_index, total_tokens)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`, int64(1), "event-1", "claude-sonnet", "2026-06-02 08:00:00", "source-a", "auth-1", 10).Error; err != nil {
+		t.Fatalf("seed legacy usage event: %v", err)
+	}
+
+	if err := addUsageEventExecutorTypeMigration(db); err != nil {
+		t.Fatalf("add usage event executor_type: %v", err)
+	}
+	if err := addUsageEventExecutorTypeMigration(db); err != nil {
+		t.Fatalf("add usage event executor_type should be idempotent: %v", err)
+	}
+
+	if !db.Migrator().HasColumn("usage_events", "executor_type") {
+		t.Fatal("expected usage_events.executor_type column to exist")
+	}
+
+	var executorType string
+	if err := db.Raw(`SELECT executor_type FROM usage_events WHERE id = ?`, int64(1)).Row().Scan(&executorType); err != nil {
+		t.Fatalf("scan executor_type: %v", err)
+	}
+	if executorType != "" {
+		t.Fatalf("expected existing usage event executor_type to default to empty string, got %q", executorType)
+	}
+}

--- a/internal/repository/migration/migration.go
+++ b/internal/repository/migration/migration.go
@@ -42,6 +42,7 @@ const (
 	migrationAddUsageEventCPAResponseFields         = "20260528_add_usage_event_cpa_response_fields"
 	migrationModelPricePricingStyle                 = "20260531_model_price_pricing_style"
 	migrationBackfillClaudeUsageTokens              = "20260601_backfill_claude_usage_tokens"
+	migrationAddUsageEventExecutorType              = "20260602_add_usage_event_executor_type"
 )
 
 type schemaMigration struct {
@@ -128,6 +129,7 @@ func orderedMigrations() []databaseMigration {
 		{version: migrationAddUsageEventCPAResponseFields, run: addUsageEventCPAResponseFieldsMigration},
 		{version: migrationModelPricePricingStyle, run: addModelPricePricingStyleMigration},
 		{version: migrationBackfillClaudeUsageTokens, run: backfillClaudeUsageTokensMigration},
+		{version: migrationAddUsageEventExecutorType, run: addUsageEventExecutorTypeMigration},
 	}
 }
 

--- a/internal/repository/migration/migration_test.go
+++ b/internal/repository/migration/migration_test.go
@@ -51,6 +51,7 @@ func TestOrderedMigrationsPreservesExecutionOrder(t *testing.T) {
 		"20260528_add_usage_event_cpa_response_fields",
 		"20260531_model_price_pricing_style",
 		"20260601_backfill_claude_usage_tokens",
+		"20260602_add_usage_event_executor_type",
 	}
 	if len(got) != len(want) {
 		t.Fatalf("expected ordered migrations %v, got %v", want, got)
@@ -72,7 +73,7 @@ func TestOpenDatabaseRunsSchemaMigrationsAndAddsUsageEventRedisFields(t *testing
 	if !db.Migrator().HasTable("schema_migrations") {
 		t.Fatal("expected schema_migrations table to exist")
 	}
-	for _, column := range []string{"provider", "endpoint", "auth_type", "request_id"} {
+	for _, column := range []string{"provider", "endpoint", "auth_type", "request_id", "executor_type"} {
 		if !db.Migrator().HasColumn(&entities.UsageEvent{}, column) {
 			t.Fatalf("expected usage_events.%s column to exist", column)
 		}
@@ -118,6 +119,7 @@ func TestOpenDatabaseRunsSchemaMigrationsAndAddsUsageEventRedisFields(t *testing
 		"20260528_add_usage_event_cpa_response_fields",
 		"20260531_model_price_pricing_style",
 		"20260601_backfill_claude_usage_tokens",
+		"20260602_add_usage_event_executor_type",
 	}
 	if len(versions) != len(expected) {
 		t.Fatalf("expected migration versions %v, got %v", expected, versions)

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -14,7 +14,7 @@ import (
 )
 
 // usageEventProjectionColumns 限制 usage_events 查询列，避免 Overview 和列表页把 RawJSON 等大字段读入内存。
-const usageEventProjectionColumns = "id, api_group_key, provider, auth_type, model, reasoning_effort, endpoint, timestamp, source, auth_index, failed, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens"
+const usageEventProjectionColumns = "id, api_group_key, provider, auth_type, model, reasoning_effort, executor_type, endpoint, timestamp, source, auth_index, failed, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens"
 
 // usageEventProjection 是 usage_events 轻量投影，专门承接 select columns 的查询结果。
 type usageEventProjection struct {
@@ -24,6 +24,7 @@ type usageEventProjection struct {
 	AuthType            string
 	Model               string
 	ReasoningEffort     string
+	ExecutorType        string
 	Endpoint            string
 	Timestamp           time.Time
 	Source              string
@@ -144,6 +145,7 @@ func usageEventProjectionToRecord(event usageEventProjection) dto.UsageEventReco
 		APIGroupKey:         strings.TrimSpace(event.APIGroupKey),
 		Model:               strings.TrimSpace(event.Model),
 		ReasoningEffort:     strings.TrimSpace(event.ReasoningEffort),
+		ExecutorType:        strings.TrimSpace(event.ExecutorType),
 		Endpoint:            strings.TrimSpace(event.Endpoint),
 		AuthType:            strings.TrimSpace(event.AuthType),
 		Provider:            strings.TrimSpace(event.Provider),
@@ -187,6 +189,7 @@ func usageEventProjectionToEntity(event usageEventProjection) entities.UsageEven
 		AuthType:            event.AuthType,
 		Model:               event.Model,
 		ReasoningEffort:     event.ReasoningEffort,
+		ExecutorType:        event.ExecutorType,
 		Endpoint:            event.Endpoint,
 		Timestamp:           event.Timestamp,
 		Source:              event.Source,

--- a/internal/repository/usage_test.go
+++ b/internal/repository/usage_test.go
@@ -16,7 +16,7 @@ func TestListUsageEventsWithFilterPreservesEventFields(t *testing.T) {
 	db := openUsageTestDatabase(t)
 	ttftMS := int64(45)
 	events := []entities.UsageEvent{
-		{EventKey: "event-1", APIGroupKey: "provider-a", Model: "claude-sonnet", Endpoint: "POST /v1/messages", Timestamp: time.Date(2026, 4, 16, 9, 0, 0, 0, time.UTC), Source: "codex-a", AuthIndex: "1", Failed: false, LatencyMS: 100, TTFTMS: &ttftMS, InputTokens: 10, OutputTokens: 20, ReasoningTokens: 5, CachedTokens: 0, CacheReadTokens: 7, CacheCreationTokens: 8, TotalTokens: 35},
+		{EventKey: "event-1", APIGroupKey: "provider-a", Model: "claude-sonnet", ExecutorType: "responses", Endpoint: "POST /v1/messages", Timestamp: time.Date(2026, 4, 16, 9, 0, 0, 0, time.UTC), Source: "codex-a", AuthIndex: "1", Failed: false, LatencyMS: 100, TTFTMS: &ttftMS, InputTokens: 10, OutputTokens: 20, ReasoningTokens: 5, CachedTokens: 0, CacheReadTokens: 7, CacheCreationTokens: 8, TotalTokens: 35},
 		{EventKey: "event-2", APIGroupKey: "provider-a", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC), Source: "codex-b", AuthIndex: "2", Failed: true, LatencyMS: 200, InputTokens: 2, OutputTokens: 3, ReasoningTokens: 0, CachedTokens: 0, TotalTokens: 5},
 		{EventKey: "event-3", APIGroupKey: "provider-b", Model: "claude-opus", Timestamp: time.Date(2026, 4, 17, 10, 0, 0, 0, time.UTC), Source: "codex-c", AuthIndex: "3", Failed: false, LatencyMS: 300, InputTokens: 100, OutputTokens: 50, ReasoningTokens: 25, CachedTokens: 10, TotalTokens: 185},
 	}
@@ -36,6 +36,9 @@ func TestListUsageEventsWithFilterPreservesEventFields(t *testing.T) {
 	}
 	if page.Events[2].Endpoint != "POST /v1/messages" {
 		t.Fatalf("expected endpoint event list field to be preserved, got %q", page.Events[2].Endpoint)
+	}
+	if page.Events[2].ExecutorType != "responses" {
+		t.Fatalf("expected executor_type event list field to be preserved, got %q", page.Events[2].ExecutorType)
 	}
 }
 

--- a/internal/service/dto/usage.go
+++ b/internal/service/dto/usage.go
@@ -46,6 +46,7 @@ type UsageEventRecord struct {
 	APIGroupKey         string
 	Model               string
 	ReasoningEffort     string
+	ExecutorType        string
 	Endpoint            string
 	AuthType            string
 	Provider            string

--- a/internal/service/redis_usage.go
+++ b/internal/service/redis_usage.go
@@ -43,6 +43,7 @@ type queuedUsageDetail struct {
 	Alias           *string        `json:"alias"`
 	ReasoningEffort string         `json:"reasoning_effort"`
 	ServiceTier     string         `json:"service_tier"`
+	ExecutorType    string         `json:"executor_type"`
 	Endpoint        string         `json:"endpoint"`
 	AuthType        string         `json:"auth_type"`
 	APIKey          string         `json:"api_key"`
@@ -90,6 +91,7 @@ func (d queuedUsageDetail) toUsageEvent(fetchedAt time.Time) entities.UsageEvent
 		ModelAlias:          trimRedisOptionalString(d.Alias),
 		ReasoningEffort:     strings.TrimSpace(d.ReasoningEffort),
 		ServiceTier:         strings.TrimSpace(d.ServiceTier),
+		ExecutorType:        strings.TrimSpace(d.ExecutorType),
 		Timestamp:           timestamp,
 		Source:              source,
 		AuthIndex:           authIndex,

--- a/internal/service/redis_usage_test.go
+++ b/internal/service/redis_usage_test.go
@@ -23,6 +23,7 @@ func TestDecodeRedisUsageMessageMapsPayloadToUsageEvent(t *testing.T) {
 		"model":"claude-sonnet-4-6",
 		"alias":"claude-sonnet-alias",
 		"reasoning_effort":"medium",
+		"executor_type":"responses",
 		"endpoint":"/v1/messages",
 		"auth_type":"api_key",
 		"api_key":"raw-key",
@@ -46,6 +47,9 @@ func TestDecodeRedisUsageMessageMapsPayloadToUsageEvent(t *testing.T) {
 	}
 	if event.ReasoningEffort != "medium" {
 		t.Fatalf("expected reasoning effort to decode, got %q", event.ReasoningEffort)
+	}
+	if event.ExecutorType != "responses" {
+		t.Fatalf("expected executor type to decode, got %q", event.ExecutorType)
 	}
 	if event.ServiceTier != "standard" {
 		t.Fatalf("expected service tier to decode, got %q", event.ServiceTier)

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -225,6 +225,7 @@ func (s *usageService) ListUsageEvents(_ context.Context, filter servicedto.Usag
 			APIGroupKey:         row.APIGroupKey,
 			Model:               row.Model,
 			ReasoningEffort:     row.ReasoningEffort,
+			ExecutorType:        row.ExecutorType,
 			Endpoint:            row.Endpoint,
 			AuthType:            row.AuthType,
 			Provider:            row.Provider,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -116,6 +116,7 @@ export interface UsageEvent {
   api_key?: string
   model: string
   reasoning_effort?: string
+  executor_type?: string
   endpoint?: string
   source: string
   source_raw?: string


### PR DESCRIPTION
## Summary
- persist upstream executor_type on usage events
- carry executor_type through Redis ingest, repository/service DTOs, and Request Events API payloads
- expose the field in frontend event typings without adding a visible column

## Verification
- env GOCACHE=/tmp/cpa-usage-keeper-go-build go test ./cmd/... ./internal/...
- npm --prefix ./web run typecheck
- npm --prefix ./web run build
- git diff --check