### PR TITLE
Refine AI provider display names

### DIFF
--- a/internal/api/usage_events_test.go
+++ b/internal/api/usage_events_test.go
@@ -304,7 +304,7 @@ func TestUsageEventsResolvesAPIKeySourceFromProviderIdentity(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d: %s", resp.Code, body)
 	}
-	if !contains(body, `"source":"Provider Name(Team Prefix)"`) {
+	if !contains(body, `"source":"Team Prefix"`) {
 		t.Fatalf("expected source to use provider identity displayName, got %s", body)
 	}
 	if !contains(body, `"source_type":"openai"`) {
@@ -348,7 +348,7 @@ func TestUsageEventsDoesNotResolveProviderIdentityFromSource(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d: %s", resp.Code, body)
 	}
-	if contains(body, `"source":"Provider Name(Team Prefix)"`) || contains(body, `"source_key"`) {
+	if contains(body, `"source":"Team Prefix"`) || contains(body, `"source_key"`) {
 		t.Fatalf("expected event source not to resolve identity through usage event source, got %s", body)
 	}
 	if !contains(body, `"source":"Fallback Provider"`) {

--- a/internal/api/usage_identities_test.go
+++ b/internal/api/usage_identities_test.go
@@ -383,8 +383,8 @@ func TestUsageIdentitiesRouteReturnsProviderDisplayName(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d: %s", resp.Code, body)
 	}
-	if !contains(body, `"displayName":"Provider Name(Team Prefix)"`) {
-		t.Fatalf("expected displayName with name and prefix, got %s", body)
+	if !contains(body, `"displayName":"Team Prefix"`) {
+		t.Fatalf("expected displayName with prefix, got %s", body)
 	}
 	if !contains(body, `"prefix":"Team Prefix"`) {
 		t.Fatalf("expected published prefix field, got %s", body)
@@ -412,7 +412,7 @@ func TestUsageIdentitiesRouteMasksAIProviderIdentity(t *testing.T) {
 	if !contains(body, `"identity":"`+maskedLookupKey+`"`) {
 		t.Fatalf("expected masked AI provider identity %q in response body: %s", maskedLookupKey, body)
 	}
-	if !contains(body, `"name":"Provider Name"`) || !contains(body, `"provider":"OpenAI"`) || !contains(body, `"displayName":"Provider Name(Team Prefix)"`) {
+	if !contains(body, `"name":"Provider Name"`) || !contains(body, `"provider":"OpenAI"`) || !contains(body, `"displayName":"Team Prefix"`) {
 		t.Fatalf("expected AI provider display fields to use usage_identities values directly, got %s", body)
 	}
 }

--- a/internal/helper/usage_identity_display_name.go
+++ b/internal/helper/usage_identity_display_name.go
@@ -24,25 +24,10 @@ func UsageIdentityDisplayName(item entities.UsageIdentity) string {
 	prefix := strings.TrimSpace(item.Prefix)
 	baseURL := formatBaseURLDisplay(item.BaseURL)
 	qualifiers := displayQualifiers(prefix, baseURL)
-	qualifierSeparator := " @ "
-	switch {
-	case name != "" && len(qualifiers) > 0:
-		return name + "(" + strings.Join(qualifiers, qualifierSeparator) + ")"
-	case name != "":
-		return name
-	case prefix != "" && baseURL != "":
-		return prefix + "(" + baseURL + ")"
-	case prefix != "":
-		return prefix
-	case provider != "" && baseURL != "":
-		return provider + "(" + baseURL + ")"
-	case provider != "":
-		return provider
-	case baseURL != "":
-		return baseURL
-	default:
-		return firstNonEmptyString(provider, item.Identity)
+	if len(qualifiers) > 0 {
+		return strings.Join(qualifiers, " @ ")
 	}
+	return name
 }
 
 func displayQualifiers(values ...string) []string {

--- a/internal/helper/usage_identity_display_name_test.go
+++ b/internal/helper/usage_identity_display_name_test.go
@@ -6,7 +6,7 @@ import (
 	"cpa-usage-keeper/internal/entities"
 )
 
-func TestDisplayNameFormatsProviderNameAndPrefix(t *testing.T) {
+func TestDisplayNameFormatsProviderPrefixWithoutName(t *testing.T) {
 	identity := entities.UsageIdentity{
 		Name:     "Provider Name",
 		Prefix:   "Team Prefix",
@@ -14,12 +14,12 @@ func TestDisplayNameFormatsProviderNameAndPrefix(t *testing.T) {
 		Identity: "provider-auth-index",
 	}
 
-	if got := UsageIdentityDisplayName(identity); got != "Provider Name(Team Prefix)" {
-		t.Fatalf("expected provider displayName to include name and prefix, got %q", got)
+	if got := UsageIdentityDisplayName(identity); got != "Team Prefix" {
+		t.Fatalf("expected provider displayName to use prefix without name, got %q", got)
 	}
 }
 
-func TestDisplayNameAddsProviderBaseURLQualifier(t *testing.T) {
+func TestDisplayNameFormatsProviderPrefixAndBaseURL(t *testing.T) {
 	withPrefix := entities.UsageIdentity{
 		Name:     "Provider Name",
 		Prefix:   "Team Prefix",
@@ -34,11 +34,11 @@ func TestDisplayNameAddsProviderBaseURLQualifier(t *testing.T) {
 		Identity: "codex-auth-index",
 	}
 
-	if got := UsageIdentityDisplayName(withPrefix); got != "Provider Name(Team Prefix @ api.openai.com)" {
-		t.Fatalf("expected base URL to be an extra display qualifier, got %q", got)
+	if got := UsageIdentityDisplayName(withPrefix); got != "Team Prefix @ api.openai.com" {
+		t.Fatalf("expected provider displayName to use prefix and base URL, got %q", got)
 	}
-	if got := UsageIdentityDisplayName(providerOnly); got != "codex(chatgpt.com/backend-api/codex)" {
-		t.Fatalf("expected provider displayName to include base URL qualifier, got %q", got)
+	if got := UsageIdentityDisplayName(providerOnly); got != "chatgpt.com/backend-api/codex" {
+		t.Fatalf("expected provider displayName to use base URL without name, got %q", got)
 	}
 }
 
@@ -68,7 +68,7 @@ func TestDisplayNameFallsBackWhenOpenAICompatibilityNameIsMissing(t *testing.T) 
 		Identity: "openrouter-auth-index",
 	}
 
-	if got := UsageIdentityDisplayName(identity); got != "openrouter(openrouter.ai/api)" {
+	if got := UsageIdentityDisplayName(identity); got != "openrouter @ openrouter.ai/api" {
 		t.Fatalf("expected unnamed openai compatibility displayName to fall back to provider qualifier rules, got %q", got)
 	}
 }
@@ -84,7 +84,7 @@ func TestDisplayNameUsesProviderWhenAuthFileNameIsMissing(t *testing.T) {
 	}
 }
 
-func TestDisplayNameFallsBackWhenProviderNameOrPrefixIsMissing(t *testing.T) {
+func TestDisplayNameUsesNameWhenProviderPrefixAndBaseURLAreMissing(t *testing.T) {
 	prefixOnly := entities.UsageIdentity{
 		Prefix:   "Team Prefix",
 		AuthType: entities.UsageIdentityAuthTypeAIProvider,
@@ -107,18 +107,7 @@ func TestDisplayNameFallsBackWhenProviderNameOrPrefixIsMissing(t *testing.T) {
 	if got := UsageIdentityDisplayName(nameOnly); got != "Provider Name" {
 		t.Fatalf("expected name-only provider displayName, got %q", got)
 	}
-	if got := UsageIdentityDisplayName(providerOnly); got != "OpenAI" {
-		t.Fatalf("expected provider-only displayName, got %q", got)
-	}
-}
-
-func TestDisplayNameFallsBackToIdentityWhenStoredLabelsAreMissing(t *testing.T) {
-	identity := entities.UsageIdentity{
-		AuthType: entities.UsageIdentityAuthTypeAIProvider,
-		Identity: "provider-auth-index",
-	}
-
-	if got := UsageIdentityDisplayName(identity); got != "provider-auth-index" {
-		t.Fatalf("expected identity fallback when stored labels are missing, got %q", got)
+	if got := UsageIdentityDisplayName(providerOnly); got != "" {
+		t.Fatalf("expected provider without name, prefix, or base URL to be blank, got %q", got)
 	}
 }

--- a/internal/repository/usage_test.go
+++ b/internal/repository/usage_test.go
@@ -440,10 +440,10 @@ func TestBuildAnalysisWithFilterBuildsIdentityCompositionsFromActiveUsageIdentit
 	if len(analysis.AIProviderComposition) != 2 {
 		t.Fatalf("expected two ai provider composition rows, got %+v", analysis.AIProviderComposition)
 	}
-	if analysis.AIProviderComposition[0].Key != "shared-index" || analysis.AIProviderComposition[0].Label != "Provider Shared(Shared Prefix)" || analysis.AIProviderComposition[0].TotalTokens != 90 {
+	if analysis.AIProviderComposition[0].Key != "shared-index" || analysis.AIProviderComposition[0].Label != "Shared Prefix" || analysis.AIProviderComposition[0].TotalTokens != 90 {
 		t.Fatalf("expected shared provider row first, got %+v", analysis.AIProviderComposition)
 	}
-	if analysis.AIProviderComposition[1].Key != "provider-1" || analysis.AIProviderComposition[1].Label != "Provider One(Team Prefix @ api.openai.com)" || analysis.AIProviderComposition[1].TotalTokens != 60 {
+	if analysis.AIProviderComposition[1].Key != "provider-1" || analysis.AIProviderComposition[1].Label != "Team Prefix @ api.openai.com" || analysis.AIProviderComposition[1].TotalTokens != 60 {
 		t.Fatalf("expected active provider row second, got %+v", analysis.AIProviderComposition)
 	}
 }

--- a/web/src/components/usage/RequestEventsDetailsCard.test.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.test.tsx
@@ -209,11 +209,11 @@ describe('RequestEventsDetailsCard pagination', () => {
   it('uses backend source values while showing resolved source labels', () => {
     const html = renderCard({
       sourceFilter: 'source-a',
-      sourceOptions: [{ value: 'source-a', label: 'Provider A', displayName: 'Provider A(Team Prefix)' }, { value: 'source-b', label: 'Provider B' }],
+      sourceOptions: [{ value: 'source-a', label: 'Provider A', displayName: 'Team Prefix' }, { value: 'source-b', label: 'Provider B' }],
     });
 
-    expect(countOccurrences(html, 'Provider A(Team Prefix)')).toBeGreaterThanOrEqual(1);
-    expect(html).toContain('aria-label="Source"><span class="_triggerText_c80422 ">Provider A(Team Prefix)</span>');
+    expect(countOccurrences(html, 'Team Prefix')).toBeGreaterThanOrEqual(1);
+    expect(html).toContain('aria-label="Source"><span class="_triggerText_c80422 ">Team Prefix</span>');
   });
 
   it('uses backend model and source options instead of current page grouping', () => {


### PR DESCRIPTION
## Summary
- Simplify AI provider display names to use `prefix @ base_url`, `prefix`, or `base_url` for the normal path.
- Keep the existing OpenAI-compatible special case unchanged.
- Update the affected Overview, Analysis, Request Events, and AI Provider list expectations.

## Why
- The old label was too long and repeated the provider type.
- This keeps the same shared backend helper as the source of truth for all AI provider display surfaces.

## Validation
- `go test ./cmd/... ./internal/...`
- `npm --prefix ./web run typecheck`
- `npm --prefix ./web run test -- RequestEventsDetailsCard.test.tsx`
- `git diff --check`