### PR TITLE
Fix analysis API key labels

### DIFF
--- a/internal/api/usage_analysis.go
+++ b/internal/api/usage_analysis.go
@@ -3,7 +3,6 @@ package api
 import (
 	"net/http"
 	"sort"
-	"strconv"
 	"time"
 
 	"cpa-usage-keeper/internal/helper"
@@ -99,7 +98,6 @@ type analysisModelEfficiency struct {
 }
 
 type analysisAPIKeyInfo struct {
-	ID    int64
 	Label string
 }
 
@@ -156,7 +154,7 @@ func loadCPAAPIKeyInfos(c *gin.Context, provider service.CPAAPIKeyProvider) (map
 	}
 	infos := make(map[string]analysisAPIKeyInfo, len(rows))
 	for _, row := range rows {
-		infos[row.APIKey] = analysisAPIKeyInfo{ID: row.ID, Label: helper.CPAAPIKeyDisplayName(row)}
+		infos[row.APIKey] = analysisAPIKeyInfo{Label: helper.CPAAPIKeyDisplayName(row)}
 	}
 	return infos, nil
 }
@@ -215,7 +213,7 @@ func buildAnalysisCompositionPayload(items []servicedto.AnalysisCompositionItem,
 		key := helper.RedactSensitiveValue(item.Key)
 		label := item.Key
 		if apiKeyInfos != nil {
-			key = analysisAPIKeyResponseKey(item.Key, apiKeyInfos)
+			key = analysisAPIKeyResponseKey(item.Key)
 			label = analysisAPIKeyLabel(item.Key, apiKeyInfos)
 		} else if item.Label != "" {
 			label = item.Label
@@ -241,10 +239,8 @@ func buildAnalysisCompositionPayload(items []servicedto.AnalysisCompositionItem,
 	return payload
 }
 
-func analysisAPIKeyResponseKey(apiKey string, apiKeyInfos map[string]analysisAPIKeyInfo) string {
-	if info, ok := apiKeyInfos[apiKey]; ok && info.ID > 0 {
-		return strconv.FormatInt(info.ID, 10)
-	}
+func analysisAPIKeyResponseKey(apiKey string) string {
+	// Analysis 只展示统计维度，不需要暴露数据库 id；用脱敏 key 保持维度唯一并避免重复别名合并。
 	return helper.RedactSensitiveValue(apiKey)
 }
 
@@ -261,7 +257,7 @@ func buildAnalysisHeatmapPayload(cells []servicedto.AnalysisHeatmapCell, apiKeyI
 	modelRequests := map[string]int64{}
 	maxTokens := int64(0)
 	for _, cell := range cells {
-		apiKey := analysisAPIKeyResponseKey(cell.APIKey, apiKeyInfos)
+		apiKey := analysisAPIKeyResponseKey(cell.APIKey)
 		apiKeyLabels[apiKey] = analysisAPIKeyLabel(cell.APIKey, apiKeyInfos)
 		apiRequests[apiKey] += cell.Requests
 		modelRequests[cell.Model] += cell.Requests
@@ -277,7 +273,7 @@ func buildAnalysisHeatmapPayload(cells []servicedto.AnalysisHeatmapCell, apiKeyI
 		if maxTokens > 0 {
 			intensity = float64(cell.TotalTokens) / float64(maxTokens)
 		}
-		apiKey := analysisAPIKeyResponseKey(cell.APIKey, apiKeyInfos)
+		apiKey := analysisAPIKeyResponseKey(cell.APIKey)
 		payloadCells = append(payloadCells, analysisHeatmapCell{
 			APIKey:          apiKey,
 			Model:           cell.Model,

--- a/internal/api/usage_analysis.go
+++ b/internal/api/usage_analysis.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 	"sort"
+	"strconv"
 	"time"
 
 	"cpa-usage-keeper/internal/helper"
@@ -98,6 +99,7 @@ type analysisModelEfficiency struct {
 }
 
 type analysisAPIKeyInfo struct {
+	ID    string
 	Label string
 }
 
@@ -154,7 +156,10 @@ func loadCPAAPIKeyInfos(c *gin.Context, provider service.CPAAPIKeyProvider) (map
 	}
 	infos := make(map[string]analysisAPIKeyInfo, len(rows))
 	for _, row := range rows {
-		infos[row.APIKey] = analysisAPIKeyInfo{Label: helper.CPAAPIKeyDisplayName(row)}
+		infos[row.APIKey] = analysisAPIKeyInfo{
+			ID:    strconv.FormatInt(row.ID, 10),
+			Label: helper.CPAAPIKeyDisplayName(row),
+		}
 	}
 	return infos, nil
 }
@@ -213,7 +218,7 @@ func buildAnalysisCompositionPayload(items []servicedto.AnalysisCompositionItem,
 		key := helper.RedactSensitiveValue(item.Key)
 		label := item.Key
 		if apiKeyInfos != nil {
-			key = analysisAPIKeyResponseKey(item.Key)
+			key = analysisAPIKeyResponseKey(item.Key, apiKeyInfos)
 			label = analysisAPIKeyLabel(item.Key, apiKeyInfos)
 		} else if item.Label != "" {
 			label = item.Label
@@ -239,8 +244,11 @@ func buildAnalysisCompositionPayload(items []servicedto.AnalysisCompositionItem,
 	return payload
 }
 
-func analysisAPIKeyResponseKey(apiKey string) string {
-	// Analysis 只展示统计维度，不需要暴露数据库 id；用脱敏 key 保持维度唯一并避免重复别名合并。
+func analysisAPIKeyResponseKey(apiKey string, apiKeyInfos map[string]analysisAPIKeyInfo) string {
+	// Analysis 的结构标识使用 CPA API Key id，展示文案独立走别名/脱敏 key，避免脱敏值碰撞。
+	if info, ok := apiKeyInfos[apiKey]; ok && info.ID != "" {
+		return info.ID
+	}
 	return helper.RedactSensitiveValue(apiKey)
 }
 
@@ -257,7 +265,7 @@ func buildAnalysisHeatmapPayload(cells []servicedto.AnalysisHeatmapCell, apiKeyI
 	modelRequests := map[string]int64{}
 	maxTokens := int64(0)
 	for _, cell := range cells {
-		apiKey := analysisAPIKeyResponseKey(cell.APIKey)
+		apiKey := analysisAPIKeyResponseKey(cell.APIKey, apiKeyInfos)
 		apiKeyLabels[apiKey] = analysisAPIKeyLabel(cell.APIKey, apiKeyInfos)
 		apiRequests[apiKey] += cell.Requests
 		modelRequests[cell.Model] += cell.Requests
@@ -273,7 +281,7 @@ func buildAnalysisHeatmapPayload(cells []servicedto.AnalysisHeatmapCell, apiKeyI
 		if maxTokens > 0 {
 			intensity = float64(cell.TotalTokens) / float64(maxTokens)
 		}
-		apiKey := analysisAPIKeyResponseKey(cell.APIKey)
+		apiKey := analysisAPIKeyResponseKey(cell.APIKey, apiKeyInfos)
 		payloadCells = append(payloadCells, analysisHeatmapCell{
 			APIKey:          apiKey,
 			Model:           cell.Model,

--- a/internal/api/usage_analysis_test.go
+++ b/internal/api/usage_analysis_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -222,14 +223,66 @@ func TestUsageAnalysisUsesCPAAPIKeyOptionLabels(t *testing.T) {
 	}
 	body := resp.Body.String()
 	maskedKey := helper.RedactSensitiveValue("sk-alpha123456")
-	if !contains(body, `"key":"`+maskedKey+`"`) || !contains(body, `"label":"Primary Key"`) || !contains(body, `"api_key":"`+maskedKey+`"`) || !contains(body, `"api_key_labels":{"`+maskedKey+`":"Primary Key"}`) {
-		t.Fatalf("expected analysis payload to use redacted CPA API key and display label, got %s", body)
+	if !contains(body, `"key":"1"`) || !contains(body, `"label":"Primary Key"`) || !contains(body, `"api_key":"1"`) || !contains(body, `"api_key_labels":{"1":"Primary Key"}`) {
+		t.Fatalf("expected analysis payload to use CPA API key id and display label, got %s", body)
 	}
-	if contains(body, "sk-alpha123456") || contains(body, `"key":"1"`) || contains(body, `"api_key":"1"`) {
-		t.Fatalf("expected raw key and database id to stay hidden when a CPA key label exists, got %s", body)
+	if contains(body, "sk-alpha123456") || contains(body, maskedKey) {
+		t.Fatalf("expected raw key and fallback redacted label to stay hidden when a CPA key alias exists, got %s", body)
 	}
 	if provider.lastFilter.APIKeyID != "1" {
 		t.Fatalf("expected API key id to pass into usage filter, got %+v", provider.lastFilter)
+	}
+}
+
+func TestUsageAnalysisUsesCPAAPIKeyIDsForCollidingDisplayKeys(t *testing.T) {
+	bucket := time.Date(2026, 4, 22, 10, 0, 0, 0, time.Local)
+	provider := &usageAnalysisStub{analysis: &servicedto.AnalysisSnapshot{
+		Granularity: servicedto.AnalysisGranularityHourly,
+		TokenUsage:  []servicedto.AnalysisTokenUsageBucket{{Bucket: bucket, TotalTokens: 300, Requests: 3}},
+		APIKeyComposition: []servicedto.AnalysisCompositionItem{
+			{Key: "sk-alpha123456", TotalTokens: 100, Requests: 1},
+			{Key: "sk-bravo123456", TotalTokens: 200, Requests: 2},
+		},
+		ModelComposition: []servicedto.AnalysisCompositionItem{{Key: "claude-sonnet", TotalTokens: 300, Requests: 3}},
+		Heatmap: []servicedto.AnalysisHeatmapCell{
+			{APIKey: "sk-alpha123456", Model: "claude-sonnet", TotalTokens: 100, Requests: 1},
+			{APIKey: "sk-bravo123456", Model: "claude-sonnet", TotalTokens: 200, Requests: 2},
+		},
+	}}
+	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "", OptionalProviders{CPAAPIKeys: usageAnalysisAPIKeyStub{rows: []entities.CPAAPIKey{
+		{ID: 1, APIKey: "sk-alpha123456", DisplayKey: "sk-*********123456", KeyAlias: "Primary Key"},
+		{ID: 2, APIKey: "sk-bravo123456", DisplayKey: "sk-*********123456"},
+	}}})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/analysis?range=24h", nil)
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.Code)
+	}
+	var payload analysisResponse
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode analysis response: %v", err)
+	}
+	if len(payload.APIKeyComposition) != 2 || payload.APIKeyComposition[0].Key != "1" || payload.APIKeyComposition[1].Key != "2" {
+		t.Fatalf("expected API key composition to use ids, got %+v", payload.APIKeyComposition)
+	}
+	if payload.APIKeyComposition[0].Label != "Primary Key" || payload.APIKeyComposition[1].Label != "sk-*********123456" {
+		t.Fatalf("expected API key composition labels to use alias first then redacted key, got %+v", payload.APIKeyComposition)
+	}
+	if len(payload.Heatmap.APIKeys) != 2 || payload.Heatmap.APIKeys[0] != "2" || payload.Heatmap.APIKeys[1] != "1" {
+		t.Fatalf("expected heatmap API keys to use ids sorted by requests, got %+v", payload.Heatmap.APIKeys)
+	}
+	if payload.Heatmap.APIKeyLabels["1"] != "Primary Key" || payload.Heatmap.APIKeyLabels["2"] != "sk-*********123456" {
+		t.Fatalf("expected heatmap labels to be keyed by id, got %+v", payload.Heatmap.APIKeyLabels)
+	}
+	if len(payload.Heatmap.Cells) != 2 || payload.Heatmap.Cells[0].APIKey != "1" || payload.Heatmap.Cells[1].APIKey != "2" {
+		t.Fatalf("expected heatmap cells to keep separate id keys, got %+v", payload.Heatmap.Cells)
+	}
+	body := resp.Body.String()
+	if contains(body, "sk-alpha123456") || contains(body, "sk-bravo123456") {
+		t.Fatalf("expected raw keys to stay hidden, got %s", body)
 	}
 }
 

--- a/internal/api/usage_analysis_test.go
+++ b/internal/api/usage_analysis_test.go
@@ -221,11 +221,12 @@ func TestUsageAnalysisUsesCPAAPIKeyOptionLabels(t *testing.T) {
 		t.Fatalf("expected status 200, got %d", resp.Code)
 	}
 	body := resp.Body.String()
-	if !contains(body, `"key":"1"`) || !contains(body, `"label":"Primary Key"`) || !contains(body, `"api_key":"1"`) || !contains(body, `"api_key_labels":{"1":"Primary Key"}`) {
-		t.Fatalf("expected analysis payload to use CPA API key id and display label, got %s", body)
+	maskedKey := helper.RedactSensitiveValue("sk-alpha123456")
+	if !contains(body, `"key":"`+maskedKey+`"`) || !contains(body, `"label":"Primary Key"`) || !contains(body, `"api_key":"`+maskedKey+`"`) || !contains(body, `"api_key_labels":{"`+maskedKey+`":"Primary Key"}`) {
+		t.Fatalf("expected analysis payload to use redacted CPA API key and display label, got %s", body)
 	}
-	if contains(body, "sk-alpha123456") {
-		t.Fatalf("expected raw key value to stay hidden when a CPA key label exists, got %s", body)
+	if contains(body, "sk-alpha123456") || contains(body, `"key":"1"`) || contains(body, `"api_key":"1"`) {
+		t.Fatalf("expected raw key and database id to stay hidden when a CPA key label exists, got %s", body)
 	}
 	if provider.lastFilter.APIKeyID != "1" {
 		t.Fatalf("expected API key id to pass into usage filter, got %+v", provider.lastFilter)
@@ -252,18 +253,20 @@ func TestBuildAnalysisHeatmapPayloadKeepsDuplicateAPIKeyLabelsSeparate(t *testin
 		{APIKey: "sk-alpha123456", Model: "model", Requests: 1, TotalTokens: 100},
 		{APIKey: "sk-beta654321", Model: "model", Requests: 2, TotalTokens: 200},
 	}, map[string]analysisAPIKeyInfo{
-		"sk-alpha123456": {ID: 1, Label: "Shared"},
-		"sk-beta654321":  {ID: 2, Label: "Shared"},
+		"sk-alpha123456": {Label: "Shared"},
+		"sk-beta654321":  {Label: "Shared"},
 	})
 
-	if got := payload.APIKeys; len(got) != 2 || got[0] != "2" || got[1] != "1" {
-		t.Fatalf("expected heatmap API keys to use stable response keys sorted by requests, got %+v", got)
+	alphaKey := helper.RedactSensitiveValue("sk-alpha123456")
+	betaKey := helper.RedactSensitiveValue("sk-beta654321")
+	if got := payload.APIKeys; len(got) != 2 || got[0] != betaKey || got[1] != alphaKey {
+		t.Fatalf("expected heatmap API keys to use redacted response keys sorted by requests, got %+v", got)
 	}
-	if payload.APIKeyLabels["1"] != "Shared" || payload.APIKeyLabels["2"] != "Shared" {
+	if payload.APIKeyLabels[alphaKey] != "Shared" || payload.APIKeyLabels[betaKey] != "Shared" {
 		t.Fatalf("expected duplicate labels to be stored separately by response key, got %+v", payload.APIKeyLabels)
 	}
-	if len(payload.Cells) != 2 || payload.Cells[0].APIKey != "1" || payload.Cells[1].APIKey != "2" {
-		t.Fatalf("expected heatmap cells to use stable response keys, got %+v", payload.Cells)
+	if len(payload.Cells) != 2 || payload.Cells[0].APIKey != alphaKey || payload.Cells[1].APIKey != betaKey {
+		t.Fatalf("expected heatmap cells to use redacted response keys, got %+v", payload.Cells)
 	}
 }
 

--- a/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
@@ -506,8 +506,8 @@ describe('AnalysisPanel token chart data', () => {
     expect(markup).not.toContain('$8,181.82');
   });
 
-  it('shows compact heatmap cells with detailed tooltip data', () => {
-    const responseKey = 'sk-*********123456';
+  it('shows compact heatmap cells with id keys and display labels', () => {
+    const responseKey = '9007199254740993';
     const analysis: AnalysisResponse = {
       ...emptyAnalysis,
       heatmap: {

--- a/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
@@ -120,6 +120,7 @@ const emptyAnalysis: AnalysisResponse = {
   model_efficiency: [],
   heatmap: {
     api_keys: [],
+    api_key_labels: {},
     models: [],
     cells: [],
   },
@@ -506,13 +507,17 @@ describe('AnalysisPanel token chart data', () => {
   });
 
   it('shows compact heatmap cells with detailed tooltip data', () => {
+    const responseKey = 'sk-*********123456';
     const analysis: AnalysisResponse = {
       ...emptyAnalysis,
       heatmap: {
-        api_keys: ['Primary Key'],
+        api_keys: [responseKey],
+        api_key_labels: {
+          [responseKey]: 'Primary Key',
+        },
         models: ['claude-3-7-sonnet-20250219-long-context'],
         cells: [{
-          api_key: 'Primary Key',
+          api_key: responseKey,
           model: 'claude-3-7-sonnet-20250219-long-context',
           input_tokens: 1000,
           output_tokens: 200,
@@ -530,6 +535,8 @@ describe('AnalysisPanel token chart data', () => {
     const markup = renderToStaticMarkup(<AnalysisPanel analysis={analysis} loading={false} isDark={false} isMobile={false} />);
 
     expect(markup).toContain('1.33K');
+    expect(markup).toContain('Primary Key');
+    expect(markup).not.toContain(responseKey);
     expect(markup).toContain('title="claude-3-7-sonnet-20250219-long-context"');
     expect(markup).toContain('usage_stats.requests_count');
     expect(markup).toContain('usage_stats.input_tokens');

--- a/web/src/components/usage/analysis/AnalysisPanel.module.scss
+++ b/web/src/components/usage/analysis/AnalysisPanel.module.scss
@@ -630,7 +630,9 @@
 }
 
 .heatmapRowLabel {
-  height: 24px;
+  height: 30px;
+  min-height: 30px;
+  align-self: center;
   display: flex;
   align-items: center;
   border: 0;

--- a/web/src/pages/UsagePage.styles.test.ts
+++ b/web/src/pages/UsagePage.styles.test.ts
@@ -215,6 +215,11 @@ describe('UsagePage toolbar styles', () => {
     expect(analysisPanelStyles).toMatch(/\.heatmapCardDark \.analysisChartSurface\s*\{[\s\S]*?background:\s*#100e16;/)
     expect(analysisPanelStyles).toMatch(/\.heatmapCell::before\s*\{[\s\S]*?radial-gradient\(circle at 50% 115%/)
     expect(analysisPanelStyles).toMatch(/\.heatmapCorner,\s*\.heatmapHeaderCell\s*\{[\s\S]*?min-height:\s*48px;/)
+    const heatmapRowLabelBlock = [...analysisPanelStyles.matchAll(/\.heatmapRowLabel\s*\{([\s\S]*?)\n\}/g)]
+      .map((match) => match[1])
+      .find((block) => block.includes('display: flex;')) ?? ''
+    expect(heatmapRowLabelBlock).toContain('height: 30px;')
+    expect(heatmapRowLabelBlock).toContain('align-self: center;')
     expect(analysisPanelStyles).toMatch(/\.heatmapModelLabel\s*\{[\s\S]*?-webkit-line-clamp:\s*2;/)
     expect(analysisPanelStyles).toMatch(/\.heatmapModelLabel\s*\{[\s\S]*?overflow-wrap:\s*anywhere;/)
     expect(analysisPanelStyles).toMatch(/\.heatmapLegendRamp\s*\{[\s\S]*?linear-gradient\(90deg, #fff7ed, #fed7aa, #fb923c, #ef4444, #7c2d12\)/)


### PR DESCRIPTION
## Summary

- Stop returning CPA API key database IDs from the Analysis API payload; Analysis now uses redacted keys as response keys while labels keep alias-first display.
- Keep duplicate CPA API key aliases separated in composition and heatmap data by using redacted response keys.
- Vertically center API key labels in the Analysis heatmap rows.

## Validation

- `rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build go test ./cmd/... ./internal/...`
- `rtk npm --prefix ./web run test`
- `rtk npm --prefix ./web run lint`
- `rtk npm --prefix ./web run typecheck`
- `rtk npm --prefix ./web run build`
