### PR TITLE
Fix CPA usage queue compatibility

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -112,29 +112,17 @@ func NewWithConfig(cfg config.Config) (*App, error) {
 	syncService := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{
 		BaseURL: cfg.CPABaseURL,
 		Client:  cpa.NewClient(cfg.CPABaseURL, cfg.CPAManagementKey, cfg.RequestTimeout, cfg.TLSSkipVerify),
-		RedisQueue: cpa.NewRedisQueueClientWithOptions(cpa.RedisQueueOptions{
-			BaseURL:       cfg.CPABaseURL,
-			RedisAddr:     cfg.RedisQueueAddr,
-			ManagementKey: cfg.CPAManagementKey,
-			Timeout:       cfg.RequestTimeout,
-			QueueKey:      cfg.RedisQueueKey,
-			BatchSize:     cfg.RedisQueueBatchSize,
-			TLS:           cfg.RedisQueueTLS,
-			TLSSkipVerify: cfg.TLSSkipVerify,
-		}),
-		RedisQueueKey: cfg.RedisQueueKey,
 		// usage_events 事务提交后通过这个缓存做非阻塞增量追加，供 Overview realtime 和右边界补偿复用。
 		RecentUsageEvents: recentUsageCache,
 	})
 	// metadataSyncRunner 提前创建，保证控制消息和后台任务使用同一个调度器实例。
 	metadataSyncRunner := NewMetadataSyncRunner(syncService, cfg.MetadataSyncInterval)
