### PR TITLE
Persist Request Events preferences

### DIFF
--- a/web/src/components/usage/RequestEventsDetailsCard.test.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import {
   RequestEventsDetailsCard,
+  isRequestEventColumnSelectionControlled,
   resolveRequestEventColumnMenuFocusIndex,
   toggleRequestEventColumnId,
   type RequestEventColumnId,
@@ -112,6 +113,16 @@ describe('RequestEventsDetailsCard pagination', () => {
 
     expect(html.indexOf('<th title="Time to First Token">TTFT</th>')).toBeLessThan(html.indexOf('<th title="Using latency_ms in ms">Latency</th>'));
     expect(html).toMatch(/Success<\/span><\/td><td class="[^"]*durationCell[^"]*">-<\/td><td class="[^"]*durationCell[^"]*">120ms<\/td>/);
+  });
+
+  it('keeps the Latency column visible when latency is missing', () => {
+    const html = renderCard({
+      events: [{ ...events[0], latency_ms: undefined }],
+    });
+
+    expect(html.indexOf('<th title="Time to First Token">TTFT</th>')).toBeLessThan(html.indexOf('<th title="Using latency_ms in ms">Latency</th>'));
+    expect(html.indexOf('<th title="Using latency_ms in ms">Latency</th>')).toBeLessThan(html.indexOf('<th>Type</th>'));
+    expect(html).toMatch(/45ms<\/td><td class="[^"]*durationCell[^"]*">--<\/td><td>SSE<\/td>/);
   });
 
   it('shows a dash for zero TTFT values', () => {
@@ -299,11 +310,31 @@ describe('RequestEventsDetailsCard pagination', () => {
     expect(html).not.toContain('title="Production Key">Production Key</td>');
   });
 
+  it('honors controlled request event column selection', () => {
+    const html = renderCard({
+      visibleColumnIds: ['timestamp', 'model'],
+    });
+
+    expect(html).toContain('<th>Timestamp</th>');
+    expect(html).toContain('<th>Model</th>');
+    expect(html).toContain('2026/04/23 02:00:00');
+    expect(html).toContain('<td class="_modelCell_');
+    expect(html).not.toContain('<th>API Key</th>');
+    expect(html).not.toContain('<th>Total Cost</th>');
+    expect(html).not.toContain('$0.1234');
+  });
+
   it('keeps at least one request event column selected', () => {
     const selected: RequestEventColumnId[] = ['timestamp'];
 
     expect(toggleRequestEventColumnId(selected, 'timestamp')).toEqual(['timestamp']);
     expect(toggleRequestEventColumnId(selected, 'model')).toEqual(['timestamp', 'model']);
+  });
+
+  it('treats request event columns as controlled only when value and callback are both provided', () => {
+    expect(isRequestEventColumnSelectionControlled(['timestamp'], () => undefined)).toBe(true);
+    expect(isRequestEventColumnSelectionControlled(undefined, () => undefined)).toBe(false);
+    expect(isRequestEventColumnSelectionControlled(['timestamp'], undefined)).toBe(false);
   });
 
   it('cycles column menu focus for arrow and tab navigation', () => {

--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -85,6 +85,11 @@ export const toggleRequestEventColumnId = (
   return availableColumnIds.filter((currentColumnId) => normalized.includes(currentColumnId) || currentColumnId === columnId);
 };
 
+export const isRequestEventColumnSelectionControlled = (
+  visibleColumnIds: readonly RequestEventColumnId[] | undefined,
+  onVisibleColumnIdsChange: ((columnIds: RequestEventColumnId[]) => void) | undefined,
+) => visibleColumnIds !== undefined && onVisibleColumnIdsChange !== undefined;
+
 const appendSelectedOption = (
   options: SelectOption[],
   selectedValue: string,
@@ -145,11 +150,13 @@ export interface RequestEventsDetailsCardProps {
   sourceFilter: string;
   resultFilter: string;
   initialVisibleColumnIds?: readonly RequestEventColumnId[];
+  visibleColumnIds?: readonly RequestEventColumnId[];
   onPageChange: (page: number) => void;
   onPageSizeChange: (pageSize: number) => void;
   onModelFilterChange: (model: string) => void;
   onSourceFilterChange: (source: string) => void;
   onResultFilterChange: (result: string) => void;
+  onVisibleColumnIdsChange?: (columnIds: RequestEventColumnId[]) => void;
 }
 
 const toNumber = (value: unknown): number => {
@@ -471,11 +478,13 @@ export function RequestEventsDetailsCard({
   sourceFilter,
   resultFilter,
   initialVisibleColumnIds,
+  visibleColumnIds,
   onPageChange,
   onPageSizeChange,
   onModelFilterChange,
   onSourceFilterChange,
   onResultFilterChange,
+  onVisibleColumnIdsChange,
 }: RequestEventsDetailsCardProps) {
   const { t } = useTranslation();
   const latencyHint = t('usage_stats.latency_unit_hint', {
@@ -541,26 +550,29 @@ export function RequestEventsDetailsCard({
     });
   }, [events]);
 
-  const hasLatencyData = useMemo(() => rows.some((row) => row.latencyMs !== null), [rows]);
-  const [visibleColumnIds, setVisibleColumnIds] = useState<RequestEventColumnId[]>(() => (
-    normalizeRequestEventVisibleColumnIds(initialVisibleColumnIds ?? REQUEST_EVENT_COLUMN_IDS)
+  const [internalVisibleColumnIds, setInternalVisibleColumnIds] = useState<RequestEventColumnId[]>(() => (
+    normalizeRequestEventVisibleColumnIds(initialVisibleColumnIds ?? visibleColumnIds ?? REQUEST_EVENT_COLUMN_IDS)
   ));
+  const isColumnSelectionControlled = isRequestEventColumnSelectionControlled(visibleColumnIds, onVisibleColumnIdsChange);
+  const selectedVisibleColumnIds = isColumnSelectionControlled && visibleColumnIds !== undefined
+    ? visibleColumnIds
+    : internalVisibleColumnIds;
 
-  const availableColumnIds = useMemo(
-    () => REQUEST_EVENT_COLUMN_IDS.filter((columnId) => columnId !== 'latency' || hasLatencyData),
-    [hasLatencyData]
-  );
   const effectiveVisibleColumnIds = useMemo(
-    () => normalizeRequestEventVisibleColumnIds(visibleColumnIds, availableColumnIds),
-    [availableColumnIds, visibleColumnIds]
+    () => normalizeRequestEventVisibleColumnIds(selectedVisibleColumnIds),
+    [selectedVisibleColumnIds]
   );
   const effectiveVisibleColumnIdSet = useMemo(
     () => new Set<RequestEventColumnId>(effectiveVisibleColumnIds),
     [effectiveVisibleColumnIds]
   );
   const handleColumnToggle = useCallback((columnId: RequestEventColumnId) => {
-    setVisibleColumnIds((currentColumnIds) => toggleRequestEventColumnId(currentColumnIds, columnId, availableColumnIds));
-  }, [availableColumnIds]);
+    const nextColumnIds = toggleRequestEventColumnId(selectedVisibleColumnIds, columnId);
+    if (!isColumnSelectionControlled) {
+      setInternalVisibleColumnIds(nextColumnIds);
+    }
+    onVisibleColumnIdsChange?.(nextColumnIds);
+  }, [isColumnSelectionControlled, onVisibleColumnIdsChange, selectedVisibleColumnIds]);
 
   const modelOptions = useMemo(() => {
     const options = [
@@ -748,8 +760,8 @@ export function RequestEventsDetailsCard({
       },
     ];
 
-    return definitions.filter((definition) => definition.id !== 'latency' || hasLatencyData);
-  }, [hasLatencyData, latencyHint, t, ttftHint]);
+    return definitions;
+  }, [latencyHint, t, ttftHint]);
 
   const visibleColumns = useMemo(
     () => columnDefinitions.filter((definition) => effectiveVisibleColumnIdSet.has(definition.id)),
@@ -759,11 +771,11 @@ export function RequestEventsDetailsCard({
     () => columnDefinitions.map((definition) => ({ id: definition.id, label: definition.label })),
     [columnDefinitions]
   );
-  const visibleColumnSummary = effectiveVisibleColumnIds.length === availableColumnIds.length
+  const visibleColumnSummary = effectiveVisibleColumnIds.length === REQUEST_EVENT_COLUMN_IDS.length
     ? t('usage_stats.request_events_columns_all')
     : t('usage_stats.request_events_columns_count', {
         selected: effectiveVisibleColumnIds.length,
-        total: availableColumnIds.length,
+        total: REQUEST_EVENT_COLUMN_IDS.length,
       });
 
   const hasActiveFilters =

--- a/web/src/pages/UsagePage.logic.test.ts
+++ b/web/src/pages/UsagePage.logic.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { buildCustomDateRangeQuery, getBackToCPALinkURL, getCredentialSectionVisibility, getCustomDateRangeBounds, getOverviewChartEndMs, getOverviewDisplayLoading, getOverviewHourWindowHours, getPreferredOverviewChartPeriod, getTimeRangeOptions, getUsageTabOptions, isCustomDateWithinBounds, isUsagePageVisible, normalizeUsageTabValue, openDateInputPicker, refreshPageData, sanitizeRequestEventFilters, scheduleOverviewAutoRefresh, scheduleStatusActiveHeartbeat, shouldAutoRefreshUsageTab, shouldShowApiKeyFilter, shouldShowRangeControls, shouldShowUpdateCheckButton, STATUS_ACTIVE_HEARTBEAT_INTERVAL_MS, getUpdateCheckToastDuration } from './UsagePage';
+import { buildCustomDateRangeQuery, getBackToCPALinkURL, getCredentialSectionVisibility, getCustomDateRangeBounds, getOverviewChartEndMs, getOverviewDisplayLoading, getOverviewHourWindowHours, getPreferredOverviewChartPeriod, getTimeRangeOptions, getUsageTabOptions, isCustomDateWithinBounds, isUsagePageVisible, loadRequestEventsPreferences, normalizeRequestEventsPreferences, normalizeUsageTabValue, openDateInputPicker, refreshPageData, REQUEST_EVENTS_PREFERENCES_STORAGE_KEY, sanitizeRequestEventFilters, saveRequestEventsPreferences, scheduleOverviewAutoRefresh, scheduleStatusActiveHeartbeat, shouldAutoRefreshUsageTab, shouldShowApiKeyFilter, shouldShowRangeControls, shouldShowUpdateCheckButton, STATUS_ACTIVE_HEARTBEAT_INTERVAL_MS, getUpdateCheckToastDuration } from './UsagePage';
 import type { StatusResponse, UsageFilterWindow } from '@/lib/types';
 
 const createAutoRefreshTestDocument = (visibilityState: DocumentVisibilityState = 'visible') => {
@@ -28,6 +28,17 @@ const createStatusResponse = (lastError = '', quotaAutoRefreshEnabled = true): S
 const flushPromises = async () => {
   await Promise.resolve();
   await Promise.resolve();
+};
+
+const createMemoryStorage = (seed: Record<string, string> = {}) => {
+  const values = new Map(Object.entries(seed));
+  return {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+    value: (key: string) => values.get(key),
+  };
 };
 
 afterEach(() => {
@@ -350,6 +361,27 @@ describe('UsagePage active tab auto-refresh guard', () => {
 });
 
 describe('UsagePage request event filters', () => {
+  it('keeps restored model and source filters until backend filter options load', () => {
+    const next = sanitizeRequestEventFilters(
+      {
+        model: 'claude-opus',
+        source: 'authidx-source-b',
+        result: 'failed',
+      },
+      {
+        models: [],
+        sources: [],
+      },
+      false,
+    );
+
+    expect(next).toEqual({
+      model: 'claude-opus',
+      source: 'authidx-source-b',
+      result: 'failed',
+    });
+  });
+
   it('clears model and source filters that are no longer available', () => {
     const next = sanitizeRequestEventFilters(
       {
@@ -387,6 +419,85 @@ describe('UsagePage request event filters', () => {
       model: 'claude-sonnet',
       source: 'authidx-source-a',
       result: 'success',
+    });
+  });
+});
+
+describe('UsagePage request event preferences', () => {
+  it('normalizes persisted filters, page size, and visible columns', () => {
+    const preferences = normalizeRequestEventsPreferences({
+      version: 1,
+      pageSize: 500,
+      filters: {
+        model: 'claude-opus',
+        source: 'authidx-source-b',
+        result: 'failed',
+      },
+      visibleColumnIds: ['model', 'timestamp', 'model', 'not-a-column', 'total_cost'],
+    });
+
+    expect(preferences).toEqual({
+      version: 1,
+      pageSize: 500,
+      filters: {
+        model: 'claude-opus',
+        source: 'authidx-source-b',
+        result: 'failed',
+      },
+      visibleColumnIds: ['model', 'timestamp', 'total_cost'],
+    });
+  });
+
+  it('falls back safely for damaged persisted request event preferences', () => {
+    const preferences = normalizeRequestEventsPreferences({
+      version: 1,
+      pageSize: 999,
+      filters: {
+        model: 42,
+        source: '',
+        result: 'maybe',
+      },
+      visibleColumnIds: ['not-a-column'],
+    });
+
+    expect(preferences.pageSize).toBe(100);
+    expect(preferences.filters).toEqual({
+      model: '__all__',
+      source: '__all__',
+      result: '__all__',
+    });
+    expect(preferences.visibleColumnIds[0]).toBe('timestamp');
+    expect(preferences.visibleColumnIds.length).toBeGreaterThan(1);
+  });
+
+  it('loads defaults from invalid JSON and persists normalized request event preferences', () => {
+    const storage = createMemoryStorage({
+      [REQUEST_EVENTS_PREFERENCES_STORAGE_KEY]: '{bad json',
+    });
+
+    expect(loadRequestEventsPreferences(storage).pageSize).toBe(100);
+
+    saveRequestEventsPreferences({
+      version: 1,
+      pageSize: 50,
+      filters: {
+        model: 'gpt-4.1',
+        source: 'source-a',
+        result: 'success',
+      },
+      visibleColumnIds: ['timestamp', 'timestamp', 'model'],
+    }, storage);
+
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(storage.value(REQUEST_EVENTS_PREFERENCES_STORAGE_KEY) ?? '')).toEqual({
+      version: 1,
+      pageSize: 50,
+      filters: {
+        model: 'gpt-4.1',
+        source: 'source-a',
+        result: 'success',
+      },
+      visibleColumnIds: ['timestamp', 'model'],
     });
   });
 });

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -36,7 +36,6 @@ import {
   AuthFileCredentialsSection,
   AiProviderCredentialsSection,
   CredentialProviderFilterBar,
-  RequestEventsDetailsCard,
   TokenBreakdownChart,
   CostTrendChart,
   ServiceHealthCard,
@@ -46,6 +45,12 @@ import {
   useChartData,
   useCredentialsTabData
 } from '@/components/usage';
+import {
+  RequestEventsDetailsCard,
+  REQUEST_EVENT_COLUMN_IDS,
+  normalizeRequestEventVisibleColumnIds,
+  type RequestEventColumnId,
+} from '@/components/usage/RequestEventsDetailsCard';
 import { buildUsageRangeQuery } from '@/utils/usage/rangeQuery';
 import {
   getOverviewModelNames,
@@ -78,6 +83,7 @@ ChartJS.register(
 const CHART_LINES_STORAGE_KEY = 'cli-proxy-usage-chart-lines-v1';
 const TIME_RANGE_STORAGE_KEY = 'cli-proxy-usage-time-range-v1';
 const CUSTOM_TIME_RANGE_STORAGE_KEY = 'cli-proxy-usage-custom-range-v1';
+export const REQUEST_EVENTS_PREFERENCES_STORAGE_KEY = 'cli-proxy-usage-request-events-preferences-v1';
 const DEFAULT_CHART_LINES = ['all'];
 const DEFAULT_TIME_RANGE: UsageTimeRange = '8h';
 const DEFAULT_CUSTOM_WINDOW_HOURS = 8;
@@ -212,6 +218,110 @@ type RequestEventFilterState = {
 type RequestEventFilterOptionsState = {
   models: string[];
   sources: UsageSourceFilterOption[];
+};
+
+export type RequestEventsPreferences = {
+  version: 1;
+  pageSize: number;
+  filters: RequestEventFilterState;
+  visibleColumnIds: RequestEventColumnId[];
+};
+
+type RequestEventsPreferenceStorage = Pick<Storage, 'getItem' | 'setItem'>;
+
+const DEFAULT_REQUEST_EVENT_FILTERS: RequestEventFilterState = {
+  model: ALL_REQUEST_EVENTS_FILTER,
+  source: ALL_REQUEST_EVENTS_FILTER,
+  result: ALL_REQUEST_EVENTS_FILTER,
+};
+
+const buildDefaultRequestEventsPreferences = (): RequestEventsPreferences => ({
+  version: 1,
+  pageSize: REQUEST_EVENTS_DEFAULT_PAGE_SIZE,
+  filters: { ...DEFAULT_REQUEST_EVENT_FILTERS },
+  visibleColumnIds: [...REQUEST_EVENT_COLUMN_IDS],
+});
+
+const isRecord = (value: unknown): value is Record<string, unknown> => (
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+);
+
+const isRequestEventPageSize = (value: unknown): value is typeof REQUEST_EVENTS_PAGE_SIZES[number] => (
+  typeof value === 'number' && REQUEST_EVENTS_PAGE_SIZES.includes(value as typeof REQUEST_EVENTS_PAGE_SIZES[number])
+);
+
+const isRequestEventColumnId = (value: unknown): value is RequestEventColumnId => (
+  typeof value === 'string' && (REQUEST_EVENT_COLUMN_IDS as readonly string[]).includes(value)
+);
+
+const normalizeRequestEventFilterValue = (value: unknown): string => (
+  typeof value === 'string' && value !== '' ? value : ALL_REQUEST_EVENTS_FILTER
+);
+
+const normalizeRequestEventResultFilter = (value: unknown): string => (
+  value === 'success' || value === 'failed' ? value : ALL_REQUEST_EVENTS_FILTER
+);
+
+const normalizeRequestEventPreferenceFilters = (value: unknown): RequestEventFilterState => {
+  const filters = isRecord(value) ? value : {};
+  return {
+    model: normalizeRequestEventFilterValue(filters.model),
+    source: normalizeRequestEventFilterValue(filters.source),
+    result: normalizeRequestEventResultFilter(filters.result),
+  };
+};
+
+const normalizeRequestEventPreferenceColumnIds = (value: unknown): RequestEventColumnId[] => {
+  if (!Array.isArray(value)) {
+    return [...REQUEST_EVENT_COLUMN_IDS];
+  }
+  return normalizeRequestEventVisibleColumnIds(value.filter(isRequestEventColumnId));
+};
+
+export const normalizeRequestEventsPreferences = (value: unknown): RequestEventsPreferences => {
+  const preferences = isRecord(value) ? value : {};
+  return {
+    version: 1,
+    pageSize: isRequestEventPageSize(preferences.pageSize) ? preferences.pageSize : REQUEST_EVENTS_DEFAULT_PAGE_SIZE,
+    filters: normalizeRequestEventPreferenceFilters(preferences.filters),
+    visibleColumnIds: normalizeRequestEventPreferenceColumnIds(preferences.visibleColumnIds),
+  };
+};
+
+const getRequestEventsPreferenceStorage = (): RequestEventsPreferenceStorage | null => {
+  try {
+    if (typeof localStorage === 'undefined') {
+      return null;
+    }
+    return localStorage;
+  } catch {
+    return null;
+  }
+};
+
+export const loadRequestEventsPreferences = (
+  storage: RequestEventsPreferenceStorage | null = getRequestEventsPreferenceStorage(),
+): RequestEventsPreferences => {
+  try {
+    const raw = storage?.getItem(REQUEST_EVENTS_PREFERENCES_STORAGE_KEY);
+    if (!raw) {
+      return buildDefaultRequestEventsPreferences();
+    }
+    return normalizeRequestEventsPreferences(JSON.parse(raw));
+  } catch {
+    return buildDefaultRequestEventsPreferences();
+  }
+};
+
+export const saveRequestEventsPreferences = (
+  preferences: RequestEventsPreferences,
+  storage: RequestEventsPreferenceStorage | null = getRequestEventsPreferenceStorage(),
+) => {
+  try {
+    storage?.setItem(REQUEST_EVENTS_PREFERENCES_STORAGE_KEY, JSON.stringify(normalizeRequestEventsPreferences(preferences)));
+  } catch {
+    // Ignore storage errors.
+  }
 };
 
 type RefreshPageDataOptions = {
@@ -398,15 +508,24 @@ export const scheduleStatusActiveHeartbeat = ({
 export const sanitizeRequestEventFilters = (
   filters: RequestEventFilterState,
   options: RequestEventFilterOptionsState,
+  optionsLoaded = true,
 ): RequestEventFilterState => {
+  const result = filters.result === 'success' || filters.result === 'failed'
+    ? filters.result
+    : ALL_REQUEST_EVENTS_FILTER;
+  if (!optionsLoaded) {
+    return {
+      model: normalizeRequestEventFilterValue(filters.model),
+      source: normalizeRequestEventFilterValue(filters.source),
+      result,
+    };
+  }
+
   const model = filters.model === ALL_REQUEST_EVENTS_FILTER || options.models.includes(filters.model)
     ? filters.model
     : ALL_REQUEST_EVENTS_FILTER;
   const source = filters.source === ALL_REQUEST_EVENTS_FILTER || options.sources.some((option) => option.value === filters.source)
     ? filters.source
-    : ALL_REQUEST_EVENTS_FILTER;
-  const result = filters.result === 'success' || filters.result === 'failed'
-    ? filters.result
     : ALL_REQUEST_EVENTS_FILTER;
 
   return { model, source, result };
@@ -694,18 +813,21 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   const updateCheckNoticeTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
   const [customRangeError, setCustomRangeError] = useState('');
   const [customRangeHint, setCustomRangeHint] = useState('');
+  const [initialRequestEventsPreferences] = useState(loadRequestEventsPreferences);
   const [eventsLoading, setEventsLoading] = useState(false);
   const [eventsError, setEventsError] = useState('');
   const [eventsData, setEventsData] = useState<UsageEvent[]>([]);
   const [eventsPage, setEventsPage] = useState(1);
-  const [eventsPageSize, setEventsPageSize] = useState<number>(REQUEST_EVENTS_DEFAULT_PAGE_SIZE);
+  const [eventsPageSize, setEventsPageSize] = useState<number>(initialRequestEventsPreferences.pageSize);
   const [eventsTotalCount, setEventsTotalCount] = useState(0);
   const [eventsTotalPages, setEventsTotalPages] = useState(0);
   const [eventsModelOptions, setEventsModelOptions] = useState<string[]>([]);
   const [eventsSourceOptions, setEventsSourceOptions] = useState<UsageSourceFilterOption[]>([]);
-  const [eventsModelFilter, setEventsModelFilter] = useState(ALL_REQUEST_EVENTS_FILTER);
-  const [eventsSourceFilter, setEventsSourceFilter] = useState(ALL_REQUEST_EVENTS_FILTER);
-  const [eventsResultFilter, setEventsResultFilter] = useState(ALL_REQUEST_EVENTS_FILTER);
+  const [eventsModelFilter, setEventsModelFilter] = useState(initialRequestEventsPreferences.filters.model);
+  const [eventsSourceFilter, setEventsSourceFilter] = useState(initialRequestEventsPreferences.filters.source);
+  const [eventsResultFilter, setEventsResultFilter] = useState(initialRequestEventsPreferences.filters.result);
+  const [eventsVisibleColumnIds, setEventsVisibleColumnIds] = useState<RequestEventColumnId[]>(initialRequestEventsPreferences.visibleColumnIds);
+  const [eventsFilterOptionsLoaded, setEventsFilterOptionsLoaded] = useState(false);
   const eventsRequestControllerRef = useRef<AbortController | null>(null);
   const eventsFilterOptionsRequestControllerRef = useRef<AbortController | null>(null);
   const [manualRefreshLoading, setManualRefreshLoading] = useState(false);
@@ -987,6 +1109,19 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   }, [activeTab]);
 
   useEffect(() => {
+    saveRequestEventsPreferences({
+      version: 1,
+      pageSize: eventsPageSize,
+      filters: {
+        model: eventsModelFilter,
+        source: eventsSourceFilter,
+        result: eventsResultFilter,
+      },
+      visibleColumnIds: eventsVisibleColumnIds,
+    });
+  }, [eventsModelFilter, eventsPageSize, eventsResultFilter, eventsSourceFilter, eventsVisibleColumnIds]);
+
+  useEffect(() => {
     setEventsPage(1);
   }, [customTimeRange.end, customTimeRange.start, selectedApiKeyId, timeRange]);
 
@@ -1057,6 +1192,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     eventsFilterOptionsRequestControllerRef.current?.abort();
     const controller = new AbortController();
     eventsFilterOptionsRequestControllerRef.current = controller;
+    setEventsFilterOptionsLoaded(false);
 
     try {
       const [modelResponse, sourceResponse] = await Promise.all([
@@ -1068,6 +1204,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
       }
       setEventsModelOptions(modelResponse.models ?? []);
       setEventsSourceOptions(sourceResponse.sources ?? []);
+      setEventsFilterOptionsLoaded(true);
     } catch (error) {
       if (controller.signal.aborted) {
         return;
@@ -1075,6 +1212,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
       if (eventsFilterOptionsRequestControllerRef.current === controller) {
         setEventsModelOptions([]);
         setEventsSourceOptions([]);
+        setEventsFilterOptionsLoaded(false);
       }
       if (error instanceof ApiError && error.status === 401) {
         onAuthRequired?.();
@@ -1336,6 +1474,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
         models: eventsModelOptions,
         sources: eventsSourceOptions,
       },
+      eventsFilterOptionsLoaded,
     );
 
     if (next.model !== eventsModelFilter) {
@@ -1350,7 +1489,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     if (next.model !== eventsModelFilter || next.source !== eventsSourceFilter || next.result !== eventsResultFilter) {
       resetEventsPage();
     }
-  }, [eventsModelFilter, eventsModelOptions, eventsResultFilter, eventsSourceFilter, eventsSourceOptions, resetEventsPage]);
+  }, [eventsFilterOptionsLoaded, eventsModelFilter, eventsModelOptions, eventsResultFilter, eventsSourceFilter, eventsSourceOptions, resetEventsPage]);
 
   const lastSyncAt = useMemo(() => {
     if (!status?.last_run_at) return null;
@@ -1773,11 +1912,13 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                   modelFilter={eventsModelFilter}
                   sourceFilter={eventsSourceFilter}
                   resultFilter={eventsResultFilter}
+                  visibleColumnIds={eventsVisibleColumnIds}
                   onPageChange={setEventsPage}
                   onPageSizeChange={handleEventsPageSizeChange}
                   onModelFilterChange={handleEventsModelFilterChange}
                   onSourceFilterChange={handleEventsSourceFilterChange}
                   onResultFilterChange={handleEventsResultFilterChange}
+                  onVisibleColumnIdsChange={setEventsVisibleColumnIds}
                 />
               </>
             )}


### PR DESCRIPTION
## Summary
- Persist Request Events page size, filters, and visible columns in browser localStorage
- Keep restored filters until backend filter options have loaded, then sanitize stale selections
- Make Request Events column selection parent-controllable while keeping uncontrolled compatibility
- Let the Columns selector fully control column visibility, including Latency

Closes #187 

## Tests
- npm --prefix ./web run test
- npm --prefix ./web run typecheck
- npm --prefix ./web run lint
- npm --prefix ./web run build
- git diff --check