### PR TITLE
Persist auth sessions across restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Security and data notes:
 - SQLite database backups store original data from the application database, and backup files are not encrypted.
 - Browser-facing APIs redact key-like source/lookup fields or map them to stable public identifiers, but raw database values are unchanged.
 - For public deployments, enable `AUTH_ENABLED=true` and terminate HTTPS at your reverse proxy.
-- Login sessions are stored in process memory and become invalid after restart.
+- Login session hashes are stored in SQLite and remain valid across service restarts until logout or `AUTH_SESSION_TTL` expiry.
 - Redis inbox raw messages are cleaned up automatically: successful rows are kept until the end of the current day, and failed rows are kept for 7 days.
 
 ## Nginx reverse proxy
@@ -355,7 +355,7 @@ CPA_PUBLIC_URL=https://cpa.example.com
 cmd/server/              Application entrypoint
 internal/api/            HTTP routes and handlers
 internal/app/            App wiring and startup
-internal/auth/           In-memory session auth
+internal/auth/           Session auth and persistence
 internal/backup/         SQLite database backup management
 internal/benchmark/      Aggregation benchmark helpers
 internal/config/         Environment config loading

--- a/README.zh.md
+++ b/README.zh.md
@@ -325,7 +325,7 @@ cp .env.example .env
 - SQLite 数据库备份会保存应用数据库中的原始数据，备份文件不做加密。
 - 面向浏览器的 API 会对 key-like source/lookup 字段做脱敏或稳定公开标识映射，但不会修改数据库原始值。
 - 公开部署建议开启 `AUTH_ENABLED=true`，并在反向代理层配置 HTTPS。
-- 登录 session 存在服务进程内存中，服务重启后已登录 session 会失效。
+- 登录 session hash 存在 SQLite 中，服务重启后仍会保持有效，直到用户退出登录或超过 `AUTH_SESSION_TTL`。
 - Redis inbox 原始消息会自动清理：成功数据保留到当天结束后清理，失败数据保留 7 天。
 
 ## Nginx反代
@@ -355,7 +355,7 @@ CPA_PUBLIC_URL=https://cpa.example.com
 cmd/server/              应用入口
 internal/api/            HTTP 路由与处理器
 internal/app/            应用装配与启动