-	// redisPullSource 保持旧 Redis queue 拉取路径不变。
+	// redisPullSource 负责 Redis batch pull，并在 usage/queue 两个 key 间做一次兼容探测。
 	redisPullSource := poller.NewRedisPullSource(cpa.RedisQueueOptions{
 		BaseURL:       cfg.CPABaseURL,
 		RedisAddr:     cfg.RedisQueueAddr,
 		ManagementKey: cfg.CPAManagementKey,
 		Timeout:       cfg.RequestTimeout,
-		QueueKey:      cfg.RedisQueueKey,
 		BatchSize:     cfg.RedisQueueBatchSize,
 		TLS:           cfg.RedisQueueTLS,
 		TLSSkipVerify: cfg.TLSSkipVerify,
@@ -151,7 +139,8 @@ func NewWithConfig(cfg config.Config) (*App, error) {
 		TLSSkipVerify: cfg.TLSSkipVerify,
 	})
 	// usage 通道可能混入 metadata 控制消息，落 inbox 前先过滤并转交 metadata runner。
-	redisInboxWriter := poller.NewControlAwareRedisInboxWriter(poller.NewRedisInboxWriter(db, cfg.RedisQueueKey), metadataSyncRunner)
+	// inbox writer 不再接收 queue key，来源由 runner 传入并写入 redis_usage_inboxes.source。
+	redisInboxWriter := poller.NewControlAwareRedisInboxWriter(poller.NewRedisInboxWriter(db), metadataSyncRunner)
 	// redisIngestRunner 继续负责三种 usage 拉取方式的选择和降级。
 	redisIngestRunner := poller.NewRedisIngestRunner(redisSubscribeSource, redisPullSource, httpPullSource, redisInboxWriter, poller.RedisIngestRunnerConfig{
 		IdleInterval:       cfg.RedisQueueIdleInterval,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,7 +16,6 @@ import (
 
 const (
 	DefaultTimeZone                 = "Asia/Shanghai"
-	RedisQueueKeyDefault            = cpa.ManagementUsageQueueKey
 	RedisQueueBatchSizeDefault      = 10000
 	MetadataSyncIntervalDefault     = 30 * time.Second
 	QuotaAutoRefreshIntervalDefault = 5 * time.Minute
@@ -56,8 +55,6 @@ type Config struct {
 	RedisQueueAddr string
 	// RedisQueueTLS 控制是否使用 TLS 连接 Redis 队列。
 	RedisQueueTLS bool
-	// RedisQueueKey 是 CPA usage 队列名。
-	RedisQueueKey string
 	// RedisQueueBatchSize 是单次 Redis LPOP 最多拉取的消息数。
 	RedisQueueBatchSize int
 	// RedisQueueIdleInterval 是 Redis 队列为空时的下一次检查间隔。
@@ -253,7 +250,6 @@ func Load(options LoadOptions) (*Config, error) {
 		CPAManagementKey:         strings.TrimSpace(os.Getenv("CPA_MANAGEMENT_KEY")),
 		RedisQueueAddr:           strings.TrimSpace(os.Getenv("REDIS_QUEUE_ADDR")),
 		RedisQueueTLS:            redisQueueTLS,
-		RedisQueueKey:            RedisQueueKeyDefault,
 		RedisQueueBatchSize:      redisQueueBatchSize,
 		RedisQueueIdleInterval:   redisQueueIdleInterval,
 		MetadataSyncInterval:     MetadataSyncIntervalDefault,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -140,9 +140,6 @@ func TestLoadFromEnvAppliesDefaults(t *testing.T) {
 	if cfg.RedisQueueAddr != "" {
 		t.Fatalf("expected default redis queue addr to be empty, got %q", cfg.RedisQueueAddr)
 	}
-	if cfg.RedisQueueKey != RedisQueueKeyDefault {
-		t.Fatalf("expected default redis queue key queue, got %s", cfg.RedisQueueKey)
-	}
 	if cfg.RedisQueueBatchSize != 10000 {
 		t.Fatalf("expected default redis queue batch size 10000, got %d", cfg.RedisQueueBatchSize)
 	}
@@ -407,20 +404,6 @@ func TestLoadFromEnvUsesRedisQueueAddrOverride(t *testing.T) {
 
 	if cfg.RedisQueueAddr != "redis-stream.example.com:6380" {
 		t.Fatalf("expected redis queue addr override, got %q", cfg.RedisQueueAddr)
-	}
-}
-
-func TestLoadFromEnvIgnoresRemovedRedisQueueKeyOverride(t *testing.T) {
-	t.Setenv("CPA_BASE_URL", "https://cpa.example.com")
-	t.Setenv("CPA_MANAGEMENT_KEY", "secret")
-	t.Setenv("REDIS_QUEUE_KEY", "custom-queue")
-
-	cfg, err := LoadFromEnv()
-	if err != nil {
-		t.Fatalf("LoadFromEnv returned error: %v", err)
-	}
-	if cfg.RedisQueueKey != RedisQueueKeyDefault {
-		t.Fatalf("expected removed redis queue key override to be ignored, got %q", cfg.RedisQueueKey)
 	}
 }
 

--- a/internal/cpa/endpoints.go
+++ b/internal/cpa/endpoints.go
@@ -19,7 +19,8 @@ const (
 	ManagementRedisAuthCommand       = "AUTH"
 	ManagementRedisPopCommand        = "LPOP"
 	ManagementRedisSubscribeCommand  = "SUBSCRIBE"
-	ManagementUsageQueueKey          = "queue"
+	ManagementUsageQueueKey          = "usage"
+	ManagementUsageLegacyQueueKey    = "queue"
 	ManagementUsageSubscribeChannel  = "usage"
 	ManagementUsageQueueMaxBatchSize = 10000
 )

--- a/internal/entities/redis_usage_inbox.go
+++ b/internal/entities/redis_usage_inbox.go
@@ -2,10 +2,11 @@ package entities
 
 import "time"
 
-// RedisUsageInbox 是从 CPA Redis queue 拉取后等待解码/入库的原始消息实体。
+// RedisUsageInbox 是从 CPA usage 拉取后等待解码/入库的原始消息实体。
 type RedisUsageInbox struct {
-	ID            int64  `gorm:"primaryKey;index:idx_redis_usage_inboxes_status_id,priority:2"`
-	QueueKey      string `gorm:"not null"`
+	ID int64 `gorm:"primaryKey;index:idx_redis_usage_inboxes_status_id,priority:2"`
+	// Source 保存完整拉取来源名，例如 redis_subscribe:usage、redis_pull:usage、redis_pull:queue。
+	Source        string `gorm:"not null"`
 	MessageHash   string `gorm:"not null"`
 	RawMessage    string `gorm:"not null"`
 	Status        string `gorm:"not null;index:idx_redis_usage_inboxes_status_id,priority:1;index:idx_redis_usage_inboxes_status_processed_at,priority:1;index:idx_redis_usage_inboxes_status_updated_at,priority:1;index:idx_redis_usage_inboxes_status_usage_event_key,priority:1"`

--- a/internal/poller/redis_inbox_writer.go
+++ b/internal/poller/redis_inbox_writer.go
@@ -3,10 +3,8 @@ package poller
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
-	"cpa-usage-keeper/internal/cpa"
 	"cpa-usage-keeper/internal/repository"
 	"gorm.io/gorm"
 )
@@ -14,22 +12,15 @@ import (
 type RepositoryRedisInboxWriter struct {
 	// db 是 redis_usage_inboxes 的落库连接。
 	db *gorm.DB
-	// queueKey 保留配置中的 Redis queue key，不能写成 source 标签，避免改变历史数据语义。
-	queueKey string
 }
 
-func NewRedisInboxWriter(db *gorm.DB, queueKey string) *RepositoryRedisInboxWriter {
-	// queue key 允许配置中带空白，这里统一 trim 后保存。
-	trimmed := strings.TrimSpace(queueKey)
-	if trimmed == "" {
-		// 配置缺省时沿用 CPA 旧 Redis usage queue key。
-		trimmed = cpa.ManagementUsageQueueKey
-	}
+func NewRedisInboxWriter(db *gorm.DB) *RepositoryRedisInboxWriter {
 	// writer 只保存依赖，不主动访问数据库。
-	return &RepositoryRedisInboxWriter{db: db, queueKey: trimmed}
+	return &RepositoryRedisInboxWriter{db: db}
 }
 
-func (w *RepositoryRedisInboxWriter) Insert(ctx context.Context, _ string, messages []string, receivedAt time.Time) (int, error) {
+func (w *RepositoryRedisInboxWriter) Insert(ctx context.Context, source string, messages []string, receivedAt time.Time) (int, error) {
+	// source 是最终写入 redis_usage_inboxes.source 的完整来源名，不再表示 Redis queue key。
 	if len(messages) == 0 {
 		// 空批次不落库，避免无意义事务和 updated_at 变化。
 		return 0, nil
@@ -42,8 +33,8 @@ func (w *RepositoryRedisInboxWriter) Insert(ctx context.Context, _ string, messa
 		// 调用方已取消时不再写数据库。
 		return 0, err
 	}
-	// 所有来源都写入同一个 queueKey，source 只用于 runner 日志/测试，不改变 inbox 语义。
-	rows, err := repository.InsertRedisUsageInboxRawMessages(w.db.WithContext(ctx), w.queueKey, messages, receivedAt)
+	// 来源名由 runner 传入，完整落库便于区分 subscribe、redis pull 和 HTTP pull。
+	rows, err := repository.InsertRedisUsageInboxRawMessages(w.db.WithContext(ctx), source, messages, receivedAt)
 	if err != nil {
 		// 插入失败交给 runner 记录 error 并进入对应失败路径。
 		return 0, err

--- a/internal/poller/redis_ingest_runner.go
+++ b/internal/poller/redis_ingest_runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,7 +20,7 @@ var errRedisIngestInboxWrite = errors.New("redis ingest inbox write failed")
 // - redis_ingest_backoff.go：定义远端拉取连续失败时的指数退避。
 // - redis_ingest_sources.go：定义订阅、拉取和 inbox writer 的接口边界。
 // - redis_subscribe_source.go：实现 Redis SUBSCRIBE usage 的连接、认证和消息读取。
-// - redis_pull_source.go：实现旧 Redis batch pull，只拉取不 fallback。
+// - redis_pull_source.go：实现 Redis batch pull，只拉取不 fallback。
 // - http_pull_source.go：实现 HTTP usage queue 拉取，只拉取不 fallback。
 // - redis_inbox_writer.go：统一把不同来源的 raw usage message 写入 redis_usage_inboxes。
 // - redis_process_runner.go：本地 inbox 到 usage_events 的处理 runner，不参与远端拉取模式选择。
@@ -34,7 +35,7 @@ type RedisIngestRunnerConfig struct {
 type RedisIngestRunner struct {
 	// subscribeSource 只负责建立 Redis SUBSCRIBE usage 连接，不处理 fallback。
 	subscribeSource UsageSubscriptionSource
-	// redisSource 只负责旧 Redis LPOP 批量拉取，失败原因交给 runner 决策。
+	// redisSource 只负责 Redis LPOP 批量拉取，失败原因交给 runner 决策。
 	redisSource UsagePullSource
 	// httpSource 只负责 HTTP usage queue 拉取，是所有模式的最终降级路径。
 	httpSource UsagePullSource
@@ -141,7 +142,7 @@ func (r *RedisIngestRunner) Run(ctx context.Context) error {
 			// subscribe 模式退出后重新回到启动探测，避免停在旧状态。
 			continue
 		}
-		// 订阅失败不是最终失败，先记录降级原因，再尝试旧 Redis pull。
+		// 订阅失败不是最终失败，先记录降级原因，再尝试 Redis batch pull。
 		r.recordWarning("subscribe_unavailable", subErr)
 		// 启动探测第二步：Redis LPOP 成功就把长期模式固定为 redis_pull。
 		redisCount, redisErr := r.serialPullAndWrite(ctx, RedisIngestSourceRedisPull, r.redisSource)
@@ -213,7 +214,7 @@ func (r *RedisIngestRunner) runSubscribeMode(ctx context.Context, sub UsageSubsc
 	defer func() { _ = current.Close() }()
 	// 外层循环表示“每次订阅连接成功后的完整生命周期”。
 	for {
-		// 每次初次连接或重连成功后都做一次旧队列 backfill。
+		// 每次初次连接或重连成功后都做一次 batch pull backfill。
 		if err := r.backfillAfterSubscribe(ctx); err != nil {
 			_ = current.Close()
 			if !r.pauseAfterInboxWriteFailure(ctx, "redis_inbox_write_failed", err) {
@@ -263,7 +264,7 @@ func (r *RedisIngestRunner) runSubscribeMode(ctx context.Context, sub UsageSubsc
 func (r *RedisIngestRunner) backfillAfterSubscribe(ctx context.Context) error {
 	// 订阅刚连接时进入 backfill 状态，补偿订阅建立前已在队列中的数据。
 	r.recordState(RedisIngestSyncModeSubscribe, RedisIngestSubStateSubscribeBackfill, "subscribe_backfill", "", "")
-	// backfill 优先复用旧 Redis queue 拉取，速度快且不经过 HTTP 管理接口。
+	// backfill 优先复用 Redis batch pull，速度快且不经过 HTTP 管理接口。
 	redisCount, redisBatches, err := r.drainBackfillSource(ctx, RedisIngestSourceRedisPull, r.redisSource)
 	if err == nil {
 		// Redis backfill 成功即清退避，后续失败重新从 1s 开始。
@@ -652,23 +653,33 @@ func (r *RedisIngestRunner) serialPullAndWrite(ctx context.Context, sourceName s
 		// 拉取失败由调用方决定是否降级或退避。
 		return 0, err
 	}
+	// writeSourceName 是最终写入 redis_usage_inboxes.source 的值，默认沿用调用方传入的来源。
+	writeSourceName := sourceName
+	// 部分 pull source 会在成功拉取后知道更精确的目标 key，例如 redis_pull:usage 或 redis_pull:queue。
+	if sourceNamer, ok := source.(UsagePullSourceNamer); ok {
+		// 动态来源名只影响落库和日志，不改变当前 runner 已选定的拉取方式。
+		if dynamicSourceName := strings.TrimSpace(sourceNamer.SourceName()); dynamicSourceName != "" {
+			// 空白来源名保持默认值，避免异常 source 覆盖掉可读的基础来源。
+			writeSourceName = dynamicSourceName
+		}
+	}
 	// 每次拉取方式和拉取数量属于可刷屏排查信息，只写 debug。
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
-		logrus.WithFields(logrus.Fields{"source": sourceName, "message_count": len(messages)}).Debug("redis ingest pulled usage messages")
+		logrus.WithFields(logrus.Fields{"source": writeSourceName, "message_count": len(messages)}).Debug("redis ingest pulled usage messages")
 	}
 	if len(messages) == 0 {
 		// 空批次不调用 writer，避免无意义 DB 事务。
 		return 0, nil
 	}
 	// 所有来源的 raw usage message 都写入 redis_usage_inboxes，保持后续 decode/process 不变。
-	inserted, err := r.writer.Insert(ctx, sourceName, messages, timeutil.NormalizeStorageTime(r.now()))
+	inserted, err := r.writer.Insert(ctx, writeSourceName, messages, timeutil.NormalizeStorageTime(r.now()))
 	if err != nil {
 		// 落库失败必须返回给上层，不能吞掉导致消息丢失不可见。
 		return 0, fmt.Errorf("%w: %v", errRedisIngestInboxWrite, err)
 	}
 	// 每次写入数量也属于可刷屏排查信息，只写 debug。
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
-		logrus.WithFields(logrus.Fields{"source": sourceName, "message_count": len(messages), "inserted_count": inserted}).Debug("redis ingest wrote usage messages")
+		logrus.WithFields(logrus.Fields{"source": writeSourceName, "message_count": len(messages), "inserted_count": inserted}).Debug("redis ingest wrote usage messages")
 	}
 	// 返回本次远端实际拉取数量，调用方据此判断是否可能还有下一批。
 	return len(messages), nil

--- a/internal/poller/redis_ingest_sources.go
+++ b/internal/poller/redis_ingest_sources.go
@@ -25,9 +25,14 @@ type UsagePullSource interface {
 	Pull(ctx context.Context) ([]string, error)
 }
 
+// UsagePullSourceNamer 可在拉取成功后提供更精确的来源名，例如 redis_pull 选定的 usage/queue key。
+type UsagePullSourceNamer interface {
+	SourceName() string
+}
+
 // RedisInboxWriter 是远端 ingest 到本地 durable inbox 的唯一写入边界。
 type RedisInboxWriter interface {
-	// Insert 把 raw usage JSON 批量写入 redis_usage_inboxes；source 用于调用方标记来源。
+	// Insert 把 raw usage JSON 批量写入 redis_usage_inboxes；source 会原样落库。
 	Insert(ctx context.Context, source string, messages []string, receivedAt time.Time) (int, error)
 }
 

--- a/internal/poller/redis_ingest_state.go
+++ b/internal/poller/redis_ingest_state.go
@@ -26,7 +26,7 @@ type RedisIngestSubState string
 const (
 	// RedisIngestSubStateStarting 表示正在做 subscribe -> redis pull -> http pull 启动探测。
 	RedisIngestSubStateStarting RedisIngestSubState = "starting"
-	// RedisIngestSubStateSubscribeBackfill 表示订阅已连接，正在用旧拉取方式补历史数据。
+	// RedisIngestSubStateSubscribeBackfill 表示订阅已连接，正在用 batch pull 补历史数据。
 	RedisIngestSubStateSubscribeBackfill RedisIngestSubState = "subscribe_backfill"
 	// RedisIngestSubStateSubscribeReceiving 表示订阅连接稳定，正在等待 Redis 推送 usage 消息。
 	RedisIngestSubStateSubscribeReceiving RedisIngestSubState = "subscribe_receiving"
@@ -41,11 +41,13 @@ const (
 )
 
 const (
-	// RedisIngestSourceSubscribe 是订阅消息来源标签，只用于状态/测试，不写入 queue_key。
+	// RedisIngestSourceSubscribe 是订阅消息来源名，会原样写入 redis_usage_inboxes.source。
 	RedisIngestSourceSubscribe = "redis_subscribe:" + cpa.ManagementUsageSubscribeChannel
-	// RedisIngestSourceRedisPull 是旧 Redis queue 拉取来源标签，只用于状态/测试。
-	RedisIngestSourceRedisPull = "redis_pull:" + cpa.ManagementUsageQueueKey
-	// RedisIngestSourceHTTPPull 是 HTTP usage queue 拉取来源标签，只用于状态/测试。
+	// RedisIngestSourceRedisPullPrefix 是 Redis batch pull 来源名前缀，后面跟实际选定的 CPA key。
+	RedisIngestSourceRedisPullPrefix = "redis_pull:"
+	// RedisIngestSourceRedisPull 是 Redis batch pull 默认来源名，新版本 CPA 使用 usage key。
+	RedisIngestSourceRedisPull = RedisIngestSourceRedisPullPrefix + cpa.ManagementUsageQueueKey
+	// RedisIngestSourceHTTPPull 是 HTTP usage queue 拉取来源名，会原样写入 redis_usage_inboxes.source。
 	RedisIngestSourceHTTPPull = "http_pull:usage_queue"
 )
 

--- a/internal/poller/redis_pull_source.go
+++ b/internal/poller/redis_pull_source.go
@@ -2,25 +2,122 @@ package poller
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
 
 	"cpa-usage-keeper/internal/cpa"
+	"github.com/sirupsen/logrus"
 )
 
 type RedisPullSource struct {
-	// client 只保留 Redis queue client；HTTP fallback 已经移到 runner 状态机。
+	// mu 保护首次探测后的 queue key 固化结果。
+	mu sync.Mutex
+	// clients 固定保存 usage/queue 两个兼容 Redis pull client，避免尝试其它 key。
+	clients []redisPullQueueClient
+	// selected 记录首次成功的 Redis queue key；一旦选定，后续不再双探测。
+	selected *redisPullQueueClient
+}
+
+type redisPullQueueClient struct {
+	// queueKey 是 CPA Redis LPOP 使用的实际 key，只能来自 usage/queue 候选列表。
+	queueKey string
+	// client 绑定 queueKey 执行一次性 Redis batch pull。
 	client *cpa.RedisQueueClient
 }
 
 func NewRedisPullSource(opts cpa.RedisQueueOptions) *RedisPullSource {
-	// Redis source 只构造 client，不主动连接 Redis。
-	return &RedisPullSource{client: cpa.NewRedisQueueClientWithOptions(opts)}
+	// Redis source 只构造候选 client，不主动连接 Redis。
+	keys := redisPullQueueKeyCandidates()
+	// clients 预分配成候选 key 数量，保证后续遍历只覆盖 usage/queue 两个固定入口。
+	clients := make([]redisPullQueueClient, 0, len(keys))
+	// 按固定顺序构造候选 client，顺序本身就是兼容策略的一部分。
+	for _, key := range keys {
+		// 每个候选都复制一份 options，避免候选 key 之间共享可变配置。
+		candidateOpts := opts
+		// QueueKey 只在候选 client 内部使用，不再从外部配置传入。
+		candidateOpts.QueueKey = key
+		// 每个候选 client 绑定自己的 key，后续成功时可以固化并记录来源。
+		clients = append(clients, redisPullQueueClient{
+			// queueKey 保存 CPA 实际 Redis key，用于成功后生成 redis_pull:<key>。
+			queueKey: key,
+			// client 仍复用底层 RedisQueueClient，不把 RESP 细节放进状态机。
+			client: cpa.NewRedisQueueClientWithOptions(candidateOpts),
+		})
+	}
+	// 构造阶段不探测远端，避免应用启动被 CPA 网络状态阻塞。
+	return &RedisPullSource{clients: clients}
 }
 
 func (s *RedisPullSource) Pull(ctx context.Context) ([]string, error) {
-	if s == nil || s.client == nil {
+	if s == nil {
 		// Redis client 缺失时返回 Redis 相关错误，让 runner 走 fallback。
 		return nil, cpa.ErrRedisQueueAuth
 	}
 	// PopUsage 现在是 Redis-only；是否降级 HTTP 完全由 RedisIngestRunner 决定。
-	return s.client.PopUsage(ctx)
+	s.mu.Lock()
+	// 锁覆盖首次探测和已选 key 拉取，避免并发 goroutine 分别消费 usage/queue。
+	defer s.mu.Unlock()
+	if s.selected != nil {
+		// 首次成功后只使用已固化 key，不再在 usage/queue 之间循环尝试。
+		return s.selected.client.PopUsage(ctx)
+	}
+
+	// pullErrs 收集本轮最多两个候选错误，最终返回给 runner 做降级判断。
+	var pullErrs []error
+	for i := range s.clients {
+		// 未选定前只按候选顺序各尝试一次，最多 usage/queue 两次。
+		candidate := &s.clients[i]
+		// 每个候选只执行一次真实 LPOP，避免 CPA 不支持 key 时在内部卡住。
+		messages, err := candidate.client.PopUsage(ctx)
+		if err == nil {
+			// 首个成功 key 立刻固化，后续所有拉取都走同一个 CPA key。
+			s.selected = candidate
+			// 选定日志只打一遍，帮助现场确认到底兼容到了 usage 还是 queue。
+			logrus.WithField("redis_key", candidate.queueKey).Info("redis usage key selected")
+			// 返回本次成功拉到的消息；空批次也算 key 可用并会固化。
+			return messages, nil
+		}
+		// 错误里带上候选 key，避免用户只看到底层 unsupported channel 而不知道尝试顺序。
+		pullErrs = append(pullErrs, fmt.Errorf("%s: %w", candidate.queueKey, err))
+		if !redisPullCanTryNextQueueKey(err) {
+			// 只有 key 不支持类错误才尝试下一个 key；认证/网络/超时直接交给 runner 降级。
+			break
+		}
+	}
+	// 到这里表示没有候选成功；errors.Join 保留两次尝试的完整上下文。
+	return nil, errors.Join(pullErrs...)
+}
+
+func (s *RedisPullSource) SourceName() string {
+	if s == nil {
+		// nil source 只能返回默认来源名，避免调用方还要额外判空。
+		return RedisIngestSourceRedisPull
+	}
+	s.mu.Lock()
+	// SourceName 与 Pull 共用锁，保证读取到的 selected 与实际消费 key 一致。
+	defer s.mu.Unlock()
+	if s.selected == nil || strings.TrimSpace(s.selected.queueKey) == "" {
+		// 尚未成功探测前使用默认 usage 来源；成功拉取后 runner 会再次读取精确值。
+		return RedisIngestSourceRedisPull
+	}
+	// 成功后把实际 key 写进 source，形成 redis_pull:usage 或 redis_pull:queue。
+	return RedisIngestSourceRedisPullPrefix + strings.TrimSpace(s.selected.queueKey)
+}
+
+func redisPullQueueKeyCandidates() []string {
+	// 新版 CPA 使用 usage，旧版 CPA 使用 queue；顺序必须保持 usage -> queue。
+	return []string{cpa.ManagementUsageQueueKey, cpa.ManagementUsageLegacyQueueKey}
+}
+
+func redisPullCanTryNextQueueKey(err error) bool {
+	if err == nil {
+		// 没有错误时不存在 fallback 判定。
+		return false
+	}
+	// CPA 不同版本的错误文本可能叫 channel 或 queue，这里只识别 key 不支持类错误。
+	message := strings.ToLower(err.Error())
+	// 其它错误如认证失败、网络失败、RESP 解析失败都不能触发第二 key 尝试。
+	return strings.Contains(message, "unsupported channel") || strings.Contains(message, "unsupported queue")
 }

--- a/internal/poller/redis_pull_source.go
+++ b/internal/poller/redis_pull_source.go
@@ -57,12 +57,16 @@ func (s *RedisPullSource) Pull(ctx context.Context) ([]string, error) {
 	}
 	// PopUsage 现在是 Redis-only；是否降级 HTTP 完全由 RedisIngestRunner 决定。
 	s.mu.Lock()
-	// 锁覆盖首次探测和已选 key 拉取，避免并发 goroutine 分别消费 usage/queue。
-	defer s.mu.Unlock()
 	if s.selected != nil {
+		// 已固化路径只需要锁内复制 client，避免 Redis I/O 阻塞 SourceName 读取来源。
+		selected := s.selected
+		// 释放 RedisPullSource 状态锁后再做网络拉取；runner 的 opMu 仍负责串行化真实消费。
+		s.mu.Unlock()
 		// 首次成功后只使用已固化 key，不再在 usage/queue 之间循环尝试。
-		return s.selected.client.PopUsage(ctx)
+		return selected.client.PopUsage(ctx)
 	}
+	// 未固化前锁覆盖整个探测过程，避免并发 goroutine 分别消费 usage/queue。
+	defer s.mu.Unlock()
 
 	// pullErrs 收集本轮最多两个候选错误，最终返回给 runner 做降级判断。
 	var pullErrs []error

--- a/internal/poller/redis_pull_source_test.go
+++ b/internal/poller/redis_pull_source_test.go
@@ -1,0 +1,269 @@
+package poller
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/cpa"
+)
+
+func TestRedisPullSourceFallsBackToLegacyQueueKeyAndReusesSelection(t *testing.T) {
+	addr, wait := newRedisPullScriptedServer(t, []redisPullExpectation{
+		{queueKey: cpa.ManagementUsageQueueKey, response: "-ERR unsupported channel 'usage'\r\n"},
+		{queueKey: cpa.ManagementUsageLegacyQueueKey, response: redisPullArrayResponse("legacy-one")},
+		{queueKey: cpa.ManagementUsageLegacyQueueKey, response: redisPullArrayResponse("legacy-two")},
+	})
+
+	source := NewRedisPullSource(cpa.RedisQueueOptions{
+		RedisAddr:     addr,
+		ManagementKey: "secret",
+		Timeout:       time.Second,
+		BatchSize:     1,
+	})
+
+	messages, err := source.Pull(context.Background())
+	if err != nil {
+		t.Fatalf("first Pull returned error: %v", err)
+	}
+	if len(messages) != 1 || messages[0] != "legacy-one" {
+		t.Fatalf("unexpected first messages: %#v", messages)
+	}
+	if source.SourceName() != "redis_pull:queue" {
+		t.Fatalf("expected legacy source name redis_pull:queue, got %q", source.SourceName())
+	}
+
+	messages, err = source.Pull(context.Background())
+	if err != nil {
+		t.Fatalf("second Pull returned error: %v", err)
+	}
+	if len(messages) != 1 || messages[0] != "legacy-two" {
+		t.Fatalf("unexpected second messages: %#v", messages)
+	}
+
+	wait()
+}
+
+func TestRedisPullSourceLocksUsageQueueKeyAfterEmptySuccess(t *testing.T) {
+	addr, wait := newRedisPullScriptedServer(t, []redisPullExpectation{
+		{queueKey: cpa.ManagementUsageQueueKey, response: "*0\r\n"},
+		{queueKey: cpa.ManagementUsageQueueKey, response: redisPullArrayResponse("usage-one")},
+	})
+
+	source := NewRedisPullSource(cpa.RedisQueueOptions{
+		RedisAddr:     addr,
+		ManagementKey: "secret",
+		Timeout:       time.Second,
+		BatchSize:     1,
+	})
+
+	messages, err := source.Pull(context.Background())
+	if err != nil {
+		t.Fatalf("first Pull returned error: %v", err)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("expected empty first messages, got %#v", messages)
+	}
+	if source.SourceName() != "redis_pull:usage" {
+		t.Fatalf("expected usage source name redis_pull:usage, got %q", source.SourceName())
+	}
+
+	messages, err = source.Pull(context.Background())
+	if err != nil {
+		t.Fatalf("second Pull returned error: %v", err)
+	}
+	if len(messages) != 1 || messages[0] != "usage-one" {
+		t.Fatalf("unexpected second messages: %#v", messages)
+	}
+
+	wait()
+}
+
+func TestRedisPullSourceStopsAfterTwoUnsupportedQueueKeyAttempts(t *testing.T) {
+	addr, wait := newRedisPullScriptedServer(t, []redisPullExpectation{
+		{queueKey: cpa.ManagementUsageQueueKey, response: "-ERR unsupported channel 'usage'\r\n"},
+		{queueKey: cpa.ManagementUsageLegacyQueueKey, response: "-ERR unsupported channel 'queue'\r\n"},
+	})
+
+	source := NewRedisPullSource(cpa.RedisQueueOptions{
+		RedisAddr:     addr,
+		ManagementKey: "secret",
+		Timeout:       time.Second,
+		BatchSize:     1,
+	})
+
+	_, err := source.Pull(context.Background())
+	if err == nil {
+		t.Fatal("expected Pull to return error")
+	}
+	errorText := err.Error()
+	if !strings.Contains(errorText, "usage") || !strings.Contains(errorText, "queue") {
+		t.Fatalf("expected joined error to include both attempted keys, got %q", errorText)
+	}
+
+	wait()
+}
+
+func TestRedisPullQueueKeyCandidatesAreUsageThenQueue(t *testing.T) {
+	got := redisPullQueueKeyCandidates()
+	want := []string{cpa.ManagementUsageQueueKey, cpa.ManagementUsageLegacyQueueKey}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("redisPullQueueKeyCandidates() = %#v, want %#v", got, want)
+	}
+	if len(got) != 2 {
+		t.Fatalf("redisPullQueueKeyCandidates() returned %d keys, want 2", len(got))
+	}
+}
+
+type redisPullExpectation struct {
+	queueKey string
+	response string
+}
+
+func newRedisPullScriptedServer(t *testing.T, expectations []redisPullExpectation) (string, func()) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen redis pull test server: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		defer close(done)
+		for i, expectation := range expectations {
+			conn, err := listener.Accept()
+			if err != nil {
+				done <- fmt.Errorf("accept connection %d: %w", i+1, err)
+				return
+			}
+			if err := handleRedisPullExpectation(conn, expectation); err != nil {
+				done <- fmt.Errorf("connection %d: %w", i+1, err)
+				return
+			}
+		}
+	}()
+
+	wait := func() {
+		t.Helper()
+		if err := listener.Close(); err != nil {
+			t.Fatalf("close redis pull test listener: %v", err)
+		}
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatal(err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for redis pull test server")
+		}
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	return listener.Addr().String(), wait
+}
+
+func handleRedisPullExpectation(conn net.Conn, expectation redisPullExpectation) error {
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+	authCommand, err := readRedisPullRESPCommand(reader)
+	if err != nil {
+		return fmt.Errorf("read auth command: %w", err)
+	}
+	if got, want := strings.Join(authCommand, " "), cpa.ManagementRedisAuthCommand+" secret"; got != want {
+		return fmt.Errorf("auth command = %q, want %q", got, want)
+	}
+	if _, err := fmt.Fprint(conn, "+OK\r\n"); err != nil {
+		return fmt.Errorf("write auth response: %w", err)
+	}
+
+	popCommand, err := readRedisPullRESPCommand(reader)
+	if err != nil {
+		return fmt.Errorf("read pop command: %w", err)
+	}
+	wantPopCommand := cpa.ManagementRedisPopCommand + " " + expectation.queueKey + " 1"
+	if got := strings.Join(popCommand, " "); got != wantPopCommand {
+		return fmt.Errorf("pop command = %q, want %q", got, wantPopCommand)
+	}
+	if _, err := fmt.Fprint(conn, expectation.response); err != nil {
+		return fmt.Errorf("write pop response: %w", err)
+	}
+	return nil
+}
+
+func readRedisPullRESPCommand(reader *bufio.Reader) ([]string, error) {
+	prefix, err := reader.ReadByte()
+	if err != nil {
+		return nil, err
+	}
+	if prefix != '*' {
+		return nil, fmt.Errorf("expected RESP array, got %q", prefix)
+	}
+	countLine, err := readRedisPullRESPLine(reader)
+	if err != nil {
+		return nil, err
+	}
+	count, err := strconv.Atoi(countLine)
+	if err != nil || count < 0 {
+		return nil, fmt.Errorf("invalid RESP array length %q", countLine)
+	}
+
+	parts := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		value, err := readRedisPullRESPBulkString(reader)
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, value)
+	}
+	return parts, nil
+}
+
+func readRedisPullRESPBulkString(reader *bufio.Reader) (string, error) {
+	prefix, err := reader.ReadByte()
+	if err != nil {
+		return "", err
+	}
+	if prefix != '$' {
+		return "", fmt.Errorf("expected RESP bulk string, got %q", prefix)
+	}
+	lengthLine, err := readRedisPullRESPLine(reader)
+	if err != nil {
+		return "", err
+	}
+	length, err := strconv.Atoi(lengthLine)
+	if err != nil || length < 0 {
+		return "", fmt.Errorf("invalid RESP bulk length %q", lengthLine)
+	}
+
+	payload := make([]byte, length+2)
+	if _, err := io.ReadFull(reader, payload); err != nil {
+		return "", err
+	}
+	if payload[length] != '\r' || payload[length+1] != '\n' {
+		return "", fmt.Errorf("malformed RESP bulk string")
+	}
+	return string(payload[:length]), nil
+}
+
+func readRedisPullRESPLine(reader *bufio.Reader) (string, error) {
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasSuffix(line, "\r\n") {
+		return "", fmt.Errorf("malformed RESP line")
+	}
+	return strings.TrimSuffix(line, "\r\n"), nil
+}
+
+func redisPullArrayResponse(value string) string {
+	return fmt.Sprintf("*1\r\n$%d\r\n%s\r\n", len(value), value)
+}

--- a/internal/poller/redis_pull_source_test.go
+++ b/internal/poller/redis_pull_source_test.go
@@ -85,6 +85,57 @@ func TestRedisPullSourceLocksUsageQueueKeyAfterEmptySuccess(t *testing.T) {
 	wait()
 }
 
+func TestRedisPullSourceNameDoesNotWaitForSelectedPop(t *testing.T) {
+	addr, releaseSecondPop, waitForSecondPop, wait := newRedisPullBlockingSecondPopServer(t)
+
+	source := NewRedisPullSource(cpa.RedisQueueOptions{
+		RedisAddr:     addr,
+		ManagementKey: "secret",
+		Timeout:       time.Second,
+		BatchSize:     1,
+	})
+
+	messages, err := source.Pull(context.Background())
+	if err != nil {
+		t.Fatalf("first Pull returned error: %v", err)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("expected empty first messages, got %#v", messages)
+	}
+
+	pullDone := make(chan error, 1)
+	go func() {
+		_, err := source.Pull(context.Background())
+		pullDone <- err
+	}()
+
+	waitForSecondPop()
+
+	sourceNameDone := make(chan string, 1)
+	go func() {
+		sourceNameDone <- source.SourceName()
+	}()
+
+	select {
+	case sourceName := <-sourceNameDone:
+		if sourceName != "redis_pull:usage" {
+			t.Fatalf("expected source name redis_pull:usage, got %q", sourceName)
+		}
+	case <-time.After(100 * time.Millisecond):
+		releaseSecondPop()
+		if err := <-pullDone; err != nil {
+			t.Fatalf("second Pull returned error after release: %v", err)
+		}
+		t.Fatal("SourceName waited for selected PopUsage to finish")
+	}
+
+	releaseSecondPop()
+	if err := <-pullDone; err != nil {
+		t.Fatalf("second Pull returned error: %v", err)
+	}
+	wait()
+}
+
 func TestRedisPullSourceStopsAfterTwoUnsupportedQueueKeyAttempts(t *testing.T) {
 	addr, wait := newRedisPullScriptedServer(t, []redisPullExpectation{
 		{queueKey: cpa.ManagementUsageQueueKey, response: "-ERR unsupported channel 'usage'\r\n"},
@@ -169,6 +220,78 @@ func newRedisPullScriptedServer(t *testing.T, expectations []redisPullExpectatio
 	return listener.Addr().String(), wait
 }
 
+func newRedisPullBlockingSecondPopServer(t *testing.T) (string, func(), func(), func()) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen redis pull blocking test server: %v", err)
+	}
+
+	secondPopReady := make(chan struct{})
+	releaseSecondPop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		defer close(done)
+		expectations := []redisPullExpectation{
+			{queueKey: cpa.ManagementUsageQueueKey, response: "*0\r\n"},
+			{queueKey: cpa.ManagementUsageQueueKey, response: redisPullArrayResponse("usage-after-release")},
+		}
+		for i, expectation := range expectations {
+			conn, err := listener.Accept()
+			if err != nil {
+				done <- fmt.Errorf("accept blocking connection %d: %w", i+1, err)
+				return
+			}
+			if i == 1 {
+				if err := handleRedisPullExpectationAfterSignal(conn, expectation, secondPopReady, releaseSecondPop); err != nil {
+					done <- fmt.Errorf("blocking connection %d: %w", i+1, err)
+					return
+				}
+				continue
+			}
+			if err := handleRedisPullExpectation(conn, expectation); err != nil {
+				done <- fmt.Errorf("blocking connection %d: %w", i+1, err)
+				return
+			}
+		}
+	}()
+
+	release := func() {
+		t.Helper()
+		select {
+		case <-releaseSecondPop:
+		default:
+			close(releaseSecondPop)
+		}
+	}
+	waitForPop := func() {
+		t.Helper()
+		select {
+		case <-secondPopReady:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for second redis pop command")
+		}
+	}
+	wait := func() {
+		t.Helper()
+		if err := listener.Close(); err != nil {
+			t.Fatalf("close redis pull blocking test listener: %v", err)
+		}
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatal(err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for redis pull blocking test server")
+		}
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	return listener.Addr().String(), release, waitForPop, wait
+}
+
 func handleRedisPullExpectation(conn net.Conn, expectation redisPullExpectation) error {
 	defer conn.Close()
 
@@ -192,6 +315,38 @@ func handleRedisPullExpectation(conn net.Conn, expectation redisPullExpectation)
 	if got := strings.Join(popCommand, " "); got != wantPopCommand {
 		return fmt.Errorf("pop command = %q, want %q", got, wantPopCommand)
 	}
+	if _, err := fmt.Fprint(conn, expectation.response); err != nil {
+		return fmt.Errorf("write pop response: %w", err)
+	}
+	return nil
+}
+
+func handleRedisPullExpectationAfterSignal(conn net.Conn, expectation redisPullExpectation, ready chan<- struct{}, release <-chan struct{}) error {
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+	authCommand, err := readRedisPullRESPCommand(reader)
+	if err != nil {
+		return fmt.Errorf("read auth command: %w", err)
+	}
+	if got, want := strings.Join(authCommand, " "), cpa.ManagementRedisAuthCommand+" secret"; got != want {
+		return fmt.Errorf("auth command = %q, want %q", got, want)
+	}
+	if _, err := fmt.Fprint(conn, "+OK\r\n"); err != nil {
+		return fmt.Errorf("write auth response: %w", err)
+	}
+
+	popCommand, err := readRedisPullRESPCommand(reader)
+	if err != nil {
+		return fmt.Errorf("read pop command: %w", err)
+	}
+	wantPopCommand := cpa.ManagementRedisPopCommand + " " + expectation.queueKey + " 1"
+	if got := strings.Join(popCommand, " "); got != wantPopCommand {
+		return fmt.Errorf("pop command = %q, want %q", got, wantPopCommand)
+	}
+	close(ready)
+	<-release
+
 	if _, err := fmt.Fprint(conn, expectation.response); err != nil {
 		return fmt.Errorf("write pop response: %w", err)
 	}

--- a/internal/poller/test/redis_inbox_writer_test.go
+++ b/internal/poller/test/redis_inbox_writer_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"cpa-usage-keeper/internal/config"
-	"cpa-usage-keeper/internal/cpa"
 	"cpa-usage-keeper/internal/entities"
 	"cpa-usage-keeper/internal/poller"
 	"cpa-usage-keeper/internal/repository"
@@ -46,7 +45,7 @@ func TestClassifyRedisControlMessage(t *testing.T) {
 
 func TestRedisInboxWriterSkipsEmptyMessages(t *testing.T) {
 	db := openPollerTestDB(t)
-	writer := poller.NewRedisInboxWriter(db, cpa.ManagementUsageQueueKey)
+	writer := poller.NewRedisInboxWriter(db)
 
 	inserted, err := writer.Insert(context.Background(), poller.RedisIngestSourceSubscribe, nil, time.Now())
 	if err != nil {
@@ -68,7 +67,7 @@ func TestRedisInboxWriterSkipsEmptyMessages(t *testing.T) {
 func TestRedisInboxWriterPersistsMessagesWithSource(t *testing.T) {
 	db := openPollerTestDB(t)
 	receivedAt := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
-	writer := poller.NewRedisInboxWriter(db, cpa.ManagementUsageQueueKey)
+	writer := poller.NewRedisInboxWriter(db)
 
 	inserted, err := writer.Insert(context.Background(), poller.RedisIngestSourceSubscribe, []string{`{"request_id":"one"}`}, receivedAt)
 	if err != nil {
@@ -85,8 +84,8 @@ func TestRedisInboxWriterPersistsMessagesWithSource(t *testing.T) {
 	if len(rows) != 1 {
 		t.Fatalf("expected one redis inbox row, got %d", len(rows))
 	}
-	if rows[0].QueueKey != cpa.ManagementUsageQueueKey {
-		t.Fatalf("expected queue key %q, got %q", cpa.ManagementUsageQueueKey, rows[0].QueueKey)
+	if rows[0].Source != poller.RedisIngestSourceSubscribe {
+		t.Fatalf("expected source %q, got %q", poller.RedisIngestSourceSubscribe, rows[0].Source)
 	}
 	if rows[0].RawMessage != `{"request_id":"one"}` {
 		t.Fatalf("unexpected raw message %q", rows[0].RawMessage)
@@ -100,7 +99,7 @@ func TestControlAwareRedisInboxWriterFiltersControlMessages(t *testing.T) {
 	db := openPollerTestDB(t)
 	observer := &controlObserverStub{}
 	writer := poller.NewControlAwareRedisInboxWriter(
-		poller.NewRedisInboxWriter(db, cpa.ManagementUsageQueueKey),
+		poller.NewRedisInboxWriter(db),
 		observer,
 	)
 
@@ -129,7 +128,7 @@ func TestControlAwareRedisInboxWriterSkipsControlOnlyBatch(t *testing.T) {
 	db := openPollerTestDB(t)
 	observer := &controlObserverStub{}
 	writer := poller.NewControlAwareRedisInboxWriter(
-		poller.NewRedisInboxWriter(db, cpa.ManagementUsageQueueKey),
+		poller.NewRedisInboxWriter(db),
 		observer,
 	)
 
@@ -154,7 +153,7 @@ func TestControlAwareRedisInboxWriterSkipsEmptyAndNullPayloads(t *testing.T) {
 	db := openPollerTestDB(t)
 	observer := &controlObserverStub{}
 	writer := poller.NewControlAwareRedisInboxWriter(
-		poller.NewRedisInboxWriter(db, cpa.ManagementUsageQueueKey),
+		poller.NewRedisInboxWriter(db),
 		observer,
 	)
 

--- a/internal/poller/test/redis_ingest_runner_test.go
+++ b/internal/poller/test/redis_ingest_runner_test.go
@@ -84,6 +84,30 @@ func TestRedisIngestRunnerSubscribeBackfillsBeforeReceiving(t *testing.T) {
 	}
 }
 
+func TestRedisIngestRunnerWritesDynamicPullSourceName(t *testing.T) {
+	writer := newFakeInboxWriter()
+	redisSource := &fakeNamedPullSource{
+		fakePullSource: &fakePullSource{batches: [][]string{{`{"request_id":"redis"}`}}},
+		sourceName:     "redis_pull:queue",
+	}
+	runner := poller.NewRedisIngestRunner(
+		fakeSubscribeSource{err: errors.New("subscribe unavailable")},
+		redisSource,
+		&fakePullSource{},
+		writer,
+		poller.RedisIngestRunnerConfig{IdleInterval: 10 * time.Millisecond, BatchSize: 10, HTTPBackoffInitial: 10 * time.Millisecond, HTTPBackoffMax: 10 * time.Millisecond},
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = runner.Run(ctx) }()
+
+	entry := writer.waitForInsert(t)
+	cancel()
+	if entry.source != "redis_pull:queue" {
+		t.Fatalf("expected dynamic Redis pull source, got %q", entry.source)
+	}
+}
+
 func TestRedisIngestRunnerSubscribeBackfillDrainsRedisBeforeReceiving(t *testing.T) {
 	writer := newFakeInboxWriter()
 	sub := &blockingSubscription{messages: make(chan string)}
@@ -491,6 +515,13 @@ func (s *fakePullSource) Pull(context.Context) ([]string, error) {
 	s.batches = s.batches[1:]
 	return batch, nil
 }
+
+type fakeNamedPullSource struct {
+	*fakePullSource
+	sourceName string
+}
+
+func (s *fakeNamedPullSource) SourceName() string { return s.sourceName }
 
 type fakeInboxInsert struct {
 	source   string

--- a/internal/repository/db_test.go
+++ b/internal/repository/db_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"cpa-usage-keeper/internal/config"
-	"cpa-usage-keeper/internal/cpa"
 	"cpa-usage-keeper/internal/entities"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
@@ -54,11 +53,17 @@ func TestOpenDatabaseCreatesFreshDatabaseFromCurrentSchemaWithoutRunningMigratio
 	if err := db.Table("schema_migrations").Count(&count).Error; err != nil {
 		t.Fatalf("count schema migrations: %v", err)
 	}
-	if count != 37 {
-		t.Fatalf("expected fresh database to mark 37 migrations applied, got %d", count)
+	if count != 38 {
+		t.Fatalf("expected fresh database to mark 38 migrations applied, got %d", count)
 	}
 	if strings.Contains(logs.String(), "schema migration started") {
 		t.Fatalf("expected fresh database creation not to run version migrations, got logs:\n%s", logs.String())
+	}
+	if !db.Migrator().HasColumn(&entities.RedisUsageInbox{}, "source") {
+		t.Fatal("expected redis_usage_inboxes.source column to exist")
+	}
+	if db.Migrator().HasColumn(&entities.RedisUsageInbox{}, "queue_key") {
+		t.Fatal("expected redis_usage_inboxes.queue_key column not to exist")
 	}
 	for _, indexName := range []string{
 		"idx_usage_events_api_group_key",
@@ -357,7 +362,7 @@ func TestDatabaseTimeFieldsUseProjectTimezoneRFC3339Nano(t *testing.T) {
 	if _, err := UpsertModelPriceSetting(db, dto.ModelPriceSettingInput{Model: "claude-sonnet", PromptPricePer1M: 1}); err != nil {
 		t.Fatalf("UpsertModelPriceSetting returned error: %v", err)
 	}
-	inboxRows, err := InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"event-storage-time"}`, PoppedAt: storageTime}})
+	inboxRows, err := InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{Source: testRedisInboxSource, RawMessage: `{"request_id":"event-storage-time"}`, PoppedAt: storageTime}})
 	if err != nil {
 		t.Fatalf("InsertRedisUsageInboxMessages returned error: %v", err)
 	}
@@ -420,8 +425,8 @@ func TestCleanupStorageCleansRedisInboxAndVacuums(t *testing.T) {
 	now := time.Date(2026, 4, 27, 2, 30, 0, 0, time.UTC)
 
 	inboxRows, err := InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"processed-old"}`, PoppedAt: now.AddDate(0, 0, -2)},
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"pending"}`, PoppedAt: now.AddDate(0, 0, -2)},
+		{Source: testRedisInboxSource, RawMessage: `{"request_id":"processed-old"}`, PoppedAt: now.AddDate(0, 0, -2)},
+		{Source: testRedisInboxSource, RawMessage: `{"request_id":"pending"}`, PoppedAt: now.AddDate(0, 0, -2)},
 	})
 	if err != nil {
 		t.Fatalf("InsertRedisUsageInboxMessages returned error: %v", err)

--- a/internal/repository/dto/redis_inbox.go
+++ b/internal/repository/dto/redis_inbox.go
@@ -2,9 +2,9 @@ package dto
 
 import "time"
 
-// RedisInboxInsert 是 Redis usage inbox 的入库参数。
+// RedisInboxInsert 是 Redis usage inbox 的入库参数，source 原样落库。
 type RedisInboxInsert struct {
-	QueueKey   string
+	Source     string
 	RawMessage string
 	PoppedAt   time.Time
 }

--- a/internal/repository/migration/20260612_redis_inbox_source.go
+++ b/internal/repository/migration/20260612_redis_inbox_source.go
@@ -1,0 +1,38 @@
+package migration
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// replaceRedisInboxQueueKeyWithSourceMigration 把历史 queue_key 列替换为可直接落库来源名的 source 列。
+func replaceRedisInboxQueueKeyWithSourceMigration(tx *gorm.DB) error {
+	// 旧库如果还没有 redis_usage_inboxes，说明对应功能未初始化，本迁移不需要做任何结构修正。
+	if !tx.Migrator().HasTable("redis_usage_inboxes") {
+		return nil
+	}
+	// source 不存在时先添加非空列；历史 queue_key 无法反推出 subscribe/redis/http 来源，所以统一标记 unknown。
+	if !tx.Migrator().HasColumn("redis_usage_inboxes", "source") {
+		// SQLite 旧行会自动获得 DEFAULT 值，避免非空列添加后已有数据违反约束。
+		if err := tx.Exec("ALTER TABLE redis_usage_inboxes ADD COLUMN source TEXT NOT NULL DEFAULT 'unknown'").Error; err != nil {
+			// 保留表名和列名，方便用户升级失败时定位具体 schema 步骤。
+			return fmt.Errorf("add redis_usage_inboxes.source column: %w", err)
+		}
+	}
+	// 删除历史 queue_key 索引，避免 DROP COLUMN 时被索引依赖阻塞，也避免保留无用 schema。
+	if err := tx.Exec("DROP INDEX IF EXISTS idx_redis_usage_inboxes_queue_key").Error; err != nil {
+		// 索引删除失败必须中断迁移，否则后续结构可能处在半升级状态。
+		return fmt.Errorf("drop redis_usage_inboxes queue_key index: %w", err)
+	}
+	// queue_key 存在时才删除，保证迁移可重复执行并兼容已经部分升级的数据库。
+	if tx.Migrator().HasColumn("redis_usage_inboxes", "queue_key") {
+		// 这里直接删除列，是因为新写入路径已经只使用 source，保留旧列会继续误导参数语义。
+		if err := tx.Exec("ALTER TABLE redis_usage_inboxes DROP COLUMN queue_key").Error; err != nil {
+			// 删除失败时带上完整列名，避免和其它 inbox schema 迁移混淆。
+			return fmt.Errorf("drop redis_usage_inboxes.queue_key column: %w", err)
+		}
+	}
+	// 结构已经收敛到 source-only，返回 nil 让迁移框架记录版本。
+	return nil
+}

--- a/internal/repository/migration/20260612_redis_inbox_source_test.go
+++ b/internal/repository/migration/20260612_redis_inbox_source_test.go
@@ -1,0 +1,68 @@
+package migration
+
+import (
+	"path/filepath"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestReplaceRedisInboxQueueKeyWithSourceMigrationAddsSourceAndDropsQueueKey(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(testSQLiteDSN(filepath.Join(t.TempDir(), "legacy.db"))), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open legacy database: %v", err)
+	}
+	defer closeOpenedDatabase(t, db)
+
+	if err := db.Exec(`CREATE TABLE redis_usage_inboxes (
+		id integer PRIMARY KEY AUTOINCREMENT,
+		queue_key text NOT NULL,
+		message_hash text NOT NULL,
+		raw_message text NOT NULL,
+		status text NOT NULL,
+		attempt_count integer NOT NULL DEFAULT 0,
+		usage_event_key text,
+		popped_at datetime NOT NULL,
+		created_at datetime,
+		updated_at datetime
+	)`).Error; err != nil {
+		t.Fatalf("create legacy redis_usage_inboxes table: %v", err)
+	}
+	if err := db.Exec(`CREATE INDEX idx_redis_usage_inboxes_queue_key ON redis_usage_inboxes(queue_key)`).Error; err != nil {
+		t.Fatalf("create legacy queue_key index: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO redis_usage_inboxes (
+		queue_key, message_hash, raw_message, status, popped_at, created_at, updated_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"queue", "hash-one", `{"request_id":"one"}`, "pending",
+		"2026-06-12T10:00:00+08:00", "2026-06-12T10:00:00+08:00", "2026-06-12T10:00:00+08:00",
+	).Error; err != nil {
+		t.Fatalf("seed legacy redis_usage_inboxes row: %v", err)
+	}
+
+	if err := replaceRedisInboxQueueKeyWithSourceMigration(db); err != nil {
+		t.Fatalf("replaceRedisInboxQueueKeyWithSourceMigration returned error: %v", err)
+	}
+	if err := replaceRedisInboxQueueKeyWithSourceMigration(db); err != nil {
+		t.Fatalf("replaceRedisInboxQueueKeyWithSourceMigration idempotently returned error: %v", err)
+	}
+
+	if !db.Migrator().HasColumn("redis_usage_inboxes", "source") {
+		t.Fatal("expected redis_usage_inboxes.source column to exist")
+	}
+	if db.Migrator().HasColumn("redis_usage_inboxes", "queue_key") {
+		t.Fatal("expected redis_usage_inboxes.queue_key column to be removed")
+	}
+	if sqliteIndexExists(t, db, "idx_redis_usage_inboxes_queue_key") {
+		t.Fatal("expected legacy queue_key index to be removed")
+	}
+
+	var source string
+	if err := db.Table("redis_usage_inboxes").Select("source").Where("id = ?", 1).Scan(&source).Error; err != nil {
+		t.Fatalf("load migrated source: %v", err)
+	}
+	if source != "unknown" {
+		t.Fatalf("expected migrated source to be unknown, got %q", source)
+	}
+}

--- a/internal/repository/migration/migration.go
+++ b/internal/repository/migration/migration.go
@@ -47,6 +47,7 @@ const (
 	migrationBackfillGeminiCodexTokenFormat         = "20260605_backfill_gemini_codex_token_format"
 	migrationRemoveUsageEventWriteHeavyIndexes      = "20260610_remove_usage_event_write_heavy_indexes"
 	migrationRemoveUsageEventLowValueIndexes        = "20260611_remove_usage_event_low_value_indexes"
+	migrationReplaceRedisInboxQueueKeyWithSource    = "20260612_replace_redis_inbox_queue_key_with_source"
 )
 
 type schemaMigration struct {
@@ -138,6 +139,7 @@ func orderedMigrations() []databaseMigration {
 		{version: migrationBackfillGeminiCodexTokenFormat, run: backfillGeminiCodexTokenFormatMigration},
 		{version: migrationRemoveUsageEventWriteHeavyIndexes, run: removeUsageEventWriteHeavyIndexesMigration},
 		{version: migrationRemoveUsageEventLowValueIndexes, run: removeUsageEventLowValueIndexesMigration},
+		{version: migrationReplaceRedisInboxQueueKeyWithSource, run: replaceRedisInboxQueueKeyWithSourceMigration},
 	}
 }
 

--- a/internal/repository/migration/migration_test.go
+++ b/internal/repository/migration/migration_test.go
@@ -56,6 +56,7 @@ func TestOrderedMigrationsPreservesExecutionOrder(t *testing.T) {
 		"20260605_backfill_gemini_codex_token_format",
 		"20260610_remove_usage_event_write_heavy_indexes",
 		"20260611_remove_usage_event_low_value_indexes",
+		"20260612_replace_redis_inbox_queue_key_with_source",
 	}
 	if len(got) != len(want) {
 		t.Fatalf("expected ordered migrations %v, got %v", want, got)
@@ -81,6 +82,12 @@ func TestOpenDatabaseRunsSchemaMigrationsAndAddsUsageEventRedisFields(t *testing
 		if !db.Migrator().HasColumn(&entities.UsageEvent{}, column) {
 			t.Fatalf("expected usage_events.%s column to exist", column)
 		}
+	}
+	if !db.Migrator().HasColumn(&entities.RedisUsageInbox{}, "source") {
+		t.Fatal("expected redis_usage_inboxes.source column to exist")
+	}
+	if db.Migrator().HasColumn(&entities.RedisUsageInbox{}, "queue_key") {
+		t.Fatal("expected redis_usage_inboxes.queue_key column not to exist")
 	}
 	if !db.Migrator().HasColumn(&entities.UsageIdentity{}, "lookup_key") {
 		t.Fatal("expected usage_identities.lookup_key column to exist")
@@ -133,6 +140,7 @@ func TestOpenDatabaseRunsSchemaMigrationsAndAddsUsageEventRedisFields(t *testing
 		"20260605_backfill_gemini_codex_token_format",
 		"20260610_remove_usage_event_write_heavy_indexes",
 		"20260611_remove_usage_event_low_value_indexes",
+		"20260612_replace_redis_inbox_queue_key_with_source",
 	}
 	if len(versions) != len(expected) {
 		t.Fatalf("expected migration versions %v, got %v", expected, versions)

--- a/internal/repository/redis_usage_inbox.go
+++ b/internal/repository/redis_usage_inbox.go
@@ -13,7 +13,7 @@ import (
 	"gorm.io/gorm"
 )
 
-const redisUsageInboxProcessingColumns = "id, queue_key, raw_message, status, attempt_count, usage_event_key, popped_at"
+const redisUsageInboxProcessingColumns = "id, source, raw_message, status, attempt_count, usage_event_key, popped_at"
 
 const (
 	RedisUsageInboxStatusPending       = "pending"
@@ -21,16 +21,21 @@ const (
 	RedisUsageInboxStatusDecodeFailed  = "decode_failed"
 	RedisUsageInboxStatusProcessFailed = "process_failed"
 	RedisUsageInboxStatusDiscarded     = "discarded"
+	// RedisUsageInboxSourceUnknown 表示历史或异常写入路径无法可靠还原真实来源。
+	RedisUsageInboxSourceUnknown = "unknown"
 
 	redisUsageInboxMaxErrorLength     = 1024
 	redisUsageInboxMaxProcessAttempts = 5
 )
 
-func InsertRedisUsageInboxRawMessages(db *gorm.DB, queueKey string, messages []string, poppedAt time.Time) ([]entities.RedisUsageInbox, error) {
+func InsertRedisUsageInboxRawMessages(db *gorm.DB, source string, messages []string, poppedAt time.Time) ([]entities.RedisUsageInbox, error) {
+	// inputs 统一走结构化 DTO，避免 raw message 快捷入口和测试入口出现两套入库逻辑。
 	inputs := make([]dto.RedisInboxInsert, 0, len(messages))
 	for _, message := range messages {
-		inputs = append(inputs, dto.RedisInboxInsert{QueueKey: queueKey, RawMessage: message, PoppedAt: poppedAt})
+		// source 原样传给标准入口，真正的 trim/兜底只在一个地方完成。
+		inputs = append(inputs, dto.RedisInboxInsert{Source: source, RawMessage: message, PoppedAt: poppedAt})
 	}
+	// InsertRedisUsageInboxMessages 是唯一实际批量写入入口。
 	return InsertRedisUsageInboxMessages(db, inputs)
 }
 
@@ -44,7 +49,7 @@ func InsertRedisUsageInboxMessages(db *gorm.DB, inputs []dto.RedisInboxInsert) (
 	for _, input := range inputs {
 		hash := sha256.Sum256([]byte(input.RawMessage))
 		rows = append(rows, entities.RedisUsageInbox{
-			QueueKey:     strings.TrimSpace(input.QueueKey),
+			Source:       redisUsageInboxSource(input.Source),
 			MessageHash:  fmt.Sprintf("%x", hash),
 			RawMessage:   input.RawMessage,
 			Status:       RedisUsageInboxStatusPending,
@@ -60,6 +65,17 @@ func InsertRedisUsageInboxMessages(db *gorm.DB, inputs []dto.RedisInboxInsert) (
 		return nil, err
 	}
 	return rows, nil
+}
+
+func redisUsageInboxSource(value string) string {
+	// 统一去掉配置或调用方传入来源名两端空白，避免同一来源出现多个字符串形态。
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		// 空来源不能写入非空列，也不能伪造成某个真实拉取方式。
+		return RedisUsageInboxSourceUnknown
+	}
+	// 非空来源保持调用方完整语义，例如 redis_subscribe:usage 或 redis_pull:queue。
+	return trimmed
 }
 
 func MarkRedisUsageInboxProcessed(db *gorm.DB, id int64, eventKey string, processedAt time.Time) error {

--- a/internal/repository/redis_usage_inbox_test.go
+++ b/internal/repository/redis_usage_inbox_test.go
@@ -8,17 +8,18 @@ import (
 	"testing"
 	"time"
 
-	"cpa-usage-keeper/internal/cpa"
 	"cpa-usage-keeper/internal/entities"
 )
+
+const testRedisInboxSource = "redis_pull:usage"
 
 func TestInsertRedisUsageInboxMessagesPersistsPendingRows(t *testing.T) {
 	db := openTestDatabase(t)
 	poppedAt := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
 
 	rows, err := InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"one"}`, PoppedAt: poppedAt},
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"two"}`, PoppedAt: poppedAt.Add(time.Second)},
+		{Source: testRedisInboxSource, RawMessage: `{"request_id":"one"}`, PoppedAt: poppedAt},
+		{Source: testRedisInboxSource, RawMessage: `{"request_id":"two"}`, PoppedAt: poppedAt.Add(time.Second)},
 	})
 	if err != nil {
 		t.Fatalf("InsertRedisUsageInboxMessages returned error: %v", err)
@@ -43,6 +44,9 @@ func TestInsertRedisUsageInboxMessagesPersistsPendingRows(t *testing.T) {
 	if stored[0].RawMessage != `{"request_id":"one"}` {
 		t.Fatalf("unexpected raw message: %q", stored[0].RawMessage)
 	}
+	if stored[0].Source != testRedisInboxSource {
+		t.Fatalf("expected source %q, got %q", testRedisInboxSource, stored[0].Source)
+	}
 	if stored[0].MessageHash != fmt.Sprintf("%x", sha256.Sum256([]byte(stored[0].RawMessage))) {
 		t.Fatalf("unexpected message hash: %q", stored[0].MessageHash)
 	}
@@ -57,7 +61,7 @@ func TestInsertRedisUsageInboxMessagesBatchesLargeInsertSet(t *testing.T) {
 	inputs := make([]dto.RedisInboxInsert, 0, 901)
 	for i := 0; i < 901; i++ {
 		inputs = append(inputs, dto.RedisInboxInsert{
-			QueueKey:   cpa.ManagementUsageQueueKey,
+			Source:     testRedisInboxSource,
 			RawMessage: fmt.Sprintf(`{"request_id":"large-%04d"}`, i),
 			PoppedAt:   poppedAt.Add(time.Duration(i) * time.Second),
 		})
@@ -102,7 +106,7 @@ func TestRedisUsageInboxStatusTransitions(t *testing.T) {
 	poppedAt := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
 	processedAt := poppedAt.Add(time.Minute)
 
-	rows, err := InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"one"}`, PoppedAt: poppedAt}})
+	rows, err := InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{Source: testRedisInboxSource, RawMessage: `{"request_id":"one"}`, PoppedAt: poppedAt}})
 	if err != nil {
 		t.Fatalf("InsertRedisUsageInboxMessages returned error: %v", err)
 	}
@@ -131,8 +135,8 @@ func TestRedisUsageInboxFailureTransitionsBoundErrors(t *testing.T) {
 	poppedAt := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
 
 	rows, err := InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{bad`, PoppedAt: poppedAt},
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"two"}`, PoppedAt: poppedAt},
+		{Source: testRedisInboxSource, RawMessage: `{bad`, PoppedAt: poppedAt},
+		{Source: testRedisInboxSource, RawMessage: `{"request_id":"two"}`, PoppedAt: poppedAt},
 	})
 	if err != nil {
 		t.Fatalf("InsertRedisUsageInboxMessages returned error: %v", err)
@@ -174,7 +178,7 @@ func TestMarkRedisUsageInboxProcessFailedDiscardsRowsAfterMaxAttempts(t *testing
 	db := openTestDatabase(t)
 	poppedAt := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
 
-	rows, err := InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"retry"}`, PoppedAt: poppedAt}})
+	rows, err := InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{Source: testRedisInboxSource, RawMessage: `{"request_id":"retry"}`, PoppedAt: poppedAt}})
 	if err != nil {
 		t.Fatalf("InsertRedisUsageInboxMessages returned error: %v", err)
 	}
@@ -213,9 +217,9 @@ func TestListProcessableRedisUsageInboxIncludesProcessFailedRows(t *testing.T) {
 	poppedAt := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
 
 	rows, err := InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"pending"}`, PoppedAt: poppedAt},
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"retry"}`, PoppedAt: poppedAt},
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{bad`, PoppedAt: poppedAt},
+		{Source: testRedisInboxSource, RawMessage: `{"request_id":"pending"}`, PoppedAt: poppedAt},
+		{Source: testRedisInboxSource, RawMessage: `{"request_id":"retry"}`, PoppedAt: poppedAt},
+		{Source: testRedisInboxSource, RawMessage: `{bad`, PoppedAt: poppedAt},
 	})
 	if err != nil {
 		t.Fatalf("InsertRedisUsageInboxMessages returned error: %v", err)
@@ -251,12 +255,12 @@ func TestCleanupRedisUsageInboxRemovesOldProcessedAndFailedRows(t *testing.T) {
 	now := time.Date(2026, 4, 27, 2, 30, 0, 0, time.UTC)
 
 	rows, err := InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"processed-old"}`, PoppedAt: now.Add(-48 * time.Hour)},
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"processed-today"}`, PoppedAt: now.Add(-time.Hour)},
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"failed-old"}`, PoppedAt: now.AddDate(0, 0, -8)},
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"discarded-old"}`, PoppedAt: now.AddDate(0, 0, -8)},
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"failed-recent"}`, PoppedAt: now.AddDate(0, 0, -6)},
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"pending-old"}`, PoppedAt: now.AddDate(0, 0, -10)},
+		{Source: testRedisInboxSource, RawMessage: `{"request_id":"processed-old"}`, PoppedAt: now.Add(-48 * time.Hour)},
+		{Source: testRedisInboxSource, RawMessage: `{"request_id":"processed-today"}`, PoppedAt: now.Add(-time.Hour)},
+		{Source: testRedisInboxSource, RawMessage: `{"request_id":"failed-old"}`, PoppedAt: now.AddDate(0, 0, -8)},
+		{Source: testRedisInboxSource, RawMessage: `{"request_id":"discarded-old"}`, PoppedAt: now.AddDate(0, 0, -8)},
+		{Source: testRedisInboxSource, RawMessage: `{"request_id":"failed-recent"}`, PoppedAt: now.AddDate(0, 0, -6)},
+		{Source: testRedisInboxSource, RawMessage: `{"request_id":"pending-old"}`, PoppedAt: now.AddDate(0, 0, -10)},
 	})
 	if err != nil {
 		t.Fatalf("InsertRedisUsageInboxMessages returned error: %v", err)
@@ -306,9 +310,9 @@ func TestListPendingRedisUsageInboxReturnsPendingRowsInIDOrder(t *testing.T) {
 	poppedAt := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
 
 	rows, err := InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"one"}`, PoppedAt: poppedAt},
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"two"}`, PoppedAt: poppedAt},
-		{QueueKey: cpa.ManagementUsageQueueKey, RawMessage: `{"request_id":"three"}`, PoppedAt: poppedAt},
+		{Source: testRedisInboxSource, RawMessage: `{"request_id":"one"}`, PoppedAt: poppedAt},
+		{Source: testRedisInboxSource, RawMessage: `{"request_id":"two"}`, PoppedAt: poppedAt},
+		{Source: testRedisInboxSource, RawMessage: `{"request_id":"three"}`, PoppedAt: poppedAt},
 	})
 	if err != nil {
 		t.Fatalf("InsertRedisUsageInboxMessages returned error: %v", err)

--- a/internal/service/redis_usage.go
+++ b/internal/service/redis_usage.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -11,10 +10,6 @@ import (
 	"cpa-usage-keeper/internal/repository/dto"
 	"cpa-usage-keeper/internal/timeutil"
 )
-
-type RedisQueue interface {
-	PopUsage(ctx context.Context) ([]string, error)
-}
 
 // DecodeRedisUsageMessage 将 redis_inboxes.raw_message 原样解码为 usage_events 入库实体。
 func DecodeRedisUsageMessage(message string, fetchedAt time.Time) (entities.UsageEvent, json.RawMessage, error) {

--- a/internal/service/redis_usage_test.go
+++ b/internal/service/redis_usage_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -87,13 +86,4 @@ func TestDecodeRedisUsageMessageReportsOnlyMessageError(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "decode redis usage message") {
 		t.Fatalf("expected decode error, got %v", err)
 	}
-}
-
-type staticRedisQueue struct {
-	messages []string
-	err      error
-}
-
-func (q staticRedisQueue) PopUsage(context.Context) ([]string, error) {
-	return q.messages, q.err
 }

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -51,34 +51,21 @@ const (
 	syncMetadataRequired = true
 )
 
-// SyncService 负责把 CPA metadata 和 Redis usage 队列同步到本地 SQLite。
+// SyncService 负责同步 CPA metadata，并处理已经落入本地 inbox 的 usage 原始消息。
 type SyncService struct {
 	db              *gorm.DB
 	client          CPAClientFetcher
-	redisQueue      RedisQueue
-	redisQueueKey   string
 	metadataFetcher MetadataFetcher
 	baseURL         string
 	now             func() time.Time
 	recentUsage     RecentUsageEventAppender
 }
 
-// NewSyncService 按生产配置组装 CPA metadata client 和 Redis queue client。
+// NewSyncService 按生产配置组装 CPA metadata client；远端 usage 拉取由 poller 独立负责。
 func NewSyncService(db *gorm.DB, cfg config.Config) *SyncService {
 	return NewSyncServiceWithOptions(db, SyncServiceOptions{
 		BaseURL: cfg.CPABaseURL,
 		Client:  cpa.NewClient(cfg.CPABaseURL, cfg.CPAManagementKey, cfg.RequestTimeout, cfg.TLSSkipVerify),
-		RedisQueue: cpa.NewRedisQueueClientWithOptions(cpa.RedisQueueOptions{
-			BaseURL:       cfg.CPABaseURL,
-			RedisAddr:     cfg.RedisQueueAddr,
-			ManagementKey: cfg.CPAManagementKey,
-			Timeout:       cfg.RequestTimeout,
-			QueueKey:      cfg.RedisQueueKey,
-			BatchSize:     cfg.RedisQueueBatchSize,
-			TLS:           cfg.RedisQueueTLS,
-			TLSSkipVerify: cfg.TLSSkipVerify,
-		}),
-		RedisQueueKey: cfg.RedisQueueKey,
 	})
 }
 
@@ -87,13 +74,11 @@ type SyncServiceOptions struct {
 	BaseURL           string
 	Client            CPAClientFetcher
 	MetadataFetcher   MetadataFetcher
-	RedisQueue        RedisQueue
-	RedisQueueKey     string
 	Now               func() time.Time
 	RecentUsageEvents RecentUsageEventAppender
 }
 
-// NewSyncServiceWithOptions 是统一构造入口，负责填充默认时钟、metadata fetcher 和 Redis 队列名。
+// NewSyncServiceWithOptions 是统一构造入口，负责填充默认时钟和 metadata fetcher。
 func NewSyncServiceWithOptions(db *gorm.DB, opts SyncServiceOptions) *SyncService {
 	now := opts.Now
 	if now == nil {
@@ -106,8 +91,6 @@ func NewSyncServiceWithOptions(db *gorm.DB, opts SyncServiceOptions) *SyncServic
 	return &SyncService{
 		db:              db,
 		client:          opts.Client,
-		redisQueue:      opts.RedisQueue,
-		redisQueueKey:   redisQueueKey(opts.RedisQueueKey),
 		metadataFetcher: metadataFetcher,
 		baseURL:         strings.TrimSpace(opts.BaseURL),
 		now:             now,
@@ -158,37 +141,6 @@ func (s *SyncService) SyncMetadata(ctx context.Context) error {
 	}
 	logrus.WithFields(fields).Debug("metadata sync finished")
 	return err
-}
-
-// PullRedisUsageInbox 是兼容测试和手动同步的旧拉取入口；生产远端 ingest 已由 poller 状态机接管。
-func (s *SyncService) PullRedisUsageInbox(ctx context.Context) (*servicedto.RedisInboxPullResult, error) {
-	if err := s.validate(syncMetadataOptional); err != nil {
-		return nil, err
-	}
-	if s.redisQueue == nil {
-		return nil, fmt.Errorf("sync service redis queue is nil")
-	}
-	fetchedAt := timeutil.NormalizeStorageTime(s.now())
-	messages, err := s.redisQueue.PopUsage(ctx)
-	if err != nil {
-		return &servicedto.RedisInboxPullResult{Status: "failed"}, fmt.Errorf("fetch redis usage: %w", err)
-	}
-	logrus.WithFields(logrus.Fields{
-		"queue_key":     s.redisQueueKey,
-		"message_count": len(messages),
-	}).Debug("redis usage batch popped")
-	if len(messages) == 0 {
-		return &servicedto.RedisInboxPullResult{Empty: true, Status: "empty"}, nil
-	}
-	inboxRows, err := insertRedisInboxMessages(s.db, s.redisQueueKey, messages, fetchedAt)
-	if err != nil {
-		return &servicedto.RedisInboxPullResult{Status: "failed"}, fmt.Errorf("insert redis usage inbox: %w", err)
-	}
-	logrus.WithFields(logrus.Fields{
-		"queue_key": s.redisQueueKey,
-		"row_count": len(inboxRows),
-	}).Debug("redis usage inbox rows inserted")
-	return &servicedto.RedisInboxPullResult{Status: "completed", InsertedRows: len(inboxRows)}, nil
 }
 
 // ProcessRedisUsageInbox 是 Redis 同步的本地处理阶段：只读取 pending/process_failed inbox 行并写入 usage_events。
@@ -550,8 +502,9 @@ func (s *SyncService) validate(syncMetadata bool) error {
 }
 
 // insertRedisInboxMessages 在解码前先把 Redis 原始消息落库，降低 LPOP 后本地处理失败导致的数据丢失风险。
-func insertRedisInboxMessages(db *gorm.DB, queueKey string, messages []string, poppedAt time.Time) ([]entities.RedisUsageInbox, error) {
-	return repository.InsertRedisUsageInboxRawMessages(db, queueKey, messages, poppedAt)
+func insertRedisInboxMessages(db *gorm.DB, source string, messages []string, poppedAt time.Time) ([]entities.RedisUsageInbox, error) {
+	// source 已经是完整来源名，这里只透传给仓储层做统一 trim/兜底。
+	return repository.InsertRedisUsageInboxRawMessages(db, source, messages, poppedAt)
 }
 
 // markRedisInboxRowsProcessFailed 记录可重试处理失败；达到仓储阈值后会转为 discarded 并打警告日志。
@@ -571,9 +524,10 @@ func markRedisInboxRowsProcessFailed(db *gorm.DB, rows []entities.RedisUsageInbo
 			continue
 		}
 		if stored.Status == repository.RedisUsageInboxStatusDiscarded {
+			// 丢弃日志保留 source，便于区分 subscribe、redis_pull 和 http_pull 写入的历史原始消息。
 			logrus.WithFields(logrus.Fields{
 				"inbox_id":      stored.ID,
-				"queue_key":     stored.QueueKey,
+				"source":        stored.Source,
 				"message_hash":  stored.MessageHash,
 				"attempt_count": stored.AttemptCount,
 				"last_error":    stored.LastError,
@@ -581,15 +535,6 @@ func markRedisInboxRowsProcessFailed(db *gorm.DB, rows []entities.RedisUsageInbo
 			}).Warn("discarded redis usage inbox row after repeated process failures")
 		}
 	}
-}
-
-// redisQueueKey 统一 Redis usage 队列名默认值，避免构造测试服务时重复传常量。
-func redisQueueKey(value string) string {
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" {
-		return cpa.ManagementUsageQueueKey
-	}
-	return trimmed
 }
 
 // errorMessage 把可选错误转成仓储 DTO 使用的稳定字符串。

--- a/internal/service/sync_test.go
+++ b/internal/service/sync_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"cpa-usage-keeper/internal/config"
-	"cpa-usage-keeper/internal/cpa"
 	"cpa-usage-keeper/internal/cpa/dto/authfiles"
 	"cpa-usage-keeper/internal/cpa/dto/cpaapikeys"
 	"cpa-usage-keeper/internal/cpa/dto/providerconfig"
@@ -27,6 +26,8 @@ import (
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
 )
+
+const redisUsageInboxTestSource = "redis_pull:usage"
 
 type stubMetadataFetcher struct {
 	authFilesResult *response.AuthFilesResult
@@ -199,43 +200,10 @@ func (s *trackingMetadataFetcher) providerCalls() int {
 	return s.geminiCalls + s.claudeCalls + s.codexCalls + s.vertexCalls + s.openAICalls
 }
 
-func TestPullRedisUsageInboxOnlyStoresPendingRows(t *testing.T) {
-	db := openSyncTestDatabase(t)
-	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
-		BaseURL: "https://cpa.example.com",
-		RedisQueue: staticRedisQueue{messages: []string{
-			`{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","request_id":"pull-only","tokens":{"input_tokens":1,"output_tokens":2}}`,
-		}},
-	})
-
-	result, err := service.PullRedisUsageInbox(context.Background())
-	if err != nil {
-		t.Fatalf("PullRedisUsageInbox returned error: %v", err)
-	}
-	if result == nil || result.Empty || result.Status != "completed" || result.InsertedRows != 1 {
-		t.Fatalf("unexpected pull result: %+v", result)
-	}
-
-	var inbox entities.RedisUsageInbox
-	if err := db.First(&inbox).Error; err != nil {
-		t.Fatalf("load inbox row: %v", err)
-	}
-	if inbox.Status != repository.RedisUsageInboxStatusPending || inbox.UsageEventKey != "" {
-		t.Fatalf("expected pending inbox row without processing links, got %+v", inbox)
-	}
-	var eventCount int64
-	if err := db.Model(&entities.UsageEvent{}).Count(&eventCount).Error; err != nil {
-		t.Fatalf("count usage events: %v", err)
-	}
-	if eventCount != 0 {
-		t.Fatalf("expected pull not to write usage events, got %d", eventCount)
-	}
-}
-
 func TestProcessRedisUsageInboxPersistsEventsWithoutSnapshot(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	rows, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
-		QueueKey:   cpa.ManagementUsageQueueKey,
+		Source:     redisUsageInboxTestSource,
 		RawMessage: `{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","endpoint":"/v1/messages","auth_type":"api_key","model":"sonnet","request_id":"process-only","tokens":{"input_tokens":1,"output_tokens":2}}`,
 		PoppedAt:   time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC),
 	}})
@@ -243,8 +211,7 @@ func TestProcessRedisUsageInboxPersistsEventsWithoutSnapshot(t *testing.T) {
 		t.Fatalf("seed inbox row: %v", err)
 	}
 	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
-		BaseURL:    "https://cpa.example.com",
-		RedisQueue: staticRedisQueue{err: errors.New("redis should not be popped while processing inbox")},
+		BaseURL: "https://cpa.example.com",
 	})
 
 	result, err := service.ProcessRedisUsageInbox(context.Background())
@@ -283,7 +250,7 @@ func TestProcessRedisUsageInboxPersistsEventsWithoutSnapshot(t *testing.T) {
 func TestProcessRedisUsageInboxNotifiesRecentCacheAfterTransactionCommit(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	if _, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
-		QueueKey:   cpa.ManagementUsageQueueKey,
+		Source:     redisUsageInboxTestSource,
 		RawMessage: `{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","auth_type":"oauth","source":"auth-user@example.com","auth_index":"auth-1","model":"sonnet","request_id":"notify-cache","tokens":{"input_tokens":1,"output_tokens":2}}`,
 		PoppedAt:   time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC),
 	}}); err != nil {
@@ -313,7 +280,7 @@ func TestProcessRedisUsageInboxNotifiesRecentCacheAfterTransactionCommit(t *test
 func TestProcessRedisUsageInboxDoesNotNotifyRecentCacheOnRollback(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	if _, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
-		QueueKey:   cpa.ManagementUsageQueueKey,
+		Source:     redisUsageInboxTestSource,
 		RawMessage: `{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","request_id":"rollback-cache-notify","tokens":{"input_tokens":1,"output_tokens":2}}`,
 		PoppedAt:   time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC),
 	}}); err != nil {
@@ -340,7 +307,7 @@ func TestProcessRedisUsageInboxDoesNotNotifyRecentCacheOnRollback(t *testing.T) 
 func TestProcessRedisUsageInboxIgnoresRecentCacheOverflow(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	if _, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
-		QueueKey:   cpa.ManagementUsageQueueKey,
+		Source:     redisUsageInboxTestSource,
 		RawMessage: `{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","request_id":"cache-overflow","tokens":{"input_tokens":1,"output_tokens":2}}`,
 		PoppedAt:   time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC),
 	}}); err != nil {
@@ -367,7 +334,7 @@ func TestProcessRedisUsageInboxIgnoresRecentCacheOverflow(t *testing.T) {
 func TestProcessRedisUsageInboxRollsBackEventsWhenProcessedMarkFails(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	if _, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
-		QueueKey:   cpa.ManagementUsageQueueKey,
+		Source:     redisUsageInboxTestSource,
 		RawMessage: `{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","request_id":"rollback-on-mark-failure","tokens":{"input_tokens":1,"output_tokens":2}}`,
 		PoppedAt:   time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC),
 	}}); err != nil {
@@ -440,7 +407,7 @@ func TestProcessRedisUsageInboxDoesNotFetchMetadata(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	metadata := &trackingMetadataFetcher{}
 	rows, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
-		QueueKey:   cpa.ManagementUsageQueueKey,
+		Source:     redisUsageInboxTestSource,
 		RawMessage: `{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","request_id":"redis-no-metadata","tokens":{"input_tokens":1,"output_tokens":2}}`,
 		PoppedAt:   time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC),
 	}})
