### PR TITLE
Add Homebrew tap release automation

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -250,3 +250,142 @@ jobs:
             dist/*.tar.gz
             dist/*.zip
             dist/checksums.txt
+
+  update-homebrew-tap:
+    runs-on: ubuntu-24.04
+    needs: publish-release
+    steps:
+      - name: Download binary package artifacts
+        uses: actions/download-artifact@v6
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Generate Homebrew formula values
+        id: formula
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+
+          cd dist
+          sha256sum *.tar.gz *.zip > checksums.txt
+
+          arm_file="cpa-usage-keeper_${tag}_darwin_arm64.tar.gz"
+          amd_file="cpa-usage-keeper_${tag}_darwin_amd64.tar.gz"
+          arm_sha="$(awk -v f="${arm_file}" '$2 == f {print $1}' checksums.txt)"
+          amd_sha="$(awk -v f="${amd_file}" '$2 == f {print $1}' checksums.txt)"
+
+          test -n "${arm_sha}"
+          test -n "${amd_sha}"
+
+          {
+            echo "tag=${tag}"
+            echo "version=${version}"
+            echo "arm_file=${arm_file}"
+            echo "amd_file=${amd_file}"
+            echo "arm_sha=${arm_sha}"
+            echo "amd_sha=${amd_sha}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v6
+        with:
+          repository: Willxup/homebrew-cpa-usage-keeper
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update formula
+        shell: bash
+        env:
+          TAG: ${{ steps.formula.outputs.tag }}
+          VERSION: ${{ steps.formula.outputs.version }}
+          ARM_FILE: ${{ steps.formula.outputs.arm_file }}
+          AMD_FILE: ${{ steps.formula.outputs.amd_file }}
+          ARM_SHA: ${{ steps.formula.outputs.arm_sha }}
+          AMD_SHA: ${{ steps.formula.outputs.amd_sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p homebrew-tap/Formula
+
+          cat > homebrew-tap/Formula/cpa-usage-keeper.rb <<EOF
+          class CpaUsageKeeper < Formula
+            desc "Standalone CPA usage persistence and dashboard service"
+            homepage "https://github.com/Willxup/cpa-usage-keeper"
+            license "MIT"
+            version "${VERSION}"
+
+            depends_on :macos
+
+            on_macos do
+              on_arm do
+                url "https://github.com/Willxup/cpa-usage-keeper/releases/download/${TAG}/${ARM_FILE}"
+                sha256 "${ARM_SHA}"
+              end
+
+              on_intel do
+                url "https://github.com/Willxup/cpa-usage-keeper/releases/download/${TAG}/${AMD_FILE}"
+                sha256 "${AMD_SHA}"
+              end
+            end
+
+            def install
+              inreplace ".env.example", "WORK_DIR=./data", "WORK_DIR=#{var}/cpa-usage-keeper"
+
+              bin.install "cpa-usage-keeper"
+              etc.install ".env.example" => "cpa-usage-keeper.env.example"
+              pkgshare.install "README.md", "README.zh.md", "LICENSE"
+            end
+
+            def post_install
+              (var/"cpa-usage-keeper").mkpath
+
+              env_file = etc/"cpa-usage-keeper.env"
+              cp etc/"cpa-usage-keeper.env.example", env_file unless env_file.exist?
+            end
+
+            service do
+              run [opt_bin/"cpa-usage-keeper", "--env", etc/"cpa-usage-keeper.env"]
+              working_dir var/"cpa-usage-keeper"
+              keep_alive true
+              log_path var/"log/cpa-usage-keeper.log"
+              error_log_path var/"log/cpa-usage-keeper.err.log"
+            end
+
+            def caveats
+              <<~EOS
+                Edit the configuration before starting the service:
+
+                  #{etc}/cpa-usage-keeper.env
+
+                Required values include CPA_BASE_URL and CPA_MANAGEMENT_KEY.
+
+                Start the service with:
+
+                  brew services start cpa-usage-keeper
+              EOS
+            end
+
+            test do
+              assert_match "Usage of", shell_output("#{bin}/cpa-usage-keeper --help 2>&1")
+            end
+          end
+          EOF
+
+      - name: Commit and push tap update
+        shell: bash
+        working-directory: homebrew-tap
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add Formula/cpa-usage-keeper.rb
+          if git diff --cached --quiet; then
+            echo "Homebrew formula already up to date"
+            exit 0
+          fi
+
+          git commit -m "Update cpa-usage-keeper to ${GITHUB_REF_NAME}"
+          git push

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Recommended deployment path:
 
 - First-time CPA + Keeper deployment: use [Docker Compose](#docker-compose-recommended).
 - CPA already runs on the host: use [Docker](#docker-cpa-already-runs-on-the-host).
-- No containers: use the [Linux binary](#linux-binary).
+- macOS: use [Homebrew](#macos-homebrew).
+- Linux without containers: use the [Linux binary](#linux-binary).
 
 For public deployments, enable `AUTH_ENABLED=true` and configure `LOGIN_PASSWORD` to protect your data.
 
@@ -151,6 +152,40 @@ docker run -d \
   -v "$(pwd)/keeper:/data" \
   --env-file .env \
   ghcr.io/willxup/cpa-usage-keeper:latest
+```
+
+### macOS Homebrew
+
+Homebrew is the recommended binary install path for macOS. It installs the macOS package from the CPA Usage Keeper tap, and future releases can be upgraded with normal Homebrew commands.
+
+Install:
+
+```bash
+brew tap Willxup/cpa-usage-keeper
+brew install cpa-usage-keeper
+```
+
+Edit the generated config file. At minimum, set `CPA_BASE_URL` and `CPA_MANAGEMENT_KEY`. For public deployments, also set `AUTH_ENABLED=true` and `LOGIN_PASSWORD`:
+
+```bash
+vim "$(brew --prefix)/etc/cpa-usage-keeper.env"
+```
+
+Start the background service:
+
+```bash
+brew services start cpa-usage-keeper
+```
+
+Homebrew stores Keeper data under `$(brew --prefix)/var/cpa-usage-keeper` and service logs under `$(brew --prefix)/var/log`.
+
+Useful commands:
+
+```bash
+brew services list
+brew services restart cpa-usage-keeper
+brew update
+brew upgrade cpa-usage-keeper
 ```
 
 ### Linux Binary

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Start the background service:
 brew services start cpa-usage-keeper
 ```
 
-Homebrew stores Keeper data under `$(brew --prefix)/var/cpa-usage-keeper` and service logs under `$(brew --prefix)/var/log`.
+Homebrew stores Keeper data under `$(brew --prefix)/var/cpa-usage-keeper`, stdout logs at `$(brew --prefix)/var/log/cpa-usage-keeper.log`, and stderr logs at `$(brew --prefix)/var/log/cpa-usage-keeper.err.log`.
 
 Useful commands:
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -177,7 +177,7 @@ vim "$(brew --prefix)/etc/cpa-usage-keeper.env"
 brew services start cpa-usage-keeper
 ```
 
-Homebrew 会把 Keeper 数据放在 `$(brew --prefix)/var/cpa-usage-keeper`，服务日志放在 `$(brew --prefix)/var/log`。
+Homebrew 会把 Keeper 数据放在 `$(brew --prefix)/var/cpa-usage-keeper`，stdout 日志放在 `$(brew --prefix)/var/log/cpa-usage-keeper.log`，stderr 日志放在 `$(brew --prefix)/var/log/cpa-usage-keeper.err.log`。
 
 常用命令：
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -37,7 +37,8 @@
 
 - 第一次部署 CPA + Keeper：优先使用 [Docker Compose](#docker-compose推荐)。
 - CPA 已在宿主机运行：使用 [Docker](#dockercpa-已在宿主机运行)。
-- 不使用容器：使用 [Linux 二进制](#linux-二进制)。
+- macOS：使用 [Homebrew](#macos-homebrew)。
+- Linux 不使用容器：使用 [Linux 二进制](#linux-二进制)。
 
 公网部署建议启用 `AUTH_ENABLED=true`，并配置 `LOGIN_PASSWORD` 保护数据。
 
@@ -151,6 +152,40 @@ docker run -d \
   -v "$(pwd)/keeper:/data" \
   --env-file .env \
   ghcr.io/willxup/cpa-usage-keeper:latest
+```
+
+### macOS Homebrew
+
+Homebrew 是 macOS 推荐的二进制安装方式。它会从 CPA Usage Keeper 的 tap 安装 macOS 包，后续新版本也可以用标准 Homebrew 命令升级。
+
+安装：
+
+```bash
+brew tap Willxup/cpa-usage-keeper
+brew install cpa-usage-keeper
+```
+
+编辑自动生成的配置文件，至少设置 `CPA_BASE_URL` 和 `CPA_MANAGEMENT_KEY`。公网部署建议同时设置 `AUTH_ENABLED=true` 和 `LOGIN_PASSWORD`：
+
+```bash
+vim "$(brew --prefix)/etc/cpa-usage-keeper.env"
+```
+
+启动后台服务：
+
+```bash
+brew services start cpa-usage-keeper
+```
+
+Homebrew 会把 Keeper 数据放在 `$(brew --prefix)/var/cpa-usage-keeper`，服务日志放在 `$(brew --prefix)/var/log`。
+
+常用命令：
+
+```bash
+brew services list
+brew services restart cpa-usage-keeper
+brew update
+brew upgrade cpa-usage-keeper
 ```
 
 ### Linux 二进制


### PR DESCRIPTION
## Summary: 
- Adds automatic Homebrew tap formula updates after release assets publish, and documents macOS Homebrew install and upgrade steps in README and README.zh.md. 

Related to #109 

## Validation: 
- actionlint .github/workflows/binary-release.yml; 
- bash -n on extracted run blocks; simulated formula generation from arm64/amd64 tarballs; 
- rtk git diff --check.