### PR TITLE
Add usage event storage cleanup

### DIFF
--- a/internal/api/usage_filter.go
+++ b/internal/api/usage_filter.go
@@ -145,6 +145,9 @@ func parseUsageFilterQuery(req *http.Request, anchor time.Time) (servicedto.Usag
 		if startTime.After(endTime) {
 			return servicedto.UsageFilter{}, fmt.Errorf("custom range start must be before end")
 		}
+		if retentionStart, ok := usageFilterRetentionStart(anchor); ok && startTime.Before(retentionStart) {
+			return servicedto.UsageFilter{}, fmt.Errorf("custom range start must be on or after %s", retentionStart.Format(time.DateOnly))
+		}
 		filter.StartTime = &startTime
 		filter.EndTime = &endTime
 		return filter, nil
@@ -159,6 +162,15 @@ func parseUsageFilterQuery(req *http.Request, anchor time.Time) (servicedto.Usag
 		filter.EndTime = &endTime
 		return filter, nil
 	}
+}
+
+func usageFilterRetentionStart(anchor time.Time) (time.Time, bool) {
+	if anchor.IsZero() {
+		return time.Time{}, false
+	}
+	localAnchor := timeutil.NormalizeStorageTime(anchor)
+	currentMonthStart := time.Date(localAnchor.Year(), localAnchor.Month(), 1, 0, 0, 0, 0, time.Local)
+	return currentMonthStart.AddDate(0, -1, 0), true
 }
 
 func parseUsageRealtimeFilterQuery(req *http.Request, anchor time.Time) (servicedto.UsageFilter, error) {

--- a/internal/api/usage_filter_test.go
+++ b/internal/api/usage_filter_test.go
@@ -224,6 +224,44 @@ func TestParseUsageFilterQueryRejectsInvalidCustomRange(t *testing.T) {
 	}
 }
 