@@ -474,7 +441,7 @@ func TestProcessRedisUsageInboxDoesNotFetchMetadata(t *testing.T) {
 func TestProcessRedisUsageInboxNormalizesClaudeTokensForOAuthProvider(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	_, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
-		QueueKey: cpa.ManagementUsageQueueKey,
+		Source: redisUsageInboxTestSource,
 		RawMessage: `{
 			"timestamp":"2026-04-27T08:00:00Z",
 			"provider":"claude",
@@ -524,7 +491,7 @@ func TestProcessRedisUsageInboxNormalizesAPIKeyTokensByUsageIdentityType(t *test
 		t.Fatalf("seed usage identity: %v", err)
 	}
 	_, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
-		QueueKey: cpa.ManagementUsageQueueKey,
+		Source: redisUsageInboxTestSource,
 		RawMessage: `{
 			"timestamp":"2026-04-27T08:00:00Z",
 			"provider":"Team Display Name",
@@ -569,7 +536,7 @@ func TestProcessRedisUsageInboxNormalizesGeminiFamilyToCodexTokenFormat(t *testi
 		t.Fatalf("seed usage identity: %v", err)
 	}
 	_, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
-		QueueKey: cpa.ManagementUsageQueueKey,
+		Source: redisUsageInboxTestSource,
 		RawMessage: `{
 			"timestamp":"2026-04-27T08:00:00Z",
 			"provider":"Google Account",
@@ -640,7 +607,7 @@ func TestNormalizeRedisUsageEventsResolvesAPIKeyAuthTypeAlias(t *testing.T) {
 func TestProcessRedisUsageInboxDoesNotFallbackWhenUsageTypeLookupErrors(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	rows, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
-		QueueKey:   cpa.ManagementUsageQueueKey,
+		Source:     redisUsageInboxTestSource,
 		RawMessage: `{"timestamp":"2026-04-27T08:00:00Z","provider":"Team Display Name","auth_type":"apikey","auth_index":"provider-auth-index","model":"claude-sonnet","request_id":"type-lookup-error","tokens":{"input_tokens":100,"output_tokens":30,"cache_read_tokens":20,"cache_creation_tokens":10,"total_tokens":160}}`,
 		PoppedAt:   time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC),
 	}})
@@ -757,7 +724,7 @@ func TestProcessRedisUsageInboxFallsBackToDeletedUsageIdentityType(t *testing.T)
 		t.Fatalf("seed deleted usage identity: %v", err)
 	}
 	_, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
-		QueueKey:   cpa.ManagementUsageQueueKey,
+		Source:     redisUsageInboxTestSource,
 		RawMessage: `{"timestamp":"2026-04-27T08:00:00Z","provider":"Deleted Team","auth_type":"apikey","auth_index":"deleted-auth-index","model":"claude-sonnet","request_id":"deleted-identity-claude","tokens":{"input_tokens":100,"output_tokens":30,"cache_read_tokens":20,"cache_creation_tokens":10,"total_tokens":160}}`,
 		PoppedAt:   time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC),
 	}})
@@ -790,12 +757,12 @@ func TestProcessRedisUsageInboxUsesOpenAIStyleForKimiAndMissingType(t *testing.T
 	}
 	_, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{
 		{
-			QueueKey:   cpa.ManagementUsageQueueKey,
+			Source:     redisUsageInboxTestSource,
 			RawMessage: `{"timestamp":"2026-04-27T08:00:00Z","provider":"Kimi","auth_type":"apikey","auth_index":"kimi-auth-index","model":"kimi-k2","request_id":"kimi-openai-style","tokens":{"input_tokens":100,"output_tokens":30,"cached_tokens":20,"cache_read_tokens":20,"cache_creation_tokens":10}}`,
 			PoppedAt:   time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC),
 		},
 		{
-			QueueKey:   cpa.ManagementUsageQueueKey,
+			Source:     redisUsageInboxTestSource,
 			RawMessage: `{"timestamp":"2026-04-27T08:00:00Z","provider":"Unknown","auth_type":"apikey","auth_index":"missing-auth-index","model":"unknown-model","request_id":"missing-type-openai-style","tokens":{"input_tokens":100,"output_tokens":30,"cached_tokens":20,"cache_read_tokens":20,"cache_creation_tokens":10}}`,
 			PoppedAt:   time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC),
 		},
@@ -819,30 +786,39 @@ func TestProcessRedisUsageInboxUsesOpenAIStyleForKimiAndMissingType(t *testing.T
 	}
 }
 
-func processPendingOrPulledRedisUsageForTest(t *testing.T, service *SyncService) (*servicedto.RedisBatchSyncResult, error) {
+func seedRedisInboxMessagesForTest(t *testing.T, db *gorm.DB, messages ...string) []entities.RedisUsageInbox {
 	t.Helper()
-	result, err := service.ProcessRedisUsageInbox(context.Background())
-	if err != nil || result == nil || !result.Empty {
-		return result, err
+	inputs := make([]dto.RedisInboxInsert, 0, len(messages))
+	for _, message := range messages {
+		inputs = append(inputs, dto.RedisInboxInsert{
+			Source:     redisUsageInboxTestSource,
+			RawMessage: message,
+			PoppedAt:   time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC),
+		})
 	}
-	if _, err := service.PullRedisUsageInbox(context.Background()); err != nil {
-		return &servicedto.RedisBatchSyncResult{Status: "failed"}, err
+	rows, err := repository.InsertRedisUsageInboxMessages(db, inputs)
+	if err != nil {
+		t.Fatalf("seed redis inbox messages: %v", err)
 	}
+	return rows
+}
+
+func processRedisUsageInboxForTest(t *testing.T, service *SyncService) (*servicedto.RedisBatchSyncResult, error) {
+	t.Helper()
 	return service.ProcessRedisUsageInbox(context.Background())
 }
 
-func TestSplitRedisUsageSyncSkipsEmptyBatchWithoutSnapshotOrMetadata(t *testing.T) {
+func TestProcessRedisUsageInboxSkipsEmptyBatchWithoutSnapshotOrMetadata(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	metadata := &trackingMetadataFetcher{}
 	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
 		BaseURL:         "https://cpa.example.com",
-		RedisQueue:      staticRedisQueue{},
 		MetadataFetcher: metadata,
 	})
 
-	result, err := processPendingOrPulledRedisUsageForTest(t, service)
+	result, err := processRedisUsageInboxForTest(t, service)
 	if err != nil {
-		t.Fatalf("split Redis usage sync returned error: %v", err)
+		t.Fatalf("process Redis usage inbox returned error: %v", err)
 	}
 	if result == nil || !result.Empty || result.Status != "empty" {
 		t.Fatalf("expected empty redis batch result, got %+v", result)
@@ -853,18 +829,18 @@ func TestSplitRedisUsageSyncSkipsEmptyBatchWithoutSnapshotOrMetadata(t *testing.
 
 }
 
-func TestSplitRedisUsageSyncPersistsNonEmptyBatchWithoutMetadata(t *testing.T) {
+func TestProcessRedisUsageInboxPersistsNonEmptyBatchWithoutMetadata(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	metadata := &trackingMetadataFetcher{}
+	seedRedisInboxMessagesForTest(t, db, `{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","request_id":"redis-1","tokens":{"input_tokens":1,"output_tokens":2}}`)
 	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
 		BaseURL:         "https://cpa.example.com",
-		RedisQueue:      staticRedisQueue{messages: []string{`{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","request_id":"redis-1","tokens":{"input_tokens":1,"output_tokens":2}}`}},
 		MetadataFetcher: metadata,
 	})
 
-	result, err := processPendingOrPulledRedisUsageForTest(t, service)
+	result, err := processRedisUsageInboxForTest(t, service)
 	if err != nil {
-		t.Fatalf("split Redis usage sync returned error: %v", err)
+		t.Fatalf("process Redis usage inbox returned error: %v", err)
 	}
 	if result == nil || result.Empty || result.Status != "completed" || result.InsertedEvents != 1 || result.DedupedEvents != 0 {
 		t.Fatalf("unexpected redis batch result: %+v", result)
@@ -889,17 +865,15 @@ func TestSplitRedisUsageSyncPersistsNonEmptyBatchWithoutMetadata(t *testing.T) {
 	}
 }
 
-func TestSplitRedisUsageSyncPersistsValidRowsWhenBatchContainsMalformedMessage(t *testing.T) {
+func TestProcessRedisUsageInboxPersistsValidRowsWhenBatchContainsMalformedMessage(t *testing.T) {
 	db := openSyncTestDatabase(t)
-	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
-		BaseURL: "https://cpa.example.com",
-		RedisQueue: staticRedisQueue{messages: []string{
-			`{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","request_id":"redis-valid","tokens":{"input_tokens":1,"output_tokens":2}}`,
-			`{bad-json}`,
-		}},
-	})
+	seedRedisInboxMessagesForTest(t, db,
+		`{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","request_id":"redis-valid","tokens":{"input_tokens":1,"output_tokens":2}}`,
+		`{bad-json}`,
+	)
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{BaseURL: "https://cpa.example.com"})
 
-	result, err := processPendingOrPulledRedisUsageForTest(t, service)
+	result, err := processRedisUsageInboxForTest(t, service)
 	if err == nil || !strings.Contains(err.Error(), "decode redis usage message") {
 		t.Fatalf("expected decode warning, got %v", err)
 	}
@@ -930,14 +904,12 @@ func TestSplitRedisUsageSyncPersistsValidRowsWhenBatchContainsMalformedMessage(t
 	}
 }
 
