### PR TITLE
Support average monthly quota windows

### DIFF
--- a/internal/quota/normalize.go
+++ b/internal/quota/normalize.go
@@ -11,9 +11,10 @@ import (
 )
 
 const (
-	quotaWindowFiveHourSeconds  int64 = 5 * 60 * 60
-	quotaWindowSevenDaySeconds  int64 = 7 * 24 * 60 * 60
-	quotaWindowThirtyDaySeconds int64 = 30 * 24 * 60 * 60
+	quotaWindowFiveHourSeconds     int64 = 5 * 60 * 60
+	quotaWindowSevenDaySeconds     int64 = 7 * 24 * 60 * 60
+	quotaWindowThirtyDaySeconds    int64 = 30 * 24 * 60 * 60
+	quotaWindowAverageMonthSeconds int64 = 365 * 24 * 60 * 60 / 12
 )
 
 func NormalizeQuotaRows(output ProviderOutput) []QuotaRow {
@@ -153,7 +154,7 @@ func codexWindowLabel(key string, label string, seconds int64) string {
 		return codexKnownWindowLabel(label, "5h")
 	case quotaWindowSevenDaySeconds:
 		return codexKnownWindowLabel(label, "Weekly")
-	case quotaWindowThirtyDaySeconds:
+	case quotaWindowThirtyDaySeconds, quotaWindowAverageMonthSeconds:
 		return codexKnownWindowLabel(label, "Monthly")
 	}
 	return codexRoleWindowLabel(key, label)

--- a/internal/quota/test/normalizer_test.go
+++ b/internal/quota/test/normalizer_test.go
@@ -132,7 +132,7 @@ func TestNormalizeCodexPrimaryWindowUsesWindowSecondsForWeeklyLabel(t *testing.T
 func TestNormalizeCodexPrimaryWindowUsesWindowSecondsForMonthlyLabel(t *testing.T) {
 	rows := quota.NormalizeQuotaRows(quota.ProviderOutput{Provider: "codex", Result: quota.CodexResult{Usage: &quota.CodexUsagePayload{
 		RateLimit: &quota.CodexRateLimitInfo{
-			PrimaryWindow: &quota.CodexUsageWindow{UsedPercent: 10, LimitWindowSeconds: 2592000},
+			PrimaryWindow: &quota.CodexUsageWindow{UsedPercent: 10, LimitWindowSeconds: 2628000},
 		},
 		CodeReviewRateLimit: &quota.CodexRateLimitInfo{
 			PrimaryWindow: &quota.CodexUsageWindow{UsedPercent: 25, LimitWindowSeconds: 2592000},
@@ -140,14 +140,14 @@ func TestNormalizeCodexPrimaryWindowUsesWindowSecondsForMonthlyLabel(t *testing.
 		AdditionalRateLimits: []quota.CodexAdditionalRateLimit{{
 			LimitName: "codex-spark",
 			RateLimit: &quota.CodexRateLimitInfo{
-				PrimaryWindow: &quota.CodexUsageWindow{UsedPercent: 40, LimitWindowSeconds: 2592000},
+				PrimaryWindow: &quota.CodexUsageWindow{UsedPercent: 40, LimitWindowSeconds: 2628000},
 			},
 		}},
 	}}})
 
 	primary := findQuotaRow(t, rows, "rate_limit.primary_window")
 	assertQuotaText(t, primary, "Monthly", "window", "")
-	assertIntField(t, primary.Window.Seconds, 2592000, "primary monthly window seconds")
+	assertIntField(t, primary.Window.Seconds, 2628000, "primary average monthly window seconds")
 	codeReview := findQuotaRow(t, rows, "code_review_rate_limit.primary_window")
 	assertQuotaText(t, codeReview, "Code Review Monthly", "code_review", "")
 	additional := findQuotaRow(t, rows, "additional_rate_limits.codex-spark.primary_window")

--- a/internal/quota/usage_stats.go
+++ b/internal/quota/usage_stats.go
@@ -81,7 +81,7 @@ func shouldBackfillWindowUsageStats(row QuotaRow) bool {
 		return false
 	}
 	switch *row.Window.Seconds {
-	case quotaWindowFiveHourSeconds, quotaWindowSevenDaySeconds, quotaWindowThirtyDaySeconds:
+	case quotaWindowFiveHourSeconds, quotaWindowSevenDaySeconds, quotaWindowThirtyDaySeconds, quotaWindowAverageMonthSeconds:
 		return true
 	default:
 		return false

--- a/internal/quota/usage_stats_test.go
+++ b/internal/quota/usage_stats_test.go
@@ -74,7 +74,7 @@ func TestAttachWindowUsageStatsOnlyBackfillsMissingKnownWindowScopeRows(t *testi
 	windowSeconds := int64(5 * 60 * 60)
 	weeklySeconds := int64(7 * 24 * 60 * 60)
 	monthlySeconds := int64(30 * 24 * 60 * 60)
-	averageMonthlySeconds := int64(2628000)
+	averageMonthlySeconds := quotaWindowAverageMonthSeconds
 	unknownSeconds := int64(60 * 60)
 	resetAt := time.Date(2026, 6, 2, 5, 0, 0, 0, time.UTC)
 	now := time.Date(2026, 6, 2, 3, 0, 0, 0, time.UTC)

--- a/internal/quota/usage_stats_test.go
+++ b/internal/quota/usage_stats_test.go
@@ -74,6 +74,7 @@ func TestAttachWindowUsageStatsOnlyBackfillsMissingKnownWindowScopeRows(t *testi
 	windowSeconds := int64(5 * 60 * 60)
 	weeklySeconds := int64(7 * 24 * 60 * 60)
 	monthlySeconds := int64(30 * 24 * 60 * 60)
+	averageMonthlySeconds := int64(2628000)
 	unknownSeconds := int64(60 * 60)
 	resetAt := time.Date(2026, 6, 2, 5, 0, 0, 0, time.UTC)
 	now := time.Date(2026, 6, 2, 3, 0, 0, 0, time.UTC)
@@ -120,6 +121,13 @@ func TestAttachWindowUsageStatsOnlyBackfillsMissingKnownWindowScopeRows(t *testi
 			ResetAt: timeutil.FormatStorageTime(resetAt),
 		},
 		{
+			Key:     "rate_limit.average_monthly_window",
+			Label:   "Monthly",
+			Scope:   "window",
+			Window:  &QuotaWindow{Seconds: &averageMonthlySeconds},
+			ResetAt: timeutil.FormatStorageTime(resetAt),
+		},
+		{
 			Key:     "code_review_rate_limit.primary_window",
 			Label:   "Code Review 5h",
 			Scope:   "code_review",
@@ -161,6 +169,13 @@ func TestAttachWindowUsageStatsOnlyBackfillsMissingKnownWindowScopeRows(t *testi
 	}
 	if monthlyWindow.WindowUsageCost == nil || *monthlyWindow.WindowUsageCost != 0 {
 		t.Fatalf("expected missing monthly window cost to be backfilled from usage_events, got %#v", monthlyWindow.WindowUsageCost)
+	}
+	averageMonthlyWindow := findQuotaUsageStatsRow(t, response.Quota, "rate_limit.average_monthly_window")
+	if averageMonthlyWindow.WindowUsageTokens == nil || *averageMonthlyWindow.WindowUsageTokens != 222 {
+		t.Fatalf("expected missing average monthly window usage to be backfilled from usage_events, got %#v", averageMonthlyWindow.WindowUsageTokens)
+	}
+	if averageMonthlyWindow.WindowUsageCost == nil || *averageMonthlyWindow.WindowUsageCost != 0 {
+		t.Fatalf("expected missing average monthly window cost to be backfilled from usage_events, got %#v", averageMonthlyWindow.WindowUsageCost)
 	}
 	codeReview := findQuotaUsageStatsRow(t, response.Quota, "code_review_rate_limit.primary_window")
 	if codeReview.WindowUsageTokens != nil || codeReview.WindowUsageCost != nil {

--- a/web/src/components/usage/credentials/credentialViewModels.test.ts
+++ b/web/src/components/usage/credentials/credentialViewModels.test.ts
@@ -330,12 +330,12 @@ describe('credentialViewModels', () => {
     expect(rows[0].displayQuotas[0]?.barPercent).toBe(90)
   })
 
-  it('uses monthly quota labels for 30 day Codex windows', () => {
+  it('uses monthly quota labels for monthly Codex windows', () => {
     const quotas = new Map<string, UsageQuotaRow[]>([
       ['auth-1', [
-        { key: 'rate_limit.primary_window', label: '5h', usedPercent: 20, window: { seconds: 2592000 } },
+        { key: 'rate_limit.primary_window', label: '5h', usedPercent: 20, window: { seconds: 2628000 } },
         { key: 'code_review_rate_limit.primary_window', label: 'Code Review Weekly', usedPercent: 40, window: { seconds: 2592000 } },
-        { key: 'additional_rate_limits.GPT-5.3-Codex-Spark.primary_window', label: 'GPT-5.3-Codex-Spark 5h', usedPercent: 60, window: { seconds: 2592000 } },
+        { key: 'additional_rate_limits.GPT-5.3-Codex-Spark.primary_window', label: 'GPT-5.3-Codex-Spark 5h', usedPercent: 60, window: { seconds: 2628000 } },
       ]],
     ])
 

--- a/web/src/components/usage/credentials/credentialViewModels.ts
+++ b/web/src/components/usage/credentials/credentialViewModels.ts
@@ -2,6 +2,10 @@ import type { UsageIdentity, UsageQuotaRow } from '@/lib/types'
 import { calculateCacheRate, formatCompactTokenValue } from '@/utils/usage'
 
 export const CREDENTIALS_PAGE_SIZE = 10
+const FIVE_HOUR_WINDOW_SECONDS = 5 * 60 * 60
+const WEEKLY_WINDOW_SECONDS = 7 * 24 * 60 * 60
+const THIRTY_DAY_WINDOW_SECONDS = 30 * 24 * 60 * 60
+const AVERAGE_MONTH_WINDOW_SECONDS = 365 * 24 * 60 * 60 / 12
 
 type QuotaStatus = 'ok' | 'warning' | 'danger' | 'unknown'
 export type PlanTypeTone = 'free' | 'team' | 'plus' | 'pro' | 'neutral'
@@ -274,13 +278,13 @@ function formatQuotaWindowCost(cost: number): string {
 function quotaLabel(row: UsageQuotaRow, windowSeconds?: number): string | undefined {
   // 对已知窗口按秒数纠正标签；未知窗口不展示 Window 占位，避免误导用户。
   const label = row.label || row.metric || row.scope || row.key
-  if (windowSeconds === 18000) {
+  if (windowSeconds === FIVE_HOUR_WINDOW_SECONDS) {
     return knownWindowLabel(label, '5h')
   }
-  if (windowSeconds === 604800) {
+  if (windowSeconds === WEEKLY_WINDOW_SECONDS) {
     return knownWindowLabel(label, 'Weekly')
   }
-  if (windowSeconds === 2592000) {
+  if (windowSeconds === THIRTY_DAY_WINDOW_SECONDS || windowSeconds === AVERAGE_MONTH_WINDOW_SECONDS) {
     return knownWindowLabel(label, 'Monthly')
   }
   if (windowSeconds !== undefined) {


### PR DESCRIPTION
Summary: Recognize both 30-day and average-month quota windows as Monthly; include average-month windows in backend token/cost backfill; keep frontend quota labels aligned. Tests: go test ./internal/quota/...; npm --prefix ./web run test -- credentialViewModels.test.ts