### PR TITLE
Reduce metadata refresh debounce

### DIFF
--- a/internal/app/metadata_sync.go
+++ b/internal/app/metadata_sync.go
@@ -13,7 +13,7 @@ type MetadataSyncer interface {
 	SyncMetadata(ctx context.Context) error
 }
 
-const metadataSyncRefreshDebounceDefault = 3 * time.Second
+const metadataSyncRefreshDebounceDefault = time.Second
 
 type MetadataSyncRunner struct {
 	// syncer 是唯一真正执行 metadata 同步的服务入口。
@@ -183,7 +183,7 @@ func (r *MetadataSyncRunner) validate() error {
 	if r.interval <= 0 {
 		return fmt.Errorf("metadata sync interval must be positive")
 	}
-	// 测试可能覆盖为非法值，运行前恢复默认 3s debounce。
+	// 测试可能覆盖为非法值，运行前恢复默认 1s debounce。
 	if r.refreshDebounce <= 0 {
 		r.refreshDebounce = metadataSyncRefreshDebounceDefault
 	}

--- a/internal/app/metadata_sync_test.go
+++ b/internal/app/metadata_sync_test.go
@@ -126,11 +126,11 @@ func TestMetadataSyncRunnerValidatesConfig(t *testing.T) {
 	}
 }
 
-func TestMetadataSyncRunnerDefaultsRefreshDebounceToThreeSeconds(t *testing.T) {
+func TestMetadataSyncRunnerDefaultsRefreshDebounceToOneSecond(t *testing.T) {
 	runner := NewMetadataSyncRunner(&metadataSyncStub{}, time.Minute)
 
-	if runner.refreshDebounce != 3*time.Second {
-		t.Fatalf("expected default refresh debounce to be 3s, got %s", runner.refreshDebounce)
+	if runner.refreshDebounce != time.Second {
+		t.Fatalf("expected default refresh debounce to be 1s, got %s", runner.refreshDebounce)
 	}
 }
 


### PR DESCRIPTION
Reduce metadata refresh debounce from 3s to 1s for notification-driven metadata sync.\n\nValidation: go test ./cmd/... ./internal/...