-func TestSplitRedisUsageSyncMarksMalformedOnlyBatchWithoutSnapshot(t *testing.T) {
+func TestProcessRedisUsageInboxMarksMalformedOnlyBatchWithoutSnapshot(t *testing.T) {
 	db := openSyncTestDatabase(t)
-	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
-		BaseURL:    "https://cpa.example.com",
-		RedisQueue: staticRedisQueue{messages: []string{`{bad-json}`}},
-	})
+	seedRedisInboxMessagesForTest(t, db, `{bad-json}`)
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{BaseURL: "https://cpa.example.com"})
 
-	result, err := processPendingOrPulledRedisUsageForTest(t, service)
+	result, err := processRedisUsageInboxForTest(t, service)
 	if err == nil || !strings.Contains(err.Error(), "decode redis usage message") {
 		t.Fatalf("expected decode warning, got %v", err)
 	}
@@ -954,15 +926,13 @@ func TestSplitRedisUsageSyncMarksMalformedOnlyBatchWithoutSnapshot(t *testing.T)
 	}
 }
 
-func TestSplitRedisUsageSyncLogsErrorAndMarksDecodeFailedWhenRequestIDMissing(t *testing.T) {
+func TestProcessRedisUsageInboxLogsErrorAndMarksDecodeFailedWhenRequestIDMissing(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	logs := captureSyncDebugLogs(t)
-	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
-		BaseURL:    "https://cpa.example.com",
-		RedisQueue: staticRedisQueue{messages: []string{`{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","tokens":{"input_tokens":1,"output_tokens":2}}`}},
-	})
+	seedRedisInboxMessagesForTest(t, db, `{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","tokens":{"input_tokens":1,"output_tokens":2}}`)
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{BaseURL: "https://cpa.example.com"})
 
