### PR TITLE
Add CPA metadata refresh notifications

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -96,7 +96,11 @@ func NewWithConfig(cfg config.Config) (*App, error) {
 	}
 	logrus.Info("completed usage overview aggregation catch-up")
 
+	// syncService 仍然是 metadata 和 usage 处理共享的业务服务入口。
 	syncService := service.NewSyncService(db, cfg)
+	// metadataSyncRunner 提前创建，保证控制消息和后台任务使用同一个调度器实例。
+	metadataSyncRunner := NewMetadataSyncRunner(syncService, cfg.MetadataSyncInterval)
+	// redisPullSource 保持旧 Redis queue 拉取路径不变。
 	redisPullSource := poller.NewRedisPullSource(cpa.RedisQueueOptions{
 		BaseURL:       cfg.CPABaseURL,
 		RedisAddr:     cfg.RedisQueueAddr,
@@ -107,7 +111,9 @@ func NewWithConfig(cfg config.Config) (*App, error) {
 		TLS:           cfg.RedisQueueTLS,
 		TLSSkipVerify: cfg.TLSSkipVerify,
 	})
+	// httpPullSource 保持 HTTP usage queue 兜底路径不变。
 	httpPullSource := poller.NewHTTPPullSource(cfg.CPABaseURL, cfg.CPAManagementKey, cfg.RequestTimeout, cfg.TLSSkipVerify, cfg.RedisQueueBatchSize)
+	// redisSubscribeSource 保持 Redis SUBSCRIBE 优先路径不变。
 	redisSubscribeSource := poller.NewRedisSubscribeSource(poller.RedisSubscribeOptions{
 		BaseURL:       cfg.CPABaseURL,
 		RedisAddr:     cfg.RedisQueueAddr,
@@ -116,13 +122,20 @@ func NewWithConfig(cfg config.Config) (*App, error) {
 		TLS:           cfg.RedisQueueTLS,
 		TLSSkipVerify: cfg.TLSSkipVerify,
 	})
-	redisIngestRunner := poller.NewRedisIngestRunner(redisSubscribeSource, redisPullSource, httpPullSource, poller.NewRedisInboxWriter(db, cfg.RedisQueueKey), poller.RedisIngestRunnerConfig{
+	// usage 通道可能混入 metadata 控制消息，落 inbox 前先过滤并转交 metadata runner。
+	redisInboxWriter := poller.NewControlAwareRedisInboxWriter(poller.NewRedisInboxWriter(db, cfg.RedisQueueKey), metadataSyncRunner)
+	// redisIngestRunner 继续负责三种 usage 拉取方式的选择和降级。
+	redisIngestRunner := poller.NewRedisIngestRunner(redisSubscribeSource, redisPullSource, httpPullSource, redisInboxWriter, poller.RedisIngestRunnerConfig{
 		IdleInterval:       cfg.RedisQueueIdleInterval,
 		BatchSize:          cfg.RedisQueueBatchSize,
 		HTTPBackoffInitial: time.Second,
 		HTTPBackoffMax:     30 * time.Second,
 	})
+	// usage 链路一旦降级或失败，metadata 同步回到轮询，直到下一条 CPA 控制消息重新启用通知模式。
+	redisIngestRunner.SetControlMessageObserver(metadataSyncRunner)
+	// redisProcessRunner 仍然只处理本地 inbox 到 usage_events 的消费。
 	redisProcessRunner := poller.NewRedisProcessRunner(syncService)
+	// backgroundPoller 继续组合远端 ingest 和本地 process 的状态展示。
 	backgroundPoller := poller.NewRedisPoller(redisIngestRunner, redisProcessRunner)
 	var backupMaintenance *DatabaseBackupRunner
 	if cfg.BackupEnabled {
@@ -161,7 +174,7 @@ func NewWithConfig(cfg config.Config) (*App, error) {
 		RedisIngest:       redisIngestRunner,
 		RedisProcess:      redisProcessRunner,
 		Maintenance:       NewStorageCleanupRunner(syncService),
-		MetadataSync:      NewMetadataSyncRunner(syncService, cfg.MetadataSyncInterval),
+		MetadataSync:      metadataSyncRunner,
 		QuotaService:      quotaService,
 		QuotaAutoRefresh:  quotaAutoRefreshService(cfg, quotaService),
 		BackupMaintenance: backupMaintenance,

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -157,6 +158,48 @@ func TestNewWithConfigBuildsRedisIngestAndRouter(t *testing.T) {
 	}
 }
 
+func TestNewWithConfigWiresMetadataRefreshControl(t *testing.T) {
+	app, err := NewWithConfig(testAppConfig(t))
+	if err != nil {
+		t.Fatalf("NewWithConfig returned error: %v", err)
+	}
+	defer app.Close()
+
+	runner, ok := app.RedisIngest.(*poller.RedisIngestRunner)
+	if !ok {
+		t.Fatalf("expected redis ingest runner, got %T", app.RedisIngest)
+	}
+	runnerValue := reflect.ValueOf(runner).Elem()
+	writer := runnerValue.FieldByName("writer")
+	if writer.IsNil() {
+		t.Fatal("expected redis ingest writer")
+	}
+	if got := writer.Elem().Type().String(); got != "*poller.ControlAwareRedisInboxWriter" {
+		t.Fatalf("expected control-aware redis inbox writer, got %s", got)
+	}
+	observer := runnerValue.FieldByName("controlObserver")
+	if observer.IsNil() {
+		t.Fatal("expected metadata sync runner to observe redis ingest control messages")
+	}
+	if got := observer.Elem().Type().String(); got != "*app.MetadataSyncRunner" {
+		t.Fatalf("expected metadata sync runner observer, got %s", got)
+	}
+	metadataSyncPtr := reflect.ValueOf(app.MetadataSync).Pointer()
+	if got := observer.Elem().Pointer(); got != metadataSyncPtr {
+		t.Fatalf("expected redis ingest observer to share app metadata sync runner, got %x want %x", got, metadataSyncPtr)
+	}
+	writerObserver := writer.Elem().Elem().FieldByName("observer")
+	if writerObserver.IsNil() {
+		t.Fatal("expected redis inbox writer observer")
+	}
+	if got := writerObserver.Elem().Type().String(); got != "*app.MetadataSyncRunner" {
+		t.Fatalf("expected redis inbox writer metadata sync observer, got %s", got)
+	}
+	if got := writerObserver.Elem().Pointer(); got != metadataSyncPtr {
+		t.Fatalf("expected redis inbox writer observer to share app metadata sync runner, got %x want %x", got, metadataSyncPtr)
+	}
+}
+
 func TestNewWithConfigExposesConfiguredCPAPublicURL(t *testing.T) {
 	cfg := testAppConfig(t)
 	cfg.CPAPublicURL = "https://cpa.public.example.com/"
@@ -288,7 +331,7 @@ func TestRunStartsPollerAndMaintenanceIndependently(t *testing.T) {
 	pullStarted := make(chan struct{})
 	processStarted := make(chan struct{})
 	maintenanceStarted := make(chan struct{})
-	metadataStarted := make(chan struct{})
+	metadataStarted := make(chan struct{}, 1)
 	backupStarted := make(chan struct{})
 	maintenance := NewStorageCleanupRunner(&maintenanceSyncStub{})
 	maintenance.sleep = func(context.Context, time.Duration) bool {
@@ -296,9 +339,11 @@ func TestRunStartsPollerAndMaintenanceIndependently(t *testing.T) {
 		return false
 	}
 	metadataRunner := NewMetadataSyncRunner(&metadataSyncStub{}, time.Second)
-	metadataRunner.sleep = func(context.Context, time.Duration) bool {
-		close(metadataStarted)
-		return false
+	metadataRunner.onStart = func() {
+		select {
+		case metadataStarted <- struct{}{}:
+		default:
+		}
 	}
 	backupRunner := NewDatabaseBackupRunner(&databaseBackupWriterStub{}, nil, time.Second, 0)
 	backupRunner.sleep = func(context.Context, time.Duration) bool {
@@ -351,7 +396,6 @@ func TestRunStartsPollerAndMaintenanceIndependently(t *testing.T) {
 		t.Fatal("expected database backup runner to start")
 	}
 }
-
 func TestRunSetsQuotaServiceContextEvenWhenAutoRefreshDisabled(t *testing.T) {
 	cfg := testAppConfig(t)
 	cfg.AppPort = "invalid-port"

--- a/internal/app/metadata_sync.go
+++ b/internal/app/metadata_sync.go
@@ -14,61 +14,289 @@ type MetadataSyncer interface {
 }
 
 type MetadataSyncRunner struct {
-	syncer   MetadataSyncer
+	// syncer 是唯一真正执行 metadata 同步的服务入口。
+	syncer MetadataSyncer
+	// interval 是轮询模式下的固定同步间隔。
 	interval time.Duration
-	sleep    func(context.Context, time.Duration) bool
+	// refreshDebounce 是 refresh=true 后的最小合并等待窗口。
+	refreshDebounce time.Duration
+	// refreshRequests 用单元素缓冲合并密集 refresh 通知。
+	refreshRequests chan struct{}
+	// onStart 只给测试确认后台 runner 已启动，生产逻辑不依赖它。
+	onStart func()
+	// now 允许测试控制 debounce 时间判断，生产使用 time.Now。
+	now func() time.Time
 
-	mu      sync.Mutex
+	// mu 保护 runner 状态和最近 refresh 时间。
+	mu sync.Mutex
+	// running 表示 metadata runner 当前是否处于 Run 生命周期内。
 	running bool
+	// notificationMode 表示 CPA 已支持通知，周期 tick 应该 no-op。
+	notificationMode bool
+	// lastRefreshRequestedAt 记录最后一条 refresh=true 的收到时间。
+	lastRefreshRequestedAt time.Time
 }
 
 func NewMetadataSyncRunner(syncer MetadataSyncer, interval time.Duration) *MetadataSyncRunner {
+	// 构造阶段只保存依赖，不主动访问 CPA 或数据库。
 	return &MetadataSyncRunner{
-		syncer:   syncer,
-		interval: interval,
-		sleep:    maintenanceSleepContext,
+		syncer:          syncer,
+		interval:        interval,
+		refreshDebounce: 5 * time.Second,
+		refreshRequests: make(chan struct{}, 1),
+		now:             time.Now,
 	}
 }
 
-// Run 启动独立 metadata 同步任务：启动后立即执行一次，之后按固定间隔刷新 auth files 和 provider metadata。
+// Run 启动独立 metadata 同步任务：默认轮询；收到 CPA 控制消息后进入通知模式，周期 tick 只保持空转。
 func (r *MetadataSyncRunner) Run(ctx context.Context) error {
+	// 启动前统一校验依赖和补齐测试可能清空的可选字段。
 	if err := r.validate(); err != nil {
 		return err
 	}
+	// 任务启动只打一条 info，后续周期 tick 不刷日志。
 	logrus.Info("metadata sync task started")
+	// running 状态用于诊断，不参与调度决策。
 	r.setRunning(true)
+	// 任何退出路径都必须清掉 running 状态。
 	defer r.setRunning(false)
+	// 测试 hook 在真正同步前触发，避免监听失败时 context 抢先取消导致测试偶发。
+	if r.onStart != nil {
+		r.onStart()
+	}
 
-	delay := time.Duration(0)
+	// 如果应用启动后立刻取消，就不再执行首次同步。
+	if ctx.Err() != nil {
+		return nil
+	}
+	// 无论后续是否进入通知模式，启动时先同步一次 metadata。
+	r.runSync(ctx)
+
+	// periodic 负责默认轮询模式的固定周期 tick。
+	periodic := time.NewTimer(r.interval)
+	// Run 退出时释放周期 timer。
+	defer periodic.Stop()
+	// debounce 只在收到 refresh=true 后创建。
+	var debounce *time.Timer
+	// debounceC 为 nil 时 select 不会监听 debounce 分支。
+	var debounceC <-chan time.Time
+	// Run 退出时释放可能仍在等待的 debounce timer。
+	defer func() {
+		if debounce != nil {
+			debounce.Stop()
+		}
+	}()
+
 	for {
-		if !r.sleep(ctx, delay) {
+		select {
+		case <-ctx.Done():
+			// 应用关闭是正常退出，不返回错误。
 			return nil
+		case <-periodic.C:
+			// 周期 tick 到达后再检查一次 context，避免关停时多同步。
+			if ctx.Err() != nil {
+				return nil
+			}
+			// 通知模式下周期 tick 完全 no-op，避免继续轮询 CPA。
+			if !r.isNotificationMode() {
+				r.runSync(ctx)
+			}
+			// 无论是否 no-op，都继续维持 tick，方便降级回轮询后恢复节奏。
+			periodic.Reset(r.interval)
+		case <-r.refreshRequests:
+			// 首个 refresh 请求创建 debounce timer。
+			if debounce == nil {
+				debounce = time.NewTimer(r.refreshDebounceDelay())
+				debounceC = debounce.C
+			} else {
+				// 后续 refresh 请求重置 timer，实现最后一条消息后的 trailing debounce。
+				resetTimer(debounce, r.refreshDebounceDelay())
+			}
+		case <-debounceC:
+			// timer 触发时先清掉 channel 里被合并的 refresh 请求。
+			r.drainRefreshRequests()
+			// 如果 drain 期间又刷新了最后请求时间，就继续等剩余 debounce。
+			if delay := r.refreshDebounceDelay(); delay > 0 {
+				resetTimer(debounce, delay)
+				continue
+			}
+			// refresh 只是无 payload 的失效通知；窗口到期后同步当前 metadata 即可。
+			if ctx.Err() != nil {
+				// 应用关停时不再发起 refresh 同步，避免关闭期多一次无效请求。
+				return nil
+			}
+			// debounce 窗口稳定后只执行一次 SyncMetadata。
+			r.runSync(ctx)
+			// 同步完成后释放 debounce 状态，等待下一轮 refresh 创建新 timer。
+			debounce = nil
+			debounceC = nil
 		}
-		if err := r.syncer.SyncMetadata(ctx); err != nil {
-			logrus.WithError(err).Error("metadata sync failed")
-		}
-		delay = r.interval
+	}
+}
+
+func (r *MetadataSyncRunner) MarkRefreshSupported() {
+	// support_refresh=true 只切到通知模式，不立即同步 metadata。
+	if r.setNotificationMode(true) {
+		// CPA 明确支持 refresh 通知后，记录一次模式切换。
+		logrus.WithField("source", "support_refresh").Info("metadata sync switched to notification mode")
+	}
+}
+
+func (r *MetadataSyncRunner) RequestMetadataRefresh() {
+	// nil runner 保护只为防御异常 wiring，正常路径不会触发。
+	if r == nil {
+		return
+	}
+	// refresh=true 同时证明通知可用，并刷新 trailing debounce 的起点。
+	changed := r.recordRefreshRequest()
+	if changed {
+		// refresh=true 也能证明 CPA 通知可用，首次进入通知模式时记录。
+		logrus.WithField("source", "refresh").Info("metadata sync switched to notification mode")
+	}
+	// channel 已满时说明已有 refresh 待处理，时间戳已更新即可。
+	select {
+	case r.refreshRequests <- struct{}{}:
+	default:
+	}
+}
+
+func (r *MetadataSyncRunner) MarkRefreshPollingRequired(reason string) {
+	// usage ingest 降级或失败后必须回到轮询，等待下一条控制消息再进通知模式。
+	if r.setNotificationMode(false) {
+		// 回到轮询只是模式切换，真实错误由 usage ingest 自己记录。
+		logrus.WithField("reason", reason).Info("metadata sync switched to polling mode")
 	}
 }
 
 func (r *MetadataSyncRunner) validate() error {
+	// nil runner 是调用方错误，不能继续启动。
 	if r == nil {
 		return fmt.Errorf("metadata sync runner is nil")
 	}
+	// syncer 缺失会导致 metadata 永远无法同步。
 	if r.syncer == nil {
 		return fmt.Errorf("metadata syncer is nil")
 	}
+	// 非正 interval 会导致轮询忙循环，必须拒绝。
 	if r.interval <= 0 {
 		return fmt.Errorf("metadata sync interval must be positive")
 	}
-	if r.sleep == nil {
-		r.sleep = maintenanceSleepContext
+	// 测试可能覆盖为非法值，运行前恢复默认 5s debounce。
+	if r.refreshDebounce <= 0 {
+		r.refreshDebounce = 5 * time.Second
+	}
+	// 测试可能清空 channel，运行前恢复单缓冲合并队列。
+	if r.refreshRequests == nil {
+		r.refreshRequests = make(chan struct{}, 1)
+	}
+	// 测试可能清空时钟函数，运行前恢复生产时钟。
+	if r.now == nil {
+		r.now = time.Now
 	}
 	return nil
 }
 
+func (r *MetadataSyncRunner) runSync(ctx context.Context) {
+	// 所有 metadata 同步都从这里串行调用 SyncMetadata。
+	if err := r.syncer.SyncMetadata(ctx); err != nil {
+		// 单次同步失败不退出 runner，下一次 tick 或 refresh 继续尝试。
+		logrus.WithError(err).Error("metadata sync failed")
+	}
+}
+
 func (r *MetadataSyncRunner) setRunning(running bool) {
+	// running 状态可能被 Run goroutine 和测试读取，必须加锁。
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.running = running
+}
+
+func (r *MetadataSyncRunner) setNotificationMode(enabled bool) bool {
+	// nil runner 保护用于 observer 异常调用时不 panic。
+	if r == nil {
+		return false
+	}
+	// notificationMode 可能被 usage ingest 和 metadata runner 并发访问。
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	changed := r.notificationMode != enabled
+	r.notificationMode = enabled
+	return changed
+}
+
+func (r *MetadataSyncRunner) recordRefreshRequest() bool {
+	// refresh 请求需要在同一把锁内更新通知模式和最后请求时间。
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	changed := !r.notificationMode
+	r.notificationMode = true
+	r.lastRefreshRequestedAt = r.currentTimeLocked()
+	return changed
+}
+
+func (r *MetadataSyncRunner) isNotificationMode() bool {
+	// 周期 tick 读取通知模式时需要加锁，避免和控制消息写入竞争。
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.notificationMode
+}
+
+func (r *MetadataSyncRunner) drainRefreshRequests() {
+	// drain 循环只清空已合并的信号，不改变最后 refresh 时间。
+	for {
+		select {
+		case <-r.refreshRequests:
+			// 已消费一条待处理信号，继续尝试清空缓冲。
+		default:
+			// channel 清空后返回，让 debounce 时间判断决定是否同步。
+			return
+		}
+	}
+}
+
+func (r *MetadataSyncRunner) refreshDebounceDelay() time.Duration {
+	// 读取最后 refresh 时间和 now 函数需要同一把锁保护。
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// 没有 refresh 时间时使用完整 debounce，通常只发生在防御性路径。
+	if r.lastRefreshRequestedAt.IsZero() {
+		return r.refreshDebounce
+	}
+	// dueAt 表示最后一条 refresh 之后允许同步的最早时间。
+	dueAt := r.lastRefreshRequestedAt.Add(r.refreshDebounce)
+	// delay 是距离允许同步还需要等待的时间。
+	delay := dueAt.Sub(r.currentTimeLocked())
+	// 已超过 debounce 窗口时返回 0，让调用方立即同步。
+	if delay < 0 {
+		return 0
+	}
+	// 未到窗口时返回剩余等待时间。
+	return delay
+}
+
+func (r *MetadataSyncRunner) currentTimeLocked() time.Time {
+	// now 可被测试替换；调用方必须已经持有 r.mu。
+	if r.now != nil {
+		return r.now()
+	}
+	// 防御性兜底，正常 validate 后不会走到这里。
+	return time.Now()
+}
+
+func resetTimer(timer *time.Timer, delay time.Duration) {
+	// timer 不接受负等待时间，负值统一按立即触发处理。
+	if delay < 0 {
+		delay = 0
+	}
+	// Reset 前必须 Stop 并清空可能已经触发的事件，避免 timer 旧事件串入新窗口。
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+			// 旧事件已被清空，可以安全 Reset。
+		default:
+			// 没有旧事件时直接 Reset。
+		}
+	}
+	// 使用新的等待时间启动或延后 debounce timer。
+	timer.Reset(delay)
 }

--- a/internal/app/metadata_sync_test.go
+++ b/internal/app/metadata_sync_test.go
@@ -4,68 +4,112 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
 
 type metadataSyncStub struct {
-	calls int
-	errs  []error
+	mu     sync.Mutex
+	calls  int
+	errs   []error
+	onCall func(int)
 }
 
 func (s *metadataSyncStub) SyncMetadata(context.Context) error {
+	var err error
+
+	s.mu.Lock()
 	s.calls++
 	call := s.calls
 	if len(s.errs) >= call {
-		return s.errs[call-1]
+		err = s.errs[call-1]
+	} else if len(s.errs) > 0 {
+		err = s.errs[len(s.errs)-1]
 	}
-	if len(s.errs) > 0 {
-		return s.errs[len(s.errs)-1]
+	onCall := s.onCall
+	s.mu.Unlock()
+
+	if onCall != nil {
+		onCall(call)
 	}
-	return nil
+	return err
+}
+
+func (s *metadataSyncStub) CallCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+type metadataSyncErrContext struct {
+	context.Context
+
+	mu   sync.Mutex
+	err  error
+	done chan struct{}
+}
+
+func newMetadataSyncErrContext() *metadataSyncErrContext {
+	return &metadataSyncErrContext{Context: context.Background(), done: make(chan struct{})}
+}
+
+func (c *metadataSyncErrContext) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *metadataSyncErrContext) Err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.err
+}
+
+func (c *metadataSyncErrContext) SetErr(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.err = err
+}
+
+func (c *metadataSyncErrContext) CloseDone() {
+	close(c.done)
 }
 
 func TestMetadataSyncRunnerRunsImmediatelyThenAtInterval(t *testing.T) {
 	syncer := &metadataSyncStub{}
-	runner := NewMetadataSyncRunner(syncer, 15*time.Minute)
-	var delays []time.Duration
-	runner.sleep = func(_ context.Context, d time.Duration) bool {
-		delays = append(delays, d)
-		return len(delays) < 3
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	syncer.onCall = func(call int) {
+		if call >= 2 {
+			cancel()
+		}
 	}
+	runner := NewMetadataSyncRunner(syncer, time.Millisecond)
 
-	if err := runner.Run(context.Background()); err != nil {
+	if err := runner.Run(ctx); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
-	if syncer.calls != 2 {
-		t.Fatalf("expected two metadata sync calls, got %d", syncer.calls)
-	}
-	expected := []time.Duration{0, 15 * time.Minute, 15 * time.Minute}
-	if len(delays) != len(expected) {
-		t.Fatalf("expected delays %+v, got %+v", expected, delays)
-	}
-	for i, want := range expected {
-		if delays[i] != want {
-			t.Fatalf("expected delay %d to be %s, got %s", i, want, delays[i])
-		}
+	if got := syncer.CallCount(); got != 2 {
+		t.Fatalf("expected two metadata sync calls, got %d", got)
 	}
 }
 
 func TestMetadataSyncRunnerLogsFailureAndContinues(t *testing.T) {
 	logs := captureAppInfoLogs(t)
 	syncer := &metadataSyncStub{errs: []error{errors.New("metadata endpoint failed"), nil}}
-	runner := NewMetadataSyncRunner(syncer, time.Minute)
-	sleepCalls := 0
-	runner.sleep = func(context.Context, time.Duration) bool {
-		sleepCalls++
-		return sleepCalls < 3
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	syncer.onCall = func(call int) {
+		if call >= 2 {
+			cancel()
+		}
 	}
+	runner := NewMetadataSyncRunner(syncer, time.Millisecond)
 
-	if err := runner.Run(context.Background()); err != nil {
+	if err := runner.Run(ctx); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
-	if syncer.calls != 2 {
-		t.Fatalf("expected runner to continue after metadata error, got %d calls", syncer.calls)
+	if got := syncer.CallCount(); got != 2 {
+		t.Fatalf("expected runner to continue after metadata error, got %d calls", got)
 	}
 	content := logs.String()
 	if !strings.Contains(content, "level=error") || !strings.Contains(content, "msg=\"metadata sync failed\"") {
@@ -79,5 +123,197 @@ func TestMetadataSyncRunnerValidatesConfig(t *testing.T) {
 	}
 	if err := NewMetadataSyncRunner(&metadataSyncStub{}, 0).Run(context.Background()); err == nil {
 		t.Fatal("expected non-positive interval validation error")
+	}
+}
+
+func TestMetadataSyncRunnerRefreshSupportMakesPeriodicTickNoop(t *testing.T) {
+	syncer := &metadataSyncStub{}
+	runner := NewMetadataSyncRunner(syncer, time.Millisecond)
+	runner.MarkRefreshSupported()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	syncer.onCall = func(call int) {
+		if call == 1 {
+			go func() {
+				time.Sleep(5 * time.Millisecond)
+				cancel()
+			}()
+		}
+	}
+
+	if err := runner.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if got := syncer.CallCount(); got != 1 {
+		t.Fatalf("expected only startup sync in notification mode, got %d", got)
+	}
+}
+
+func TestMetadataSyncRunnerLogsModeSwitches(t *testing.T) {
+	logs := captureAppInfoLogs(t)
+	runner := NewMetadataSyncRunner(&metadataSyncStub{}, time.Minute)
+
+	runner.MarkRefreshSupported()
+	runner.MarkRefreshSupported()
+	runner.MarkRefreshPollingRequired("redis_degraded_http")
+	runner.MarkRefreshPollingRequired("redis_degraded_http")
+	content := logs.String()
+	if strings.Count(content, "metadata sync switched to notification mode") != 1 {
+		t.Fatalf("expected one log per real mode switch, got:\n%s", content)
+	}
+	if !strings.Contains(content, "level=info") || !strings.Contains(content, "source=support_refresh") {
+		t.Fatalf("expected notification mode log with source, got:\n%s", content)
+	}
+	if strings.Count(content, "metadata sync switched to polling mode") != 1 {
+		t.Fatalf("expected one polling mode restore log, got:\n%s", content)
+	}
+	if strings.Count(content, "level=info") < 2 || !strings.Contains(content, "reason=redis_degraded_http") {
+		t.Fatalf("expected polling mode restore info log with reason, got:\n%s", content)
+	}
+}
+
+func TestMetadataSyncRunnerRefreshSupportDoesNotSyncWithoutRefreshRequest(t *testing.T) {
+	syncer := &metadataSyncStub{}
+	runner := NewMetadataSyncRunner(syncer, time.Millisecond)
+	runner.refreshDebounce = time.Millisecond
+	runner.MarkRefreshSupported()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	syncer.onCall = func(call int) {
+		if call == 1 {
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				cancel()
+			}()
+		}
+	}
+
+	if err := runner.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if got := syncer.CallCount(); got != 1 {
+		t.Fatalf("expected support-only notification mode not to sync without refresh, got %d", got)
+	}
+}
+
+func TestMetadataSyncRunnerRefreshRequestDebounces(t *testing.T) {
+	syncer := &metadataSyncStub{}
+	runner := NewMetadataSyncRunner(syncer, time.Hour)
+	runner.refreshDebounce = 5 * time.Millisecond
+	runner.RequestMetadataRefresh()
+	runner.RequestMetadataRefresh()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	syncer.onCall = func(call int) {
+		if call >= 2 {
+			cancel()
+		}
+	}
+
+	if err := runner.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if got := syncer.CallCount(); got != 2 {
+		t.Fatalf("expected startup sync plus one debounced refresh sync, got %d", got)
+	}
+}
+
+func TestMetadataSyncRunnerRefreshRequestUsesTrailingDebounce(t *testing.T) {
+	syncer := &metadataSyncStub{}
+	runner := NewMetadataSyncRunner(syncer, time.Hour)
+	runner.refreshDebounce = 150 * time.Millisecond
+	calls := make(chan time.Time, 3)
+	syncer.onCall = func(int) {
+		calls <- time.Now()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- runner.Run(ctx)
+	}()
+	select {
+	case <-calls:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for startup sync")
+	}
+
+	runner.RequestMetadataRefresh()
+	time.Sleep(20 * time.Millisecond)
+	secondRefreshAt := time.Now()
+	runner.RequestMetadataRefresh()
+
+	var refreshedAt time.Time
+	select {
+	case refreshedAt = <-calls:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for debounced refresh")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runner to stop")
+	}
+	if elapsed := refreshedAt.Sub(secondRefreshAt); elapsed < 120*time.Millisecond {
+		t.Fatalf("expected debounce to wait after the last refresh request, elapsed %s", elapsed)
+	}
+	if got := syncer.CallCount(); got != 2 {
+		t.Fatalf("expected startup sync plus one trailing refresh sync, got %d", got)
+	}
+}
+
+func TestMetadataSyncRunnerSkipsDebouncedRefreshAfterContextError(t *testing.T) {
+	syncer := &metadataSyncStub{}
+	runner := NewMetadataSyncRunner(syncer, time.Hour)
+	runner.refreshDebounce = time.Millisecond
+	ctx := newMetadataSyncErrContext()
+	syncer.onCall = func(call int) {
+		if call == 1 {
+			ctx.SetErr(context.Canceled)
+			runner.RequestMetadataRefresh()
+			return
+		}
+		ctx.CloseDone()
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runner.Run(ctx)
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runner to stop")
+	}
+	if got := syncer.CallCount(); got != 1 {
+		t.Fatalf("expected debounce to skip sync after context error, got %d calls", got)
+	}
+}
+
+func TestMetadataSyncRunnerFallbackRestoresPolling(t *testing.T) {
+	syncer := &metadataSyncStub{}
+	runner := NewMetadataSyncRunner(syncer, time.Millisecond)
+	runner.MarkRefreshSupported()
+	runner.MarkRefreshPollingRequired("redis_degraded_http")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	syncer.onCall = func(call int) {
+		if call >= 2 {
+			cancel()
+		}
+	}
+
+	if err := runner.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if got := syncer.CallCount(); got != 2 {
+		t.Fatalf("expected startup sync plus restored periodic sync, got %d", got)
 	}
 }

--- a/internal/poller/control_message.go
+++ b/internal/poller/control_message.go
@@ -1,0 +1,153 @@
+package poller
+
+import "strings"
+
+const (
+	redisControlNone = iota
+	redisControlSupportRefresh
+	redisControlRefresh
+)
+
+type RedisControlMessage struct {
+	// IsControl 表示当前 raw JSON 只是一条 CPA 控制通知。
+	IsControl bool
+	// SupportRefresh 表示 CPA 已声明或已证明支持 refresh 通知。
+	SupportRefresh bool
+	// Refresh 表示 CPA 通知 metadata 相关配置已经变化。
+	Refresh bool
+}
+
+func ClassifyRedisControlMessage(raw string) RedisControlMessage {
+	// usage payload 必须有 request_id，看到它就直接放行，避免热路径 JSON 解析。
+	if strings.Contains(raw, `"request_id"`) {
+		return RedisControlMessage{}
+	}
+	// 无 request_id 的少量消息才进入轻量控制结构扫描。
+	switch parseSingleTrueControlField(raw) {
+	case redisControlSupportRefresh:
+		// support_refresh=true 只表示后续可能收到 refresh 通知。
+		return RedisControlMessage{IsControl: true, SupportRefresh: true}
+	case redisControlRefresh:
+		// refresh=true 本身也证明 CPA 支持 refresh 通知。
+		return RedisControlMessage{IsControl: true, SupportRefresh: true, Refresh: true}
+	default:
+		// 未命中两个精确控制结构时保持 passthrough。
+		return RedisControlMessage{}
+	}
+}
+
+func parseSingleTrueControlField(raw string) int {
+	// 从第一个非空白字符开始，避免 TrimSpace 分配。
+	i := skipJSONWhitespace(raw, 0)
+	// 控制消息必须是单个 JSON object。
+	if i >= len(raw) || raw[i] != '{' {
+		return redisControlNone
+	}
+	// 跳过 object 左括号。
+	i++
+	// 字段名前允许 JSON 空白。
+	i = skipJSONWhitespace(raw, i)
+	// 只接受 support_refresh 或 refresh 两个单字段 key。
+	field, next := matchControlField(raw, i)
+	// 未命中控制 key 时不再继续解析。
+	if field == redisControlNone {
+		return redisControlNone
+	}
+	// 移动到字段名之后的位置。
+	i = next
+	// 冒号前允许 JSON 空白。
+	i = skipJSONWhitespace(raw, i)
+	// 控制字段后必须紧跟冒号。
+	if i >= len(raw) || raw[i] != ':' {
+		return redisControlNone
+	}
+	// 跳过冒号。
+	i++
+	// true 前允许 JSON 空白。
+	i = skipJSONWhitespace(raw, i)
+	// 控制消息只接受 boolean true，不接受 false 或字符串。
+	if !hasLiteralAt(raw, i, "true") {
+		return redisControlNone
+	}
+	// 跳过 true 字面量。
+	i += len("true")
+	// true 后允许 JSON 空白。
+	i = skipJSONWhitespace(raw, i)
+	// 控制消息必须只有一个字段；看到逗号等其它内容就 passthrough。
+	if i >= len(raw) || raw[i] != '}' {
+		return redisControlNone
+	}
+	// 跳过 object 右括号。
+	i++
+	// 右括号后只允许 JSON 空白。
+	i = skipJSONWhitespace(raw, i)
+	// 后面还有其它字节时不是精确控制消息。
+	if i != len(raw) {
+		return redisControlNone
+	}
+	// 返回命中的控制字段类型。
+	return field
+}
+
+func matchControlField(raw string, i int) (int, int) {
+	// 先匹配更长的 support_refresh，避免和其它字段做无意义比较。
+	if next, ok := matchJSONStringLiteral(raw, i, "support_refresh"); ok {
+		return redisControlSupportRefresh, next
+	}
+	// 再匹配 refresh 控制字段。
+	if next, ok := matchJSONStringLiteral(raw, i, "refresh"); ok {
+		return redisControlRefresh, next
+	}
+	// 未命中控制字段。
+	return redisControlNone, i
+}
+
+func matchJSONStringLiteral(raw string, i int, value string) (int, bool) {
+	// JSON object key 必须以双引号开始。
+	if i >= len(raw) || raw[i] != '"' {
+		return i, false
+	}
+	// 跳过起始双引号。
+	start := i + 1
+	// end 是期望字段名结束的位置。
+	end := start + len(value)
+	// 字段名长度不足时直接失败。
+	if end >= len(raw) {
+		return i, false
+	}
+	// 字段名内容必须精确等于目标控制字段。
+	if raw[start:end] != value {
+		return i, false
+	}
+	// 字段名后必须是结束双引号。
+	if raw[end] != '"' {
+		return i, false
+	}
+	// 返回结束双引号之后的位置。
+	return end + 1, true
+}
+
+func hasLiteralAt(raw string, i int, literal string) bool {
+	// 字面量长度不足时直接失败。
+	if i+len(literal) > len(raw) {
+		return false
+	}
+	// 控制消息只需要比较 true 这一个字面量。
+	return raw[i:i+len(literal)] == literal
+}
+
+func skipJSONWhitespace(raw string, i int) int {
+	// 只跳过 JSON 标准空白字符，避免误接受其它不可见字符。
+	for i < len(raw) {
+		switch raw[i] {
+		case ' ', '\n', '\r', '\t':
+			// 当前字节是 JSON 空白，继续向后扫描。
+			i++
+		default:
+			// 第一个非空白字符即为调用方继续解析的位置。
+			return i
+		}
+	}
+	// 全部扫描完时返回 len(raw)。
+	return i
+}

--- a/internal/poller/http_pull_source.go
+++ b/internal/poller/http_pull_source.go
@@ -37,18 +37,14 @@ func (s *HTTPPullSource) Pull(ctx context.Context) ([]string, error) {
 		// HTTP/network/API 错误交给 runner 决定退避或记录。
 		return nil, err
 	}
-	// 预分配 payload 数量大小，后面会过滤空值和 null。
+	// 预分配 payload 数量大小；source 层保留 null，避免破坏 runner 的满批判断。
 	messages := make([]string, 0, len(result.Payload))
 	for _, item := range result.Payload {
 		// HTTP 返回的是 json.RawMessage，这里只 trim 外层空白，保持原始 JSON 内容。
 		trimmed := strings.TrimSpace(string(item))
-		if trimmed == "" || trimmed == "null" {
-			// 空 payload 和 null 不写入 inbox，避免后续 decode 产生无效失败。
-			continue
-		}
-		// 保留 raw usage JSON，交给既有 inbox process 解码。
+		// 空 payload 和 null 交给统一 writer 过滤，保证本函数返回数量等于远端 payload 数量。
 		messages = append(messages, trimmed)
 	}
-	// 返回过滤后的 raw messages。
+	// 返回 HTTP payload 的 raw messages，后续由 writer 决定哪些可以入 inbox。
 	return messages, nil
 }

--- a/internal/poller/http_pull_source.go
+++ b/internal/poller/http_pull_source.go
@@ -3,7 +3,6 @@ package poller
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"cpa-usage-keeper/internal/cpa"
@@ -40,11 +39,59 @@ func (s *HTTPPullSource) Pull(ctx context.Context) ([]string, error) {
 	// 预分配 payload 数量大小；source 层保留 null，避免破坏 runner 的满批判断。
 	messages := make([]string, 0, len(result.Payload))
 	for _, item := range result.Payload {
-		// HTTP 返回的是 json.RawMessage，这里只 trim 外层空白，保持原始 JSON 内容。
-		trimmed := strings.TrimSpace(string(item))
+		// HTTP 返回的是 json.RawMessage；先按 byte 处理空值，减少热路径 string 分配。
+		trimmed := httpRawUsageMessage(item)
 		// 空 payload 和 null 交给统一 writer 过滤，保证本函数返回数量等于远端 payload 数量。
 		messages = append(messages, trimmed)
 	}
 	// 返回 HTTP payload 的 raw messages，后续由 writer 决定哪些可以入 inbox。
 	return messages, nil
+}
+
+func httpRawUsageMessage(item []byte) string {
+	// 只裁剪 JSON 标准空白，和上游 RawMessage 的合法外层空白保持一致。
+	start, end := trimJSONRawMessageBounds(item)
+	if start == end {
+		// 全空白 payload 用空字符串占位，保留批量计数且避免分配。
+		return ""
+	}
+	if isRawJSONNull(item[start:end]) {
+		// null payload 用常量字符串占位，后续 writer 会统一丢弃。
+		return "null"
+	}
+	// 普通 usage/control payload 需要转成 string，交给后续 writer 分类或落库。
+	return string(item[start:end])
+}
+
+func trimJSONRawMessageBounds(item []byte) (int, int) {
+	// start 指向第一个非 JSON 空白字节。
+	start := 0
+	for start < len(item) && isJSONWhitespaceByte(item[start]) {
+		// 跳过 RawMessage 前置 JSON 空白。
+		start++
+	}
+	// end 指向最后一个非 JSON 空白字节之后。
+	end := len(item)
+	for end > start && isJSONWhitespaceByte(item[end-1]) {
+		// 跳过 RawMessage 后置 JSON 空白。
+		end--
+	}
+	// 返回半开区间，避免创建中间 slice。
+	return start, end
+}
+
+func isJSONWhitespaceByte(b byte) bool {
+	switch b {
+	case ' ', '\n', '\r', '\t':
+		// JSON 只定义这四类外层空白。
+		return true
+	default:
+		// 其它字节由 JSON payload 原样保留。
+		return false
+	}
+}
+
+func isRawJSONNull(item []byte) bool {
+	// null 是固定四字节字面量，逐字节比较避免临时 string。
+	return len(item) == len("null") && item[0] == 'n' && item[1] == 'u' && item[2] == 'l' && item[3] == 'l'
 }

--- a/internal/poller/http_pull_source_test.go
+++ b/internal/poller/http_pull_source_test.go
@@ -1,0 +1,35 @@
+package poller
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHTTPPullSourcePreservesNullPayloadForBatchCounting(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/management/usage-queue" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("count"); got != "2" {
+			t.Fatalf("expected count=2, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"request_id":"req-1"},null]`))
+	}))
+	defer server.Close()
+
+	source := NewHTTPPullSource(server.URL, "management-secret", time.Second, false, 2)
+	messages, err := source.Pull(context.Background())
+	if err != nil {
+		t.Fatalf("Pull returned error: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected raw HTTP payload count to be preserved, got %d messages: %+v", len(messages), messages)
+	}
+	if messages[0] != `{"request_id":"req-1"}` || messages[1] != "null" {
+		t.Fatalf("unexpected messages: %+v", messages)
+	}
+}

--- a/internal/poller/http_pull_source_test.go
+++ b/internal/poller/http_pull_source_test.go
@@ -33,3 +33,29 @@ func TestHTTPPullSourcePreservesNullPayloadForBatchCounting(t *testing.T) {
 		t.Fatalf("unexpected messages: %+v", messages)
 	}
 }
+
+func TestHTTPRawUsageMessageAvoidsAllocationForIgnorablePayloads(t *testing.T) {
+	nullPayload := []byte(" \n null \t")
+	emptyPayload := []byte(" \r\n\t ")
+
+	if got := httpRawUsageMessage(nullPayload); got != "null" {
+		t.Fatalf("expected null payload to normalize to null, got %q", got)
+	}
+	if got := httpRawUsageMessage(emptyPayload); got != "" {
+		t.Fatalf("expected empty payload to normalize to empty string, got %q", got)
+	}
+
+	nullAllocs := testing.AllocsPerRun(1000, func() {
+		_ = httpRawUsageMessage(nullPayload)
+	})
+	if nullAllocs != 0 {
+		t.Fatalf("expected null payload normalization to avoid allocations, got %.2f", nullAllocs)
+	}
+
+	emptyAllocs := testing.AllocsPerRun(1000, func() {
+		_ = httpRawUsageMessage(emptyPayload)
+	})
+	if emptyAllocs != 0 {
+		t.Fatalf("expected empty payload normalization to avoid allocations, got %.2f", emptyAllocs)
+	}
+}

--- a/internal/poller/redis_inbox_writer.go
+++ b/internal/poller/redis_inbox_writer.go
@@ -51,3 +51,98 @@ func (w *RepositoryRedisInboxWriter) Insert(ctx context.Context, _ string, messa
 	// 返回实际插入行数，供状态机判断是否有数据。
 	return len(rows), nil
 }
+
+type ControlAwareRedisInboxWriter struct {
+	// delegate 继续负责普通 usage raw message 的持久化。
+	delegate RedisInboxWriter
+	// observer 接收控制消息，不参与普通 usage 落库。
+	observer RedisControlMessageObserver
+}
+
+func NewControlAwareRedisInboxWriter(delegate RedisInboxWriter, observer RedisControlMessageObserver) *ControlAwareRedisInboxWriter {
+	// wrapper 只组合依赖，不主动访问数据库或启动同步。
+	return &ControlAwareRedisInboxWriter{delegate: delegate, observer: observer}
+}
+
+func (w *ControlAwareRedisInboxWriter) Insert(ctx context.Context, source string, messages []string, receivedAt time.Time) (int, error) {
+	// delegate 缺失会导致普通 usage 无法落库，必须显式失败。
+	if w == nil || w.delegate == nil {
+		return 0, fmt.Errorf("redis inbox writer delegate is nil")
+	}
+	if len(messages) == 0 {
+		// 空批次保持 no-op，不把空 slice 继续委托给底层 writer。
+		return 0, nil
+	}
+
+	// usageMessages 只在遇到需过滤消息时创建，usage-only 热路径直接委托原 slice。
+	var usageMessages []string
+	filtered := false
+	for i, message := range messages {
+		// 空 payload/null 不是 usage，也不是控制通知；统一在 writer 层丢弃。
+		if isIgnorableRawPayload(message) {
+			if !filtered {
+				// 首次过滤时复制前面的 usage 前缀，后续只 append 保留项。
+				usageMessages = cloneUsagePrefix(messages, i)
+				filtered = true
+			}
+			continue
+		}
+		// 每条 raw message 先做轻量分类，再决定是通知还是落库。
+		control := ClassifyRedisControlMessage(message)
+		// 普通 usage、非法 JSON、未知结构都保持 passthrough，避免误丢数据。
+		if !control.IsControl {
+			if filtered {
+				usageMessages = append(usageMessages, message)
+			}
+			continue
+		}
+
+		if !filtered {
+			// 控制消息也需要从落库批次里移除，因此在这里启动过滤 slice。
+			usageMessages = cloneUsagePrefix(messages, i)
+			filtered = true
+		}
+		// 控制消息只驱动 metadata 调度状态，不进入 redis_usage_inboxes。
+		if w.observer != nil && control.SupportRefresh {
+			// support_refresh=true 让 metadata runner 进入通知模式。
+			w.observer.MarkRefreshSupported()
+		}
+		if w.observer != nil && control.Refresh {
+			// refresh=true 触发 metadata runner 的 debounce 同步请求。
+			w.observer.RequestMetadataRefresh()
+		}
+	}
+	if !filtered {
+		// usage-only 批次保持原 slice，减少高吞吐路径上的分配和 string header 拷贝。
+		return w.delegate.Insert(ctx, source, messages, receivedAt)
+	}
+	// 整批都是控制消息时不调用底层 writer，避免空事务。
+	if len(usageMessages) == 0 {
+		return 0, nil
+	}
+
+	// 非控制消息原样委托给原 writer，保持三种 usage 获取路径的落库语义。
+	return w.delegate.Insert(ctx, source, usageMessages, receivedAt)
+}
+
+func cloneUsagePrefix(messages []string, end int) []string {
+	// 预留原批次容量，避免后续保留消息 append 时多次扩容。
+	usageMessages := make([]string, end, len(messages))
+	copy(usageMessages, messages[:end])
+	return usageMessages
+}
+
+func isIgnorableRawPayload(raw string) bool {
+	// 只跳过 JSON 标准空白，保持和控制消息扫描一致且避免 TrimSpace 额外语义。
+	i := skipJSONWhitespace(raw, 0)
+	if i == len(raw) {
+		// 全空白 payload 不能进入 inbox。
+		return true
+	}
+	if !hasLiteralAt(raw, i, "null") {
+		// 普通 usage 热路径通常在这里快速返回。
+		return false
+	}
+	// null 后面只允许 JSON 空白，避免误丢 nullx 这类未知内容。
+	return skipJSONWhitespace(raw, i+len("null")) == len(raw)
+}

--- a/internal/poller/redis_inbox_writer_lazy_test.go
+++ b/internal/poller/redis_inbox_writer_lazy_test.go
@@ -1,0 +1,36 @@
+package poller
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type capturingRedisInboxWriter struct {
+	messages []string
+}
+
+func (w *capturingRedisInboxWriter) Insert(_ context.Context, _ string, messages []string, _ time.Time) (int, error) {
+	w.messages = messages
+	return len(messages), nil
+}
+
+func TestControlAwareRedisInboxWriterDelegatesUsageOnlyBatchWithoutCopy(t *testing.T) {
+	delegate := &capturingRedisInboxWriter{}
+	writer := NewControlAwareRedisInboxWriter(delegate, nil)
+	messages := []string{`{"request_id":"one"}`, `{"request_id":"two"}`}
+
+	inserted, err := writer.Insert(context.Background(), RedisIngestSourceHTTPPull, messages, time.Now())
+	if err != nil {
+		t.Fatalf("Insert returned error: %v", err)
+	}
+	if inserted != 2 {
+		t.Fatalf("expected two inserted rows, got %d", inserted)
+	}
+	if len(delegate.messages) != len(messages) {
+		t.Fatalf("expected delegated usage batch, got %+v", delegate.messages)
+	}
+	if &delegate.messages[0] != &messages[0] {
+		t.Fatal("expected usage-only hot path to delegate the original message slice")
+	}
+}

--- a/internal/poller/redis_ingest_runner.go
+++ b/internal/poller/redis_ingest_runner.go
@@ -40,6 +40,8 @@ type RedisIngestRunner struct {
 	httpSource UsagePullSource
 	// writer 是唯一落库出口，保证订阅、Redis pull、HTTP pull 都先进入 redis_usage_inboxes。
 	writer RedisInboxWriter
+	// controlObserver 接收 usage 链路降级信号，控制 metadata 同步回到轮询模式。
+	controlObserver RedisControlMessageObserver
 	// config 保存批量大小和空闲等待时间，避免状态机中散落硬编码。
 	config RedisIngestRunnerConfig
 	// now 允许测试控制时间，特别是恢复探测和退避截断。
@@ -97,6 +99,14 @@ func NewRedisIngestRunner(sub UsageSubscriptionSource, redis UsagePullSource, ht
 		mode:     RedisIngestSyncModeUnknown,
 		subState: RedisIngestSubStateStarting,
 	}
+}
+
+func (r *RedisIngestRunner) SetControlMessageObserver(observer RedisControlMessageObserver) {
+	// observer 跟状态字段共用锁，避免 Run 中失败回调读取到半更新状态。
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// observer 可以为空，用于测试或未来关闭 metadata 控制联动。
+	r.controlObserver = observer
 }
 
 func (r *RedisIngestRunner) Run(ctx context.Context) error {
@@ -298,6 +308,9 @@ func (r *RedisIngestRunner) drainBackfillSource(ctx context.Context, sourceName 
 		}
 		total += count
 		batches++
+		if !r.pulledFullBatch(count) {
+			return total, batches, nil
+		}
 	}
 }
 
@@ -389,11 +402,11 @@ func (r *RedisIngestRunner) runSubscribeDegradedPolling(ctx context.Context) (Us
 			r.recordAvailable(RedisIngestSyncModeSubscribe, RedisIngestSubStateSubscribeDegradedPolling, pullStatus(count), count)
 			// Redis pull 成功表示降级拉取链路健康，清掉连续失败退避。
 			r.failureBackoff.Reset()
-			if count > 0 {
-				// 有数据时立即下一轮，尽快把 backlog drain 到 inbox。
+			if r.pulledFullBatch(count) {
+				// 拉满批量时立即下一轮，尽快把可能存在的 backlog drain 到 inbox。
 				continue
 			}
-			// 无数据时睡到 idle interval，但不能睡过下一次 subscribe 恢复探测点。
+			// 未拉满时认为当前 backlog 基本清空，睡到 idle interval，但不能睡过下一次 subscribe 恢复探测点。
 			if !r.sleepUntilRecovery(ctx, r.config.IdleInterval, nextSubscribeRetryAt) {
 				return nil, context.Canceled
 			}
@@ -416,11 +429,11 @@ func (r *RedisIngestRunner) runSubscribeDegradedPolling(ctx context.Context) (Us
 			r.recordAvailable(RedisIngestSyncModeSubscribe, RedisIngestSubStateSubscribeDegradedPolling, pullStatus(count), count)
 			// HTTP 成功表示兜底链路健康，清掉失败退避。
 			r.failureBackoff.Reset()
-			if count > 0 {
-				// 有数据时立即继续拉，避免 backlog 积压。
+			if r.pulledFullBatch(count) {
+				// 拉满批量时立即继续拉，避免 backlog 积压。
 				continue
 			}
-			// 无数据时同样不能睡过 subscribe 恢复探测点。
+			// 未拉满时同样不能睡过 subscribe 恢复探测点。
 			if !r.sleepUntilRecovery(ctx, r.config.IdleInterval, nextSubscribeRetryAt) {
 				return nil, context.Canceled
 			}
@@ -466,7 +479,7 @@ func (r *RedisIngestRunner) runRedisPullMode(ctx context.Context) error {
 					r.failureBackoff.Reset()
 					degraded = false
 					r.recordState(RedisIngestSyncModeRedisPull, RedisIngestSubStateRedisPullActive, pullStatus(count), "", "")
-					if count > 0 {
+					if r.pulledFullBatch(count) {
 						continue
 					}
 					if !r.sleep(ctx, r.config.IdleInterval) {
@@ -491,10 +504,10 @@ func (r *RedisIngestRunner) runRedisPullMode(ctx context.Context) error {
 				r.recordAvailable(RedisIngestSyncModeRedisPull, RedisIngestSubStateRedisPullDegradedHTTP, pullStatus(count), count)
 				// HTTP 成功后清退避。
 				r.failureBackoff.Reset()
-				if count > 0 {
+				if r.pulledFullBatch(count) {
 					continue
 				}
-				// 空批次按 idle interval 等待，但不能睡过下一次 Redis 恢复探测点。
+				// 未拉满时按 idle interval 等待，但不能睡过下一次 Redis 恢复探测点。
 				if !r.sleepUntilRecovery(ctx, r.config.IdleInterval, nextRedisRetryAt) {
 					return context.Canceled
 				}
@@ -525,11 +538,11 @@ func (r *RedisIngestRunner) runRedisPullMode(ctx context.Context) error {
 			r.recordAvailable(RedisIngestSyncModeRedisPull, RedisIngestSubStateRedisPullActive, pullStatus(count), count)
 			// Redis 成功后清掉失败退避。
 			r.failureBackoff.Reset()
-			if count > 0 {
-				// 有数据时不 sleep，继续快速 drain。
+			if r.pulledFullBatch(count) {
+				// 拉满批量时不 sleep，继续快速 drain。
 				continue
 			}
-			// 空批次按 idle interval 等待，降低 CPU 和远端请求频率。
+			// 未拉满时按 idle interval 等待，降低 CPU 和远端请求频率。
 			if !r.sleep(ctx, r.config.IdleInterval) {
 				return context.Canceled
 			}
@@ -556,7 +569,7 @@ func (r *RedisIngestRunner) runRedisPullMode(ctx context.Context) error {
 			r.recordState(RedisIngestSyncModeRedisPull, RedisIngestSubStateRedisPullDegradedHTTP, pullStatus(count), "", "")
 			// HTTP 已经接管拉取，不能把 Redis 失败继续保留在状态快照中。
 			r.recordAvailable(RedisIngestSyncModeRedisPull, RedisIngestSubStateRedisPullDegradedHTTP, pullStatus(count), count)
-			if count > 0 {
+			if r.pulledFullBatch(count) {
 				continue
 			}
 			if !r.sleepUntilRecovery(ctx, r.config.IdleInterval, nextRedisRetryAt) {
@@ -599,11 +612,11 @@ func (r *RedisIngestRunner) runHTTPPullMode(ctx context.Context) error {
 			r.recordRecovery(RedisIngestSyncModeHTTPPull, RedisIngestSubStateHTTPPullActive, "http_pull_recovered", count)
 			// HTTP 成功后清掉连续失败退避。
 			r.failureBackoff.Reset()
-			if count > 0 {
-				// 有数据时继续快速拉取，避免远端队列积压。
+			if r.pulledFullBatch(count) {
+				// 拉满批量时继续快速拉取，避免远端队列积压。
 				continue
 			}
-			// 空批次时按 idle interval 休眠，避免高频空请求。
+			// 未拉满时按 idle interval 休眠，避免高频空请求。
 			if !r.sleep(ctx, r.config.IdleInterval) {
 				return context.Canceled
 			}
@@ -657,8 +670,8 @@ func (r *RedisIngestRunner) serialPullAndWrite(ctx context.Context, sourceName s
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		logrus.WithFields(logrus.Fields{"source": sourceName, "message_count": len(messages), "inserted_count": inserted}).Debug("redis ingest wrote usage messages")
 	}
-	// 返回实际插入行数，用于状态和日志。
-	return inserted, nil
+	// 返回本次远端实际拉取数量，调用方据此判断是否可能还有下一批。
+	return len(messages), nil
 }
 
 func (r *RedisIngestRunner) Status() Status {
@@ -843,6 +856,8 @@ func (r *RedisIngestRunner) recordFailure(status string, err error, final bool) 
 	if !shouldLogSyncError(err) {
 		return
 	}
+	// 任一 usage 链路失败/降级都让 metadata 恢复轮询；只有后续真实控制消息才能再进通知模式。
+	r.markRefreshPollingRequired(status)
 	// warning/error 状态更新需要锁保护。
 	r.mu.Lock()
 	// 更新时间用于状态快照记录最近失败时间。
@@ -873,6 +888,18 @@ func (r *RedisIngestRunner) recordFailure(status string, err error, final bool) 
 	entry.Warn("redis ingest fallback failed")
 }
 
+func (r *RedisIngestRunner) markRefreshPollingRequired(reason string) {
+	// 先在锁内复制 observer，避免回调时持有 runner 锁造成锁链。
+	r.mu.Lock()
+	observer := r.controlObserver
+	r.mu.Unlock()
+	// 没有 observer 时只保持原有 usage ingest 行为。
+	if observer != nil {
+		// 回调 metadata runner，让它从通知模式回到轮询模式。
+		observer.MarkRefreshPollingRequired(reason)
+	}
+}
+
 func (r *RedisIngestRunner) sleepUntilRecovery(ctx context.Context, delay time.Duration, retryAt time.Time) bool {
 	// 用 runner 时钟计算剩余时间，避免测试替换 now 后混用真实时钟。
 	remaining := retryAt.Sub(r.now())
@@ -900,6 +927,11 @@ func pullStatus(count int) string {
 	}
 	// 空批次不是失败，单独标记 empty。
 	return "empty"
+}
+
+func (r *RedisIngestRunner) pulledFullBatch(count int) bool {
+	// 只有拉满配置批量时，才说明远端后面可能还有下一批。
+	return count >= r.config.BatchSize
 }
 
 func resolvePositiveDuration(value time.Duration, fallback time.Duration) time.Duration {

--- a/internal/poller/redis_ingest_sources.go
+++ b/internal/poller/redis_ingest_sources.go
@@ -30,3 +30,13 @@ type RedisInboxWriter interface {
 	// Insert 把 raw usage JSON 批量写入 redis_usage_inboxes；source 用于调用方标记来源。
 	Insert(ctx context.Context, source string, messages []string, receivedAt time.Time) (int, error)
 }
+
+// RedisControlMessageObserver 接收 usage 通道里的 metadata 控制信号。
+type RedisControlMessageObserver interface {
+	// MarkRefreshSupported 表示 CPA 已支持 metadata refresh 通知，周期轮询可以 no-op。
+	MarkRefreshSupported()
+	// RequestMetadataRefresh 表示 CPA metadata 配置已变化，需要 debounce 后同步。
+	RequestMetadataRefresh()
+	// MarkRefreshPollingRequired 表示 usage 链路降级或失败，metadata 同步必须恢复轮询。
+	MarkRefreshPollingRequired(reason string)
+}

--- a/internal/poller/test/redis_inbox_writer_test.go
+++ b/internal/poller/test/redis_inbox_writer_test.go
@@ -14,6 +14,36 @@ import (
 	"gorm.io/gorm"
 )
 
+func TestClassifyRedisControlMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		control bool
+		support bool
+		refresh bool
+	}{
+		{name: "support refresh", raw: `{"support_refresh":true}`, control: true, support: true},
+		{name: "support refresh with spaces", raw: `{ "support_refresh" : true }`, control: true, support: true},
+		{name: "refresh", raw: `{"refresh":true}`, control: true, support: true, refresh: true},
+		{name: "both ignored", raw: `{"support_refresh":true,"refresh":true}`, control: false},
+		{name: "false ignored", raw: `{"support_refresh":false,"refresh":false}`, control: false},
+		{name: "usage passthrough", raw: `{"request_id":"req-1","refresh":false}`, control: false},
+		{name: "usage refresh true passthrough", raw: `{"request_id":"req-1","refresh":true}`, control: false},
+		{name: "usage support true passthrough", raw: `{"request_id":"req-1","support_refresh":true}`, control: false},
+		{name: "invalid passthrough", raw: `{not-json`, control: false},
+		{name: "array passthrough", raw: `[{"refresh":true}]`, control: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := poller.ClassifyRedisControlMessage(tt.raw)
+			if got.IsControl != tt.control || got.SupportRefresh != tt.support || got.Refresh != tt.refresh {
+				t.Fatalf("unexpected classification: %+v", got)
+			}
+		})
+	}
+}
+
 func TestRedisInboxWriterSkipsEmptyMessages(t *testing.T) {
 	db := openPollerTestDB(t)
 	writer := poller.NewRedisInboxWriter(db, cpa.ManagementUsageQueueKey)
@@ -64,6 +94,106 @@ func TestRedisInboxWriterPersistsMessagesWithSource(t *testing.T) {
 	if !rows[0].PoppedAt.Equal(receivedAt) {
 		t.Fatalf("expected received at %s, got %s", receivedAt, rows[0].PoppedAt)
 	}
+}
+
+func TestControlAwareRedisInboxWriterFiltersControlMessages(t *testing.T) {
+	db := openPollerTestDB(t)
+	observer := &controlObserverStub{}
+	writer := poller.NewControlAwareRedisInboxWriter(
+		poller.NewRedisInboxWriter(db, cpa.ManagementUsageQueueKey),
+		observer,
+	)
+
+	messages := []string{`{"support_refresh":true}`, `{"refresh":true}`, `{"request_id":"usage"}`, `{"request_id":"usage-refresh","refresh":true}`}
+	inserted, err := writer.Insert(context.Background(), poller.RedisIngestSourceSubscribe, messages, time.Now())
+	if err != nil {
+		t.Fatalf("Insert returned error: %v", err)
+	}
+	if inserted != 2 {
+		t.Fatalf("expected two usage rows, got %d", inserted)
+	}
+	if observer.support != 2 || observer.refresh != 1 {
+		t.Fatalf("unexpected observer calls: %+v", observer)
+	}
+
+	var rows []entities.RedisUsageInbox
+	if err := db.Order("id asc").Find(&rows).Error; err != nil {
+		t.Fatalf("list rows: %v", err)
+	}
+	if len(rows) != 2 || rows[0].RawMessage != `{"request_id":"usage"}` || rows[1].RawMessage != `{"request_id":"usage-refresh","refresh":true}` {
+		t.Fatalf("unexpected rows: %+v", rows)
+	}
+}
+
+func TestControlAwareRedisInboxWriterSkipsControlOnlyBatch(t *testing.T) {
+	db := openPollerTestDB(t)
+	observer := &controlObserverStub{}
+	writer := poller.NewControlAwareRedisInboxWriter(
+		poller.NewRedisInboxWriter(db, cpa.ManagementUsageQueueKey),
+		observer,
+	)
+
+	inserted, err := writer.Insert(context.Background(), poller.RedisIngestSourceHTTPPull, []string{`{"refresh":true}`}, time.Now())
+	if err != nil {
+		t.Fatalf("Insert returned error: %v", err)
+	}
+	if inserted != 0 || observer.refresh != 1 {
+		t.Fatalf("expected filtered refresh only, inserted=%d observer=%+v", inserted, observer)
+	}
+
+	var count int64
+	if err := db.Model(&entities.RedisUsageInbox{}).Count(&count).Error; err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected no inbox rows, got %d", count)
+	}
+}
+
+func TestControlAwareRedisInboxWriterSkipsEmptyAndNullPayloads(t *testing.T) {
+	db := openPollerTestDB(t)
+	observer := &controlObserverStub{}
+	writer := poller.NewControlAwareRedisInboxWriter(
+		poller.NewRedisInboxWriter(db, cpa.ManagementUsageQueueKey),
+		observer,
+	)
+
+	inserted, err := writer.Insert(context.Background(), poller.RedisIngestSourceHTTPPull, []string{"", " \n\t", " null ", `{"request_id":"usage"}`}, time.Now())
+	if err != nil {
+		t.Fatalf("Insert returned error: %v", err)
+	}
+	if inserted != 1 {
+		t.Fatalf("expected one usage row, got %d", inserted)
+	}
+	if observer.support != 0 || observer.refresh != 0 {
+		t.Fatalf("expected empty/null payloads not to trigger control observer, got %+v", observer)
+	}
+
+	var rows []entities.RedisUsageInbox
+	if err := db.Order("id asc").Find(&rows).Error; err != nil {
+		t.Fatalf("list rows: %v", err)
+	}
+	if len(rows) != 1 || rows[0].RawMessage != `{"request_id":"usage"}` {
+		t.Fatalf("unexpected rows: %+v", rows)
+	}
+}
+
+type controlObserverStub struct {
+	support int
+	refresh int
+	polling int
+}
+
+func (s *controlObserverStub) MarkRefreshSupported() {
+	s.support++
+}
+
+func (s *controlObserverStub) RequestMetadataRefresh() {
+	s.refresh++
+}
+
+func (s *controlObserverStub) MarkRefreshPollingRequired(string) {
+	s.polling++
 }
 
 func openPollerTestDB(t *testing.T) *gorm.DB {

--- a/internal/poller/test/redis_ingest_runner_test.go
+++ b/internal/poller/test/redis_ingest_runner_test.go
@@ -109,6 +109,62 @@ func TestRedisIngestRunnerSubscribeBackfillDrainsRedisBeforeReceiving(t *testing
 	}
 }
 
+func TestRedisIngestRunnerSubscribeBackfillContinuesAfterFullControlOnlyBatch(t *testing.T) {
+	delegate := newFakeInboxWriter()
+	writer := poller.NewControlAwareRedisInboxWriter(delegate, &controlObserverStub{})
+	sub := &blockingSubscription{messages: make(chan string)}
+	runner := poller.NewRedisIngestRunner(
+		fakeSubscribeSource{sub: sub},
+		&fakePullSource{batches: [][]string{
+			{`{"refresh":true}`},
+			{`{"request_id":"redis-after-control"}`},
+		}},
+		&fakePullSource{},
+		writer,
+		poller.RedisIngestRunnerConfig{IdleInterval: 10 * time.Millisecond, BatchSize: 1, HTTPBackoffInitial: 10 * time.Millisecond, HTTPBackoffMax: 10 * time.Millisecond},
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = runner.Run(ctx) }()
+
+	entry := delegate.waitForInsert(t)
+	cancel()
+	if entry.source != poller.RedisIngestSourceRedisPull {
+		t.Fatalf("expected Redis backfill source, got %q", entry.source)
+	}
+	if len(entry.messages) != 1 || entry.messages[0] != `{"request_id":"redis-after-control"}` {
+		t.Fatalf("expected usage after full control batch, got %+v", entry.messages)
+	}
+}
+
+func TestRedisIngestRunnerSubscribeBackfillStopsAfterPartialControlOnlyBatch(t *testing.T) {
+	delegate := newFakeInboxWriter()
+	writer := poller.NewControlAwareRedisInboxWriter(delegate, &controlObserverStub{})
+	sub := &blockingSubscription{messages: make(chan string)}
+	redisSource := &fakePullSource{batches: [][]string{
+		{`{"refresh":true}`},
+		{`{"request_id":"should-not-pull"}`},
+	}}
+	runner := poller.NewRedisIngestRunner(
+		fakeSubscribeSource{sub: sub},
+		redisSource,
+		&fakePullSource{},
+		writer,
+		poller.RedisIngestRunnerConfig{IdleInterval: 10 * time.Millisecond, BatchSize: 10, HTTPBackoffInitial: 10 * time.Millisecond, HTTPBackoffMax: 10 * time.Millisecond},
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = runner.Run(ctx) }()
+
+	_ = waitForStatus(t, runner, func(status poller.Status) bool {
+		return status.LastStatus == "subscribing"
+	})
+	cancel()
+	if calls := redisSource.callCount(); calls != 1 {
+		t.Fatalf("expected backfill to stop after partial control-only batch, got %d calls", calls)
+	}
+}
+
 func TestRedisIngestRunnerInfoLogsSubscribeBackfillOnce(t *testing.T) {
 	logs := capturePollerLogs(t, logrus.InfoLevel)
 	writer := newFakeInboxWriter()
@@ -284,6 +340,37 @@ func TestRedisIngestRunnerDegradedHTTPSuccessClearsStatusError(t *testing.T) {
 		return status.LastError == "" && status.LastWarning == "" && status.SyncRunning
 	})
 	cancel()
+}
+
+func TestRedisIngestRunnerMarksMetadataPollingRequiredOnSubscribeDisconnect(t *testing.T) {
+	observer := &controlObserverStub{}
+	runner := poller.NewRedisIngestRunner(
+		fakeSubscribeSource{sub: failingSubscription{err: io.EOF}},
+		&fakePullSource{},
+		&fakePullSource{},
+		newFakeInboxWriter(),
+		poller.RedisIngestRunnerConfig{IdleInterval: 10 * time.Millisecond, BatchSize: 10, HTTPBackoffInitial: 10 * time.Millisecond, HTTPBackoffMax: 10 * time.Millisecond},
+	)
+	runner.SetControlMessageObserver(observer)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		_ = runner.Run(ctx)
+		close(done)
+	}()
+
+	_ = waitForStatus(t, runner, func(status poller.Status) bool {
+		return status.LastStatus == "subscribe_degraded_polling" || strings.Contains(status.LastError, "EOF")
+	})
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runner to stop")
+	}
+	if observer.polling == 0 {
+		t.Fatal("expected subscribe disconnect to restore metadata polling")
+	}
 }
 
 func TestRedisIngestRunnerInboxWriteFailureDoesNotConsumeFallbackSource(t *testing.T) {


### PR DESCRIPTION
## Summary
- Filter CPA refresh control messages before inbox writes so refresh notifications do not enter redis_usage_inboxes.
- Switch metadata sync between polling and notification modes with trailing debounce, and return to polling on usage ingest degradation or failure.
- Preserve HTTP usage queue batch counts while null and empty payloads are still filtered by the unified writer.

## Tests
- `GOCACHE=/tmp/cpa-usage-keeper-go-build go test -count=1 ./cmd/... ./internal/...`
- `npm --prefix ./web run build`
- `git diff --check`