-internal/auth/           内存 session 鉴权
+internal/auth/           session 鉴权与持久化
 internal/backup/         SQLite 数据库备份管理
 internal/benchmark/      聚合性能基准测试辅助
 internal/config/         环境配置加载

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -178,6 +178,9 @@ func NewWithConfig(cfg config.Config) (*App, error) {
 	pricingService := service.NewPricingService(db, cpaClient)
 	quotaService := quota.NewServiceWithOptions(db, cpaClient, quota.ServiceOptions{RefreshWorkerLimit: cfg.QuotaRefreshWorkerLimit, AutoRefreshInterval: cfg.QuotaAutoRefreshInterval})
 	sessionManager := auth.NewSessionManager(cfg.AuthSessionTTL)
+	if cfg.AuthEnabled {
+		sessionManager = auth.NewPersistentSessionManager(cfg.AuthSessionTTL, auth.NewGormSessionStore(db))
+	}
 	authHandler := api.NewAuthHandler(api.AuthConfig{
 		Enabled:       cfg.AuthEnabled,
 		LoginPassword: cfg.LoginPassword,

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -2,10 +2,97 @@ package auth
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
+	"errors"
+	"fmt"
 	"sync"
 	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/timeutil"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
+
+type SessionStore interface {
+	Save(string, Session) error
+	Get(string) (Session, bool, error)
+	Delete(string) error
+	DeleteExpired(time.Time) error
+}
+
+type GormSessionStore struct {
+	db *gorm.DB
+}
+
+func NewGormSessionStore(db *gorm.DB) *GormSessionStore {
+	return &GormSessionStore{db: db}
+}
+
+func (s *GormSessionStore) Save(token string, session Session) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("auth session store is not configured")
+	}
+	row := entities.AuthSession{
+		TokenHash:   sessionTokenHash(token),
+		Role:        string(session.Role),
+		CPAAPIKeyID: session.CPAAPIKeyID,
+		ExpiresAt:   session.ExpiresAt,
+	}
+	return s.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "token_hash"}},
+		UpdateAll: true,
+	}).Create(&row).Error
+}
+
+func (s *GormSessionStore) Get(token string) (Session, bool, error) {
+	if s == nil || s.db == nil {
+		return Session{}, false, fmt.Errorf("auth session store is not configured")
+	}
+	var row entities.AuthSession
+	if err := s.db.Where("token_hash = ?", sessionTokenHash(token)).First(&row).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return Session{}, false, nil
+		}
+		return Session{}, false, err
+	}
+	session, err := authSessionFromRow(row)
+	if err != nil {
+		return Session{}, false, err
+	}
+	return session, true, nil
+}
+
+func (s *GormSessionStore) Delete(token string) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("auth session store is not configured")
+	}
+	return s.db.Where("token_hash = ?", sessionTokenHash(token)).Delete(&entities.AuthSession{}).Error
+}
+
+func (s *GormSessionStore) DeleteExpired(now time.Time) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("auth session store is not configured")
+	}
+	return s.db.Where("expires_at <= ?", timeutil.FormatStorageTime(now)).Delete(&entities.AuthSession{}).Error
+}
+
+func authSessionFromRow(row entities.AuthSession) (Session, error) {
+	switch Role(row.Role) {
+	case RoleAdmin:
+		return Session{Role: RoleAdmin, ExpiresAt: row.ExpiresAt}, nil
+	case RoleAPIKeyViewer:
+		return Session{Role: RoleAPIKeyViewer, CPAAPIKeyID: row.CPAAPIKeyID, ExpiresAt: row.ExpiresAt}, nil
+	default:
+		return Session{}, fmt.Errorf("unknown auth session role %q", row.Role)
+	}
+}
+
+func sessionTokenHash(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
 
 type Role string
 
@@ -24,6 +111,7 @@ type SessionManager struct {
 	ttl      time.Duration
 	now      func() time.Time
 	generate func() (string, error)
+	store    SessionStore
 
 	mu       sync.RWMutex
 	sessions map[string]Session
@@ -36,6 +124,12 @@ func NewSessionManager(ttl time.Duration) *SessionManager {
 		generate: generateToken,
 		sessions: make(map[string]Session),
 	}
+}
+
+func NewPersistentSessionManager(ttl time.Duration, store SessionStore) *SessionManager {
+	manager := NewSessionManager(ttl)
+	manager.store = store
+	return manager
 }
 
 func (m *SessionManager) Create() (string, time.Time, error) {
@@ -58,6 +152,11 @@ func (m *SessionManager) create(session Session) (string, time.Time, error) {
 	m.cleanupExpiredLocked()
 	expiresAt := m.now().Add(m.ttl)
 	session.ExpiresAt = expiresAt
+	if m.store != nil {
+		if err := m.store.Save(token, session); err != nil {
+			return "", time.Time{}, fmt.Errorf("save auth session: %w", err)
+		}
+	}
 	m.sessions[token] = session
 
 	return token, expiresAt, nil
@@ -77,6 +176,24 @@ func (m *SessionManager) Get(token string) (Session, bool) {
 	session, ok := m.sessions[token]
 	m.mu.RUnlock()
 	if !ok {
+		return m.getPersisted(token)
+	}
+	if !session.ExpiresAt.After(m.now()) {
+		m.Delete(token)
+		return Session{}, false
+	}
+	return session, true
+}
+
+func (m *SessionManager) getPersisted(token string) (Session, bool) {
+	if m.store == nil {
+		return Session{}, false
+	}
+	session, ok, err := m.store.Get(token)
+	if err != nil {
+		panic(fmt.Errorf("load auth session: %w", err))
+	}
+	if !ok {
 		return Session{}, false
 	}
 	if !session.ExpiresAt.After(m.now()) {
@@ -93,6 +210,11 @@ func (m *SessionManager) Delete(token string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.sessions, token)
+	if m.store != nil {
+		if err := m.store.Delete(token); err != nil {
+			panic(fmt.Errorf("delete auth session: %w", err))
+		}
+	}
 }
 
 func (m *SessionManager) CleanupExpired() {
@@ -106,6 +228,11 @@ func (m *SessionManager) cleanupExpiredLocked() {
 	for token, session := range m.sessions {
 		if !session.ExpiresAt.After(now) {
 			delete(m.sessions, token)
+		}
+	}
+	if m.store != nil {
+		if err := m.store.DeleteExpired(now); err != nil {
+			panic(fmt.Errorf("delete expired auth sessions: %w", err))
 		}
 	}
 }

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -68,14 +68,14 @@ func (s *GormSessionStore) Delete(token string) error {
 	if s == nil || s.db == nil {
 		return fmt.Errorf("auth session store is not configured")
 	}
-	return s.db.Where("token_hash = ?", sessionTokenHash(token)).Delete(&entities.AuthSession{}).Error
+	return s.db.Unscoped().Where("token_hash = ?", sessionTokenHash(token)).Delete(&entities.AuthSession{}).Error
 }
 
 func (s *GormSessionStore) DeleteExpired(now time.Time) error {
 	if s == nil || s.db == nil {
 		return fmt.Errorf("auth session store is not configured")
 	}
-	return s.db.Where("expires_at <= ?", timeutil.FormatStorageTime(now)).Delete(&entities.AuthSession{}).Error
+	return s.db.Unscoped().Where("expires_at <= ?", timeutil.FormatStorageTime(now)).Delete(&entities.AuthSession{}).Error
 }
 
 func authSessionFromRow(row entities.AuthSession) (Session, error) {
@@ -189,6 +189,19 @@ func (m *SessionManager) getPersisted(token string) (Session, bool) {
 	if m.store == nil {
 		return Session{}, false
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if session, ok := m.sessions[token]; ok {
+		if !session.ExpiresAt.After(m.now()) {
+			delete(m.sessions, token)
+			if err := m.store.Delete(token); err != nil {
+				panic(fmt.Errorf("delete auth session: %w", err))
+			}
+			return Session{}, false
+		}
+		return session, true
+	}
+
 	session, ok, err := m.store.Get(token)
 	if err != nil {
 		panic(fmt.Errorf("load auth session: %w", err))
@@ -197,9 +210,12 @@ func (m *SessionManager) getPersisted(token string) (Session, bool) {
 		return Session{}, false
 	}
 	if !session.ExpiresAt.After(m.now()) {
-		m.Delete(token)
+		if err := m.store.Delete(token); err != nil {
+			panic(fmt.Errorf("delete auth session: %w", err))
+		}
 		return Session{}, false
 	}
+	m.sessions[token] = session
 	return session, true
 }
 

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -1,8 +1,13 @@
 package auth
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 func TestSessionManagerCreateValidateDelete(t *testing.T) {
@@ -124,4 +129,84 @@ func TestSessionManagerCleanupExpired(t *testing.T) {
 	if !activeExists {
 		t.Fatal("expected active token to remain")
 	}
+}
+
+func TestPersistentSessionManagerLoadsSessionAfterRestart(t *testing.T) {
+	db := openSessionStoreTestDatabase(t)
+	store := NewGormSessionStore(db)
+	baseTime := time.Date(2026, 6, 20, 10, 0, 0, 0, time.UTC)
+	manager := NewPersistentSessionManager(2*time.Hour, store)
+	manager.now = func() time.Time { return baseTime }
+	manager.generate = func() (string, error) { return "persisted-token", nil }
+
+	token, expiresAt, err := manager.CreateAPIKeyViewer(42)
+	if err != nil {
+		t.Fatalf("CreateAPIKeyViewer returned error: %v", err)
+	}
+	var row entities.AuthSession
+	if err := db.First(&row).Error; err != nil {
+		t.Fatalf("load persisted auth session: %v", err)
+	}
+	if row.TokenHash == token {
+		t.Fatal("expected persisted session token hash not to equal raw token")
+	}
+	if row.TokenHash != sessionTokenHash(token) {
+		t.Fatalf("expected persisted token hash %q, got %q", sessionTokenHash(token), row.TokenHash)
+	}
+
+	restarted := NewPersistentSessionManager(2*time.Hour, store)
+	restarted.now = func() time.Time { return baseTime.Add(time.Minute) }
+	session, ok := restarted.Get(token)
+	if !ok {
+		t.Fatal("expected persisted session to validate after manager restart")
+	}
+	if session.Role != RoleAPIKeyViewer || session.CPAAPIKeyID != 42 {
+		t.Fatalf("unexpected persisted session metadata: %+v", session)
+	}
+	if !session.ExpiresAt.Equal(expiresAt) {
+		t.Fatalf("expected persisted expiry %s, got %s", expiresAt, session.ExpiresAt)
+	}
+}
+
+func TestPersistentSessionManagerDeletesExpiredPersistedSession(t *testing.T) {
+	db := openSessionStoreTestDatabase(t)
+	store := NewGormSessionStore(db)
+	baseTime := time.Date(2026, 6, 20, 10, 0, 0, 0, time.UTC)
+	if err := store.Save("expired-token", Session{Role: RoleAdmin, ExpiresAt: baseTime.Add(-time.Minute)}); err != nil {
+		t.Fatalf("save expired session: %v", err)
+	}
+	manager := NewPersistentSessionManager(time.Hour, store)
+	manager.now = func() time.Time { return baseTime }
+
+	if manager.Validate("expired-token") {
+		t.Fatal("expected expired persisted session to fail validation")
+	}
+	var count int64
+	if err := db.Model(&entities.AuthSession{}).Where("token_hash = ?", sessionTokenHash("expired-token")).Count(&count).Error; err != nil {
+		t.Fatalf("count auth sessions: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected expired persisted session to be deleted, got %d rows", count)
+	}
+}
+
+func openSessionStoreTestDatabase(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "sessions.db")), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite database: %v", err)
+	}
+	if err := db.AutoMigrate(&entities.AuthSession{}); err != nil {
+		t.Fatalf("auto migrate auth sessions: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sql database: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Fatalf("close sqlite database: %v", err)
+		}
+	})
+	return db
 }

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -154,7 +154,8 @@ func TestPersistentSessionManagerLoadsSessionAfterRestart(t *testing.T) {
 		t.Fatalf("expected persisted token hash %q, got %q", sessionTokenHash(token), row.TokenHash)
 	}
 
-	restarted := NewPersistentSessionManager(2*time.Hour, store)
+	restartedStore := &trackingSessionStore{store: store}
+	restarted := NewPersistentSessionManager(2*time.Hour, restartedStore)
 	restarted.now = func() time.Time { return baseTime.Add(time.Minute) }
 	session, ok := restarted.Get(token)
 	if !ok {
@@ -165,6 +166,20 @@ func TestPersistentSessionManagerLoadsSessionAfterRestart(t *testing.T) {
 	}
 	if !session.ExpiresAt.Equal(expiresAt) {
 		t.Fatalf("expected persisted expiry %s, got %s", expiresAt, session.ExpiresAt)
+	}
+	if restartedStore.getCalls != 1 {
+		t.Fatalf("expected first restart lookup to load from store once, got %d", restartedStore.getCalls)
+	}
+
+	session, ok = restarted.Get(token)
+	if !ok {
+		t.Fatal("expected cached persisted session to validate")
+	}
+	if session.CPAAPIKeyID != 42 {
+		t.Fatalf("unexpected cached session metadata: %+v", session)
+	}
+	if restartedStore.getCalls != 1 {
+		t.Fatalf("expected cached restart lookup not to hit store again, got %d calls", restartedStore.getCalls)
 	}
 }
 
@@ -209,4 +224,26 @@ func openSessionStoreTestDatabase(t *testing.T) *gorm.DB {
 		}
 	})
 	return db
+}
+
+type trackingSessionStore struct {
+	store    SessionStore
+	getCalls int
+}
+
+func (s *trackingSessionStore) Save(token string, session Session) error {
+	return s.store.Save(token, session)
+}
+
+func (s *trackingSessionStore) Get(token string) (Session, bool, error) {
+	s.getCalls++
+	return s.store.Get(token)
+}
+
+func (s *trackingSessionStore) Delete(token string) error {
+	return s.store.Delete(token)
+}
+
+func (s *trackingSessionStore) DeleteExpired(now time.Time) error {
+	return s.store.DeleteExpired(now)
 }

--- a/internal/entities/all.go
+++ b/internal/entities/all.go
@@ -12,5 +12,6 @@ func All() []any {
 		&UsageOverviewDailyStat{},
 		&UsageOverviewHealthStat{},
 		&UsageOverviewAggregationCheckpoint{},
+		&AuthSession{},
 	}
 }

--- a/internal/entities/auth_session.go
+++ b/internal/entities/auth_session.go
@@ -1,0 +1,13 @@
+package entities
+
+import "time"
+
+// AuthSession persists browser login sessions across service restarts.
+type AuthSession struct {
+	TokenHash   string    `gorm:"primaryKey;column:token_hash"`
+	Role        string    `gorm:"not null;index:idx_auth_sessions_role"`
+	CPAAPIKeyID int64     `gorm:"index:idx_auth_sessions_cpa_api_key_id"`
+	ExpiresAt   time.Time `gorm:"serializer:storageTime;not null;index:idx_auth_sessions_expires_at"`
+	CreatedAt   time.Time `gorm:"serializer:storageTime"`
+	UpdatedAt   time.Time `gorm:"serializer:storageTime"`
+}

--- a/internal/entities/entities_test.go
+++ b/internal/entities/entities_test.go
@@ -17,6 +17,7 @@ func TestAllIncludesCoreModels(t *testing.T) {
 		&UsageOverviewDailyStat{},
 		&UsageOverviewHealthStat{},
 		&UsageOverviewAggregationCheckpoint{},
+		&AuthSession{},
 	}
 	if len(items) != len(expected) {
 		t.Fatalf("expected %d registered models, got %d", len(expected), len(items))

--- a/internal/repository/db_test.go
+++ b/internal/repository/db_test.go
@@ -37,6 +37,9 @@ func TestOpenDatabaseAutoMigratesCoreTables(t *testing.T) {
 	if !db.Migrator().HasTable("redis_usage_inboxes") {
 		t.Fatal("expected redis_usage_inboxes table to exist")
 	}
+	if !db.Migrator().HasTable("auth_sessions") {
+		t.Fatal("expected auth_sessions table to exist")
+	}
 }
 
 func TestOpenDatabaseCreatesFreshDatabaseFromCurrentSchemaWithoutRunningMigrations(t *testing.T) {
@@ -53,8 +56,8 @@ func TestOpenDatabaseCreatesFreshDatabaseFromCurrentSchemaWithoutRunningMigratio
 	if err := db.Table("schema_migrations").Count(&count).Error; err != nil {
 		t.Fatalf("count schema migrations: %v", err)
 	}
-	if count != 38 {
-		t.Fatalf("expected fresh database to mark 38 migrations applied, got %d", count)
+	if count != 39 {
+		t.Fatalf("expected fresh database to mark 39 migrations applied, got %d", count)
 	}
 	if strings.Contains(logs.String(), "schema migration started") {
 		t.Fatalf("expected fresh database creation not to run version migrations, got logs:\n%s", logs.String())
@@ -64,6 +67,15 @@ func TestOpenDatabaseCreatesFreshDatabaseFromCurrentSchemaWithoutRunningMigratio
 	}
 	if db.Migrator().HasColumn(&entities.RedisUsageInbox{}, "queue_key") {
 		t.Fatal("expected redis_usage_inboxes.queue_key column not to exist")
+	}
+	if !db.Migrator().HasTable(&entities.AuthSession{}) {
+		t.Fatal("expected auth_sessions table to exist")
+	}
+	if !db.Migrator().HasColumn(&entities.AuthSession{}, "token_hash") {
+		t.Fatal("expected auth_sessions.token_hash column to exist")
+	}
+	if db.Migrator().HasColumn(&entities.AuthSession{}, "token") {
+		t.Fatal("expected auth_sessions.token column not to exist")
 	}
 	for _, indexName := range []string{
 		"idx_usage_events_api_group_key",

--- a/internal/repository/migration/20260620_auth_sessions.go
+++ b/internal/repository/migration/20260620_auth_sessions.go
@@ -1,0 +1,15 @@
+package migration
+
+import (
+	"fmt"
+
+	"cpa-usage-keeper/internal/entities"
+	"gorm.io/gorm"
+)
+
+func createAuthSessionsMigration(tx *gorm.DB) error {
+	if err := tx.AutoMigrate(&entities.AuthSession{}); err != nil {
+		return fmt.Errorf("auto migrate auth sessions: %w", err)
+	}
+	return nil
+}

--- a/internal/repository/migration/migration.go
+++ b/internal/repository/migration/migration.go
@@ -48,6 +48,7 @@ const (
 	migrationRemoveUsageEventWriteHeavyIndexes      = "20260610_remove_usage_event_write_heavy_indexes"
 	migrationRemoveUsageEventLowValueIndexes        = "20260611_remove_usage_event_low_value_indexes"
 	migrationReplaceRedisInboxQueueKeyWithSource    = "20260612_replace_redis_inbox_queue_key_with_source"
+	migrationCreateAuthSessions                     = "20260620_create_auth_sessions"
 )
 
 type schemaMigration struct {
@@ -140,6 +141,7 @@ func orderedMigrations() []databaseMigration {
 		{version: migrationRemoveUsageEventWriteHeavyIndexes, run: removeUsageEventWriteHeavyIndexesMigration},
 		{version: migrationRemoveUsageEventLowValueIndexes, run: removeUsageEventLowValueIndexesMigration},
 		{version: migrationReplaceRedisInboxQueueKeyWithSource, run: replaceRedisInboxQueueKeyWithSourceMigration},
+		{version: migrationCreateAuthSessions, run: createAuthSessionsMigration},
 	}
 }
 

--- a/internal/repository/migration/migration_test.go
+++ b/internal/repository/migration/migration_test.go
@@ -57,6 +57,7 @@ func TestOrderedMigrationsPreservesExecutionOrder(t *testing.T) {
 		"20260610_remove_usage_event_write_heavy_indexes",
 		"20260611_remove_usage_event_low_value_indexes",
 		"20260612_replace_redis_inbox_queue_key_with_source",
+		"20260620_create_auth_sessions",
 	}
 	if len(got) != len(want) {
 		t.Fatalf("expected ordered migrations %v, got %v", want, got)
@@ -85,6 +86,18 @@ func TestOpenDatabaseRunsSchemaMigrationsAndAddsUsageEventRedisFields(t *testing
 	}
 	if !db.Migrator().HasColumn(&entities.RedisUsageInbox{}, "source") {
 		t.Fatal("expected redis_usage_inboxes.source column to exist")
+	}
+	if !db.Migrator().HasTable(&entities.AuthSession{}) {
+		t.Fatal("expected auth_sessions table to exist")
+	}
+	if !db.Migrator().HasColumn(&entities.AuthSession{}, "token_hash") {
+		t.Fatal("expected auth_sessions.token_hash column to exist")
+	}
+	if db.Migrator().HasColumn(&entities.AuthSession{}, "token") {
+		t.Fatal("expected auth_sessions.token column not to exist")
+	}
+	if !db.Migrator().HasColumn(&entities.AuthSession{}, "expires_at") {
+		t.Fatal("expected auth_sessions.expires_at column to exist")
 	}
 	if db.Migrator().HasColumn(&entities.RedisUsageInbox{}, "queue_key") {
 		t.Fatal("expected redis_usage_inboxes.queue_key column not to exist")
@@ -141,6 +154,7 @@ func TestOpenDatabaseRunsSchemaMigrationsAndAddsUsageEventRedisFields(t *testing
 		"20260610_remove_usage_event_write_heavy_indexes",
 		"20260611_remove_usage_event_low_value_indexes",
 		"20260612_replace_redis_inbox_queue_key_with_source",
+		"20260620_create_auth_sessions",
 	}
 	if len(versions) != len(expected) {
 		t.Fatalf("expected migration versions %v, got %v", expected, versions)


### PR DESCRIPTION
## Summary

- persist authentication sessions in SQLite so login cookies survive service restarts
- store only SHA-256 session token hashes in the database
- add schema migration, fresh-schema registration, tests, and README updates

## Root cause

Auth sessions were stored only in the process-local session map. Restarting the service recreated an empty session manager, so existing browser cookies no longer matched any known session.

## Validation

- `go test ./...`
- `git diff --cached --check` before commit