-	result, err := processPendingOrPulledRedisUsageForTest(t, service)
+	result, err := processRedisUsageInboxForTest(t, service)
 	if err == nil || !strings.Contains(err.Error(), "request_id is required") {
 		t.Fatalf("expected missing request_id warning, got %v", err)
 	}
@@ -983,25 +953,22 @@ func TestSplitRedisUsageSyncLogsErrorAndMarksDecodeFailedWhenRequestIDMissing(t 
 	}
 }
 
-func TestSplitRedisUsageSyncProcessesPendingInboxBeforePoppingRedis(t *testing.T) {
+func TestProcessRedisUsageInboxProcessesPendingInbox(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	poppedAt := time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC)
 	rows, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
-		QueueKey:   cpa.ManagementUsageQueueKey,
+		Source:     redisUsageInboxTestSource,
 		RawMessage: `{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","request_id":"pending-1","tokens":{"input_tokens":1,"output_tokens":2}}`,
 		PoppedAt:   poppedAt,
 	}})
 	if err != nil {
 		t.Fatalf("seed inbox row: %v", err)
 	}
-	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
-		BaseURL:    "https://cpa.example.com",
-		RedisQueue: staticRedisQueue{err: errors.New("redis should not be popped while inbox is pending")},
-	})
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{BaseURL: "https://cpa.example.com"})
 