+func TestParseUsageFilterQueryRejectsCustomRangeBeforeRetentionStart(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	t.Cleanup(func() { time.Local = previousLocal })
+	time.Local = location
+	anchor := time.Date(2026, 6, 16, 9, 0, 0, 0, location)
+
+	for _, tc := range []struct {
+		name      string
+		path      string
+		wantError bool
+	}{
+		{name: "before retention", path: "/api/v1/usage/overview?range=custom&start=2026-04-30&end=2026-05-01", wantError: true},
+		{name: "at retention boundary", path: "/api/v1/usage/overview?range=custom&start=2026-05-01&end=2026-05-01"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tc.path, nil)
+			filter, err := parseUsageFilterQuery(req, anchor)
+			if tc.wantError {
+				if err == nil {
+					t.Fatal("expected custom range before retention start to be rejected")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected retention boundary custom range to be accepted: %v", err)
+			}
+			expectedStart := time.Date(2026, 5, 1, 0, 0, 0, 0, location)
+			if filter.StartTime == nil || !filter.StartTime.Equal(expectedStart) {
+				t.Fatalf("expected boundary start %s, got %+v", expectedStart, filter)
+			}
+		})
+	}
+}
+
 func TestParseUsageFilterQueryRejectsMissingRange(t *testing.T) {
 	req := httptest.NewRequest("GET", "/api/v1/usage/events", nil)
 

--- a/internal/api/usage_overview_test.go
+++ b/internal/api/usage_overview_test.go
@@ -241,7 +241,13 @@ func TestUsageOverviewResponseIncludesResolvedRangeAndTimezone(t *testing.T) {
 
 	provider := &usageFilterStub{overview: &servicedto.UsageOverviewSnapshot{}}
 	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "")
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/overview?range=custom&start=2026-04-20&end=2026-04-21", nil)
+	retentionStart, ok := usageFilterRetentionStart(time.Now())
+	if !ok {
+		t.Fatal("expected current time to provide a retention start")
+	}
+	startDate := retentionStart.Format(time.DateOnly)
+	endDate := retentionStart.AddDate(0, 0, 1).Format(time.DateOnly)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/overview?range=custom&start="+startDate+"&end="+endDate, nil)
 	resp := httptest.NewRecorder()
 
 	router.ServeHTTP(resp, req)
@@ -249,8 +255,8 @@ func TestUsageOverviewResponseIncludesResolvedRangeAndTimezone(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", resp.Code)
 	}
-	expectedStart := time.Date(2026, 4, 20, 0, 0, 0, 0, location).Format(time.RFC3339Nano)
-	expectedEnd := time.Date(2026, 4, 22, 0, 0, 0, 0, location).Add(-time.Nanosecond).Format(time.RFC3339Nano)
+	expectedStart := retentionStart.Format(time.RFC3339Nano)
+	expectedEnd := retentionStart.AddDate(0, 0, 2).Add(-time.Nanosecond).Format(time.RFC3339Nano)
 	body := resp.Body.String()
 	if !contains(body, `"timezone":"Asia/Shanghai"`) || !contains(body, `"range_start":"`+expectedStart+`"`) || !contains(body, `"range_end":"`+expectedEnd+`"`) {
 		t.Fatalf("expected overview response to include resolved range and timezone, got %s", body)

--- a/internal/app/backup_runner_test.go
+++ b/internal/app/backup_runner_test.go
@@ -13,11 +13,11 @@ func TestNextDailyBackupAtUsesLocal0400(t *testing.T) {
 	time.Local = time.FixedZone("Test/Local", 8*60*60)
 	t.Cleanup(func() { time.Local = previousLocal })
 
-	before := time.Date(2026, 4, 16, 3, 30, 0, 0, time.Local)
+	before := time.Date(2026, 4, 15, 19, 30, 0, 0, time.UTC)
 	if got := nextDailyBackupAt(before); !got.Equal(time.Date(2026, 4, 16, 4, 0, 0, 0, time.Local)) {
 		t.Fatalf("expected same-day 04:00 backup, got %s", got)
 	}
-	after := time.Date(2026, 4, 16, 4, 1, 0, 0, time.Local)
+	after := time.Date(2026, 4, 15, 20, 1, 0, 0, time.UTC)
 	if got := nextDailyBackupAt(after); !got.Equal(time.Date(2026, 4, 17, 4, 0, 0, 0, time.Local)) {
 		t.Fatalf("expected next-day 04:00 backup, got %s", got)
 	}

--- a/internal/app/maintenance.go
+++ b/internal/app/maintenance.go
@@ -30,7 +30,7 @@ func NewStorageCleanupRunner(syncer StorageCleanupSyncer) *StorageCleanupRunner 
 	}
 }
 
-// Run 每天按项目本地时区 03:00 执行一次统一存储清理，失败只记录日志，不终止后台任务。
+// Run 每天按项目本地时区 04:30 执行一次统一存储清理，失败只记录日志，不终止后台任务。
 func (r *StorageCleanupRunner) Run(ctx context.Context) error {
 	if err := r.validate(); err != nil {
 		return err
@@ -54,10 +54,10 @@ func (r *StorageCleanupRunner) Run(ctx context.Context) error {
 	}
 }
 
-// nextDailyCleanupAt 用 time.Local 计算下一次 03:00，因此 TZ 同时控制业务日期边界和清理触发时间。
+// nextDailyCleanupAt 用 time.Local 计算下一次 04:30，因此 TZ 同时控制业务日期边界和清理触发时间。
 func nextDailyCleanupAt(now time.Time) time.Time {
 	localNow := now.In(time.Local)
-	cleanupAt := time.Date(localNow.Year(), localNow.Month(), localNow.Day(), 3, 0, 0, 0, time.Local)
+	cleanupAt := time.Date(localNow.Year(), localNow.Month(), localNow.Day(), 4, 30, 0, 0, time.Local)
 	if !localNow.Before(cleanupAt) {
 		cleanupAt = cleanupAt.AddDate(0, 0, 1)
 	}

--- a/internal/app/maintenance_test.go
+++ b/internal/app/maintenance_test.go
@@ -19,7 +19,7 @@ func (s *maintenanceSyncStub) CleanupStorage(context.Context) error {
 	return nil
 }
 
-func TestNextDailyCleanupAtUsesLocalThreeAM(t *testing.T) {
+func TestNextDailyCleanupAtUsesLocal0430(t *testing.T) {
 	previousLocal := time.Local
 	location, err := time.LoadLocation("Asia/Shanghai")
 	if err != nil {
@@ -29,12 +29,12 @@ func TestNextDailyCleanupAtUsesLocalThreeAM(t *testing.T) {
 	t.Cleanup(func() { time.Local = previousLocal })
 
 	before := nextDailyCleanupAt(time.Date(2026, 4, 26, 18, 30, 0, 0, time.UTC))
-	if !before.Equal(time.Date(2026, 4, 26, 19, 0, 0, 0, time.UTC)) {
-		t.Fatalf("expected same local day 03:00 cleanup, got %s", before)
+	if !before.Equal(time.Date(2026, 4, 26, 20, 30, 0, 0, time.UTC)) {
+		t.Fatalf("expected same local day 04:30 cleanup, got %s", before)
 	}
 	after := nextDailyCleanupAt(time.Date(2026, 4, 26, 20, 30, 0, 0, time.UTC))
-	if !after.Equal(time.Date(2026, 4, 27, 19, 0, 0, 0, time.UTC)) {
-		t.Fatalf("expected next local day 03:00 cleanup, got %s", after)
+	if !after.Equal(time.Date(2026, 4, 27, 20, 30, 0, 0, time.UTC)) {
+		t.Fatalf("expected next local day 04:30 cleanup, got %s", after)
 	}
 }
 
@@ -71,8 +71,8 @@ func TestStorageCleanupRunnerRunsAtScheduledTime(t *testing.T) {
 	runner.sleep = func(_ context.Context, d time.Duration) bool {
 		calls++
 		if calls == 1 {
-			if d != 30*time.Minute {
-				t.Fatalf("expected cleanup sleep until local 03:00, got %s", d)
+			if d != 2*time.Hour {
+				t.Fatalf("expected cleanup sleep until local 04:30, got %s", d)
 			}
 			return true
 		}

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -141,7 +141,8 @@ func Cleanup(dir string, retentionDays int, now time.Time) (int, error) {
 	}
 
 	localNow := now.In(time.Local)
-	cutoff := time.Date(localNow.Year(), localNow.Month(), localNow.Day(), 0, 0, 0, 0, time.Local).AddDate(0, 0, -retentionDays)
+	localDayStart := time.Date(localNow.Year(), localNow.Month(), localNow.Day(), 0, 0, 0, 0, time.Local)
+	keepStart := localDayStart.AddDate(0, 0, -(retentionDays - 1))
 	removed := 0
 	for _, entry := range entries {
 		if !entry.IsDir() {
@@ -152,7 +153,7 @@ func Cleanup(dir string, retentionDays int, now time.Time) (int, error) {
 		if err != nil {
 			continue
 		}
-		if backupDay.Before(cutoff.Truncate(24 * time.Hour)) {
+		if backupDay.Before(keepStart) {
 			if err := os.RemoveAll(filepath.Join(dir, entry.Name())); err != nil {
 				return removed, fmt.Errorf("remove expired backup directory %s: %w", entry.Name(), err)
 			}

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -59,7 +59,7 @@ func TestWriterWriteDatabaseUsesLocalDateDirectory(t *testing.T) {
 		t.Fatalf("create table: %v", err)
 	}
 	writer := NewWriter(root)
-	backupAt := time.Date(2026, 4, 16, 4, 0, 0, 0, time.Local)
+	backupAt := time.Date(2026, 4, 15, 20, 0, 0, 0, time.UTC)
 
 	path, err := writer.WriteDatabase(context.Background(), source, backupAt)
 	if err != nil {
@@ -176,9 +176,16 @@ func TestCleanupUsesLocalDateBoundaries(t *testing.T) {
 	time.Local = time.FixedZone("Test/Local", 8*60*60)
 	t.Cleanup(func() { time.Local = previousLocal })
 	root := t.TempDir()
-	keepDir := filepath.Join(root, "2026-04-15")
+	oldDir := filepath.Join(root, "2026-04-15")
+	keepDir := filepath.Join(root, "2026-04-16")
+	if err := os.MkdirAll(oldDir, 0o700); err != nil {
+		t.Fatalf("create old dir: %v", err)
+	}
 	if err := os.MkdirAll(keepDir, 0o700); err != nil {
 		t.Fatalf("create keep dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(oldDir, "database_old.db"), []byte("old"), 0o600); err != nil {
+		t.Fatalf("write old backup: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(keepDir, "database_keep.db"), []byte("keep"), 0o600); err != nil {
 		t.Fatalf("write keep backup: %v", err)
@@ -188,8 +195,49 @@ func TestCleanupUsesLocalDateBoundaries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cleanup returned error: %v", err)
 	}
-	if removed != 0 {
-		t.Fatalf("expected local-date retention to keep previous local day, removed %d", removed)
+	if removed != 1 {
+		t.Fatalf("expected local-date retention to keep only current local day, removed %d", removed)
+	}
+
+	files, err := ListFiles(root)
+	if err != nil {
+		t.Fatalf("ListFiles returned error: %v", err)
+	}
+	if len(files) != 1 || filepath.Base(filepath.Dir(files[0])) != "2026-04-16" {
+		t.Fatalf("unexpected remaining files: %+v", files)
+	}
+}
+
+func TestCleanupRemovesBackupDirectoryOutsideRetentionCount(t *testing.T) {
+	previousLocal := time.Local
+	time.Local = time.FixedZone("Test/Local", 8*60*60)
+	t.Cleanup(func() { time.Local = previousLocal })
+	root := t.TempDir()
+	expiredDir := filepath.Join(root, "2026-04-09")
+	keepDir := filepath.Join(root, "2026-04-10")
+	for _, dir := range []string{expiredDir, keepDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("create backup dir %s: %v", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "database.db"), []byte("backup"), 0o600); err != nil {
+			t.Fatalf("write backup file %s: %v", dir, err)
+		}
+	}
+
+	removed, err := Cleanup(root, 7, time.Date(2026, 4, 16, 4, 30, 0, 0, time.Local))
+	if err != nil {
+		t.Fatalf("Cleanup returned error: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("expected one backup directory outside 7-day retention to be removed, got %d", removed)
+	}
+
+	files, err := ListFiles(root)
+	if err != nil {
+		t.Fatalf("ListFiles returned error: %v", err)
+	}
+	if len(files) != 1 || filepath.Base(filepath.Dir(files[0])) != "2026-04-10" {
+		t.Fatalf("unexpected remaining files: %+v", files)
 	}
 }
 

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -150,22 +150,45 @@ func InsertUsageEvents(db *gorm.DB, events []entities.UsageEvent) (int, int, err
 	return inserted, 0, nil
 }
 
-// CleanupStorage 是每日维护任务的统一仓储清理入口：先清 Redis inbox，再清 Overview health 细粒度统计，最后执行 VACUUM。
+// CleanupStorage 是每日维护任务的统一仓储清理入口：先清 Redis inbox 和过期 usage_events，再清 Overview health 细粒度统计，最后执行 VACUUM。
 // VACUUM 必须在删除完成后单独执行，任何一步失败都会停止后续步骤并把已完成部分的结果返回给上层日志。
 func CleanupStorage(db *gorm.DB, now time.Time) (dto.StorageCleanupResult, error) {
 	redisResult, err := CleanupRedisUsageInbox(db, now)
 	if err != nil {
 		return dto.StorageCleanupResult{RedisInbox: redisResult}, err
 	}
+	usageEventsDeleted, err := CleanupUsageEvents(db, now)
+	if err != nil {
+		return dto.StorageCleanupResult{RedisInbox: redisResult, UsageEventsDeleted: usageEventsDeleted}, err
+	}
 	// Health stats 只服务最近窗口展示，过期数据在每日维护中清掉，避免表无限增长。
 	if err := CleanupUsageOverviewHealthStats(db, now); err != nil {
-		return dto.StorageCleanupResult{RedisInbox: redisResult}, err
+		return dto.StorageCleanupResult{RedisInbox: redisResult, UsageEventsDeleted: usageEventsDeleted}, err
 	}
 	// SQLite 删除不会立即缩小文件，维护窗口最后统一 VACUUM。
 	if err := db.Exec("VACUUM").Error; err != nil {
-		return dto.StorageCleanupResult{RedisInbox: redisResult}, err
+		return dto.StorageCleanupResult{RedisInbox: redisResult, UsageEventsDeleted: usageEventsDeleted}, err
 	}
-	return dto.StorageCleanupResult{RedisInbox: redisResult}, nil
+	return dto.StorageCleanupResult{RedisInbox: redisResult, UsageEventsDeleted: usageEventsDeleted}, nil
+}
+
+// CleanupUsageEvents 删除当前页面查询窗口外的原始 usage_events，保留从上个月 1 日本地零点开始的数据。
+func CleanupUsageEvents(db *gorm.DB, now time.Time) (int64, error) {
+	if db == nil {
+		return 0, fmt.Errorf("database is nil")
+	}
+	cutoff := usageEventsCleanupCutoff(now)
+	result := db.Where("timestamp < ?", timeutil.FormatStorageTime(cutoff)).Delete(&entities.UsageEvent{})
+	if result.Error != nil {
+		return result.RowsAffected, fmt.Errorf("cleanup usage events: %w", result.Error)
+	}
+	return result.RowsAffected, nil
+}
+
+func usageEventsCleanupCutoff(now time.Time) time.Time {
+	localNow := now.In(time.Local)
+	currentMonthStart := time.Date(localNow.Year(), localNow.Month(), 1, 0, 0, 0, 0, time.Local)
+	return currentMonthStart.AddDate(0, -1, 0)
 }
 
 // Vacuum 提供单独的 SQLite 收缩入口，供需要只做文件整理的调用方使用。

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -178,7 +178,7 @@ func CleanupUsageEvents(db *gorm.DB, now time.Time) (int64, error) {
 		return 0, fmt.Errorf("database is nil")
 	}
 	cutoff := usageEventsCleanupCutoff(now)
-	result := db.Where("timestamp < ?", timeutil.FormatStorageTime(cutoff)).Delete(&entities.UsageEvent{})
+	result := db.Unscoped().Where("timestamp < ?", timeutil.FormatStorageTime(cutoff)).Delete(&entities.UsageEvent{})
 	if result.Error != nil {
 		return result.RowsAffected, fmt.Errorf("cleanup usage events: %w", result.Error)
 	}

--- a/internal/repository/db_test.go
+++ b/internal/repository/db_test.go
@@ -465,6 +465,122 @@ func TestCleanupStorageCleansRedisInboxAndVacuums(t *testing.T) {
 	}
 }
 
+func TestCleanupStorageCleansUsageEventsBeforePreviousMonthStart(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	time.Local = location
+	t.Cleanup(func() { time.Local = previousLocal })
+	db := openTestDatabase(t)
+	now := time.Date(2026, 6, 16, 9, 0, 0, 0, time.Local)
+
+	if _, _, err := InsertUsageEvents(db, []entities.UsageEvent{
+		{EventKey: "old", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 30, 23, 59, 59, 0, time.Local), TotalTokens: 1},
+		{EventKey: "boundary", Model: "claude-sonnet", Timestamp: time.Date(2026, 5, 1, 0, 0, 0, 0, time.Local), TotalTokens: 2},
+		{EventKey: "recent", Model: "claude-sonnet", Timestamp: time.Date(2026, 6, 16, 8, 0, 0, 0, time.Local), TotalTokens: 3},
+	}); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+	result, err := CleanupStorage(db, now)
+	if err != nil {
+		t.Fatalf("CleanupStorage returned error: %v", err)
+	}
+	if result.UsageEventsDeleted != 1 {
+		t.Fatalf("expected one old usage event to be deleted, got %+v", result)
+	}
+
+	var remainingKeys []string
+	if err := db.Model(&entities.UsageEvent{}).Order("event_key asc").Pluck("event_key", &remainingKeys).Error; err != nil {
+		t.Fatalf("load remaining usage events: %v", err)
+	}
+	expectedKeys := []string{"boundary", "recent"}
+	if fmt.Sprint(remainingKeys) != fmt.Sprint(expectedKeys) {
+		t.Fatalf("expected remaining usage events %v, got %v", expectedKeys, remainingKeys)
+	}
+}
+
+func TestCleanupStorageCleansUsageEventsWithoutOverviewCheckpointGuard(t *testing.T) {
+	db := openTestDatabase(t)
+	now := time.Date(2026, 6, 16, 9, 0, 0, 0, time.Local)
+
+	if _, _, err := InsertUsageEvents(db, []entities.UsageEvent{
+		{EventKey: "old-without-checkpoint", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 29, 10, 0, 0, 0, time.Local), TotalTokens: 1},
+		{EventKey: "old-beyond-checkpoint", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 30, 10, 0, 0, 0, time.Local), TotalTokens: 2},
+	}); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+	var first entities.UsageEvent
+	if err := db.Where("event_key = ?", "old-without-checkpoint").First(&first).Error; err != nil {
+		t.Fatalf("load first event: %v", err)
+	}
+	if err := db.Create(&entities.UsageOverviewAggregationCheckpoint{Name: usageOverviewAggregationCheckpointName, LastAggregatedUsageEventID: first.ID, CreatedAt: now, UpdatedAt: now}).Error; err != nil {
+		t.Fatalf("seed overview checkpoint: %v", err)
+	}
+
+	result, err := CleanupStorage(db, now)
+	if err != nil {
+		t.Fatalf("CleanupStorage returned error: %v", err)
+	}
+	if result.UsageEventsDeleted != 2 {
+		t.Fatalf("expected all expired usage events to be deleted, got %+v", result)
+	}
+
+	var remainingCount int64
+	if err := db.Model(&entities.UsageEvent{}).Count(&remainingCount).Error; err != nil {
+		t.Fatalf("count remaining usage events: %v", err)
+	}
+	if remainingCount != 0 {
+		t.Fatalf("expected no remaining expired usage events, got %d", remainingCount)
+	}
+}
+
+func TestCleanupStorageCleansUsageEventsWithoutIdentityCheckpointGuard(t *testing.T) {
+	db := openTestDatabase(t)
+	now := time.Date(2026, 6, 16, 9, 0, 0, 0, time.Local)
+
+	if _, _, err := InsertUsageEvents(db, []entities.UsageEvent{
+		{EventKey: "identity-aggregated-old", AuthType: "oauth", AuthIndex: "auth-1", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 29, 10, 0, 0, 0, time.Local), TotalTokens: 1},
+		{EventKey: "identity-pending-old", AuthType: "oauth", AuthIndex: "auth-1", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 30, 10, 0, 0, 0, time.Local), TotalTokens: 2},
+	}); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+	var events []entities.UsageEvent
+	if err := db.Order("id asc").Find(&events).Error; err != nil {
+		t.Fatalf("load usage events: %v", err)
+	}
+	if err := db.Create(&entities.UsageOverviewAggregationCheckpoint{Name: usageOverviewAggregationCheckpointName, LastAggregatedUsageEventID: events[1].ID, CreatedAt: now, UpdatedAt: now}).Error; err != nil {
+		t.Fatalf("seed overview checkpoint: %v", err)
+	}
+	if err := db.Create(&entities.UsageIdentity{
+		Name:                       "Auth 1",
+		AuthType:                   entities.UsageIdentityAuthTypeAuthFile,
+		Identity:                   "auth-1",
+		LastAggregatedUsageEventID: events[0].ID,
+		CreatedAt:                  now,
+		UpdatedAt:                  now,
+	}).Error; err != nil {
+		t.Fatalf("seed usage identity: %v", err)
+	}
+
+	result, err := CleanupStorage(db, now)
+	if err != nil {
+		t.Fatalf("CleanupStorage returned error: %v", err)
+	}
+	if result.UsageEventsDeleted != 2 {
+		t.Fatalf("expected all expired usage events to be deleted, got %+v", result)
+	}
+
+	var remainingCount int64
+	if err := db.Model(&entities.UsageEvent{}).Count(&remainingCount).Error; err != nil {
+		t.Fatalf("count remaining usage events: %v", err)
+	}
+	if remainingCount != 0 {
+		t.Fatalf("expected no remaining expired usage events, got %d", remainingCount)
+	}
+}
+
 func openTestDatabase(t *testing.T) *gorm.DB {
 	t.Helper()
 

--- a/internal/repository/dto/storage.go
+++ b/internal/repository/dto/storage.go
@@ -2,5 +2,6 @@ package dto
 
 // StorageCleanupResult 是仓储层每日清理的结果。
 type StorageCleanupResult struct {
-	RedisInbox RedisUsageInboxCleanupResult
+	RedisInbox         RedisUsageInboxCleanupResult
+	UsageEventsDeleted int64
 }

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -181,12 +181,17 @@ func (s *SyncService) CleanupRedisUsageInbox(ctx context.Context) error {
 	return err
 }
 
-// CleanupStorage 是每日 03:00 维护任务调用的统一入口：先清 Redis inbox，最后 VACUUM 收缩 SQLite。
+// CleanupStorage 是每日 04:30 维护任务调用的统一入口：先清 Redis inbox 和过期 usage_events，最后 VACUUM 收缩 SQLite。
 func (s *SyncService) CleanupStorage(ctx context.Context) error {
 	if err := s.validate(syncMetadataOptional); err != nil {
 		return err
 	}
-	_, err := repository.CleanupStorage(s.db, s.now())
+	result, err := repository.CleanupStorage(s.db, s.now())
+	logrus.WithFields(logrus.Fields{
+		"redis_processed_deleted": result.RedisInbox.ProcessedDeleted,
+		"redis_failed_deleted":    result.RedisInbox.FailedDeleted,
+		"usage_events_deleted":    result.UsageEventsDeleted,
+	}).Debug("storage cleanup finished")
 	return err
 }
 

--- a/web/src/pages/UsagePage.logic.test.ts
+++ b/web/src/pages/UsagePage.logic.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { buildCustomDateRangeQuery, getBackToCPALinkURL, getCredentialSectionVisibility, getCustomDateRangeBounds, getOverviewDisplayLoading, getTimeRangeOptions, getUsageTabOptions, isCustomDateWithinBounds, isUsagePageVisible, loadRequestEventsPreferences, normalizeRequestEventsPreferences, normalizeUsageTabValue, openDateInputPicker, refreshPageData, REQUEST_EVENTS_PREFERENCES_STORAGE_KEY, sanitizeRequestEventFilters, saveRequestEventsPreferences, scheduleOverviewAutoRefresh, scheduleStatusActiveHeartbeat, shouldAutoRefreshUsageTab, shouldShowApiKeyFilter, shouldShowRangeControls, shouldShowUpdateCheckButton, STATUS_ACTIVE_HEARTBEAT_INTERVAL_MS, getUpdateCheckToastDuration } from './UsagePage';
+import { buildCustomDateRangeQuery, clampCustomDateRangeToBounds, getBackToCPALinkURL, getCredentialSectionVisibility, getCustomDateRangeBounds, getOverviewDisplayLoading, getTimeRangeOptions, getUsageTabOptions, isCustomDateWithinBounds, isUsagePageVisible, loadRequestEventsPreferences, normalizeRequestEventsPreferences, normalizeUsageTabValue, openDateInputPicker, refreshPageData, REQUEST_EVENTS_PREFERENCES_STORAGE_KEY, sanitizeRequestEventFilters, saveRequestEventsPreferences, scheduleOverviewAutoRefresh, scheduleStatusActiveHeartbeat, shouldAutoRefreshUsageTab, shouldShowApiKeyFilter, shouldShowRangeControls, shouldShowUpdateCheckButton, STATUS_ACTIVE_HEARTBEAT_INTERVAL_MS, getUpdateCheckToastDuration } from './UsagePage';
 import { REQUEST_EVENT_COLUMN_IDS } from '@/components/usage/RequestEventsDetailsCard';
 import type { StatusResponse, UsageFilterWindow } from '@/lib/types';
 
@@ -623,6 +623,15 @@ describe('UsagePage custom date input bounds', () => {
     expect(isCustomDateWithinBounds('2026-04-01', bounds)).toBe(true);
     expect(isCustomDateWithinBounds('2026-05-14', bounds)).toBe(false);
     expect(isCustomDateWithinBounds('2026-03-31', bounds)).toBe(false);
+  });
+
+  it('clamps saved Custom dates to the moving bounds', () => {
+    const bounds = { min: '2026-05-01', max: '2026-06-16' };
+
+    expect(clampCustomDateRangeToBounds({ start: '2026-04-20', end: '2026-06-20' }, bounds)).toEqual({
+      start: '2026-05-01',
+      end: '2026-06-16',
+    });
   });
 
   it('opens the native date picker when the date field is activated', () => {

--- a/web/src/pages/UsagePage.logic.test.ts
+++ b/web/src/pages/UsagePage.logic.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { buildCustomDateRangeQuery, clampCustomDateRangeToBounds, getBackToCPALinkURL, getCredentialSectionVisibility, getCustomDateRangeBounds, getOverviewDisplayLoading, getTimeRangeOptions, getUsageTabOptions, isCustomDateWithinBounds, isUsagePageVisible, loadRequestEventsPreferences, normalizeRequestEventsPreferences, normalizeUsageTabValue, openDateInputPicker, refreshPageData, REQUEST_EVENTS_PREFERENCES_STORAGE_KEY, sanitizeRequestEventFilters, saveRequestEventsPreferences, scheduleOverviewAutoRefresh, scheduleStatusActiveHeartbeat, shouldAutoRefreshUsageTab, shouldShowApiKeyFilter, shouldShowRangeControls, shouldShowUpdateCheckButton, STATUS_ACTIVE_HEARTBEAT_INTERVAL_MS, getUpdateCheckToastDuration } from './UsagePage';
+import { buildCustomDateRangeQuery, clampCustomDateRangeToBounds, CUSTOM_DATE_RANGE_BOUNDS_REFRESH_INTERVAL_MS, getBackToCPALinkURL, getCredentialSectionVisibility, getCustomDateRangeBounds, getOverviewDisplayLoading, getTimeRangeOptions, getUsageTabOptions, isCustomDateWithinBounds, isUsagePageVisible, loadRequestEventsPreferences, normalizeRequestEventsPreferences, normalizeUsageTabValue, openDateInputPicker, refreshPageData, REQUEST_EVENTS_PREFERENCES_STORAGE_KEY, sanitizeRequestEventFilters, saveRequestEventsPreferences, scheduleCustomDateRangeBoundsRefresh, scheduleOverviewAutoRefresh, scheduleStatusActiveHeartbeat, shouldAutoRefreshUsageTab, shouldShowApiKeyFilter, shouldShowRangeControls, shouldShowUpdateCheckButton, STATUS_ACTIVE_HEARTBEAT_INTERVAL_MS, getUpdateCheckToastDuration } from './UsagePage';
 import { REQUEST_EVENT_COLUMN_IDS } from '@/components/usage/RequestEventsDetailsCard';
 import type { StatusResponse, UsageFilterWindow } from '@/lib/types';
 
@@ -357,6 +357,83 @@ describe('UsagePage status active heartbeat', () => {
     expect(capturedSignal?.aborted).toBe(true);
     expect(timerTarget.setInterval).not.toHaveBeenCalled();
     expect(timerTarget.clearInterval).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+});
+
+describe('UsagePage Custom date range bounds refresh', () => {
+  it('refreshes the bounds anchor immediately and on the visible interval when Custom is active', () => {
+    let intervalHandler: (() => void) | undefined;
+    const testDocument = createAutoRefreshTestDocument();
+    const timerTarget = {
+      setInterval: vi.fn((handler: () => void, timeout: number) => {
+        intervalHandler = handler;
+        expect(timeout).toBe(CUSTOM_DATE_RANGE_BOUNDS_REFRESH_INTERVAL_MS);
+        return 11;
+      }),
+      clearInterval: vi.fn(),
+    };
+    const refreshBoundsAnchor = vi.fn();
+
+    const cleanup = scheduleCustomDateRangeBoundsRefresh({
+      enabled: true,
+      refreshBoundsAnchor,
+      documentRef: testDocument,
+      timerTarget,
+    });
+
+    expect(refreshBoundsAnchor).toHaveBeenCalledTimes(1);
+    intervalHandler?.();
+    expect(refreshBoundsAnchor).toHaveBeenCalledTimes(2);
+
+    cleanup();
+    intervalHandler?.();
+
+    expect(timerTarget.clearInterval).toHaveBeenCalledWith(11);
+    expect(refreshBoundsAnchor).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not refresh while Custom is inactive', () => {
+    const timerTarget = {
+      setInterval: vi.fn(() => 12),
+      clearInterval: vi.fn(),
+    };
+    const refreshBoundsAnchor = vi.fn();
+
+    const cleanup = scheduleCustomDateRangeBoundsRefresh({
+      enabled: false,
+      refreshBoundsAnchor,
+      timerTarget,
+    });
+
+    expect(refreshBoundsAnchor).not.toHaveBeenCalled();
+    expect(timerTarget.setInterval).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('refreshes when a hidden Custom page becomes visible again', () => {
+    const testDocument = createAutoRefreshTestDocument('hidden');
+    const timerTarget = {
+      setInterval: vi.fn(() => 13),
+      clearInterval: vi.fn(),
+    };
+    const refreshBoundsAnchor = vi.fn();
+
+    const cleanup = scheduleCustomDateRangeBoundsRefresh({
+      enabled: true,
+      refreshBoundsAnchor,
+      documentRef: testDocument,
+      timerTarget,
+    });
+
+    expect(refreshBoundsAnchor).not.toHaveBeenCalled();
+
+    testDocument.setVisibilityState('visible');
+    testDocument.dispatchEvent(new Event('visibilitychange'));
+
+    expect(refreshBoundsAnchor).toHaveBeenCalledTimes(1);
 
     cleanup();
   });

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -760,7 +760,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   const customDateRangeBounds = useMemo(() => getCustomDateRangeBounds(customDateRangeAnchorMs, status?.timezone), [customDateRangeAnchorMs, status?.timezone]);
   const effectiveCustomTimeRange = useMemo(
     () => clampCustomDateRangeToBounds(customTimeRange, customDateRangeBounds),
-    [customDateRangeBounds.max, customDateRangeBounds.min, customTimeRange.end, customTimeRange.start],
+    [customDateRangeBounds, customTimeRange],
   );
 
   const {
@@ -1055,7 +1055,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
       if (next.start === current.start && next.end === current.end) return current;
       return next;
     });
-  }, [customDateRangeBounds.max, customDateRangeBounds.min]);
+  }, [customDateRangeBounds]);
 
   useEffect(() => {
     try {

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -540,6 +540,21 @@ export const isCustomDateWithinBounds = (value: string, bounds: { min: string; m
   value === '' || (value >= bounds.min && value <= bounds.max)
 );
 
+const clampCustomDateValueToBounds = (value: string, bounds: { min: string; max: string }) => {
+  if (value === '') return value;
+  if (value < bounds.min) return bounds.min;
+  if (value > bounds.max) return bounds.max;
+  return value;
+};
+
+export const clampCustomDateRangeToBounds = (
+  range: { start: string; end: string },
+  bounds: { min: string; max: string },
+) => ({
+  start: clampCustomDateValueToBounds(range.start, bounds),
+  end: clampCustomDateValueToBounds(range.end, bounds),
+});
+
 export const openDateInputPicker = (input: HTMLInputElement) => {
   try {
     input.showPicker?.();
@@ -682,8 +697,14 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   const [customTimeRange, setCustomTimeRange] = useState<{ start: string; end: string }>(loadCustomTimeRange);
   const [selectedApiKeyId, setSelectedApiKeyId] = useState('');
   const [apiKeyOptions, setApiKeyOptions] = useState<CpaApiKeyOption[]>([]);
+  const [status, setStatus] = useState<StatusResponse | null>(null);
   const apiKeyOptionsRequestControllerRef = useRef<AbortController | null>(null);
   const credentialSectionVisibility = getCredentialSectionVisibility(activeTab);
+  const customDateRangeBounds = useMemo(() => getCustomDateRangeBounds(Date.now(), status?.timezone), [status?.timezone]);
+  const effectiveCustomTimeRange = useMemo(
+    () => clampCustomDateRangeToBounds(customTimeRange, customDateRangeBounds),
+    [customDateRangeBounds.max, customDateRangeBounds.min, customTimeRange.end, customTimeRange.start],
+  );
 
   const {
     usage,
@@ -694,8 +715,8 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   } = useUsageData({
     onAuthRequired,
     range: timeRange,
-    customStart: customTimeRange.start,
-    customEnd: customTimeRange.end,
+    customStart: effectiveCustomTimeRange.start,
+    customEnd: effectiveCustomTimeRange.end,
     enabled: activeTab === 'overview',
     apiKeyId: selectedApiKeyId,
   });
@@ -728,7 +749,6 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   const [apiKeySettingsError, setApiKeySettingsError] = useState('');
   const [apiKeySettingsSavingId, setApiKeySettingsSavingId] = useState<string | null>(null);
   const apiKeySettingsRequestControllerRef = useRef<AbortController | null>(null);
-  const [status, setStatus] = useState<StatusResponse | null>(null);
   const [statusError, setStatusError] = useState('');
   const [updateCheckLoading, setUpdateCheckLoading] = useState(false);
   const [topNotice, setTopNotice] = useState<{ kind: TopNoticeKind; message: string } | null>(null);
@@ -915,7 +935,11 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   }, [onAuthRequired, showTopNotice, t]);
 
   const loadAnalysis = useCallback(async () => {
-    const queryWindow = buildUsageRangeQuery({ range: timeRange, customStart: customTimeRange.start, customEnd: customTimeRange.end });
+    const queryWindow = buildUsageRangeQuery({
+      range: timeRange,
+      customStart: effectiveCustomTimeRange.start,
+      customEnd: effectiveCustomTimeRange.end,
+    });
     if (!queryWindow.valid) {
       analysisRequestControllerRef.current?.abort();
       analysisRequestControllerRef.current = null;
@@ -957,9 +981,8 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
         analysisRequestControllerRef.current = null;
       }
     }
-  }, [customTimeRange.end, customTimeRange.start, onAuthRequired, selectedApiKeyId, timeRange]);
+  }, [effectiveCustomTimeRange.end, effectiveCustomTimeRange.start, onAuthRequired, selectedApiKeyId, timeRange]);
   const isCustomRange = timeRange === 'custom';
-  const customDateRangeBounds = useMemo(() => getCustomDateRangeBounds(Date.now(), status?.timezone), [status?.timezone]);
   const handleCustomDateInputKeyDown = useCallback((event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Tab') return;
     event.preventDefault();
@@ -968,6 +991,14 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   const handleCustomDateInputActivate = useCallback((event: SyntheticEvent<HTMLInputElement>) => {
     openDateInputPicker(event.currentTarget);
   }, []);
+
+  useEffect(() => {
+    setCustomTimeRange((current) => {
+      const next = clampCustomDateRangeToBounds(current, customDateRangeBounds);
+      if (next.start === current.start && next.end === current.end) return current;
+      return next;
+    });
+  }, [customDateRangeBounds.max, customDateRangeBounds.min]);
 
   useEffect(() => {
     try {
@@ -1089,9 +1120,13 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   }, []);
 
   const getEventQueryWindow = useCallback(() => {
-    const query = buildUsageRangeQuery({ range: timeRange, customStart: customTimeRange.start, customEnd: customTimeRange.end });
+    const query = buildUsageRangeQuery({
+      range: timeRange,
+      customStart: effectiveCustomTimeRange.start,
+      customEnd: effectiveCustomTimeRange.end,
+    });
     return { valid: query.valid, start: query.start, end: query.end };
-  }, [customTimeRange.end, customTimeRange.start, timeRange]);
+  }, [effectiveCustomTimeRange.end, effectiveCustomTimeRange.start, timeRange]);
 
   const loadEventFilterOptions = useCallback(async () => {
     eventsFilterOptionsRequestControllerRef.current?.abort();

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -79,6 +79,7 @@ const REQUEST_EVENTS_PAGE_SIZES = [20, 50, 100, 500, 1000] as const;
 const REQUEST_EVENTS_DEFAULT_PAGE_SIZE = 100;
 const ALL_REQUEST_EVENTS_FILTER = '__all__';
 const OVERVIEW_AUTO_REFRESH_INTERVAL_MS = 10_000;
+export const CUSTOM_DATE_RANGE_BOUNDS_REFRESH_INTERVAL_MS = 60_000;
 export const STATUS_ACTIVE_HEARTBEAT_INTERVAL_MS = 30_000;
 const CPA_MANAGEMENT_PAGE = 'management.html';
 const ABSOLUTE_HTTP_URL_PATTERN = /^https?:\/\//i;
@@ -290,6 +291,21 @@ type OverviewAutoRefreshOptions = {
   intervalMs?: number;
 };
 
+type CustomDateRangeBoundsRefreshDocument = Pick<Document, 'visibilityState' | 'addEventListener' | 'removeEventListener'>;
+
+type CustomDateRangeBoundsRefreshTimerTarget = {
+  setInterval: (handler: () => void, timeout: number) => number;
+  clearInterval: (handle: number) => void;
+};
+
+type CustomDateRangeBoundsRefreshOptions = {
+  enabled: boolean;
+  refreshBoundsAnchor: () => void;
+  documentRef?: CustomDateRangeBoundsRefreshDocument;
+  timerTarget?: CustomDateRangeBoundsRefreshTimerTarget;
+  intervalMs?: number;
+};
+
 type StatusActiveHeartbeatDocument = Pick<Document, 'visibilityState' | 'addEventListener' | 'removeEventListener'>;
 
 type StatusActiveHeartbeatTimerTarget = {
@@ -370,6 +386,46 @@ export const scheduleOverviewAutoRefresh = ({
   return () => {
     stopTimer();
     targetDocument.removeEventListener('visibilitychange', handleVisibilityChange);
+  };
+};
+
+export const scheduleCustomDateRangeBoundsRefresh = ({
+  enabled,
+  refreshBoundsAnchor,
+  documentRef,
+  timerTarget,
+  intervalMs = CUSTOM_DATE_RANGE_BOUNDS_REFRESH_INTERVAL_MS,
+}: CustomDateRangeBoundsRefreshOptions) => {
+  if (!enabled) {
+    return () => undefined;
+  }
+
+  const targetDocument = documentRef ?? (typeof document === 'undefined' ? undefined : document);
+  const timers = timerTarget ?? (typeof window === 'undefined' ? undefined : {
+    setInterval: window.setInterval.bind(window),
+    clearInterval: window.clearInterval.bind(window),
+  });
+  if (!timers) {
+    return () => undefined;
+  }
+
+  let active = true;
+  const refreshIfVisible = () => {
+    if (!active || !isUsagePageVisible(targetDocument)) return;
+    refreshBoundsAnchor();
+  };
+  const handleVisibilityChange = () => {
+    refreshIfVisible();
+  };
+
+  refreshIfVisible();
+  const timer = timers.setInterval(refreshIfVisible, intervalMs);
+  targetDocument?.addEventListener('visibilitychange', handleVisibilityChange);
+
+  return () => {
+    active = false;
+    timers.clearInterval(timer);
+    targetDocument?.removeEventListener('visibilitychange', handleVisibilityChange);
   };
 };
 
@@ -698,9 +754,10 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   const [selectedApiKeyId, setSelectedApiKeyId] = useState('');
   const [apiKeyOptions, setApiKeyOptions] = useState<CpaApiKeyOption[]>([]);
   const [status, setStatus] = useState<StatusResponse | null>(null);
+  const [customDateRangeAnchorMs, setCustomDateRangeAnchorMs] = useState(() => Date.now());
   const apiKeyOptionsRequestControllerRef = useRef<AbortController | null>(null);
   const credentialSectionVisibility = getCredentialSectionVisibility(activeTab);
-  const customDateRangeBounds = useMemo(() => getCustomDateRangeBounds(Date.now(), status?.timezone), [status?.timezone]);
+  const customDateRangeBounds = useMemo(() => getCustomDateRangeBounds(customDateRangeAnchorMs, status?.timezone), [customDateRangeAnchorMs, status?.timezone]);
   const effectiveCustomTimeRange = useMemo(
     () => clampCustomDateRangeToBounds(customTimeRange, customDateRangeBounds),
     [customDateRangeBounds.max, customDateRangeBounds.min, customTimeRange.end, customTimeRange.start],
@@ -1067,6 +1124,11 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     const anchorMs = lastRefreshedAt?.getTime() ?? Date.now();
     setCustomTimeRange(buildDefaultCustomRange(anchorMs));
   }, [customTimeRange.end, customTimeRange.start, lastRefreshedAt, timeRange]);
+
+  useEffect(() => scheduleCustomDateRangeBoundsRefresh({
+    enabled: timeRange === 'custom',
+    refreshBoundsAnchor: () => setCustomDateRangeAnchorMs(Date.now()),
+  }), [timeRange]);
 
   useEffect(() => {
     // Credentials 列表、quota cache 和 task polling 都跟页面可见性绑定，隐藏页不保持续约或轮询。


### PR DESCRIPTION
## Summary
- Schedule storage cleanup at 04:30 in the configured project timezone after the 04:00 database backup.
- Clean old usage_events before the previous month start, clean Redis inbox and overview health stats, then run VACUUM.
- Tighten backup retention and clamp custom usage ranges to the available retention window.

Related to #219 

## Validation
- rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build go test -count=1 ./cmd/... ./internal/...
- rtk npm --prefix web test -- UsagePage.logic.test.ts
- rtk npm --prefix web run typecheck