### PR TITLE
Handle provider quota window usage

### DIFF
--- a/internal/quota/normalize.go
+++ b/internal/quota/normalize.go
@@ -212,13 +212,15 @@ func appendCodexWindowQuotaRow(rows []QuotaRow, key string, label string, scope 
 	}
 	label = codexWindowLabel(key, label, window.LimitWindowSeconds)
 	row := QuotaRow{
-		Key:          key,
-		Label:        label,
-		Scope:        scope,
-		Metric:       metric,
-		UsedPercent:  floatPtr(window.UsedPercent),
-		Allowed:      info.Allowed,
-		LimitReached: info.LimitReached,
+		Key:               key,
+		Label:             label,
+		Scope:             scope,
+		Metric:            metric,
+		UsedPercent:       floatPtr(window.UsedPercent),
+		Allowed:           info.Allowed,
+		LimitReached:      info.LimitReached,
+		WindowUsageTokens: window.WindowUsageTokens,
+		WindowUsageCost:   window.WindowUsageCost,
 	}
 	if window.LimitWindowSeconds != 0 {
 		row.Window = &QuotaWindow{Seconds: intPtr(window.LimitWindowSeconds)}

--- a/internal/quota/payloads.go
+++ b/internal/quota/payloads.go
@@ -383,7 +383,7 @@ func floatPtrField(object map[string]json.RawMessage, keys ...string) *float64 {
 func floatValue(object map[string]json.RawMessage, keys ...string) (float64, bool) {
 	for _, key := range keys {
 		if raw, ok := object[key]; ok {
-			if strings.TrimSpace(string(raw)) == "null" {
+			if rawJSONNull(raw) {
 				continue
 			}
 			var number float64
@@ -400,6 +400,10 @@ func floatValue(object map[string]json.RawMessage, keys ...string) (float64, boo
 		}
 	}
 	return 0, false
+}
+
+func rawJSONNull(raw json.RawMessage) bool {
+	return len(raw) == 4 && raw[0] == 'n' && raw[1] == 'u' && raw[2] == 'l' && raw[3] == 'l'
 }
 
 func intField(object map[string]json.RawMessage, keys ...string) int64 {

--- a/internal/quota/payloads.go
+++ b/internal/quota/payloads.go
@@ -87,6 +87,8 @@ func parseCodexUsageWindow(object map[string]json.RawMessage) *CodexUsageWindow 
 		LimitWindowSeconds: intField(object, "limit_window_seconds", "limitWindowSeconds"),
 		ResetAfterSeconds:  intField(object, "reset_after_seconds", "resetAfterSeconds"),
 		ResetAt:            intField(object, "reset_at", "resetAt"),
+		WindowUsageTokens:  intPtrField(object, "window_usage_tokens", "windowUsageTokens"),
+		WindowUsageCost:    floatPtrField(object, "window_usage_cost", "windowUsageCost"),
 	}
 }
 
@@ -381,6 +383,9 @@ func floatPtrField(object map[string]json.RawMessage, keys ...string) *float64 {
 func floatValue(object map[string]json.RawMessage, keys ...string) (float64, bool) {
 	for _, key := range keys {
 		if raw, ok := object[key]; ok {
+			if strings.TrimSpace(string(raw)) == "null" {
+				continue
+			}
 			var number float64
 			if err := json.Unmarshal(raw, &number); err == nil {
 				return number, true
@@ -403,6 +408,15 @@ func intField(object map[string]json.RawMessage, keys ...string) int64 {
 		return 0
 	}
 	return int64(value)
+}
+
+func intPtrField(object map[string]json.RawMessage, keys ...string) *int64 {
+	value, ok := floatValue(object, keys...)
+	if !ok {
+		return nil
+	}
+	parsed := int64(value)
+	return &parsed
 }
 
 func boolField(object map[string]json.RawMessage, keys ...string) bool {

--- a/internal/quota/test/codex_test.go
+++ b/internal/quota/test/codex_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"testing"
 
 	"cpa-usage-keeper/internal/cpa/dto/apicall"
@@ -75,6 +76,60 @@ func TestCodexProviderUsesAccountIDForUsageRequest(t *testing.T) {
 	}
 }
 
+func TestCodexProviderPreservesProWindowUsageFields(t *testing.T) {
+	codexUsageJSON := `{"plan_type":"pro","rate_limit":{"allowed":true,"limit_reached":false,"primary_window":{"used_percent":3,"limit_window_seconds":18000,"reset_after_seconds":13422,"reset_at":1780331042,"window_usage_tokens":11368055,"window_usage_cost":14.83442025},"secondary_window":{"used_percent":15,"limit_window_seconds":604800,"reset_after_seconds":528051,"reset_at":1780845672,"window_usage_tokens":623087989,"window_usage_cost":614.6869810999999}},"additional_rate_limits":[{"limit_name":"GPT-5.3-Codex-Spark","metered_feature":"codex_bengalfox","rate_limit":{"allowed":true,"limit_reached":false,"primary_window":{"used_percent":0,"limit_window_seconds":18000,"reset_after_seconds":17698,"reset_at":1780335318,"window_usage_tokens":393311,"window_usage_cost":0.458464},"secondary_window":{"used_percent":0,"limit_window_seconds":604800,"reset_after_seconds":568595,"reset_at":1780886215,"window_usage_tokens":418184136,"window_usage_cost":405.1611734}}}]}`
+	caller := &recordingManagementCaller{responses: []*apicall.Response{{
+		StatusCode: 200,
+		BodyText:   codexUsageJSON,
+		Body:       json.RawMessage(codexUsageJSON),
+	}}}
+	provider := quota.NewCodexProvider(caller, quota.DefaultProviderConfigs().Codex)
+
+	output, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "codex-pro-auth"}})
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	rows := quota.NormalizeQuotaRows(output)
+
+	primary := findCodexQuotaRow(t, rows, "rate_limit.primary_window")
+	assertWindowUsage(t, primary, 11368055, 14.83442025)
+	secondary := findCodexQuotaRow(t, rows, "rate_limit.secondary_window")
+	assertWindowUsage(t, secondary, 623087989, 614.6869810999999)
+	additional := findCodexQuotaRow(t, rows, "additional_rate_limits.GPT-5.3-Codex-Spark.primary_window")
+	assertWindowUsage(t, additional, 393311, 0.458464)
+	if additional.Scope != "additional" || additional.Metric != "codex_bengalfox" || additional.PlanType != "pro" {
+		t.Fatalf("expected additional row metadata to survive normalization, got %#v", additional)
+	}
+	additionalSecondary := findCodexQuotaRow(t, rows, "additional_rate_limits.GPT-5.3-Codex-Spark.secondary_window")
+	assertWindowUsage(t, additionalSecondary, 418184136, 405.1611734)
+	if additionalSecondary.Scope != "additional" || additionalSecondary.Metric != "codex_bengalfox" || additionalSecondary.PlanType != "pro" {
+		t.Fatalf("expected additional secondary row metadata to survive normalization, got %#v", additionalSecondary)
+	}
+}
+
+func TestCodexProviderTreatsNullWindowUsageAsMissingAndPreservesCamelCaseZero(t *testing.T) {
+	codexUsageJSON := `{"plan_type":"pro","rate_limit":{"allowed":true,"limit_reached":false,"primary_window":{"used_percent":0,"limit_window_seconds":18000,"window_usage_tokens":null,"window_usage_cost":null},"secondary_window":{"used_percent":0,"limit_window_seconds":604800,"windowUsageTokens":0,"windowUsageCost":0}}}`
+	caller := &recordingManagementCaller{responses: []*apicall.Response{{
+		StatusCode: 200,
+		BodyText:   codexUsageJSON,
+		Body:       json.RawMessage(codexUsageJSON),
+	}}}
+	provider := quota.NewCodexProvider(caller, quota.DefaultProviderConfigs().Codex)
+
+	output, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "codex-pro-auth"}})
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	rows := quota.NormalizeQuotaRows(output)
+
+	primary := findCodexQuotaRow(t, rows, "rate_limit.primary_window")
+	if primary.WindowUsageTokens != nil || primary.WindowUsageCost != nil {
+		t.Fatalf("expected null provider window usage to stay missing, got tokens=%#v cost=%#v", primary.WindowUsageTokens, primary.WindowUsageCost)
+	}
+	secondary := findCodexQuotaRow(t, rows, "rate_limit.secondary_window")
+	assertWindowUsage(t, secondary, 0, 0)
+}
+
 func TestCodexProviderOmitsAccountIDHeaderWhenMissing(t *testing.T) {
 	caller := &recordingManagementCaller{responses: []*apicall.Response{{
 		StatusCode: 200,
@@ -109,5 +164,26 @@ func TestCodexProviderRejectsNonSuccessUsageResponse(t *testing.T) {
 	}})
 	if err == nil || err.Error() != "HTTP 429: rate limited" {
 		t.Fatalf("expected target HTTP message, got %v", err)
+	}
+}
+
+func findCodexQuotaRow(t *testing.T, rows []quota.QuotaRow, key string) quota.QuotaRow {
+	t.Helper()
+	for _, row := range rows {
+		if row.Key == key {
+			return row
+		}
+	}
+	t.Fatalf("missing quota row %q in %#v", key, rows)
+	return quota.QuotaRow{}
+}
+
+func assertWindowUsage(t *testing.T, row quota.QuotaRow, tokens int64, cost float64) {
+	t.Helper()
+	if row.WindowUsageTokens == nil || *row.WindowUsageTokens != tokens {
+		t.Fatalf("expected %s window usage tokens %d, got %#v", row.Key, tokens, row.WindowUsageTokens)
+	}
+	if row.WindowUsageCost == nil || math.Abs(*row.WindowUsageCost-cost) > 0.000000001 {
+		t.Fatalf("expected %s window usage cost %.8f, got %#v", row.Key, cost, row.WindowUsageCost)
 	}
 }

--- a/internal/quota/types.go
+++ b/internal/quota/types.go
@@ -62,10 +62,12 @@ type AntigravityQuotaPayload struct {
 }
 
 type CodexUsageWindow struct {
-	UsedPercent        float64 `json:"usedPercent,omitempty"`
-	LimitWindowSeconds int64   `json:"limitWindowSeconds,omitempty"`
-	ResetAfterSeconds  int64   `json:"resetAfterSeconds,omitempty"`
-	ResetAt            int64   `json:"resetAt,omitempty"`
+	UsedPercent        float64  `json:"usedPercent,omitempty"`
+	LimitWindowSeconds int64    `json:"limitWindowSeconds,omitempty"`
+	ResetAfterSeconds  int64    `json:"resetAfterSeconds,omitempty"`
+	ResetAt            int64    `json:"resetAt,omitempty"`
+	WindowUsageTokens  *int64   `json:"window_usage_tokens,omitempty"`
+	WindowUsageCost    *float64 `json:"window_usage_cost,omitempty"`
 }
 
 type CodexRateLimitInfo struct {

--- a/internal/quota/usage_stats.go
+++ b/internal/quota/usage_stats.go
@@ -2,6 +2,7 @@ package quota
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"cpa-usage-keeper/internal/repository"
@@ -21,8 +22,16 @@ func (s *Service) attachWindowUsageStats(ctx context.Context, authIndex string, 
 	}
 	// 同一个 quota response 可能包含多个相同窗口，按 start/end 去重后再查询数据库。
 	statsByWindow := make(map[quotaUsageWindowKey]repository.UsageWindowStats)
-	// 遍历每一条 quota row，只有明确窗口的 row 才会补 token/cost。
+	// 遍历每一条 quota row，只对没有完整 provider 用量的普通窗口补 token/cost。
 	for index := range response.Quota {
+		// Pro 等上游可能已经返回窗口 token/cost；非 window scope 不用本地 auth 级统计兜底。
+		if !shouldBackfillWindowUsageStats(response.Quota[index]) {
+			// 保留 provider 原始字段，避免覆盖 additional/code_review 等专项限额。
+			continue
+		}
+		// provider pair 不完整时先丢弃单边字段，避免 fallback 失败后输出不同口径的半套数据。
+		response.Quota[index].WindowUsageTokens = nil
+		response.Quota[index].WindowUsageCost = nil
 		// 根据 reset_at 和 window.seconds 计算该 row 对应的统计窗口。
 		windowStart, windowEnd, ok := quotaRowUsageWindow(response.Quota[index], now)
 		// 没有明确窗口或 reset_at 无法解析时跳过该 row。
@@ -48,17 +57,35 @@ func (s *Service) attachWindowUsageStats(ctx context.Context, authIndex string, 
 			// 把查询结果放入本次响应缓存，供相同窗口的其它 row 复用。
 			statsByWindow[key] = stats
 		}
-		// 复制 tokens 值，确保指针指向当前 row 独立变量。
+		// 复制 tokens/cost 值，确保指针指向当前 row 独立变量。
 		tokens := stats.Tokens
-		// 复制 cost 值，确保指针指向当前 row 独立变量。
 		cost := stats.Cost
-		// 写入窗口 token，前端在进度条下方展示。
+		// token 和 cost 必须来自同一统计口径；provider pair 不完整时整对使用本地统计。
 		response.Quota[index].WindowUsageTokens = &tokens
-		// 写入窗口 cost，前端在进度条下方展示。
 		response.Quota[index].WindowUsageCost = &cost
 	}
 	// 返回已经补充窗口用量的 quota 响应。
 	return response
+}
+
+func shouldBackfillWindowUsageStats(row QuotaRow) bool {
+	// provider 已给完整窗口用量时直接信任上游，不再用 usage_events 覆盖。
+	if row.WindowUsageTokens != nil && row.WindowUsageCost != nil {
+		return false
+	}
+	// 本地 usage_events 兜底只适用于普通 5h/Weekly/Monthly window scope。
+	if !strings.EqualFold(strings.TrimSpace(row.Scope), "window") {
+		return false
+	}
+	if row.Window == nil || row.Window.Seconds == nil {
+		return false
+	}
+	switch *row.Window.Seconds {
+	case quotaWindowFiveHourSeconds, quotaWindowSevenDaySeconds, quotaWindowThirtyDaySeconds:
+		return true
+	default:
+		return false
+	}
 }
 
 func quotaRowUsageWindow(row QuotaRow, now time.Time) (time.Time, time.Time, bool) {

--- a/internal/quota/usage_stats_test.go
+++ b/internal/quota/usage_stats_test.go
@@ -1,8 +1,18 @@
 package quota
 
 import (
+	"context"
+	"math"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"cpa-usage-keeper/internal/config"
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+	"cpa-usage-keeper/internal/repository/dto"
+	"cpa-usage-keeper/internal/timeutil"
+	"gorm.io/gorm"
 )
 
 func TestQuotaRowUsageWindowParsesStorageTimeResetAt(t *testing.T) {
@@ -56,4 +66,288 @@ func TestQuotaRowUsageWindowRejectsNegativeResetAfterSeconds(t *testing.T) {
 	if ok {
 		t.Fatal("expected negative reset_after_seconds to be ignored")
 	}
+}
+
+func TestAttachWindowUsageStatsOnlyBackfillsMissingKnownWindowScopeRows(t *testing.T) {
+	db := openQuotaUsageStatsTestDB(t)
+	service := &Service{db: db}
+	windowSeconds := int64(5 * 60 * 60)
+	weeklySeconds := int64(7 * 24 * 60 * 60)
+	monthlySeconds := int64(30 * 24 * 60 * 60)
+	unknownSeconds := int64(60 * 60)
+	resetAt := time.Date(2026, 6, 2, 5, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 6, 2, 3, 0, 0, 0, time.UTC)
+
+	if err := db.Create(&entities.UsageEvent{
+		AuthIndex:   "auth-pro",
+		Model:       "gpt-codex",
+		Timestamp:   now.Add(-time.Hour),
+		TotalTokens: 222,
+	}).Error; err != nil {
+		t.Fatalf("seed usage event: %v", err)
+	}
+
+	response := service.attachWindowUsageStats(context.Background(), "auth-pro", CheckResponse{ID: "auth-pro", Quota: []QuotaRow{
+		{
+			Key:               "rate_limit.primary_window",
+			Label:             "5h",
+			Scope:             "window",
+			Window:            &QuotaWindow{Seconds: &windowSeconds},
+			ResetAt:           timeutil.FormatStorageTime(resetAt),
+			WindowUsageTokens: intPtr(11),
+			WindowUsageCost:   floatPtr(0.42),
+		},
+		{
+			Key:     "additional_rate_limits.GPT-5.3-Codex-Spark.primary_window",
+			Label:   "GPT-5.3-Codex-Spark 5h",
+			Scope:   "additional",
+			Metric:  "codex_bengalfox",
+			Window:  &QuotaWindow{Seconds: &windowSeconds},
+			ResetAt: timeutil.FormatStorageTime(resetAt),
+		},
+		{
+			Key:     "rate_limit.secondary_window",
+			Label:   "Weekly",
+			Scope:   "window",
+			Window:  &QuotaWindow{Seconds: &weeklySeconds},
+			ResetAt: timeutil.FormatStorageTime(resetAt),
+		},
+		{
+			Key:     "rate_limit.monthly_window",
+			Label:   "Monthly",
+			Scope:   "window",
+			Window:  &QuotaWindow{Seconds: &monthlySeconds},
+			ResetAt: timeutil.FormatStorageTime(resetAt),
+		},
+		{
+			Key:     "code_review_rate_limit.primary_window",
+			Label:   "Code Review 5h",
+			Scope:   "code_review",
+			Window:  &QuotaWindow{Seconds: &windowSeconds},
+			ResetAt: timeutil.FormatStorageTime(resetAt),
+		},
+		{
+			Key:     "rate_limit.unknown_window",
+			Label:   "Unknown",
+			Scope:   "window",
+			Window:  &QuotaWindow{Seconds: &unknownSeconds},
+			ResetAt: timeutil.FormatStorageTime(resetAt),
+		},
+	}}, now)
+
+	providerWindow := findQuotaUsageStatsRow(t, response.Quota, "rate_limit.primary_window")
+	if providerWindow.WindowUsageTokens == nil || *providerWindow.WindowUsageTokens != 11 {
+		t.Fatalf("expected provider window_usage_tokens to be preserved, got %#v", providerWindow.WindowUsageTokens)
+	}
+	if providerWindow.WindowUsageCost == nil || math.Abs(*providerWindow.WindowUsageCost-0.42) > 0.000000001 {
+		t.Fatalf("expected provider window_usage_cost to be preserved, got %#v", providerWindow.WindowUsageCost)
+	}
+
+	additional := findQuotaUsageStatsRow(t, response.Quota, "additional_rate_limits.GPT-5.3-Codex-Spark.primary_window")
+	if additional.WindowUsageTokens != nil || additional.WindowUsageCost != nil {
+		t.Fatalf("expected additional quota without provider usage to stay empty, got tokens=%#v cost=%#v", additional.WindowUsageTokens, additional.WindowUsageCost)
+	}
+
+	weeklyWindow := findQuotaUsageStatsRow(t, response.Quota, "rate_limit.secondary_window")
+	if weeklyWindow.WindowUsageTokens == nil || *weeklyWindow.WindowUsageTokens != 222 {
+		t.Fatalf("expected missing weekly window usage to be backfilled from usage_events, got %#v", weeklyWindow.WindowUsageTokens)
+	}
+	if weeklyWindow.WindowUsageCost == nil || *weeklyWindow.WindowUsageCost != 0 {
+		t.Fatalf("expected missing weekly window cost to be backfilled from usage_events, got %#v", weeklyWindow.WindowUsageCost)
+	}
+	monthlyWindow := findQuotaUsageStatsRow(t, response.Quota, "rate_limit.monthly_window")
+	if monthlyWindow.WindowUsageTokens == nil || *monthlyWindow.WindowUsageTokens != 222 {
+		t.Fatalf("expected missing monthly window usage to be backfilled from usage_events, got %#v", monthlyWindow.WindowUsageTokens)
+	}
+	if monthlyWindow.WindowUsageCost == nil || *monthlyWindow.WindowUsageCost != 0 {
+		t.Fatalf("expected missing monthly window cost to be backfilled from usage_events, got %#v", monthlyWindow.WindowUsageCost)
+	}
+	codeReview := findQuotaUsageStatsRow(t, response.Quota, "code_review_rate_limit.primary_window")
+	if codeReview.WindowUsageTokens != nil || codeReview.WindowUsageCost != nil {
+		t.Fatalf("expected code review quota without provider usage to stay empty, got tokens=%#v cost=%#v", codeReview.WindowUsageTokens, codeReview.WindowUsageCost)
+	}
+	unknownWindow := findQuotaUsageStatsRow(t, response.Quota, "rate_limit.unknown_window")
+	if unknownWindow.WindowUsageTokens != nil || unknownWindow.WindowUsageCost != nil {
+		t.Fatalf("expected unknown window quota to stay empty, got tokens=%#v cost=%#v", unknownWindow.WindowUsageTokens, unknownWindow.WindowUsageCost)
+	}
+}
+
+func TestAttachWindowUsageStatsBackfillsBothFieldsWhenProviderWindowUsageIncomplete(t *testing.T) {
+	db := openQuotaUsageStatsTestDB(t)
+	service := &Service{db: db}
+	windowSeconds := int64(5 * 60 * 60)
+	resetAt := time.Date(2026, 6, 2, 5, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 6, 2, 3, 0, 0, 0, time.UTC)
+
+	if err := db.Create(&entities.UsageEvent{
+		AuthIndex:   "auth-partial",
+		Model:       "gpt-codex",
+		Timestamp:   now.Add(-time.Hour),
+		TotalTokens: 333,
+	}).Error; err != nil {
+		t.Fatalf("seed usage event: %v", err)
+	}
+
+	response := service.attachWindowUsageStats(context.Background(), "auth-partial", CheckResponse{ID: "auth-partial", Quota: []QuotaRow{
+		{
+			Key:               "rate_limit.primary_window",
+			Label:             "5h",
+			Scope:             "window",
+			Window:            &QuotaWindow{Seconds: &windowSeconds},
+			ResetAt:           timeutil.FormatStorageTime(resetAt),
+			WindowUsageTokens: intPtr(11),
+		},
+		{
+			Key:             "rate_limit.secondary_window",
+			Label:           "5h",
+			Scope:           "window",
+			Window:          &QuotaWindow{Seconds: &windowSeconds},
+			ResetAt:         timeutil.FormatStorageTime(resetAt),
+			WindowUsageCost: floatPtr(0.42),
+		},
+	}}, now)
+
+	tokensOnly := findQuotaUsageStatsRow(t, response.Quota, "rate_limit.primary_window")
+	if tokensOnly.WindowUsageTokens == nil || *tokensOnly.WindowUsageTokens != 333 {
+		t.Fatalf("expected incomplete provider tokens to be replaced by local usage, got %#v", tokensOnly.WindowUsageTokens)
+	}
+	if tokensOnly.WindowUsageCost == nil || *tokensOnly.WindowUsageCost != 0 {
+		t.Fatalf("expected incomplete provider cost to be replaced by local usage, got %#v", tokensOnly.WindowUsageCost)
+	}
+	costOnly := findQuotaUsageStatsRow(t, response.Quota, "rate_limit.secondary_window")
+	if costOnly.WindowUsageTokens == nil || *costOnly.WindowUsageTokens != 333 {
+		t.Fatalf("expected incomplete provider tokens to be replaced by local usage, got %#v", costOnly.WindowUsageTokens)
+	}
+	if costOnly.WindowUsageCost == nil || *costOnly.WindowUsageCost != 0 {
+		t.Fatalf("expected incomplete provider cost to be replaced by local usage, got %#v", costOnly.WindowUsageCost)
+	}
+}
+
+func TestAttachWindowUsageStatsDropsIncompleteProviderWindowUsageWhenFallbackUnavailable(t *testing.T) {
+	db := openQuotaUsageStatsTestDB(t)
+	service := &Service{db: db}
+	windowSeconds := int64(5 * 60 * 60)
+
+	response := service.attachWindowUsageStats(context.Background(), "auth-partial", CheckResponse{ID: "auth-partial", Quota: []QuotaRow{{
+		Key:               "rate_limit.primary_window",
+		Label:             "5h",
+		Scope:             "window",
+		Window:            &QuotaWindow{Seconds: &windowSeconds},
+		WindowUsageTokens: intPtr(11),
+	}}}, time.Date(2026, 6, 2, 3, 0, 0, 0, time.UTC))
+
+	row := findQuotaUsageStatsRow(t, response.Quota, "rate_limit.primary_window")
+	if row.WindowUsageTokens != nil || row.WindowUsageCost != nil {
+		t.Fatalf("expected incomplete provider usage to be dropped when local fallback is unavailable, got tokens=%#v cost=%#v", row.WindowUsageTokens, row.WindowUsageCost)
+	}
+}
+
+func TestAttachWindowUsageStatsDoesNotBackfillPartialAdditionalOrCodeReviewRows(t *testing.T) {
+	db := openQuotaUsageStatsTestDB(t)
+	service := &Service{db: db}
+	windowSeconds := int64(5 * 60 * 60)
+	resetAt := time.Date(2026, 6, 2, 5, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 6, 2, 3, 0, 0, 0, time.UTC)
+
+	if err := db.Create(&entities.UsageEvent{
+		AuthIndex:   "auth-special",
+		Model:       "gpt-codex",
+		Timestamp:   now.Add(-time.Hour),
+		TotalTokens: 444,
+	}).Error; err != nil {
+		t.Fatalf("seed usage event: %v", err)
+	}
+
+	response := service.attachWindowUsageStats(context.Background(), "auth-special", CheckResponse{ID: "auth-special", Quota: []QuotaRow{
+		{
+			Key:               "additional_rate_limits.GPT-5.3-Codex-Spark.primary_window",
+			Label:             "GPT-5.3-Codex-Spark 5h",
+			Scope:             "additional",
+			Metric:            "codex_bengalfox",
+			Window:            &QuotaWindow{Seconds: &windowSeconds},
+			ResetAt:           timeutil.FormatStorageTime(resetAt),
+			WindowUsageTokens: intPtr(11),
+		},
+		{
+			Key:             "code_review_rate_limit.primary_window",
+			Label:           "Code Review 5h",
+			Scope:           "code_review",
+			Window:          &QuotaWindow{Seconds: &windowSeconds},
+			ResetAt:         timeutil.FormatStorageTime(resetAt),
+			WindowUsageCost: floatPtr(0.42),
+		},
+	}}, now)
+
+	additional := findQuotaUsageStatsRow(t, response.Quota, "additional_rate_limits.GPT-5.3-Codex-Spark.primary_window")
+	if additional.WindowUsageTokens == nil || *additional.WindowUsageTokens != 11 || additional.WindowUsageCost != nil {
+		t.Fatalf("expected partial additional provider usage to be preserved without fallback, got tokens=%#v cost=%#v", additional.WindowUsageTokens, additional.WindowUsageCost)
+	}
+	codeReview := findQuotaUsageStatsRow(t, response.Quota, "code_review_rate_limit.primary_window")
+	if codeReview.WindowUsageTokens != nil || codeReview.WindowUsageCost == nil || math.Abs(*codeReview.WindowUsageCost-0.42) > 0.000000001 {
+		t.Fatalf("expected partial code review provider usage to be preserved without fallback, got tokens=%#v cost=%#v", codeReview.WindowUsageTokens, codeReview.WindowUsageCost)
+	}
+}
+
+func TestAttachWindowUsageStatsPreservesProviderZeroWindowUsage(t *testing.T) {
+	db := openQuotaUsageStatsTestDB(t)
+	service := &Service{db: db}
+	windowSeconds := int64(5 * 60 * 60)
+	resetAt := time.Date(2026, 6, 2, 5, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 6, 2, 3, 0, 0, 0, time.UTC)
+	if _, err := repository.UpsertModelPriceSetting(db, dto.ModelPriceSettingInput{Model: "priced", PromptPricePer1M: 10, CompletionPricePer1M: 20, CachePricePer1M: 1}); err != nil {
+		t.Fatalf("UpsertModelPriceSetting returned error: %v", err)
+	}
+	if err := db.Create(&entities.UsageEvent{
+		AuthIndex:    "auth-zero",
+		Model:        "priced",
+		Timestamp:    now.Add(-time.Hour),
+		InputTokens:  1_000_000,
+		OutputTokens: 500_000,
+		TotalTokens:  1_500_000,
+	}).Error; err != nil {
+		t.Fatalf("seed usage event: %v", err)
+	}
+
+	response := service.attachWindowUsageStats(context.Background(), "auth-zero", CheckResponse{ID: "auth-zero", Quota: []QuotaRow{{
+		Key:               "rate_limit.primary_window",
+		Label:             "5h",
+		Scope:             "window",
+		Window:            &QuotaWindow{Seconds: &windowSeconds},
+		ResetAt:           timeutil.FormatStorageTime(resetAt),
+		WindowUsageTokens: intPtr(0),
+		WindowUsageCost:   floatPtr(0),
+	}}}, now)
+
+	row := findQuotaUsageStatsRow(t, response.Quota, "rate_limit.primary_window")
+	if row.WindowUsageTokens == nil || *row.WindowUsageTokens != 0 {
+		t.Fatalf("expected provider zero tokens to be preserved, got %#v", row.WindowUsageTokens)
+	}
+	if row.WindowUsageCost == nil || *row.WindowUsageCost != 0 {
+		t.Fatalf("expected provider zero cost to be preserved, got %#v", row.WindowUsageCost)
+	}
+}
+
+func openQuotaUsageStatsTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := repository.OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "quota-usage-stats.db")})
+	if err != nil {
+		t.Fatalf("OpenDatabase returned error: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("db.DB returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return db
+}
+
+func findQuotaUsageStatsRow(t *testing.T, rows []QuotaRow, key string) QuotaRow {
+	t.Helper()
+	for _, row := range rows {
+		if row.Key == key {
+			return row
+		}
+	}
+	t.Fatalf("missing quota row %q in %#v", key, rows)
+	return QuotaRow{}
 }

--- a/web/src/components/usage/credentials/credentialViewModels.test.ts
+++ b/web/src/components/usage/credentials/credentialViewModels.test.ts
@@ -189,6 +189,44 @@ describe('credentialViewModels', () => {
     expect(rows[0].displayQuotas[0].windowUsage).toEqual({ tokens: '0', cost: '$0.00' })
   })
 
+  it('formats provider quota window usage with fixed compact units and US dollar decimals', () => {
+    const quotas = new Map<string, UsageQuotaRow[]>([
+      ['auth-1', [
+        { key: 'rate_limit.primary_window', label: '5h', usedPercent: 3, window_usage_tokens: 11_368_055, window_usage_cost: 14.83442025 },
+        { key: 'additional_rate_limits.GPT-5.3-Codex-Spark.primary_window', label: 'GPT-5.3-Codex-Spark 5h', usedPercent: 0, window_usage_tokens: 393_311, window_usage_cost: 0.458464 },
+      ]],
+    ])
+
+    const rows = buildAuthFileCredentialRows([identity({ identity: 'auth-1' })], quotas)
+
+    expect(rows[0].displayQuotas.map((quota) => quota.windowUsage)).toEqual([
+      { tokens: '11.37M', cost: '$14.83' },
+      { tokens: '393.31K', cost: '$0.46' },
+    ])
+  })
+
+  it('uses an explicit US locale for quota window cost formatting', () => {
+    const numberFormatSpy = vi.spyOn(Intl, 'NumberFormat')
+    try {
+      const quotas = new Map<string, UsageQuotaRow[]>([
+        ['auth-1', [
+          { key: 'rate_limit.primary_window', label: '5h', usedPercent: 3, window_usage_tokens: 11_368_055, window_usage_cost: 14.83442025 },
+        ]],
+      ])
+
+      buildAuthFileCredentialRows([identity({ identity: 'auth-1' })], quotas)
+
+      expect(numberFormatSpy).toHaveBeenCalledWith('en-US', expect.objectContaining({
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }))
+    } finally {
+      numberFormatSpy.mockRestore()
+    }
+  })
+
   it('uses normalized input token semantics for auth file cache rate', () => {
     const rows = buildAuthFileCredentialRows([
       identity({ identity: 'auth-claude', type: 'claude', input_tokens: 1000, cached_tokens: 600 }),

--- a/web/src/components/usage/credentials/credentialViewModels.ts
+++ b/web/src/components/usage/credentials/credentialViewModels.ts
@@ -214,7 +214,7 @@ function quotaWindowUsage(row: UsageQuotaRow): QuotaWindowUsageDisplay | undefin
 
 function formatQuotaWindowCost(cost: number): string {
   // 限额条下方空间很紧，窗口成本统一展示两位小数，避免 0 显示成 0.0000。
-  return new Intl.NumberFormat(undefined, {
+  return new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: 'USD',
     minimumFractionDigits: 2,


### PR DESCRIPTION
## Summary
- Preserve upstream quota window token/cost pairs when both fields are present
- Backfill only ordinary 5h/Weekly/Monthly window rows from usage_events when provider usage is incomplete or missing
- Keep additional and code review usage provider-only, with consistent credential UI formatting

Related #136 

## Verification
- rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build make verify