-	result, err := processPendingOrPulledRedisUsageForTest(t, service)
+	result, err := processRedisUsageInboxForTest(t, service)
 	if err != nil {
-		t.Fatalf("split Redis usage sync returned error: %v", err)
+		t.Fatalf("process Redis usage inbox returned error: %v", err)
 	}
 	if result == nil || result.Status != "completed" || result.InsertedEvents != 1 {
 		t.Fatalf("expected pending inbox row to be processed, got %+v", result)
@@ -1023,7 +990,7 @@ func TestSplitRedisUsageSyncProcessesPendingInboxBeforePoppingRedis(t *testing.T
 	}
 }
 
-func TestSplitRedisUsageSyncDoesNotWatermarkFilterRedisInboxEvents(t *testing.T) {
+func TestProcessRedisUsageInboxDoesNotWatermarkFilterRedisInboxEvents(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{{
 		EventKey:    "future-watermark",
@@ -1033,16 +1000,12 @@ func TestSplitRedisUsageSyncDoesNotWatermarkFilterRedisInboxEvents(t *testing.T)
 	}}); err != nil {
 		t.Fatalf("seed future event: %v", err)
 	}
-	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
-		BaseURL: "https://cpa.example.com",
-		RedisQueue: staticRedisQueue{messages: []string{
-			`{"timestamp":"2026-04-26T07:00:00Z","provider":"claude","model":"sonnet","request_id":"old-but-unique","tokens":{"input_tokens":1,"output_tokens":2}}`,
-		}},
-	})
+	seedRedisInboxMessagesForTest(t, db, `{"timestamp":"2026-04-26T07:00:00Z","provider":"claude","model":"sonnet","request_id":"old-but-unique","tokens":{"input_tokens":1,"output_tokens":2}}`)
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{BaseURL: "https://cpa.example.com"})
 
