### PR TITLE
Fix homepage API key alias labels

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -98,7 +98,7 @@ func NewRouter(
 	adminProtected.Use(authHandler.adminMiddleware())
 	registerStatusRoutes(adminProtected, statusProvider, statusConfig)
 	registerUpdateRoutes(adminProtected, nil)
-	registerUsageOverviewRoute(adminProtected, usageProvider)
+	registerUsageOverviewRoute(adminProtected, usageProvider, cpaAPIKeyProvider)
 	registerUsageAnalysisRoute(adminProtected, usageProvider, cpaAPIKeyProvider)
 	registerUsageEventsRoute(adminProtected, usageProvider, usageIdentityProvider, cpaAPIKeyProvider)
 	registerUsageIdentityRoutes(adminProtected, usageIdentityProvider)

--- a/internal/api/usage_overview.go
+++ b/internal/api/usage_overview.go
@@ -250,7 +250,7 @@ func registerKeyOverviewRoute(router gin.IRoutes, usageProvider service.UsagePro
 	})
 }
 
-func registerUsageOverviewRoute(router gin.IRoutes, usageProvider service.UsageProvider) {
+func registerUsageOverviewRoute(router gin.IRoutes, usageProvider service.UsageProvider, cpaAPIKeyProvider service.CPAAPIKeyProvider) {
 	router.GET("/usage/overview", func(c *gin.Context) {
 		if usageProvider == nil {
 			writeUsageOverviewResponse(c, usageProvider, servicedto.UsageFilter{})
@@ -269,7 +269,7 @@ func registerUsageOverviewRoute(router gin.IRoutes, usageProvider service.UsageP
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		writeUsageOverviewRealtimeResponse(c, usageProvider, filter)
+		writeUsageOverviewRealtimeResponse(c, usageProvider, cpaAPIKeyProvider, filter)
 	})
 }
 
@@ -320,7 +320,7 @@ func writeUsageOverviewResponse(c *gin.Context, usageProvider service.UsageProvi
 	})
 }
 
-func writeUsageOverviewRealtimeResponse(c *gin.Context, usageProvider service.UsageProvider, filter servicedto.UsageFilter) {
+func writeUsageOverviewRealtimeResponse(c *gin.Context, usageProvider service.UsageProvider, cpaAPIKeyProvider service.CPAAPIKeyProvider, filter servicedto.UsageFilter) {
 	if usageProvider == nil {
 		c.JSON(http.StatusOK, emptyUsageOverviewRealtime(filter.RealtimeWindow))
 		return
@@ -330,7 +330,11 @@ func writeUsageOverviewRealtimeResponse(c *gin.Context, usageProvider service.Us
 		writeUsageOverviewProviderError(c, "get usage overview realtime failed", err)
 		return
 	}
-	c.JSON(http.StatusOK, buildUsageOverviewRealtime(realtime, filter.RealtimeWindow))
+	apiKeyInfos, err := loadCPAAPIKeyInfos(c, cpaAPIKeyProvider)
+	if err != nil {
+		return
+	}
+	c.JSON(http.StatusOK, buildUsageOverviewRealtime(realtime, filter.RealtimeWindow, apiKeyInfos))
 }
 
 func writeKeyUsageOverviewRealtimeResponse(c *gin.Context, usageProvider service.UsageProvider, filter servicedto.UsageFilter) {
@@ -521,7 +525,7 @@ func realtimeBucketSeconds(window string) int64 {
 	}
 }
 
-func buildUsageOverviewRealtime(realtime *servicedto.UsageOverviewRealtime, window string) usageOverviewRealtime {
+func buildUsageOverviewRealtime(realtime *servicedto.UsageOverviewRealtime, window string, apiKeyInfos map[string]analysisAPIKeyInfo) usageOverviewRealtime {
 	if realtime == nil {
 		return emptyUsageOverviewRealtime(window)
 	}
@@ -534,7 +538,7 @@ func buildUsageOverviewRealtime(realtime *servicedto.UsageOverviewRealtime, wind
 		ResponseDistribution: mapUsageOverviewResponseDistribution(realtime.ResponseDistribution),
 		CurrentUsage: usageOverviewRealtimeCurrentUsage{
 			Models:      mapUsageOverviewRealtimeTopItems(realtime.CurrentUsage.Models, false),
-			APIKeys:     mapUsageOverviewRealtimeTopItems(realtime.CurrentUsage.APIKeys, true),
+			APIKeys:     mapUsageOverviewRealtimeAPIKeyTopItems(realtime.CurrentUsage.APIKeys, apiKeyInfos),
 			AuthFiles:   mapUsageOverviewRealtimeTopItems(realtime.CurrentUsage.AuthFiles, false),
 			AIProviders: mapUsageOverviewRealtimeTopItems(realtime.CurrentUsage.AIProviders, false),
 		},
@@ -692,6 +696,21 @@ func mapUsageOverviewRealtimeTopItems(items []servicedto.RealtimeUsageTopItem, r
 		result = append(result, usageOverviewRealtimeUsageTopItem{
 			Key:      key,
 			Label:    label,
+			Tokens:   item.Tokens,
+			Requests: item.Requests,
+			Cost:     item.CostUSD,
+			Share:    item.Share,
+		})
+	}
+	return result
+}
+
+func mapUsageOverviewRealtimeAPIKeyTopItems(items []servicedto.RealtimeUsageTopItem, apiKeyInfos map[string]analysisAPIKeyInfo) []usageOverviewRealtimeUsageTopItem {
+	result := make([]usageOverviewRealtimeUsageTopItem, 0, len(items))
+	for _, item := range items {
+		result = append(result, usageOverviewRealtimeUsageTopItem{
+			Key:      analysisAPIKeyResponseKey(item.Key, apiKeyInfos),
+			Label:    analysisAPIKeyLabel(item.Key, apiKeyInfos),
 			Tokens:   item.Tokens,
 			Requests: item.Requests,
 			Cost:     item.CostUSD,

--- a/internal/api/usage_overview_test.go
+++ b/internal/api/usage_overview_test.go
@@ -257,6 +257,39 @@ func TestUsageOverviewResponseIncludesResolvedRangeAndTimezone(t *testing.T) {
 	}
 }
 
+func TestUsageOverviewRealtimeUsesCPAAPIKeyAliasLabels(t *testing.T) {
+	provider := &usageFilterStub{realtime: &servicedto.UsageOverviewRealtime{
+		Window:        "15m",
+		BucketSeconds: 30,
+		CurrentUsage: servicedto.RealtimeCurrentUsage{
+			APIKeys: []servicedto.RealtimeUsageTopItem{{
+				Key:      "sk-alpha123456",
+				Label:    "sk-alpha123456",
+				Tokens:   20,
+				Requests: 1,
+				Share:    100,
+			}},
+		},
+	}}
+	keyProvider := &authCPAAPIKeyStub{row: entities.CPAAPIKey{ID: 42, APIKey: "sk-alpha123456", KeyAlias: "Primary Key"}}
+	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "", OptionalProviders{CPAAPIKeys: keyProvider})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/overview/realtime?window=15m", nil)
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d %s", resp.Code, resp.Body.String())
+	}
+	body := resp.Body.String()
+	if !contains(body, `"api_keys":[{"key":"42","label":"Primary Key","tokens":20,"requests":1,"share":100}]`) {
+		t.Fatalf("expected realtime API key usage to use CPA API key id and alias label, got %s", body)
+	}
+	if contains(body, "sk-alpha123456") {
+		t.Fatalf("expected realtime API key usage to avoid raw key output, got %s", body)
+	}
+}
+
 func TestUsageOverviewRealtimeAcceptsWindowAndReturnsRealtimeBlock(t *testing.T) {
 	previousLocal := time.Local
 	location, err := time.LoadLocation("Asia/Shanghai")


### PR DESCRIPTION
## Summary
- reuse CPA API key metadata when building Overview realtime API key usage labels
- return the managed API key id with the alias/standard masked fallback for homepage token-share labels
- add regression coverage for alias labels and raw key redaction

## Tests
- `git diff --check`
- `rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build go test ./cmd/... ./internal/...`

Fixes #206