### PR TITLE
Add cached rate overview card

### DIFF
--- a/web/src/components/ui/icons.tsx
+++ b/web/src/components/ui/icons.tsx
@@ -304,6 +304,16 @@ export function IconTrendingUp({ size = 20, ...props }: IconProps) {
   );
 }
 
+export function IconPercent({ size = 20, ...props }: IconProps) {
+  return (
+    <svg {...baseSvgProps} width={size} height={size} {...props}>
+      <line x1="19" x2="5" y1="5" y2="19" />
+      <circle cx="6.5" cy="6.5" r="2.5" />
+      <circle cx="17.5" cy="17.5" r="2.5" />
+    </svg>
+  );
+}
+
 export function IconDollarSign({ size = 20, ...props }: IconProps) {
   return (
     <svg {...baseSvgProps} width={size} height={size} {...props}>

--- a/web/src/components/usage/StatCards.test.ts
+++ b/web/src/components/usage/StatCards.test.ts
@@ -49,6 +49,7 @@ describe('buildStatCardMetrics', () => {
     expect(metrics.rateStats.windowMinutes).toBe(120);
     expect(metrics.rateStats.rpm).toBe(0.025);
     expect(metrics.rateStats.tpm).toBe(6.475);
+    expect(metrics.requestStats.successRate).toBeCloseTo(88.8888888889);
     expect(metrics.tokenBreakdown.cachedTokens).toBe(22);
     expect(metrics.tokenBreakdown.reasoningTokens).toBe(33);
     expect(metrics.cacheRateStats.cachedRate).toBe(10);
@@ -69,6 +70,21 @@ describe('buildStatCardMetrics', () => {
 
     expect(metrics.cacheRateStats.cachedRate).toBeNull();
     expect(metrics.cacheRateStats.inputTokens).toBe(0);
+  });
+
+  it('keeps success rate empty when total requests are missing', () => {
+    const metrics = buildStatCardMetrics({
+      usage: {
+        ...usageWithBackendSummary,
+        usage: {
+          ...usageWithBackendSummary,
+          total_requests: 0,
+          success_count: 3,
+        },
+      },
+    });
+
+    expect(metrics.requestStats.successRate).toBeNull();
   });
 
   it('keeps priced total cost visible when availability is partial', () => {

--- a/web/src/components/usage/StatCards.test.ts
+++ b/web/src/components/usage/StatCards.test.ts
@@ -22,6 +22,20 @@ const usageWithBackendSummary: UsagePayload = {
     cached_tokens: 22,
     reasoning_tokens: 33,
   },
+  series: {
+    requests: {},
+    tokens: {},
+    rpm: {},
+    tpm: {},
+    cost: {},
+    input_tokens: {
+      '2026-04-23T10:00:00Z': 120,
+      '2026-04-23T11:00:00Z': 100,
+    },
+    output_tokens: {},
+    cached_tokens: {},
+    reasoning_tokens: {},
+  },
 };
 
 describe('buildStatCardMetrics', () => {
@@ -37,7 +51,24 @@ describe('buildStatCardMetrics', () => {
     expect(metrics.rateStats.tpm).toBe(6.475);
     expect(metrics.tokenBreakdown.cachedTokens).toBe(22);
     expect(metrics.tokenBreakdown.reasoningTokens).toBe(33);
+    expect(metrics.cacheRateStats.cachedRate).toBe(10);
+    expect(metrics.cacheRateStats.inputTokens).toBe(220);
     expect(metrics.totalCost).toBe(1.234);
+  });
+
+  it('keeps cache rate empty when overview input tokens are missing', () => {
+    const metrics = buildStatCardMetrics({
+      usage: {
+        ...usageWithBackendSummary,
+        series: {
+          ...usageWithBackendSummary.series!,
+          input_tokens: {},
+        },
+      },
+    });
+
+    expect(metrics.cacheRateStats.cachedRate).toBeNull();
+    expect(metrics.cacheRateStats.inputTokens).toBe(0);
   });
 
   it('keeps priced total cost visible when availability is partial', () => {

--- a/web/src/components/usage/StatCards.tsx
+++ b/web/src/components/usage/StatCards.tsx
@@ -17,7 +17,7 @@ import {
   formatUsd,
 } from '@/utils/usage';
 import { sparklineOptions } from '@/utils/usage/chartConfig';
-import type { UsageOverviewPayload } from './hooks/useUsageData';
+import type { UsageOverviewPayload, UsagePayload } from './hooks/useUsageData';
 import type { SparklineBundle } from './hooks/useSparklines';
 import styles from '@/pages/UsagePage.module.scss';
 
@@ -47,6 +47,7 @@ export interface StatCardsProps {
 }
 
 interface StatCardMetrics {
+  requestStats: { successRate: number | null };
   tokenBreakdown: { cachedTokens: number; reasoningTokens: number };
   rateStats: { rpm: number; tpm: number; windowMinutes: number; requestCount: number; tokenCount: number };
   cacheRateStats: { cachedRate: number | null; cachedTokens: number; inputTokens: number };
@@ -63,9 +64,22 @@ const sumNumberRecord = (record?: Record<string, number>): number => (
   Object.values(record ?? {}).reduce((sum, value) => sum + Math.max(safeNumber(value), 0), 0)
 );
 
+const calculateSuccessRate = (usageSnapshot: UsagePayload | null): number | null => {
+  const totalRequests = Math.max(safeNumber(usageSnapshot?.total_requests), 0);
+  if (totalRequests <= 0) {
+    return null;
+  }
+  return (Math.max(safeNumber(usageSnapshot?.success_count), 0) / totalRequests) * 100;
+};
+
 export function buildStatCardMetrics({ usage }: { usage: UsageOverviewPayload | null }): StatCardMetrics {
+  // overview 运行态和旧测试夹具的 snapshot 位置不同，这里统一后再计算请求成功率。
+  const usageSnapshot = (usage?.usage ?? usage) as UsagePayload | null;
+  const requestStats = { successRate: calculateSuccessRate(usageSnapshot) };
+
   if (!usage?.summary) {
     return {
+      requestStats,
       tokenBreakdown: { cachedTokens: 0, reasoningTokens: 0 },
       rateStats: { rpm: 0, tpm: 0, windowMinutes: 1, requestCount: 0, tokenCount: 0 },
       cacheRateStats: { cachedRate: null, cachedTokens: 0, inputTokens: 0 },
@@ -78,6 +92,7 @@ export function buildStatCardMetrics({ usage }: { usage: UsageOverviewPayload | 
   const inputTokens = sumNumberRecord(usage.series?.input_tokens);
 
   return {
+    requestStats,
     tokenBreakdown: {
       cachedTokens,
       reasoningTokens: usage.summary.reasoning_tokens ?? 0,
@@ -102,7 +117,7 @@ export function buildStatCardMetrics({ usage }: { usage: UsageOverviewPayload | 
 export function StatCards({ usage, loading, sparklines }: StatCardsProps) {
   const { t } = useTranslation();
   const usageSnapshot = usage?.usage ?? null;
-  const { tokenBreakdown, rateStats, cacheRateStats, totalCost, costAvailable } = useMemo(
+  const { requestStats, tokenBreakdown, rateStats, cacheRateStats, totalCost, costAvailable } = useMemo(
     () => buildStatCardMetrics({ usage }),
     [usage]
   );
@@ -112,9 +127,9 @@ export function StatCards({ usage, loading, sparklines }: StatCardsProps) {
       key: 'requests',
       label: t('usage_stats.total_requests'),
       icon: <IconSatellite size={16} />,
-      accent: '#8b8680',
-      accentSoft: 'rgba(139, 134, 128, 0.18)',
-      accentBorder: 'rgba(139, 134, 128, 0.35)',
+      accent: '#3b82f6',
+      accentSoft: 'rgba(59, 130, 246, 0.18)',
+      accentBorder: 'rgba(59, 130, 246, 0.34)',
       value: loading ? '-' : (usageSnapshot?.total_requests ?? 0).toLocaleString(),
       meta: (
         <>
@@ -125,6 +140,10 @@ export function StatCards({ usage, loading, sparklines }: StatCardsProps) {
           <span className={styles.statMetaItem}>
             <span className={styles.statMetaDot} style={{ backgroundColor: '#c65746' }} />
             {t('usage_stats.failed_requests')}: {loading ? '-' : (usageSnapshot?.failure_count ?? 0)}
+          </span>
+          <span className={styles.statMetaItem}>
+            {t('usage_stats.success_rate')}:{' '}
+            {loading || requestStats.successRate === null ? '-' : `${formatFixedTwoDecimals(requestStats.successRate)}%`}
           </span>
         </>
       ),

--- a/web/src/components/usage/StatCards.tsx
+++ b/web/src/components/usage/StatCards.tsx
@@ -4,12 +4,15 @@ import { Line } from 'react-chartjs-2';
 import {
   IconDiamond,
   IconDollarSign,
+  IconPercent,
   IconSatellite,
   IconTimer,
   IconTrendingUp,
 } from '@/components/ui/icons';
 import {
+  calculateCacheRate,
   formatCompactNumber,
+  formatFixedTwoDecimals,
   formatPerMinuteValue,
   formatUsd,
 } from '@/utils/usage';
@@ -38,6 +41,7 @@ export interface StatCardsProps {
     tokens: SparklineBundle | null;
     rpm: SparklineBundle | null;
     tpm: SparklineBundle | null;
+    cachedRate: SparklineBundle | null;
     cost: SparklineBundle | null;
   };
 }
@@ -45,23 +49,37 @@ export interface StatCardsProps {
 interface StatCardMetrics {
   tokenBreakdown: { cachedTokens: number; reasoningTokens: number };
   rateStats: { rpm: number; tpm: number; windowMinutes: number; requestCount: number; tokenCount: number };
+  cacheRateStats: { cachedRate: number | null; cachedTokens: number; inputTokens: number };
   totalCost: number;
   costAvailable: boolean;
 }
+
+const safeNumber = (value: unknown): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const sumNumberRecord = (record?: Record<string, number>): number => (
+  Object.values(record ?? {}).reduce((sum, value) => sum + Math.max(safeNumber(value), 0), 0)
+);
 
 export function buildStatCardMetrics({ usage }: { usage: UsageOverviewPayload | null }): StatCardMetrics {
   if (!usage?.summary) {
     return {
       tokenBreakdown: { cachedTokens: 0, reasoningTokens: 0 },
       rateStats: { rpm: 0, tpm: 0, windowMinutes: 1, requestCount: 0, tokenCount: 0 },
+      cacheRateStats: { cachedRate: null, cachedTokens: 0, inputTokens: 0 },
       totalCost: 0,
       costAvailable: false,
     };
   }
 
+  const cachedTokens = Math.max(safeNumber(usage.summary.cached_tokens), 0);
+  const inputTokens = sumNumberRecord(usage.series?.input_tokens);
+
   return {
     tokenBreakdown: {
-      cachedTokens: usage.summary.cached_tokens ?? 0,
+      cachedTokens,
       reasoningTokens: usage.summary.reasoning_tokens ?? 0,
     },
     rateStats: {
@@ -71,6 +89,11 @@ export function buildStatCardMetrics({ usage }: { usage: UsageOverviewPayload | 
       requestCount: usage.summary.request_count ?? 0,
       tokenCount: usage.summary.token_count ?? 0,
     },
+    cacheRateStats: {
+      cachedRate: calculateCacheRate({ inputTokens, cachedTokens }),
+      cachedTokens,
+      inputTokens,
+    },
     totalCost: usage.summary.total_cost ?? 0,
     costAvailable: usage.summary.cost_available === true,
   };
@@ -79,7 +102,7 @@ export function buildStatCardMetrics({ usage }: { usage: UsageOverviewPayload | 
 export function StatCards({ usage, loading, sparklines }: StatCardsProps) {
   const { t } = useTranslation();
   const usageSnapshot = usage?.usage ?? null;
-  const { tokenBreakdown, rateStats, totalCost, costAvailable } = useMemo(
+  const { tokenBreakdown, rateStats, cacheRateStats, totalCost, costAvailable } = useMemo(
     () => buildStatCardMetrics({ usage }),
     [usage]
   );
@@ -160,6 +183,28 @@ export function StatCards({ usage, loading, sparklines }: StatCardsProps) {
         </span>
       ),
       trend: sparklines.tpm,
+    },
+    {
+      key: 'cache-rate',
+      label: t('usage_stats.cache_rate'),
+      icon: <IconPercent size={16} />,
+      accent: '#14b8a6',
+      accentSoft: 'rgba(20, 184, 166, 0.18)',
+      accentBorder: 'rgba(20, 184, 166, 0.34)',
+      value: loading || cacheRateStats.cachedRate === null ? '-' : `${formatFixedTwoDecimals(cacheRateStats.cachedRate)}%`,
+      meta: (
+        <>
+          <span className={styles.statMetaItem}>
+            {t('usage_stats.cached_tokens')}:{' '}
+            {loading ? '-' : formatCompactNumber(cacheRateStats.cachedTokens)}
+          </span>
+          <span className={styles.statMetaItem}>
+            {t('usage_stats.input_tokens')}:{' '}
+            {loading ? '-' : formatCompactNumber(cacheRateStats.inputTokens)}
+          </span>
+        </>
+      ),
+      trend: sparklines.cachedRate,
     },
     {
       key: 'cost',

--- a/web/src/components/usage/hooks/useSparklines.test.ts
+++ b/web/src/components/usage/hooks/useSparklines.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildUsageSparklineSeries } from './useSparklines';
+import { SPARKLINE_COLORS, buildUsageSparklineSeries } from './useSparklines';
 import type { UsagePayload } from './useUsageData';
 
 const usageWithBackendSeries: UsagePayload = {
@@ -80,5 +80,12 @@ describe('buildUsageSparklineSeries', () => {
     });
 
     expect(series.cachedRate).toEqual([0]);
+  });
+});
+
+describe('SPARKLINE_COLORS', () => {
+  it('keeps the requests sparkline aligned with the Total Requests card accent', () => {
+    expect(SPARKLINE_COLORS.requests.border).toBe('#3b82f6');
+    expect(SPARKLINE_COLORS.requests.background).toBe('rgba(59, 130, 246, 0.18)');
   });
 });

--- a/web/src/components/usage/hooks/useSparklines.test.ts
+++ b/web/src/components/usage/hooks/useSparklines.test.ts
@@ -81,6 +81,46 @@ describe('buildUsageSparklineSeries', () => {
 
     expect(series.cachedRate).toEqual([0]);
   });
+
+  it('normalizes invalid sparkline series values to zero', () => {
+    const invalidNumber = 'not-a-number' as unknown as number;
+    const series = buildUsageSparklineSeries({
+      usage: {
+        ...usageWithBackendSeries,
+        series: {
+          ...usageWithBackendSeries.series!,
+          requests: {
+            '2026-04-23T10:00:00Z': invalidNumber,
+          },
+          tokens: {
+            '2026-04-23T10:00:00Z': -4,
+          },
+          rpm: {
+            '2026-04-23T10:00:00Z': Number.POSITIVE_INFINITY,
+          },
+          tpm: {
+            '2026-04-23T10:00:00Z': Number.NaN,
+          },
+          cost: {
+            '2026-04-23T10:00:00Z': invalidNumber,
+          },
+          input_tokens: {
+            '2026-04-23T10:00:00Z': invalidNumber,
+          },
+          cached_tokens: {
+            '2026-04-23T10:00:00Z': 25,
+          },
+        },
+      },
+    });
+
+    expect(series.requests).toEqual([0]);
+    expect(series.tokens).toEqual([0]);
+    expect(series.rpm).toEqual([0]);
+    expect(series.tpm).toEqual([0]);
+    expect(series.cost).toEqual([0]);
+    expect(series.cachedRate).toEqual([0]);
+  });
 });
 
 describe('SPARKLINE_COLORS', () => {

--- a/web/src/components/usage/hooks/useSparklines.test.ts
+++ b/web/src/components/usage/hooks/useSparklines.test.ts
@@ -32,6 +32,16 @@ const usageWithBackendSeries: UsagePayload = {
       '2026-04-23T10:00:00Z': 0.2,
       '2026-04-23T11:00:00Z': 0.8,
     },
+    input_tokens: {
+      '2026-04-23T10:00:00Z': 100,
+      '2026-04-23T11:00:00Z': 400,
+    },
+    output_tokens: {},
+    cached_tokens: {
+      '2026-04-23T10:00:00Z': 25,
+      '2026-04-23T11:00:00Z': 0,
+    },
+    reasoning_tokens: {},
   },
 };
 
@@ -47,5 +57,28 @@ describe('buildUsageSparklineSeries', () => {
     expect(series.rpm).toEqual([2 / 60, 4 / 60]);
     expect(series.tpm).toEqual([200 / 60, 800 / 60]);
     expect(series.cost).toEqual([0.2, 0.8]);
+    expect(series.cachedRate).toEqual([25, 0]);
+  });
+
+  it('keeps cache rate at zero when a bucket has no input tokens', () => {
+    const series = buildUsageSparklineSeries({
+      usage: {
+        ...usageWithBackendSeries,
+        series: {
+          ...usageWithBackendSeries.series!,
+          requests: {
+            '2026-04-23T10:00:00Z': 1,
+          },
+          input_tokens: {
+            '2026-04-23T10:00:00Z': 0,
+          },
+          cached_tokens: {
+            '2026-04-23T10:00:00Z': 25,
+          },
+        },
+      },
+    });
+
+    expect(series.cachedRate).toEqual([0]);
   });
 });

--- a/web/src/components/usage/hooks/useSparklines.ts
+++ b/web/src/components/usage/hooks/useSparklines.ts
@@ -54,6 +54,11 @@ export const SPARKLINE_COLORS = {
   cost: { border: '#f59e0b', background: 'rgba(245, 158, 11, 0.18)' },
 } as const;
 
+const normalizeSparklineNumber = (value: unknown): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.max(parsed, 0) : 0;
+};
+
 export function buildUsageSparklineSeries({ usage }: Omit<UseSparklinesOptions, 'loading'>): UsageSparklineSeries {
   if (!usage?.series) {
     return { labels: [], requests: [], tokens: [], rpm: [], tpm: [], cachedRate: [], cost: [] };
@@ -66,16 +71,16 @@ export function buildUsageSparklineSeries({ usage }: Omit<UseSparklinesOptions, 
 
   return {
     labels,
-    requests: labels.map((label) => Number(usage.series?.requests?.[label] ?? 0)),
-    tokens: labels.map((label) => Number(usage.series?.tokens?.[label] ?? 0)),
-    rpm: labels.map((label) => Number(usage.series?.rpm?.[label] ?? 0)),
-    tpm: labels.map((label) => Number(usage.series?.tpm?.[label] ?? 0)),
+    requests: labels.map((label) => normalizeSparklineNumber(usage.series?.requests?.[label])),
+    tokens: labels.map((label) => normalizeSparklineNumber(usage.series?.tokens?.[label])),
+    rpm: labels.map((label) => normalizeSparklineNumber(usage.series?.rpm?.[label])),
+    tpm: labels.map((label) => normalizeSparklineNumber(usage.series?.tpm?.[label])),
     cachedRate: labels.map((label) => {
-      const inputTokens = Math.max(Number(usage.series?.input_tokens?.[label] ?? 0), 0);
-      const cachedTokens = Math.max(Number(usage.series?.cached_tokens?.[label] ?? 0), 0);
+      const inputTokens = normalizeSparklineNumber(usage.series?.input_tokens?.[label]);
+      const cachedTokens = normalizeSparklineNumber(usage.series?.cached_tokens?.[label]);
       return calculateCacheRate({ inputTokens, cachedTokens }) ?? 0;
     }),
-    cost: labels.map((label) => Number(usage.series?.cost?.[label] ?? 0)),
+    cost: labels.map((label) => normalizeSparklineNumber(usage.series?.cost?.[label])),
   };
 }
 

--- a/web/src/components/usage/hooks/useSparklines.ts
+++ b/web/src/components/usage/hooks/useSparklines.ts
@@ -45,6 +45,15 @@ export interface UsageSparklineSeries {
   cost: number[];
 }
 
+export const SPARKLINE_COLORS = {
+  requests: { border: '#3b82f6', background: 'rgba(59, 130, 246, 0.18)' },
+  tokens: { border: '#8b5cf6', background: 'rgba(139, 92, 246, 0.18)' },
+  rpm: { border: '#22c55e', background: 'rgba(34, 197, 94, 0.18)' },
+  tpm: { border: '#f97316', background: 'rgba(249, 115, 22, 0.18)' },
+  cachedRate: { border: '#14b8a6', background: 'rgba(20, 184, 166, 0.18)' },
+  cost: { border: '#f59e0b', background: 'rgba(245, 158, 11, 0.18)' },
+} as const;
+
 export function buildUsageSparklineSeries({ usage }: Omit<UseSparklinesOptions, 'loading'>): UsageSparklineSeries {
   if (!usage?.series) {
     return { labels: [], requests: [], tokens: [], rpm: [], tpm: [], cachedRate: [], cost: [] };
@@ -106,32 +115,32 @@ export function useSparklines({ usage, loading }: UseSparklinesOptions): UseSpar
   );
 
   const requestsSparkline = useMemo(
-    () => buildSparkline({ labels: series.labels, data: series.requests }, '#8b8680', 'rgba(139, 134, 128, 0.18)'),
+    () => buildSparkline({ labels: series.labels, data: series.requests }, SPARKLINE_COLORS.requests.border, SPARKLINE_COLORS.requests.background),
     [buildSparkline, series.labels, series.requests]
   );
 
   const tokensSparkline = useMemo(
-    () => buildSparkline({ labels: series.labels, data: series.tokens }, '#8b5cf6', 'rgba(139, 92, 246, 0.18)'),
+    () => buildSparkline({ labels: series.labels, data: series.tokens }, SPARKLINE_COLORS.tokens.border, SPARKLINE_COLORS.tokens.background),
     [buildSparkline, series.labels, series.tokens]
   );
 
   const rpmSparkline = useMemo(
-    () => buildSparkline({ labels: series.labels, data: series.rpm }, '#22c55e', 'rgba(34, 197, 94, 0.18)'),
+    () => buildSparkline({ labels: series.labels, data: series.rpm }, SPARKLINE_COLORS.rpm.border, SPARKLINE_COLORS.rpm.background),
     [buildSparkline, series.labels, series.rpm]
   );
 
   const tpmSparkline = useMemo(
-    () => buildSparkline({ labels: series.labels, data: series.tpm }, '#f97316', 'rgba(249, 115, 22, 0.18)'),
+    () => buildSparkline({ labels: series.labels, data: series.tpm }, SPARKLINE_COLORS.tpm.border, SPARKLINE_COLORS.tpm.background),
     [buildSparkline, series.labels, series.tpm]
   );
 
   const cachedRateSparkline = useMemo(
-    () => buildSparkline({ labels: series.labels, data: series.cachedRate }, '#14b8a6', 'rgba(20, 184, 166, 0.18)'),
+    () => buildSparkline({ labels: series.labels, data: series.cachedRate }, SPARKLINE_COLORS.cachedRate.border, SPARKLINE_COLORS.cachedRate.background),
     [buildSparkline, series.cachedRate, series.labels]
   );
 
   const costSparkline = useMemo(
-    () => buildSparkline({ labels: series.labels, data: series.cost }, '#f59e0b', 'rgba(245, 158, 11, 0.18)'),
+    () => buildSparkline({ labels: series.labels, data: series.cost }, SPARKLINE_COLORS.cost.border, SPARKLINE_COLORS.cost.background),
     [buildSparkline, series.labels, series.cost]
   );
 

--- a/web/src/components/usage/hooks/useSparklines.ts
+++ b/web/src/components/usage/hooks/useSparklines.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import { calculateCacheRate } from '@/utils/usage';
 import type { UsageOverviewPayload } from './useUsageData';
 
 export interface SparklineData {
@@ -30,6 +31,7 @@ export interface UseSparklinesReturn {
   tokensSparkline: SparklineBundle | null;
   rpmSparkline: SparklineBundle | null;
   tpmSparkline: SparklineBundle | null;
+  cachedRateSparkline: SparklineBundle | null;
   costSparkline: SparklineBundle | null;
 }
 
@@ -39,17 +41,18 @@ export interface UsageSparklineSeries {
   tokens: number[];
   rpm: number[];
   tpm: number[];
+  cachedRate: number[];
   cost: number[];
 }
 
 export function buildUsageSparklineSeries({ usage }: Omit<UseSparklinesOptions, 'loading'>): UsageSparklineSeries {
   if (!usage?.series) {
-    return { labels: [], requests: [], tokens: [], rpm: [], tpm: [], cost: [] };
+    return { labels: [], requests: [], tokens: [], rpm: [], tpm: [], cachedRate: [], cost: [] };
   }
 
   const labels = Object.keys(usage.series.requests ?? {}).sort((a, b) => a.localeCompare(b));
   if (!labels.length) {
-    return { labels: [], requests: [], tokens: [], rpm: [], tpm: [], cost: [] };
+    return { labels: [], requests: [], tokens: [], rpm: [], tpm: [], cachedRate: [], cost: [] };
   }
 
   return {
@@ -58,6 +61,11 @@ export function buildUsageSparklineSeries({ usage }: Omit<UseSparklinesOptions, 
     tokens: labels.map((label) => Number(usage.series?.tokens?.[label] ?? 0)),
     rpm: labels.map((label) => Number(usage.series?.rpm?.[label] ?? 0)),
     tpm: labels.map((label) => Number(usage.series?.tpm?.[label] ?? 0)),
+    cachedRate: labels.map((label) => {
+      const inputTokens = Math.max(Number(usage.series?.input_tokens?.[label] ?? 0), 0);
+      const cachedTokens = Math.max(Number(usage.series?.cached_tokens?.[label] ?? 0), 0);
+      return calculateCacheRate({ inputTokens, cachedTokens }) ?? 0;
+    }),
     cost: labels.map((label) => Number(usage.series?.cost?.[label] ?? 0)),
   };
 }
@@ -117,6 +125,11 @@ export function useSparklines({ usage, loading }: UseSparklinesOptions): UseSpar
     [buildSparkline, series.labels, series.tpm]
   );
 
+  const cachedRateSparkline = useMemo(
+    () => buildSparkline({ labels: series.labels, data: series.cachedRate }, '#14b8a6', 'rgba(20, 184, 166, 0.18)'),
+    [buildSparkline, series.cachedRate, series.labels]
+  );
+
   const costSparkline = useMemo(
     () => buildSparkline({ labels: series.labels, data: series.cost }, '#f59e0b', 'rgba(245, 158, 11, 0.18)'),
     [buildSparkline, series.labels, series.cost]
@@ -127,6 +140,7 @@ export function useSparklines({ usage, loading }: UseSparklinesOptions): UseSpar
     tokensSparkline,
     rpmSparkline,
     tpmSparkline,
+    cachedRateSparkline,
     costSparkline
   };
 }

--- a/web/src/pages/KeyOverviewPage.tsx
+++ b/web/src/pages/KeyOverviewPage.tsx
@@ -251,6 +251,7 @@ export function KeyOverviewPage({ apiKey, onAuthRequired }: KeyOverviewPageProps
     tokensSparkline,
     rpmSparkline,
     tpmSparkline,
+    cachedRateSparkline,
     costSparkline,
   } = useSparklines({ usage, loading });
   const {
@@ -426,6 +427,7 @@ export function KeyOverviewPage({ apiKey, onAuthRequired }: KeyOverviewPageProps
                 tokens: tokensSparkline,
                 rpm: rpmSparkline,
                 tpm: tpmSparkline,
+                cachedRate: cachedRateSparkline,
                 cost: costSparkline,
               }}
             />

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -1184,7 +1184,7 @@
   --accent-soft: rgba($primary-color, 0.18);
   --accent-border: rgba($primary-color, 0.35);
 
-  grid-column: span 4;
+  grid-column: span 3;
   position: relative;
   padding: 18px;
   background:
@@ -1293,7 +1293,7 @@
   font-size: 12px;
   color: var(--text-tertiary);
   font-weight: 700;
-  letter-spacing: 0.02em;
+  letter-spacing: 0;
 }
 
 .statValue {

--- a/web/src/pages/UsagePage.styles.test.ts
+++ b/web/src/pages/UsagePage.styles.test.ts
@@ -30,6 +30,8 @@ describe('UsagePage toolbar styles', () => {
     expect(usagePageStyles).toMatch(/\.statCard\s*\{[\s\S]*?grid-column:\s*span 3;/)
     expect(usagePageStyles).toMatch(/\.statCard:nth-child\(-n \+ 2\)\s*\{[\s\S]*?grid-column:\s*span 6;/)
     expect(usagePageStyles).toMatch(/\.statLabel\s*\{[\s\S]*?letter-spacing:\s*0;/)
+    expect(statCardsSource).toContain("key: 'requests'")
+    expect(statCardsSource).toContain("accent: '#3b82f6'")
     expect(statCardsSource).toContain("key: 'cache-rate'")
     expect(statCardsSource).toContain("accent: '#14b8a6'")
     expect(statCardsSource.match(/accent:\s*'#[0-9a-f]{6}'/g)).toHaveLength(new Set(statCardsSource.match(/accent:\s*'#[0-9a-f]{6}'/g)).size)

--- a/web/src/pages/UsagePage.styles.test.ts
+++ b/web/src/pages/UsagePage.styles.test.ts
@@ -18,11 +18,21 @@ const analysisPanelStyles = readSource(new URL('../components/usage/analysis/Ana
 const usageChartSource = readSource(new URL('../components/usage/UsageChart.tsx', import.meta.url))
 const tokenBreakdownChartSource = readSource(new URL('../components/usage/TokenBreakdownChart.tsx', import.meta.url))
 const costTrendChartSource = readSource(new URL('../components/usage/CostTrendChart.tsx', import.meta.url))
+const statCardsSource = readSource(new URL('../components/usage/StatCards.tsx', import.meta.url))
 
 describe('UsagePage toolbar styles', () => {
   it('keeps visible range controls content-sized in narrow layouts', () => {
     expect(usagePageStyles).toMatch(/\.timeRangeGroup\s*\{[\s\S]*?width:\s*fit-content;/)
     expect(usagePageStyles).toMatch(/\.timeRangeSelectControl\s*\{[\s\S]*?flex:\s*0 0 164px;/)
+  })
+
+  it('keeps overview stat cards in a two-plus-four desktop grid with a distinct cache-rate color', () => {
+    expect(usagePageStyles).toMatch(/\.statCard\s*\{[\s\S]*?grid-column:\s*span 3;/)
+    expect(usagePageStyles).toMatch(/\.statCard:nth-child\(-n \+ 2\)\s*\{[\s\S]*?grid-column:\s*span 6;/)
+    expect(usagePageStyles).toMatch(/\.statLabel\s*\{[\s\S]*?letter-spacing:\s*0;/)
+    expect(statCardsSource).toContain("key: 'cache-rate'")
+    expect(statCardsSource).toContain("accent: '#14b8a6'")
+    expect(statCardsSource.match(/accent:\s*'#[0-9a-f]{6}'/g)).toHaveLength(new Set(statCardsSource.match(/accent:\s*'#[0-9a-f]{6}'/g)).size)
   })
 
   it('keeps refresh controls outside the query filter layout', () => {

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -1359,6 +1359,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     tokensSparkline,
     rpmSparkline,
     tpmSparkline,
+    cachedRateSparkline,
     costSparkline
   } = useSparklines({ usage, loading });
 
@@ -1684,6 +1685,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                     tokens: tokensSparkline,
                     rpm: rpmSparkline,
                     tpm: tpmSparkline,
+                    cachedRate: cachedRateSparkline,
                     cost: costSparkline
                   }}
                 />


### PR DESCRIPTION
## Summary
- Add a Cached Rate stat card between TPM and Total Cost with a dedicated teal accent and sparkline.
- Keep PRM, TPM, Cached Rate, and Total Cost on one desktop row while preserving the wider top cards.
- Refresh the Total Requests card with a blue accent, matching request sparkline color, and two-decimal success rate metadata.

## Validation
- npm --prefix ./web run test -- StatCards.test.ts useSparklines.test.ts UsagePage.styles.test.ts
- npm --prefix ./web run typecheck
- npm --prefix ./web run build