-	result, err := processPendingOrPulledRedisUsageForTest(t, service)
+	result, err := processRedisUsageInboxForTest(t, service)
 	if err != nil {
-		t.Fatalf("split Redis usage sync returned error: %v", err)
+		t.Fatalf("process Redis usage inbox returned error: %v", err)
 	}
 	if result == nil || result.InsertedEvents != 1 {
 		t.Fatalf("expected old unique Redis event to insert despite watermark, got %+v", result)
@@ -1054,11 +1017,11 @@ func TestSplitRedisUsageSyncDoesNotWatermarkFilterRedisInboxEvents(t *testing.T)
 	}
 }
 
-func TestSplitRedisUsageSyncRetriesProcessFailedInboxBeforePoppingRedis(t *testing.T) {
+func TestProcessRedisUsageInboxRetriesProcessFailedInbox(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	poppedAt := time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC)
 	rows, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
-		QueueKey:   cpa.ManagementUsageQueueKey,
+		Source:     redisUsageInboxTestSource,
 		RawMessage: `{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","request_id":"retry-process-failed","tokens":{"input_tokens":1,"output_tokens":2}}`,
 		PoppedAt:   poppedAt,
 	}})
@@ -1068,14 +1031,11 @@ func TestSplitRedisUsageSyncRetriesProcessFailedInboxBeforePoppingRedis(t *testi
 	if err := repository.MarkRedisUsageInboxProcessFailed(db, rows[0].ID, errors.New("temporary insert failure")); err != nil {
 		t.Fatalf("mark process failed: %v", err)
 	}
-	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
-		BaseURL:    "https://cpa.example.com",
-		RedisQueue: staticRedisQueue{err: errors.New("redis should not be popped while process_failed inbox is retryable")},
-	})
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{BaseURL: "https://cpa.example.com"})
 
