### PR TITLE
Fix analysis unpriced cost displays

### DIFF
--- a/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
@@ -379,52 +379,6 @@ describe('AnalysisPanel token chart data', () => {
     expect(typeof chartCapture.scatterOptions?.plugins?.tooltip?.external).toBe('function');
   });
 
-  it('keeps the model efficiency y-axis logarithmic when zero and positive costs are mixed', () => {
-    const analysis: AnalysisResponse = {
-      ...emptyAnalysis,
-      model_efficiency: [
-        {
-          model: 'unpriced-model',
-          requests: 3,
-          input_tokens: 1000,
-          output_tokens: 100,
-          cached_tokens: 0,
-          reasoning_tokens: 0,
-          total_tokens: 1_000_000,
-          cost_usd: 0,
-          cost_available: false,
-          cost_per_request_usd: 0,
-          output_tokens_per_request: 33.33,
-          cache_rate: 0,
-        },
-        {
-          model: 'priced-model',
-          requests: 4,
-          input_tokens: 1200,
-          output_tokens: 300,
-          cached_tokens: 100,
-          reasoning_tokens: 20,
-          total_tokens: 2_000_000,
-          cost_usd: 2,
-          cost_available: true,
-          cost_per_request_usd: 0.5,
-          output_tokens_per_request: 80,
-          cache_rate: 0.1,
-        },
-      ],
-    };
-
-    renderToStaticMarkup(<AnalysisPanel analysis={analysis} loading={false} isDark={false} isMobile={false} />);
-
-    const points = chartCapture.scatterData?.datasets[0]?.data as Array<{ y: number; cost: number; costPerMillion: number }> | undefined;
-    expect(points).toHaveLength(2);
-    expect(points?.[0]).toMatchObject({ cost: 0, costPerMillion: 0 });
-    expect(points?.[0]?.y).toBeGreaterThan(0);
-    expect(points?.[0]?.y).toBeLessThan(points?.[1]?.y ?? 0);
-    expect(chartCapture.scatterOptions?.scales?.y?.type).toBe('logarithmic');
-    expect(chartCapture.scatterOptions?.scales?.y).not.toHaveProperty('beginAtZero');
-  });
-
   it('keeps each overlapped model name grouped with its own model efficiency values', () => {
     const analysis: AnalysisResponse = {
       ...emptyAnalysis,
@@ -577,9 +531,7 @@ describe('AnalysisPanel token chart data', () => {
 
     const costDataset = chartCapture.barData?.datasets.find((dataset) => dataset.label === 'usage_stats.total_cost');
     expect(costDataset?.data).toEqual([0]);
-    expect(chartCapture.scatterData?.datasets[0]?.data[0]).toMatchObject({ x: 1_000_000, y: 0 });
-    expect(chartCapture.scatterOptions?.scales?.y?.type).toBe('linear');
-    expect(chartCapture.scatterOptions?.scales?.y).toHaveProperty('beginAtZero', true);
+    expect(chartCapture.scatterData).toBeNull();
     expect(markup).toMatch(/Unpriced Key[\s\S]*\$0\.0000/);
     expect(markup).toContain('usage_stats.cost_need_price');
     expect(markup).toContain('<div class="_cardTitleLine_');

--- a/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
@@ -544,6 +544,41 @@ describe('AnalysisPanel token chart data', () => {
     expect(markup).toContain('usage_stats.total_cost: $0.0000');
   });
 
+  it('keeps partially priced cost breakdown rates visible under the card-level pricing hint', () => {
+    const analysis: AnalysisResponse = {
+      ...emptyAnalysis,
+      token_usage: [{
+        bucket: '2026-05-28T01:00:00Z',
+        input_tokens: 1000,
+        output_tokens: 100,
+        cached_tokens: 0,
+        reasoning_tokens: 0,
+        total_tokens: 1100,
+        requests: 3,
+        cost_usd: 9,
+        cost_available: false,
+      }],
+      cost_breakdown: {
+        input_cost_usd: 9,
+        output_cost_usd: 0,
+        cached_cost_usd: 0,
+        total_cost_usd: 9,
+        cost_available: false,
+      },
+    };
+
+    const markup = renderToStaticMarkup(<AnalysisPanel analysis={analysis} loading={false} isDark={false} isMobile={false} />);
+
+    const costDataset = chartCapture.barData?.datasets.find((dataset) => dataset.label === 'usage_stats.total_cost');
+    expect(costDataset?.data).toEqual([9]);
+    expect(markup).toContain('<h2>usage_stats.analysis_cost_breakdown_title</h2><small class="_costHeaderHint_');
+    expect(markup).toContain('usage_stats.cost_need_price');
+    expect(markup).toContain('usage_stats.total_cost</span><strong>$9.00</strong>');
+    expect(markup).toContain('usage_stats.analysis_cost_per_million_tokens</span><strong>$8,181.82</strong>');
+    expect(markup).not.toContain('usage_stats.analysis_cost_per_million_tokens</span><strong>usage_stats.cost_need_price</strong>');
+    expect(markup).not.toContain('costWarning');
+  });
+
   it('shows compact heatmap cells with id keys and display labels', () => {
     const responseKey = '9007199254740993';
     const analysis: AnalysisResponse = {

--- a/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
@@ -379,6 +379,52 @@ describe('AnalysisPanel token chart data', () => {
     expect(typeof chartCapture.scatterOptions?.plugins?.tooltip?.external).toBe('function');
   });
 
+  it('keeps the model efficiency y-axis logarithmic when zero and positive costs are mixed', () => {
+    const analysis: AnalysisResponse = {
+      ...emptyAnalysis,
+      model_efficiency: [
+        {
+          model: 'unpriced-model',
+          requests: 3,
+          input_tokens: 1000,
+          output_tokens: 100,
+          cached_tokens: 0,
+          reasoning_tokens: 0,
+          total_tokens: 1_000_000,
+          cost_usd: 0,
+          cost_available: false,
+          cost_per_request_usd: 0,
+          output_tokens_per_request: 33.33,
+          cache_rate: 0,
+        },
+        {
+          model: 'priced-model',
+          requests: 4,
+          input_tokens: 1200,
+          output_tokens: 300,
+          cached_tokens: 100,
+          reasoning_tokens: 20,
+          total_tokens: 2_000_000,
+          cost_usd: 2,
+          cost_available: true,
+          cost_per_request_usd: 0.5,
+          output_tokens_per_request: 80,
+          cache_rate: 0.1,
+        },
+      ],
+    };
+
+    renderToStaticMarkup(<AnalysisPanel analysis={analysis} loading={false} isDark={false} isMobile={false} />);
+
+    const points = chartCapture.scatterData?.datasets[0]?.data as Array<{ y: number; cost: number; costPerMillion: number }> | undefined;
+    expect(points).toHaveLength(2);
+    expect(points?.[0]).toMatchObject({ cost: 0, costPerMillion: 0 });
+    expect(points?.[0]?.y).toBeGreaterThan(0);
+    expect(points?.[0]?.y).toBeLessThan(points?.[1]?.y ?? 0);
+    expect(chartCapture.scatterOptions?.scales?.y?.type).toBe('logarithmic');
+    expect(chartCapture.scatterOptions?.scales?.y).not.toHaveProperty('beginAtZero');
+  });
+
   it('keeps each overlapped model name grouped with its own model efficiency values', () => {
     const analysis: AnalysisResponse = {
       ...emptyAnalysis,
@@ -459,7 +505,7 @@ describe('AnalysisPanel token chart data', () => {
     ]);
   });
 
-  it('does not plot unavailable cost as zero in token and model efficiency charts', () => {
+  it('keeps partial cost values visible and shows pricing hints near analysis charts', () => {
     const analysis: AnalysisResponse = {
       ...emptyAnalysis,
       token_usage: [{
@@ -470,7 +516,20 @@ describe('AnalysisPanel token chart data', () => {
         reasoning_tokens: 0,
         total_tokens: 1100,
         requests: 3,
-        cost_usd: 9,
+        cost_usd: 0,
+        cost_available: false,
+      }],
+      api_key_composition: [{
+        key: 'unpriced-key',
+        label: 'Unpriced Key',
+        requests: 3,
+        input_tokens: 1000,
+        output_tokens: 100,
+        cached_tokens: 0,
+        reasoning_tokens: 0,
+        total_tokens: 1100,
+        percent: 100,
+        cost_usd: 0,
         cost_available: false,
       }],
       model_efficiency: [{
@@ -480,7 +539,7 @@ describe('AnalysisPanel token chart data', () => {
         output_tokens: 100,
         cached_tokens: 0,
         reasoning_tokens: 0,
-        total_tokens: 1100,
+        total_tokens: 1_000_000,
         cost_usd: 0,
         cost_available: false,
         cost_per_request_usd: 0,
@@ -488,22 +547,49 @@ describe('AnalysisPanel token chart data', () => {
         cache_rate: 0,
       }],
       cost_breakdown: {
-        input_cost_usd: 9,
+        input_cost_usd: 0,
         output_cost_usd: 0,
         cached_cost_usd: 0,
-        total_cost_usd: 9,
+        total_cost_usd: 0,
         cost_available: false,
+      },
+      heatmap: {
+        api_keys: ['unpriced-key'],
+        api_key_labels: { 'unpriced-key': 'Unpriced Key' },
+        models: ['unpriced-model'],
+        cells: [{
+          api_key: 'unpriced-key',
+          model: 'unpriced-model',
+          input_tokens: 1000,
+          output_tokens: 100,
+          cached_tokens: 0,
+          reasoning_tokens: 0,
+          total_tokens: 1100,
+          requests: 3,
+          cost_usd: 0,
+          cost_available: false,
+          intensity: 1,
+        }],
       },
     };
 
     const markup = renderToStaticMarkup(<AnalysisPanel analysis={analysis} loading={false} isDark={false} isMobile={false} />);
 
     const costDataset = chartCapture.barData?.datasets.find((dataset) => dataset.label === 'usage_stats.total_cost');
-    expect(costDataset?.data).toEqual([null]);
-    expect(chartCapture.scatterData).toBeNull();
+    expect(costDataset?.data).toEqual([0]);
+    expect(chartCapture.scatterData?.datasets[0]?.data[0]).toMatchObject({ x: 1_000_000, y: 0 });
+    expect(chartCapture.scatterOptions?.scales?.y?.type).toBe('linear');
+    expect(chartCapture.scatterOptions?.scales?.y).toHaveProperty('beginAtZero', true);
+    expect(markup).toMatch(/Unpriced Key[\s\S]*\$0\.0000/);
     expect(markup).toContain('usage_stats.cost_need_price');
-    expect(markup).toContain('usage_stats.analysis_cost_per_million_tokens</span><strong>usage_stats.cost_need_price</strong>');
-    expect(markup).not.toContain('$8,181.82');
+    expect(markup).toContain('<div class="_cardTitleLine_');
+    expect(markup).toContain('<h2>usage_stats.analysis_token_usage_title</h2><small class="_costHeaderHint_');
+    expect(markup).toContain('</small></div><p>usage_stats.analysis_token_usage_subtitle</p>');
+    expect(markup).not.toContain('usage_stats.analysis_token_usage_subtitle (usage_stats.cost_need_price)');
+    expect(markup.match(/costHeaderHint/g)?.length).toBe(5);
+    expect(markup).not.toContain('costWarning');
+    expect(markup).toContain('usage_stats.analysis_cost_per_million_tokens</span><strong>$0.0000</strong>');
+    expect(markup).toContain('usage_stats.total_cost: $0.0000');
   });
 
   it('shows compact heatmap cells with id keys and display labels', () => {

--- a/web/src/components/usage/analysis/AnalysisPanel.module.scss
+++ b/web/src/components/usage/analysis/AnalysisPanel.module.scss
@@ -38,8 +38,8 @@
 
 .cardHeader {
   display: flex;
-  justify-content: space-between;
-  gap: 14px;
+  flex-direction: column;
+  gap: 6px;
   margin-bottom: 16px;
 
   h2 {
@@ -50,10 +50,45 @@
   }
 
   p {
-    margin: 6px 0 0;
+    margin: 0;
     color: var(--text-secondary);
     font-size: 13px;
     line-height: 1.45;
+  }
+}
+
+.cardTitleLine {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 14px;
+  min-width: 0;
+
+  h2 {
+    min-width: 0;
+  }
+
+  @include mobile {
+    flex-wrap: wrap;
+    row-gap: 4px;
+  }
+}
+
+.costHeaderHint {
+  flex: 0 1 180px;
+  align-self: flex-start;
+  margin-top: 2px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.35;
+  text-align: right;
+
+  @include mobile {
+    flex-basis: 100%;
+    max-width: 100%;
+    margin-top: 0;
+    text-align: left;
   }
 }
 

--- a/web/src/components/usage/analysis/AnalysisPanel.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.tsx
@@ -112,7 +112,6 @@ const MODEL_EFFICIENCY_HOVER_RADIUS_DELTA = 4;
 const MODEL_EFFICIENCY_RADIUS_EASING = 0.75;
 const MODEL_EFFICIENCY_OUTLIER_RATIO = 8;
 const MODEL_EFFICIENCY_AXIS_PADDING_FACTOR = 2.5;
-const MODEL_EFFICIENCY_ZERO_RATE_FLOOR_DIVISOR = 10;
 const EMPTY_COMPOSITION_ITEMS: AnalysisCompositionItem[] = [];
 type TokenLabels = {
   input: string;
@@ -757,7 +756,6 @@ type EfficiencyPoint = {
   model: string;
   requests: number;
   cost: number;
-  costPerMillion: number;
   totalTokens: number;
   cacheRate: number;
 };
@@ -936,17 +934,7 @@ function createModelEfficiencyTooltipHandler({
 function ModelEfficiencyCard({ rows, loading, isDark, isMobile }: { rows: AnalysisModelEfficiencyItem[]; loading: boolean; isDark: boolean; isMobile: boolean }) {
   const { t } = useTranslation();
   const chartTheme = useMemo(() => getChartTheme(isDark), [isDark]);
-  const pricedRows = useMemo(() => rows.filter((row) => toNumber(row.total_tokens) > 0), [rows]);
-  const efficiencyRates = useMemo(() => pricedRows.map((row) => getModelEfficiencyRate(row)), [pricedRows]);
-  const positiveEfficiencyRates = useMemo(() => efficiencyRates.filter((rate) => Number.isFinite(rate) && rate > 0), [efficiencyRates]);
-  const zeroRateFloor = positiveEfficiencyRates.length > 0
-    ? Math.max(Math.min(...positiveEfficiencyRates) / MODEL_EFFICIENCY_ZERO_RATE_FLOOR_DIVISOR, Number.EPSILON)
-    : 0;
-  const plotEfficiencyRates = useMemo(
-    () => efficiencyRates.map((rate) => (Number.isFinite(rate) && rate > 0 ? rate : zeroRateFloor)),
-    [efficiencyRates, zeroRateFloor],
-  );
-  const useLinearCostScale = positiveEfficiencyRates.length === 0;
+  const pricedRows = useMemo(() => rows.filter((row) => row.cost_available !== false && toNumber(row.total_tokens) > 0 && getModelEfficiencyRate(row) > 0), [rows]);
   const tooltipLabels = useMemo(() => ({
     totalTokens: t('usage_stats.total_tokens'),
     costPerMillion: t('usage_stats.analysis_cost_per_million_tokens'),
@@ -957,13 +945,12 @@ function ModelEfficiencyCard({ rows, loading, isDark, isMobile }: { rows: Analys
     labels: pricedRows.map((row) => row.model),
     datasets: [{
       label: t('usage_stats.analysis_model_efficiency_title'),
-      data: pricedRows.map((row, index) => ({
+      data: pricedRows.map((row) => ({
         x: toNumber(row.total_tokens),
-        y: plotEfficiencyRates[index] ?? 0,
+        y: getModelEfficiencyRate(row),
         model: row.model,
         requests: toNumber(row.requests),
         cost: toNumber(row.cost_usd),
-        costPerMillion: efficiencyRates[index] ?? 0,
         totalTokens: toNumber(row.total_tokens),
         cacheRate: toNumber(row.cache_rate),
       })),
@@ -974,7 +961,7 @@ function ModelEfficiencyCard({ rows, loading, isDark, isMobile }: { rows: Analys
       borderWidth: 1,
       clip: false,
     }],
-  }), [efficiencyRates, plotEfficiencyRates, pointRadii, pricedRows, t]);
+  }), [pointRadii, pricedRows, t]);
   const chartOptions = useMemo<ChartOptions<'scatter'>>(() => ({
     responsive: true,
     maintainAspectRatio: false,
@@ -1012,24 +999,15 @@ function ModelEfficiencyCard({ rows, loading, isDark, isMobile }: { rows: Analys
         border: { color: chartTheme.axis },
         ticks: { color: chartTheme.textSecondary, font: { size: 10 }, maxTicksLimit: isMobile ? 4 : 5, callback: (value) => formatCompactNumber(Number(value)) },
       },
-      y: useLinearCostScale
-        ? {
-          type: 'linear',
-          beginAtZero: true,
-          suggestedMax: Math.max(1, ...efficiencyRates.filter((rate) => Number.isFinite(rate))) * MODEL_EFFICIENCY_AXIS_PADDING_FACTOR,
-          grid: { color: chartTheme.grid },
-          border: { color: chartTheme.axis },
-          ticks: { color: chartTheme.textSecondary, font: { size: 10 }, maxTicksLimit: isMobile ? 4 : 5, callback: (value) => formatUsd(Number(value)) },
-        }
-        : {
-          type: 'logarithmic',
-          ...getLogScaleBounds(plotEfficiencyRates),
-          grid: { color: chartTheme.grid },
-          border: { color: chartTheme.axis },
-          ticks: { color: chartTheme.textSecondary, font: { size: 10 }, maxTicksLimit: isMobile ? 4 : 5, callback: (value) => formatUsd(Number(value)) },
-        },
+      y: {
+        type: 'logarithmic',
+        ...getLogScaleBounds(pricedRows.map((row) => getModelEfficiencyRate(row))),
+        grid: { color: chartTheme.grid },
+        border: { color: chartTheme.axis },
+        ticks: { color: chartTheme.textSecondary, font: { size: 10 }, maxTicksLimit: isMobile ? 4 : 5, callback: (value) => formatUsd(Number(value)) },
+      },
     },
-  }), [chartTheme, efficiencyRates, isMobile, plotEfficiencyRates, pricedRows, t, tooltipLabels, useLinearCostScale]);
+  }), [chartTheme, isMobile, pricedRows, t, tooltipLabels]);
   useEffect(() => {
     removeModelEfficiencyTooltip();
   }, [pricedRows]);

--- a/web/src/components/usage/analysis/AnalysisPanel.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.tsx
@@ -112,6 +112,7 @@ const MODEL_EFFICIENCY_HOVER_RADIUS_DELTA = 4;
 const MODEL_EFFICIENCY_RADIUS_EASING = 0.75;
 const MODEL_EFFICIENCY_OUTLIER_RATIO = 8;
 const MODEL_EFFICIENCY_AXIS_PADDING_FACTOR = 2.5;
+const MODEL_EFFICIENCY_ZERO_RATE_FLOOR_DIVISOR = 10;
 const EMPTY_COMPOSITION_ITEMS: AnalysisCompositionItem[] = [];
 type TokenLabels = {
   input: string;
@@ -398,7 +399,7 @@ function buildAnalysisTokenChartData(rows: ChartRow[], labels: TokenLabels): Mix
       {
         type: 'line',
         label: labels.cost,
-        data: rows.map((row) => (row.costAvailable ? row.cost : null)),
+        data: rows.map((row) => row.cost),
         borderColor: tokenColors.cost,
         backgroundColor: tokenColors.cost,
         pointBackgroundColor: tokenColors.cost,
@@ -410,6 +411,22 @@ function buildAnalysisTokenChartData(rows: ChartRow[], labels: TokenLabels): Mix
       } as unknown as MixedTokenChartData['datasets'][number],
     ],
   };
+}
+
+function CostHeaderHint({ show, label }: { show: boolean; label: string }) {
+  return show ? <small className={styles.costHeaderHint}>{label}</small> : null;
+}
+
+function AnalysisCardHeader({ title, subtitle, showPricingHint, hint }: { title: string; subtitle: string; showPricingHint: boolean; hint: string }) {
+  return (
+    <div className={styles.cardHeader}>
+      <div className={styles.cardTitleLine}>
+        <h2>{title}</h2>
+        <CostHeaderHint show={showPricingHint} label={hint} />
+      </div>
+      <p>{subtitle}</p>
+    </div>
+  );
 }
 
 function buildCompositionChartData(items: AnalysisCompositionItem[]): ChartData<'doughnut', number[], string> {
@@ -468,14 +485,15 @@ function TokenUsageChart({ rows, loading, isDark, isMobile }: { rows: ChartRow[]
     totalLabel: tokenLabels.total,
   }), [chartTheme, isMobile, rows, tokenLabels.total]);
   const legendItems = useMemo(() => buildTokenLegendItems(tokenLabels), [tokenLabels]);
+  const hasUnavailableCost = rows.some((row) => !row.costAvailable);
   return (
     <section className={`${styles.analysisCard} ${styles.tokenUsageCard}`}>
-      <div className={styles.cardHeader}>
-        <div>
-          <h2>{t('usage_stats.analysis_token_usage_title')}</h2>
-          <p>{t('usage_stats.analysis_token_usage_subtitle')}</p>
-        </div>
-      </div>
+      <AnalysisCardHeader
+        title={t('usage_stats.analysis_token_usage_title')}
+        subtitle={t('usage_stats.analysis_token_usage_subtitle')}
+        showPricingHint={hasUnavailableCost}
+        hint={t('usage_stats.cost_need_price')}
+      />
       {loading ? (
         <div className={styles.emptyState}>{t('common.loading')}</div>
       ) : rows.length === 0 ? (
@@ -514,14 +532,15 @@ function CompositionPanel({ tabs, loading, isDark }: { tabs: CompositionTab[]; l
   const chartTheme = useMemo(() => getChartTheme(isDark), [isDark]);
   const chartData = useMemo(() => buildCompositionChartData(items), [items]);
   const chartOptions = useMemo(() => buildCompositionChartOptions(chartTheme), [chartTheme]);
+  const hasUnavailableCost = items.some((item) => item.cost_available === false);
   return (
     <section className={`${styles.analysisCard} ${styles.compositionCard}`}>
-      <div className={styles.cardHeader}>
-        <div>
-          <h2>{t('usage_stats.analysis_composition_title')}</h2>
-          <p>{t('usage_stats.analysis_composition_subtitle')}</p>
-        </div>
-      </div>
+      <AnalysisCardHeader
+        title={t('usage_stats.analysis_composition_title')}
+        subtitle={t('usage_stats.analysis_composition_subtitle')}
+        showPricingHint={hasUnavailableCost}
+        hint={t('usage_stats.cost_need_price')}
+      />
       <div className={styles.compositionTabs} role="tablist" aria-label={t('usage_stats.analysis_composition_title')}>
         {tabs.map((tab) => (
           <button
@@ -566,7 +585,7 @@ function CompositionPanel({ tabs, loading, isDark }: { tabs: CompositionTab[]; l
                       </td>
                       <td>{formatCompactNumber(toNumber(item.total_tokens))}</td>
                       <td>{formatPercent(toNumber(item.percent))}</td>
-                      <td>{item.cost_available === false ? t('usage_stats.cost_need_price') : formatUsd(toNumber(item.cost_usd))}</td>
+                      <td>{formatUsd(toNumber(item.cost_usd))}</td>
                       <td>{formatCompactNumber(toNumber(item.requests))}</td>
                     </tr>
                   ))}
@@ -603,19 +622,17 @@ function CostBreakdownCard({ breakdown, rows, loading }: { breakdown: AnalysisCo
   const totalTokens = rows.reduce((sum, row) => sum + row.total, 0);
   const segmentTokens = getCostSegmentTokens(rows);
   const costAvailable = safeBreakdown.cost_available !== false;
-  const blendedRate = costAvailable ? getCostRatePerMillion(totalCost, totalTokens) : null;
-  const ratePoints = costAvailable
-    ? rows
-      .filter((row) => row.costAvailable && row.total > 0)
-      .map((row) => getCostRatePerMillion(row.cost, row.total))
-    : [];
+  const blendedRate = getCostRatePerMillion(totalCost, totalTokens);
+  const ratePoints = rows
+    .filter((row) => row.total > 0)
+    .map((row) => getCostRatePerMillion(row.cost, row.total));
   const rateMax = Math.max(0, ...ratePoints);
   const segments: CostBreakdownSegment[] = [
     { key: 'input', label: t('usage_stats.input_tokens'), value: toNumber(safeBreakdown.input_cost_usd), color: TOKEN_COLORS.input.base, tokens: segmentTokens.input },
     { key: 'output', label: t('usage_stats.output_tokens'), value: toNumber(safeBreakdown.output_cost_usd), color: TOKEN_COLORS.output.base, tokens: segmentTokens.output },
     { key: 'cached', label: t('usage_stats.cached_tokens'), value: toNumber(safeBreakdown.cached_cost_usd), color: TOKEN_COLORS.cached.base, tokens: segmentTokens.cached },
   ];
-  const hasData = totalCost > 0 || segments.some((segment) => segment.value > 0);
+  const hasData = rows.length > 0 || totalCost > 0 || segments.some((segment) => segment.value > 0);
   const buildCostTooltipLines = (segment: CostBreakdownSegment, percent: number) => [
     segment.label,
     `${t('usage_stats.total_cost')}: ${formatUsd(segment.value)}`,
@@ -643,19 +660,18 @@ function CostBreakdownCard({ breakdown, rows, loading }: { breakdown: AnalysisCo
   const hideCostTooltip = () => setCostTooltip(null);
   return (
     <section className={`${styles.analysisCard} ${styles.costBreakdownCard}`}>
-      <div className={styles.cardHeader}>
-        <div>
-          <h2>{t('usage_stats.analysis_cost_breakdown_title')}</h2>
-          <p>{t('usage_stats.analysis_cost_breakdown_subtitle')}</p>
-        </div>
-      </div>
+      <AnalysisCardHeader
+        title={t('usage_stats.analysis_cost_breakdown_title')}
+        subtitle={t('usage_stats.analysis_cost_breakdown_subtitle')}
+        showPricingHint={!costAvailable}
+        hint={t('usage_stats.cost_need_price')}
+      />
       {loading ? (
         <div className={styles.emptyState}>{t('common.loading')}</div>
       ) : !hasData ? (
-        <div className={styles.emptyState}>{safeBreakdown.cost_available === false ? t('usage_stats.cost_need_price') : t('usage_stats.no_data')}</div>
+        <div className={styles.emptyState}>{t('usage_stats.no_data')}</div>
       ) : (
         <div className={styles.costBreakdownBody}>
-          {safeBreakdown.cost_available === false ? <div className={styles.costWarning}>{t('usage_stats.cost_need_price')}</div> : null}
           <div className={styles.costStack} aria-label={t('usage_stats.analysis_cost_breakdown_title')}>
             {segments.map((segment) => {
               const percent = totalCost > 0 ? (segment.value / totalCost) * 100 : 0;
@@ -699,11 +715,11 @@ function CostBreakdownCard({ breakdown, rows, loading }: { breakdown: AnalysisCo
           <div className={styles.costRatePanel}>
             <div className={styles.costRateMetric}>
               <span>{t('usage_stats.total_cost')}</span>
-              <strong>{safeBreakdown.cost_available === false ? t('usage_stats.cost_need_price') : formatUsd(totalCost)}</strong>
+              <strong>{formatUsd(totalCost)}</strong>
             </div>
             <div className={styles.costRateMetric}>
               <span>{t('usage_stats.analysis_cost_per_million_tokens')}</span>
-              <strong>{blendedRate === null ? t('usage_stats.cost_need_price') : formatUsd(blendedRate)}</strong>
+              <strong>{formatUsd(blendedRate)}</strong>
               <small>{t('usage_stats.analysis_blended_rate')}</small>
             </div>
             <div className={styles.costRateSparkline} aria-label={t('usage_stats.analysis_cost_per_million_tokens')}>
@@ -741,6 +757,7 @@ type EfficiencyPoint = {
   model: string;
   requests: number;
   cost: number;
+  costPerMillion: number;
   totalTokens: number;
   cacheRate: number;
 };
@@ -919,7 +936,17 @@ function createModelEfficiencyTooltipHandler({
 function ModelEfficiencyCard({ rows, loading, isDark, isMobile }: { rows: AnalysisModelEfficiencyItem[]; loading: boolean; isDark: boolean; isMobile: boolean }) {
   const { t } = useTranslation();
   const chartTheme = useMemo(() => getChartTheme(isDark), [isDark]);
-  const pricedRows = useMemo(() => rows.filter((row) => row.cost_available !== false && toNumber(row.total_tokens) > 0 && getModelEfficiencyRate(row) > 0), [rows]);
+  const pricedRows = useMemo(() => rows.filter((row) => toNumber(row.total_tokens) > 0), [rows]);
+  const efficiencyRates = useMemo(() => pricedRows.map((row) => getModelEfficiencyRate(row)), [pricedRows]);
+  const positiveEfficiencyRates = useMemo(() => efficiencyRates.filter((rate) => Number.isFinite(rate) && rate > 0), [efficiencyRates]);
+  const zeroRateFloor = positiveEfficiencyRates.length > 0
+    ? Math.max(Math.min(...positiveEfficiencyRates) / MODEL_EFFICIENCY_ZERO_RATE_FLOOR_DIVISOR, Number.EPSILON)
+    : 0;
+  const plotEfficiencyRates = useMemo(
+    () => efficiencyRates.map((rate) => (Number.isFinite(rate) && rate > 0 ? rate : zeroRateFloor)),
+    [efficiencyRates, zeroRateFloor],
+  );
+  const useLinearCostScale = positiveEfficiencyRates.length === 0;
   const tooltipLabels = useMemo(() => ({
     totalTokens: t('usage_stats.total_tokens'),
     costPerMillion: t('usage_stats.analysis_cost_per_million_tokens'),
@@ -930,12 +957,13 @@ function ModelEfficiencyCard({ rows, loading, isDark, isMobile }: { rows: Analys
     labels: pricedRows.map((row) => row.model),
     datasets: [{
       label: t('usage_stats.analysis_model_efficiency_title'),
-      data: pricedRows.map((row) => ({
+      data: pricedRows.map((row, index) => ({
         x: toNumber(row.total_tokens),
-        y: getModelEfficiencyRate(row),
+        y: plotEfficiencyRates[index] ?? 0,
         model: row.model,
         requests: toNumber(row.requests),
         cost: toNumber(row.cost_usd),
+        costPerMillion: efficiencyRates[index] ?? 0,
         totalTokens: toNumber(row.total_tokens),
         cacheRate: toNumber(row.cache_rate),
       })),
@@ -946,7 +974,7 @@ function ModelEfficiencyCard({ rows, loading, isDark, isMobile }: { rows: Analys
       borderWidth: 1,
       clip: false,
     }],
-  }), [pointRadii, pricedRows, t]);
+  }), [efficiencyRates, plotEfficiencyRates, pointRadii, pricedRows, t]);
   const chartOptions = useMemo<ChartOptions<'scatter'>>(() => ({
     responsive: true,
     maintainAspectRatio: false,
@@ -984,15 +1012,24 @@ function ModelEfficiencyCard({ rows, loading, isDark, isMobile }: { rows: Analys
         border: { color: chartTheme.axis },
         ticks: { color: chartTheme.textSecondary, font: { size: 10 }, maxTicksLimit: isMobile ? 4 : 5, callback: (value) => formatCompactNumber(Number(value)) },
       },
-      y: {
-        type: 'logarithmic',
-        ...getLogScaleBounds(pricedRows.map((row) => getModelEfficiencyRate(row))),
-        grid: { color: chartTheme.grid },
-        border: { color: chartTheme.axis },
-        ticks: { color: chartTheme.textSecondary, font: { size: 10 }, maxTicksLimit: isMobile ? 4 : 5, callback: (value) => formatUsd(Number(value)) },
-      },
+      y: useLinearCostScale
+        ? {
+          type: 'linear',
+          beginAtZero: true,
+          suggestedMax: Math.max(1, ...efficiencyRates.filter((rate) => Number.isFinite(rate))) * MODEL_EFFICIENCY_AXIS_PADDING_FACTOR,
+          grid: { color: chartTheme.grid },
+          border: { color: chartTheme.axis },
+          ticks: { color: chartTheme.textSecondary, font: { size: 10 }, maxTicksLimit: isMobile ? 4 : 5, callback: (value) => formatUsd(Number(value)) },
+        }
+        : {
+          type: 'logarithmic',
+          ...getLogScaleBounds(plotEfficiencyRates),
+          grid: { color: chartTheme.grid },
+          border: { color: chartTheme.axis },
+          ticks: { color: chartTheme.textSecondary, font: { size: 10 }, maxTicksLimit: isMobile ? 4 : 5, callback: (value) => formatUsd(Number(value)) },
+        },
     },
-  }), [chartTheme, isMobile, pricedRows, t, tooltipLabels]);
+  }), [chartTheme, efficiencyRates, isMobile, plotEfficiencyRates, pricedRows, t, tooltipLabels, useLinearCostScale]);
   useEffect(() => {
     removeModelEfficiencyTooltip();
   }, [pricedRows]);
@@ -1004,25 +1041,24 @@ function ModelEfficiencyCard({ rows, loading, isDark, isMobile }: { rows: Analys
   const hasUnavailableCost = rows.some((row) => row.cost_available === false);
   return (
     <section className={`${styles.analysisCard} ${styles.modelEfficiencyCard}`}>
-      <div className={styles.cardHeader}>
-        <div>
-          <h2>{t('usage_stats.analysis_model_efficiency_title')}</h2>
-          <p>{t('usage_stats.analysis_model_efficiency_subtitle')}</p>
-        </div>
-      </div>
+      <AnalysisCardHeader
+        title={t('usage_stats.analysis_model_efficiency_title')}
+        subtitle={t('usage_stats.analysis_model_efficiency_subtitle')}
+        showPricingHint={hasUnavailableCost}
+        hint={t('usage_stats.cost_need_price')}
+      />
       {loading ? (
         <div className={styles.emptyState}>{t('common.loading')}</div>
       ) : !hasData ? (
         <div className={styles.emptyState}>{t('usage_stats.no_data')}</div>
       ) : (
         <div className={styles.modelEfficiencyBody}>
-          {hasUnavailableCost ? <div className={styles.costWarning}>{t('usage_stats.cost_need_price')}</div> : null}
           {hasPricedData ? (
             <div className={styles.efficiencyChartFrame}>
               <Scatter data={chartData} options={chartOptions} />
             </div>
           ) : (
-            <div className={styles.emptyState}>{t('usage_stats.cost_need_price')}</div>
+            <div className={styles.emptyState}>{t('usage_stats.no_data')}</div>
           )}
         </div>
       )}
@@ -1034,6 +1070,7 @@ function Heatmap({ cells, apiKeys, apiKeyLabels, models, loading, isDark }: { ce
   const { t } = useTranslation();
   const [tooltip, setTooltip] = useState<FloatingTooltipState | null>(null);
   const cellMap = useMemo(() => new Map(cells.map((cell) => [`${cell.api_key}\0${cell.model}`, cell])), [cells]);
+  const hasUnavailableCost = useMemo(() => cells.some((cell) => cell.cost_available === false), [cells]);
   const maxHeatmapTokens = useMemo(
     () => cells.reduce((max, cell) => Math.max(max, toNumber(cell.total_tokens)), 0),
     [cells],
@@ -1055,7 +1092,7 @@ function Heatmap({ cells, apiKeys, apiKeyLabels, models, loading, isDark }: { ce
       `${t('usage_stats.reasoning_tokens')}: ${formatCompactNumber(reasoning)}`,
       `${t('usage_stats.cached_tokens')}: ${formatCompactNumber(cached)}`,
       `${t('usage_stats.total_tokens')}: ${formatCompactNumber(total)}`,
-      `${t('usage_stats.total_cost')}: ${cell?.cost_available === false ? t('usage_stats.cost_need_price') : formatUsd(cost)}`,
+      `${t('usage_stats.total_cost')}: ${formatUsd(cost)}`,
     ];
   };
   const showTooltip = (
@@ -1078,12 +1115,12 @@ function Heatmap({ cells, apiKeys, apiKeyLabels, models, loading, isDark }: { ce
   const hideTooltip = () => setTooltip(null);
   return (
     <section className={`${styles.analysisCard} ${styles.heatmapCard} ${isDark ? styles.heatmapCardDark : styles.heatmapCardLight}`}>
-      <div className={styles.cardHeader}>
-        <div>
-          <h2>{t('usage_stats.analysis_heatmap_title')}</h2>
-          <p>{t('usage_stats.analysis_heatmap_subtitle')}</p>
-        </div>
-      </div>
+      <AnalysisCardHeader
+        title={t('usage_stats.analysis_heatmap_title')}
+        subtitle={t('usage_stats.analysis_heatmap_subtitle')}
+        showPricingHint={hasUnavailableCost}
+        hint={t('usage_stats.cost_need_price')}
+      />
       {loading ? (
         <div className={styles.emptyState}>{t('common.loading')}</div>
       ) : cells.length === 0 ? (


### PR DESCRIPTION
## Summary
- keep Analysis cost views rendering numeric cost values when pricing is missing
- add subtle pricing hints in Analysis card headers with mobile-friendly ordering
- preserve Model Efficiency logarithmic scaling for positive or mixed cost data while still showing zero-cost models

## Validation
- npm --prefix ./web run test
- npm --prefix ./web run typecheck
- npm --prefix ./web run lint
- npm --prefix ./web run build
- git diff --check