-	result, err := processPendingOrPulledRedisUsageForTest(t, service)
+	result, err := processRedisUsageInboxForTest(t, service)
 	if err != nil {
-		t.Fatalf("split Redis usage sync returned error: %v", err)
+		t.Fatalf("process Redis usage inbox returned error: %v", err)
 	}
 	if result == nil || result.InsertedEvents != 1 {
 		t.Fatalf("expected process_failed row retry to insert, got %+v", result)
@@ -1089,51 +1049,47 @@ func TestSplitRedisUsageSyncRetriesProcessFailedInboxBeforePoppingRedis(t *testi
 	}
 }
 
-func TestSplitRedisUsageSyncUsesDurableInbox(t *testing.T) {
+func TestProcessRedisUsageInboxUsesDurableInbox(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	metadata := &trackingMetadataFetcher{}
+	seedRedisInboxMessagesForTest(t, db, `{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","request_id":"sync-now-redis","tokens":{"input_tokens":1,"output_tokens":2}}`)
 	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
-		BaseURL: "https://cpa.example.com",
-		RedisQueue: staticRedisQueue{messages: []string{
-			`{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","request_id":"sync-now-redis","tokens":{"input_tokens":1,"output_tokens":2}}`,
-		}},
+		BaseURL:         "https://cpa.example.com",
 		MetadataFetcher: metadata,
 	})
 
-	result, err := processPendingOrPulledRedisUsageForTest(t, service)
+	result, err := processRedisUsageInboxForTest(t, service)
 	if err != nil {
-		t.Fatalf("split Redis usage sync returned error: %v", err)
+		t.Fatalf("process Redis usage inbox returned error: %v", err)
 	}
 	if result == nil || result.InsertedEvents != 1 {
-		t.Fatalf("unexpected split Redis usage sync result: %+v", result)
+		t.Fatalf("unexpected process Redis usage inbox result: %+v", result)
 	}
 	if metadata.authCalls != 0 || metadata.providerCalls() != 0 {
-		t.Fatalf("expected split Redis usage sync not to fetch metadata, got auth=%d provider=%d", metadata.authCalls, metadata.providerCalls())
+		t.Fatalf("expected process Redis usage inbox not to fetch metadata, got auth=%d provider=%d", metadata.authCalls, metadata.providerCalls())
 	}
 	var inbox entities.RedisUsageInbox
 	if err := db.First(&inbox).Error; err != nil {
 		t.Fatalf("load inbox row: %v", err)
 	}
 	if inbox.Status != repository.RedisUsageInboxStatusProcessed || inbox.UsageEventKey != "sync-now-redis" {
-		t.Fatalf("expected split Redis usage sync redis path to use inbox, got %+v", inbox)
+		t.Fatalf("expected process Redis usage inbox redis path to use inbox, got %+v", inbox)
 	}
 }
 
-func TestSplitRedisUsageSyncKeepsDistinctRedisRequestIDsWithSameEventFields(t *testing.T) {
+func TestProcessRedisUsageInboxKeepsDistinctRedisRequestIDsWithSameEventFields(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	timestamp := time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC)
 	tokens := dto.TokenStats{InputTokens: 10, OutputTokens: 20, ReasoningTokens: 5, CachedTokens: 4, TotalTokens: 39}
-	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
-		BaseURL: "https://cpa.example.com",
-		RedisQueue: staticRedisQueue{messages: []string{
-			equivalentRedisMessage("external-api-key", "claude-sonnet", timestamp, "codex-a", "1", false, 123, tokens, "redis-request-1"),
-			equivalentRedisMessage("external-api-key", "claude-sonnet", timestamp, "codex-a", "1", false, 123, tokens, "redis-request-2"),
-		}},
-	})
+	seedRedisInboxMessagesForTest(t, db,
+		equivalentRedisMessage("external-api-key", "claude-sonnet", timestamp, "codex-a", "1", false, 123, tokens, "redis-request-1"),
+		equivalentRedisMessage("external-api-key", "claude-sonnet", timestamp, "codex-a", "1", false, 123, tokens, "redis-request-2"),
+	)
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{BaseURL: "https://cpa.example.com"})
 
-	result, err := processPendingOrPulledRedisUsageForTest(t, service)
+	result, err := processRedisUsageInboxForTest(t, service)
 	if err != nil {
-		t.Fatalf("split Redis usage sync returned error: %v", err)
+		t.Fatalf("process Redis usage inbox returned error: %v", err)
 	}
 	if result.InsertedEvents != 2 || result.DedupedEvents != 0 {
 		t.Fatalf("expected distinct Redis request IDs to insert separately, got %+v", result)
@@ -1141,30 +1097,20 @@ func TestSplitRedisUsageSyncKeepsDistinctRedisRequestIDsWithSameEventFields(t *t
 	assertUsageEventCount(t, db, 2)
 }
 
-func TestSplitRedisUsageSyncWritesDebugLogsWithoutRawPayload(t *testing.T) {
+func TestProcessRedisUsageInboxWritesDebugLogsWithoutRawPayload(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	logs := captureSyncDebugLogs(t)
 
-	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
-		BaseURL: "https://cpa.example.com",
-		RedisQueue: staticRedisQueue{messages: []string{
-			`{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","request_id":"redis-log","api_key":"raw-secret-key","tokens":{"input_tokens":1,"output_tokens":2}}`,
-		}},
-	})
+	seedRedisInboxMessagesForTest(t, db, `{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","request_id":"redis-log","api_key":"raw-secret-key","tokens":{"input_tokens":1,"output_tokens":2}}`)
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{BaseURL: "https://cpa.example.com"})
 
-	_, err := processPendingOrPulledRedisUsageForTest(t, service)
+	_, err := processRedisUsageInboxForTest(t, service)
 	if err != nil {
-		t.Fatalf("split Redis usage sync returned error: %v", err)
+		t.Fatalf("process Redis usage inbox returned error: %v", err)
 	}
 	output := logs.String()
-	for _, expected := range []string{
-		"redis usage batch popped",
-		"redis usage inbox rows inserted",
-		"redis usage inbox rows processed",
-	} {
-		if !strings.Contains(output, expected) {
-			t.Fatalf("expected debug log %q in output:\n%s", expected, output)
-		}
+	if !strings.Contains(output, "redis usage inbox rows processed") {
+		t.Fatalf("expected process debug log in output:\n%s", output)
 	}
 	if strings.Contains(output, "raw-secret-key") || strings.Contains(output, "redis-log") {
 		t.Fatalf("debug logs should not include raw payload fields, got:\n%s", output)
@@ -1815,19 +1761,6 @@ func TestSyncMetadataKeepsProviderUsageIdentitiesWhenEndpointReturnsNilResult(t 
 	oldGemini := byIdentity["old-gemini-key"]
 	if oldGemini.Identity == "" || oldGemini.IsDeleted || oldGemini.DeletedAt != nil {
 		t.Fatalf("expected old gemini usage identity to remain, got %+v", oldGemini)
-	}
-}
-
-func TestSplitRedisUsageSyncErrorDoesNotCreateSnapshot(t *testing.T) {
-	db := openSyncTestDatabase(t)
-	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
-		BaseURL:    "https://cpa.example.com",
-		RedisQueue: staticRedisQueue{err: errors.New("dial failed")},
-	})
-
-	result, err := processPendingOrPulledRedisUsageForTest(t, service)
-	if err == nil || result == nil || result.Status != "failed" {
-		t.Fatalf("expected failed redis batch result, got result=%+v err=%v", result, err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add Redis pull compatibility for CPA usage/queue keys and lock onto the first successful key.
- Store durable inbox provenance as source values such as redis_pull:usage, redis_pull:queue, redis_subscribe:usage, and http_pull:usage_queue.
- Remove the unused SyncService Redis pull entrypoint and migrate redis_usage_inboxes from queue_key to source via a new migration.

Fixes #209 

## Test Plan
- rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build go test ./cmd/... ./internal/...
- rtk git diff --check
- npm --prefix ./web run build
- Manual startup with /root/projects/cpa-usage-keeper/.env and health check at /cpa/healthz