### PR TITLE
Refine realtime response distributions

### DIFF
--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -1523,7 +1523,6 @@ func usageOverviewHealthBlockIndex(blocks []dto.UsageOverviewHealthBlockRecord, 
 }
 
 const usageOverviewRealtimeBucketCount = 30
-const usageOverviewRealtimeParticleMaxBins = 6
 
 type usageOverviewRealtimeBucket struct {
 	bucketStart    time.Time
@@ -1958,15 +1957,16 @@ func finalizeUsageOverviewRealtime(window, span time.Duration, buckets []usageOv
 	aggregationBucketCount := usageOverviewRealtimeAggregationBucketCount(span, aggregationWindow)
 	aggregationMinutes := aggregationWindow.Minutes()
 	for index := visibleStartIndex; index < len(buckets); index++ {
-		bucket := aggregateUsageOverviewRealtimeBucket(buckets, index, aggregationBucketCount)
-		bucketKey := timeutil.FormatStorageTime(bucket.bucketStart)
-		ttftP50, ttftP95 := usageOverviewRealtimePercentilePair(bucket.ttftSamples, 0.50, 0.95)
-		latencyP50, latencyP95 := usageOverviewRealtimePercentilePair(bucket.latencySamples, 0.50, 0.95)
+		rollingBucket := aggregateUsageOverviewRealtimeBucket(buckets, index, aggregationBucketCount)
+		rawBucket := buckets[index]
+		bucketKey := timeutil.FormatStorageTime(rollingBucket.bucketStart)
+		ttftP50, ttftP95 := usageOverviewRealtimePercentilePair(rollingBucket.ttftSamples, 0.50, 0.95)
+		latencyP50, latencyP95 := usageOverviewRealtimePercentilePair(rollingBucket.latencySamples, 0.50, 0.95)
 		tokenVelocity = append(tokenVelocity, dto.RealtimeTokenVelocityPointRecord{
 			Bucket:          bucketKey,
-			TokensPerMinute: float64(bucket.tokens) / aggregationMinutes,
-			Tokens:          bucket.tokens,
-			CostUSD:         usageOverviewRealtimeCostPtr(bucket.costUSD, bucket.costAvailable),
+			TokensPerMinute: float64(rollingBucket.tokens) / aggregationMinutes,
+			Tokens:          rollingBucket.tokens,
+			CostUSD:         usageOverviewRealtimeCostPtr(rollingBucket.costUSD, rollingBucket.costAvailable),
 		})
 		responseLevel = append(responseLevel, dto.RealtimeResponseLevelPointRecord{
 			Bucket:       bucketKey,
@@ -1977,24 +1977,24 @@ func finalizeUsageOverviewRealtime(window, span time.Duration, buckets []usageOv
 		})
 		responseDistribution.TTFT.AverageLine = append(responseDistribution.TTFT.AverageLine, dto.RealtimeResponseAveragePointRecord{
 			Bucket: bucketKey,
-			AvgMS:  usageOverviewRealtimeAverage(bucket.ttftSamples),
+			AvgMS:  usageOverviewRealtimeAverage(rollingBucket.ttftSamples),
 		})
-		responseDistribution.TTFT.Particles = append(responseDistribution.TTFT.Particles, usageOverviewRealtimeDistributionParticles(bucketKey, bucket.ttftSamples)...)
+		responseDistribution.TTFT.Particles = append(responseDistribution.TTFT.Particles, usageOverviewRealtimeDistributionParticles(bucketKey, rawBucket.ttftSamples)...)
 		responseDistribution.Latency.AverageLine = append(responseDistribution.Latency.AverageLine, dto.RealtimeResponseAveragePointRecord{
 			Bucket: bucketKey,
-			AvgMS:  usageOverviewRealtimeAverage(bucket.latencySamples),
+			AvgMS:  usageOverviewRealtimeAverage(rollingBucket.latencySamples),
 		})
-		responseDistribution.Latency.Particles = append(responseDistribution.Latency.Particles, usageOverviewRealtimeDistributionParticles(bucketKey, bucket.latencySamples)...)
+		responseDistribution.Latency.Particles = append(responseDistribution.Latency.Particles, usageOverviewRealtimeDistributionParticles(bucketKey, rawBucket.latencySamples)...)
 		requestLevel = append(requestLevel, dto.RealtimeRequestLevelPointRecord{
 			Bucket:            bucketKey,
-			RequestsPerMinute: float64(bucket.requests) / aggregationMinutes,
-			Requests:          bucket.requests,
+			RequestsPerMinute: float64(rollingBucket.requests) / aggregationMinutes,
+			Requests:          rollingBucket.requests,
 		})
 		cacheLevel = append(cacheLevel, dto.RealtimeCacheLevelPointRecord{
 			Bucket:       bucketKey,
-			CacheRate:    usageOverviewRealtimeCacheRate(bucket.cachedTokens, bucket.inputTokens),
-			CachedTokens: bucket.cachedTokens,
-			InputTokens:  bucket.inputTokens,
+			CacheRate:    usageOverviewRealtimeCacheRate(rollingBucket.cachedTokens, rollingBucket.inputTokens),
+			CachedTokens: rollingBucket.cachedTokens,
+			InputTokens:  rollingBucket.inputTokens,
 		})
 	}
 	return dto.UsageOverviewRealtimeRecord{
@@ -2030,63 +2030,15 @@ func usageOverviewRealtimeDistributionParticles(bucket string, samples []int64) 
 	if len(samples) == 0 {
 		return []dto.RealtimeResponseParticleRecord{}
 	}
-	minValue, maxValue := samples[0], samples[0]
-	for _, sample := range samples[1:] {
-		if sample < minValue {
-			minValue = sample
-		}
-		if sample > maxValue {
-			maxValue = sample
-		}
-	}
-	binCount := usageOverviewRealtimeParticleBinCount(len(samples))
-	if minValue == maxValue || binCount == 1 {
-		return []dto.RealtimeResponseParticleRecord{{
-			Bucket: bucket,
-			MS:     minValue,
-			Count:  int64(len(samples)),
-		}}
-	}
-	counts := make([]int64, binCount)
-	sums := make([]int64, binCount)
-	valueSpan := maxValue - minValue + 1
+	particles := make([]dto.RealtimeResponseParticleRecord, 0, len(samples))
 	for _, sample := range samples {
-		binIndex := int(((sample - minValue) * int64(binCount)) / valueSpan)
-		if binIndex < 0 {
-			binIndex = 0
-		}
-		if binIndex >= binCount {
-			binIndex = binCount - 1
-		}
-		counts[binIndex]++
-		sums[binIndex] += sample
-	}
-	particles := make([]dto.RealtimeResponseParticleRecord, 0, binCount)
-	for index, count := range counts {
-		if count == 0 {
-			continue
-		}
 		particles = append(particles, dto.RealtimeResponseParticleRecord{
 			Bucket: bucket,
-			MS:     sums[index] / count,
-			Count:  count,
+			MS:     sample,
+			Count:  1,
 		})
 	}
 	return particles
-}
-
-func usageOverviewRealtimeParticleBinCount(sampleCount int) int {
-	if sampleCount <= 1 {
-		return 1
-	}
-	binCount := int(math.Ceil(math.Sqrt(float64(sampleCount))))
-	if binCount < 1 {
-		return 1
-	}
-	if binCount > usageOverviewRealtimeParticleMaxBins {
-		return usageOverviewRealtimeParticleMaxBins
-	}
-	return binCount
 }
 
 func usageOverviewRealtimeCostPtr(cost float64, available bool) *float64 {

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -1611,8 +1611,8 @@ func buildUsageOverviewRealtime(db *gorm.DB, filter dto.UsageQueryFilter, pricin
 			// current usage 的请求数同样包含成功和失败，token 后续只由成功请求累计。
 			applyUsageOverviewRealtimeRequest(realtimeEvent, modelUsage, apiKeyUsage, authFileUsage, aiProviderUsage, identityLookup)
 		}
-		// TTFT 缺失时不补 0，避免 percentile 被无样本 bucket 拉低。
-		if event.TTFTMS != nil {
+		// TTFT 缺失或非正数时不补 0，避免 log 分布和 percentile 被无效样本拉低。
+		if event.TTFTMS != nil && *event.TTFTMS > 0 {
 			bucket.ttftSamples = append(bucket.ttftSamples, *event.TTFTMS)
 		}
 		// Latency 只有正数才作为样本。
@@ -1979,12 +1979,12 @@ func finalizeUsageOverviewRealtime(window, span time.Duration, buckets []usageOv
 			Bucket: bucketKey,
 			AvgMS:  usageOverviewRealtimeAverage(rollingBucket.ttftSamples),
 		})
-		responseDistribution.TTFT.Particles = append(responseDistribution.TTFT.Particles, usageOverviewRealtimeDistributionParticles(bucketKey, rawBucket.ttftSamples)...)
+		responseDistribution.TTFT.Particles = appendUsageOverviewRealtimeDistributionParticles(responseDistribution.TTFT.Particles, bucketKey, rawBucket.ttftSamples)
 		responseDistribution.Latency.AverageLine = append(responseDistribution.Latency.AverageLine, dto.RealtimeResponseAveragePointRecord{
 			Bucket: bucketKey,
 			AvgMS:  usageOverviewRealtimeAverage(rollingBucket.latencySamples),
 		})
-		responseDistribution.Latency.Particles = append(responseDistribution.Latency.Particles, usageOverviewRealtimeDistributionParticles(bucketKey, rawBucket.latencySamples)...)
+		responseDistribution.Latency.Particles = appendUsageOverviewRealtimeDistributionParticles(responseDistribution.Latency.Particles, bucketKey, rawBucket.latencySamples)
 		requestLevel = append(requestLevel, dto.RealtimeRequestLevelPointRecord{
 			Bucket:            bucketKey,
 			RequestsPerMinute: float64(rollingBucket.requests) / aggregationMinutes,
@@ -2026,19 +2026,15 @@ func usageOverviewRealtimeAverage(samples []int64) *float64 {
 	return &value
 }
 
-func usageOverviewRealtimeDistributionParticles(bucket string, samples []int64) []dto.RealtimeResponseParticleRecord {
-	if len(samples) == 0 {
-		return []dto.RealtimeResponseParticleRecord{}
-	}
-	particles := make([]dto.RealtimeResponseParticleRecord, 0, len(samples))
+func appendUsageOverviewRealtimeDistributionParticles(dst []dto.RealtimeResponseParticleRecord, bucket string, samples []int64) []dto.RealtimeResponseParticleRecord {
 	for _, sample := range samples {
-		particles = append(particles, dto.RealtimeResponseParticleRecord{
+		dst = append(dst, dto.RealtimeResponseParticleRecord{
 			Bucket: bucket,
 			MS:     sample,
 			Count:  1,
 		})
 	}
-	return particles
+	return dst
 }
 
 func usageOverviewRealtimeCostPtr(cost float64, available bool) *float64 {

--- a/internal/repository/usage_filter_test.go
+++ b/internal/repository/usage_filter_test.go
@@ -1314,8 +1314,21 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 		realtime.ResponseDistribution.Latency.AverageLine[26].AvgMS == nil || math.Abs(*realtime.ResponseDistribution.Latency.AverageLine[26].AvgMS-900) > 0.000000001 {
 		t.Fatalf("expected failed request latency distribution without ttft after sliding carry, got ttft=%+v latency=%+v", realtime.ResponseDistribution.TTFT.AverageLine[26], realtime.ResponseDistribution.Latency.AverageLine[26])
 	}
-	if len(realtime.ResponseDistribution.TTFT.Particles) == 0 || len(realtime.ResponseDistribution.Latency.Particles) == 0 {
-		t.Fatalf("expected response distribution particles to be populated, got ttft=%+v latency=%+v", realtime.ResponseDistribution.TTFT.Particles, realtime.ResponseDistribution.Latency.Particles)
+	expectedTTFTParticles := []dto.RealtimeResponseParticleRecord{
+		{Bucket: "2026-06-09T11:55:00Z", MS: 100, Count: 1},
+		{Bucket: "2026-06-09T11:55:00Z", MS: 200, Count: 1},
+	}
+	if !reflect.DeepEqual(realtime.ResponseDistribution.TTFT.Particles, expectedTTFTParticles) {
+		t.Fatalf("expected response distribution TTFT particles to map one usage event to one point, got %+v", realtime.ResponseDistribution.TTFT.Particles)
+	}
+	expectedLatencyParticles := []dto.RealtimeResponseParticleRecord{
+		{Bucket: "2026-06-09T11:55:00Z", MS: 500, Count: 1},
+		{Bucket: "2026-06-09T11:55:00Z", MS: 700, Count: 1},
+		{Bucket: "2026-06-09T11:55:30Z", MS: 900, Count: 1},
+		{Bucket: "2026-06-09T11:59:30Z", MS: 300, Count: 1},
+	}
+	if !reflect.DeepEqual(realtime.ResponseDistribution.Latency.Particles, expectedLatencyParticles) {
+		t.Fatalf("expected response distribution latency particles to map one usage event to one point, got %+v", realtime.ResponseDistribution.Latency.Particles)
 	}
 	if realtime.RequestLevel[21].Requests != 3 || realtime.RequestLevel[21].RequestsPerMinute != 1 {
 		t.Fatalf("expected request level to use the 3m sliding window, got %+v", realtime.RequestLevel[21])

--- a/internal/repository/usage_filter_test.go
+++ b/internal/repository/usage_filter_test.go
@@ -1243,12 +1243,14 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 	now := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
 	ttft100 := int64(100)
 	ttft200 := int64(200)
+	ttftZero := int64(0)
 	cache := newEmptyUsageRecentEventCache(UsageRecentEventCacheOptions{Now: func() time.Time { return now }})
 	t.Cleanup(cache.Close)
 	cache.appendEvents([]entities.UsageEvent{
 		{APIGroupKey: "provider-a", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-1", Timestamp: now.Add(-16 * time.Minute), InputTokens: 900, TotalTokens: 900},
 		{APIGroupKey: "provider-a", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-1", Timestamp: now.Add(-4*time.Minute - 50*time.Second), InputTokens: 100, OutputTokens: 60, CachedTokens: 20, TotalTokens: 120, LatencyMS: 500, TTFTMS: &ttft100},
 		{APIGroupKey: "provider-a", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-1", Timestamp: now.Add(-4*time.Minute - 45*time.Second), InputTokens: 50, OutputTokens: 40, CachedTokens: 5, TotalTokens: 80, LatencyMS: 700, TTFTMS: &ttft200},
+		{APIGroupKey: "provider-a", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-1", Timestamp: now.Add(-4*time.Minute - 40*time.Second), InputTokens: 10, OutputTokens: 10, TotalTokens: 20, LatencyMS: 650, TTFTMS: &ttftZero},
 		{APIGroupKey: "provider-a", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-1", Timestamp: now.Add(-4*time.Minute - 30*time.Second), Failed: true, InputTokens: 1000, TotalTokens: 1000, LatencyMS: 900},
 		{APIGroupKey: "provider-a", Model: "claude-sonnet", AuthType: "apikey", Provider: "OpenAI Provider", AuthIndex: "provider-1", Timestamp: now.Add(-20 * time.Second), InputTokens: 100, OutputTokens: 25, TotalTokens: 50, LatencyMS: 300},
 		{APIGroupKey: "provider-b", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-2", Timestamp: now.Add(-10 * time.Second), InputTokens: 700, TotalTokens: 700, LatencyMS: 100},
@@ -1280,11 +1282,11 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 	}
 
 	firstUsageBucket := realtime.TokenVelocity[20]
-	if firstUsageBucket.Bucket != "2026-06-09T11:55:00Z" || firstUsageBucket.Tokens != 200 || math.Abs(firstUsageBucket.TokensPerMinute-(200.0/3.0)) > 0.000000001 {
+	if firstUsageBucket.Bucket != "2026-06-09T11:55:00Z" || firstUsageBucket.Tokens != 220 || math.Abs(firstUsageBucket.TokensPerMinute-(220.0/3.0)) > 0.000000001 {
 		t.Fatalf("unexpected first token velocity bucket: %+v", firstUsageBucket)
 	}
 	carriedUsageBucket := realtime.TokenVelocity[25]
-	if carriedUsageBucket.Tokens != 200 || math.Abs(carriedUsageBucket.TokensPerMinute-(200.0/3.0)) > 0.000000001 {
+	if carriedUsageBucket.Tokens != 220 || math.Abs(carriedUsageBucket.TokensPerMinute-(220.0/3.0)) > 0.000000001 {
 		t.Fatalf("expected token velocity to carry over the 3m sliding window, got %+v", carriedUsageBucket)
 	}
 	expiredUsageBucket := realtime.TokenVelocity[26]
@@ -1307,7 +1309,7 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 	if realtime.ResponseDistribution.TTFT.AverageLine[21].AvgMS == nil || math.Abs(*realtime.ResponseDistribution.TTFT.AverageLine[21].AvgMS-150) > 0.000000001 {
 		t.Fatalf("expected ttft average line to use sliding samples, got %+v", realtime.ResponseDistribution.TTFT.AverageLine[21])
 	}
-	if realtime.ResponseDistribution.Latency.AverageLine[21].AvgMS == nil || math.Abs(*realtime.ResponseDistribution.Latency.AverageLine[21].AvgMS-700) > 0.000000001 {
+	if realtime.ResponseDistribution.Latency.AverageLine[21].AvgMS == nil || math.Abs(*realtime.ResponseDistribution.Latency.AverageLine[21].AvgMS-687.5) > 0.000000001 {
 		t.Fatalf("expected latency average line to include failed request latency, got %+v", realtime.ResponseDistribution.Latency.AverageLine[21])
 	}
 	if realtime.ResponseDistribution.TTFT.AverageLine[26].AvgMS != nil ||
@@ -1324,24 +1326,25 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 	expectedLatencyParticles := []dto.RealtimeResponseParticleRecord{
 		{Bucket: "2026-06-09T11:55:00Z", MS: 500, Count: 1},
 		{Bucket: "2026-06-09T11:55:00Z", MS: 700, Count: 1},
+		{Bucket: "2026-06-09T11:55:00Z", MS: 650, Count: 1},
 		{Bucket: "2026-06-09T11:55:30Z", MS: 900, Count: 1},
 		{Bucket: "2026-06-09T11:59:30Z", MS: 300, Count: 1},
 	}
 	if !reflect.DeepEqual(realtime.ResponseDistribution.Latency.Particles, expectedLatencyParticles) {
 		t.Fatalf("expected response distribution latency particles to map one usage event to one point, got %+v", realtime.ResponseDistribution.Latency.Particles)
 	}
-	if realtime.RequestLevel[21].Requests != 3 || realtime.RequestLevel[21].RequestsPerMinute != 1 {
+	if realtime.RequestLevel[21].Requests != 4 || math.Abs(realtime.RequestLevel[21].RequestsPerMinute-(4.0/3.0)) > 0.000000001 {
 		t.Fatalf("expected request level to use the 3m sliding window, got %+v", realtime.RequestLevel[21])
 	}
 	if realtime.RequestLevel[26].Requests != 1 || math.Abs(realtime.RequestLevel[26].RequestsPerMinute-(1.0/3.0)) > 0.000000001 {
 		t.Fatalf("expected failed request to remain visible inside the sliding window, got %+v", realtime.RequestLevel[26])
 	}
-	if realtime.CacheLevel[20].InputTokens != 150 || realtime.CacheLevel[20].CachedTokens != 25 ||
-		realtime.CacheLevel[20].CacheRate == nil || math.Abs(*realtime.CacheLevel[20].CacheRate-(25.0/150.0)*100) > 0.000000001 {
+	if realtime.CacheLevel[20].InputTokens != 160 || realtime.CacheLevel[20].CachedTokens != 25 ||
+		realtime.CacheLevel[20].CacheRate == nil || math.Abs(*realtime.CacheLevel[20].CacheRate-(25.0/160.0)*100) > 0.000000001 {
 		t.Fatalf("unexpected cache level bucket: %+v", realtime.CacheLevel[20])
 	}
-	if realtime.CacheLevel[25].InputTokens != 150 || realtime.CacheLevel[25].CachedTokens != 25 ||
-		realtime.CacheLevel[25].CacheRate == nil || math.Abs(*realtime.CacheLevel[25].CacheRate-(25.0/150.0)*100) > 0.000000001 {
+	if realtime.CacheLevel[25].InputTokens != 160 || realtime.CacheLevel[25].CachedTokens != 25 ||
+		realtime.CacheLevel[25].CacheRate == nil || math.Abs(*realtime.CacheLevel[25].CacheRate-(25.0/160.0)*100) > 0.000000001 {
 		t.Fatalf("expected cache level to carry over the sliding window, got %+v", realtime.CacheLevel[25])
 	}
 	if realtime.CacheLevel[26].CacheRate != nil || realtime.CacheLevel[26].InputTokens != 0 || realtime.CacheLevel[26].CachedTokens != 0 {
@@ -1350,19 +1353,19 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 
 	if len(realtime.CurrentUsage.Models) != 2 ||
 		realtime.CurrentUsage.Models[0].Key != "gpt-5" ||
-		realtime.CurrentUsage.Models[0].Tokens != 200 ||
-		math.Abs(realtime.CurrentUsage.Models[0].Share-80) > 0.000000001 {
+		realtime.CurrentUsage.Models[0].Tokens != 220 ||
+		math.Abs(realtime.CurrentUsage.Models[0].Share-(220.0/270.0)*100) > 0.000000001 {
 		t.Fatalf("unexpected realtime model usage: %+v", realtime.CurrentUsage.Models)
 	}
 	if len(realtime.CurrentUsage.APIKeys) != 1 ||
 		realtime.CurrentUsage.APIKeys[0].Key != "provider-a" ||
-		realtime.CurrentUsage.APIKeys[0].Requests != 4 ||
-		realtime.CurrentUsage.APIKeys[0].Tokens != 250 {
+		realtime.CurrentUsage.APIKeys[0].Requests != 5 ||
+		realtime.CurrentUsage.APIKeys[0].Tokens != 270 {
 		t.Fatalf("unexpected realtime api key usage: %+v", realtime.CurrentUsage.APIKeys)
 	}
 	if len(realtime.CurrentUsage.AuthFiles) != 1 ||
 		realtime.CurrentUsage.AuthFiles[0].Label != "Claude Account" ||
-		realtime.CurrentUsage.AuthFiles[0].Tokens != 200 {
+		realtime.CurrentUsage.AuthFiles[0].Tokens != 220 {
 		t.Fatalf("unexpected realtime auth file usage: %+v", realtime.CurrentUsage.AuthFiles)
 	}
 	if len(realtime.CurrentUsage.AIProviders) != 1 ||

--- a/web/src/components/usage/OverviewRealtimePanel.logic.test.tsx
+++ b/web/src/components/usage/OverviewRealtimePanel.logic.test.tsx
@@ -249,6 +249,89 @@ describe('OverviewRealtimePanel', () => {
     ]);
   });
 
+  it('uses data-driven logarithmic response axes per distribution chart', () => {
+    renderToStaticMarkup(
+      <OverviewRealtimePanel
+        realtime={{
+          ...realtime,
+          response_distribution: {
+            ttft: {
+              average_line: [
+                { bucket: '2026-06-09T11:55:00Z', avg_ms: 1200 },
+                { bucket: '2026-06-09T11:55:30Z', avg_ms: 5000 },
+              ],
+              particles: [
+                { bucket: '2026-06-09T11:55:00Z', ms: 800, count: 1 },
+                { bucket: '2026-06-09T11:55:30Z', ms: 30_000, count: 1 },
+              ],
+            },
+            latency: {
+              average_line: [
+                { bucket: '2026-06-09T11:55:00Z', avg_ms: 500 },
+                { bucket: '2026-06-09T11:55:30Z', avg_ms: 900 },
+              ],
+              particles: [
+                { bucket: '2026-06-09T11:55:00Z', ms: 300, count: 1 },
+                { bucket: '2026-06-09T11:55:30Z', ms: 1200, count: 1 },
+              ],
+            },
+          },
+        }}
+        loading={false}
+        window="15m"
+        onWindowChange={() => {}}
+        isDark={false}
+        isMobile={false}
+      />
+    );
+
+    const ttftYAxis = chartCapture.chartCalls[0].options.scales?.y as { type?: string; beginAtZero?: boolean; min?: number; max?: number };
+    const latencyYAxis = chartCapture.chartCalls[1].options.scales?.y as { type?: string; beginAtZero?: boolean; min?: number; max?: number };
+
+    expect(ttftYAxis.type).toBe('logarithmic');
+    expect(ttftYAxis.beginAtZero).toBeUndefined();
+    expect(ttftYAxis.min).toBeGreaterThan(0);
+    expect(ttftYAxis.max).toBeGreaterThan(30_000);
+    expect(latencyYAxis.type).toBe('logarithmic');
+    expect(latencyYAxis.beginAtZero).toBeUndefined();
+    expect(latencyYAxis.min).toBeGreaterThan(0);
+    expect(latencyYAxis.max).toBeLessThan(2_000);
+  });
+
+  it('caps response distribution particles at one thousand points', () => {
+    const particles = Array.from({ length: 1_205 }, (_, index) => ({
+      bucket: `2026-06-09T11:${String(40 + Math.floor(index / 60)).padStart(2, '0')}:${String(index % 60).padStart(2, '0')}Z`,
+      ms: index + 1,
+      count: 1,
+    }));
+
+    renderToStaticMarkup(
+      <OverviewRealtimePanel
+        realtime={{
+          ...realtime,
+          response_distribution: {
+            ...realtime.response_distribution,
+            ttft: {
+              average_line: realtime.response_distribution.ttft.average_line,
+              particles,
+            },
+          },
+        }}
+        loading={false}
+        window="15m"
+        onWindowChange={() => {}}
+        isDark={false}
+        isMobile={false}
+      />
+    );
+
+    const ttftParticleData = chartCapture.chartCalls[0].data.datasets[1].data as Array<{ y: number }>;
+
+    expect(ttftParticleData).toHaveLength(1_000);
+    expect(ttftParticleData[0].y).toBe(1);
+    expect(ttftParticleData[ttftParticleData.length - 1].y).toBe(1_205);
+  });
+
   it('shows an error state before realtime data has loaded', () => {
     const html = renderToStaticMarkup(
       <OverviewRealtimePanel
@@ -466,7 +549,7 @@ describe('OverviewRealtimePanel', () => {
     expect(chartCapture.chartCalls[1].options.spanGaps).toBeUndefined();
   });
 
-  it('keeps response axis linear and cache axis light', () => {
+  it('keeps response axis logarithmic and cache axis light', () => {
     renderToStaticMarkup(
       <OverviewRealtimePanel
         realtime={realtime}
@@ -481,9 +564,9 @@ describe('OverviewRealtimePanel', () => {
     const responseYAxis = chartCapture.chartCalls[0].options.scales?.y as { type?: string; beginAtZero?: boolean; min?: number; ticks?: { maxTicksLimit?: number } };
     const cacheYAxis = chartCapture.lineCalls[2].options.scales?.y as { ticks?: { maxTicksLimit?: number } };
 
-    expect(responseYAxis.type).toBeUndefined();
-    expect(responseYAxis.beginAtZero).toBe(true);
-    expect(responseYAxis.min).toBeUndefined();
+    expect(responseYAxis.type).toBe('logarithmic');
+    expect(responseYAxis.beginAtZero).toBeUndefined();
+    expect(responseYAxis.min).toBeGreaterThan(0);
     expect(responseYAxis.ticks?.maxTicksLimit).toBe(5);
     expect(cacheYAxis.ticks?.maxTicksLimit).toBe(5);
   });

--- a/web/src/components/usage/OverviewRealtimePanel.logic.test.tsx
+++ b/web/src/components/usage/OverviewRealtimePanel.logic.test.tsx
@@ -298,6 +298,51 @@ describe('OverviewRealtimePanel', () => {
     expect(latencyYAxis.max).toBeLessThan(2_000);
   });
 
+  it('omits non-positive response values from logarithmic distribution charts', () => {
+    const malformedRealtime = {
+      ...realtime,
+      response_distribution: {
+        ttft: {
+          average_line: [
+            { bucket: '2026-06-09T11:55:00Z', avg_ms: 0 },
+            { bucket: '2026-06-09T11:55:30Z', avg_ms: -5 },
+            { bucket: '2026-06-09T11:56:00Z', avg_ms: 120 },
+          ],
+          particles: undefined,
+        },
+        latency: {
+          average_line: [
+            { bucket: '2026-06-09T11:55:00Z', avg_ms: 0 },
+            { bucket: '2026-06-09T11:55:30Z', avg_ms: 800 },
+          ],
+          particles: [
+            { bucket: '2026-06-09T11:55:00Z', ms: 0, count: 1 },
+            { bucket: '2026-06-09T11:55:30Z', ms: 900, count: 1 },
+          ],
+        },
+      },
+    } as unknown as OverviewRealtimeBlock;
+
+    renderToStaticMarkup(
+      <OverviewRealtimePanel
+        realtime={malformedRealtime}
+        loading={false}
+        window="15m"
+        onWindowChange={() => {}}
+        isDark={false}
+        isMobile={false}
+        timezone="UTC"
+      />
+    );
+
+    expect(chartCapture.chartCalls[0].data.datasets[0].data).toEqual([null, null, 120]);
+    expect(chartCapture.chartCalls[0].data.datasets[1].data).toEqual([]);
+    expect(chartCapture.chartCalls[1].data.datasets[0].data).toEqual([null, 800]);
+    expect(chartCapture.chartCalls[1].data.datasets[1].data).toEqual([
+      { x: '11:55:30', y: 900, count: 1 },
+    ]);
+  });
+
   it('caps response distribution particles at one thousand points', () => {
     const particles = Array.from({ length: 1_205 }, (_, index) => ({
       bucket: `2026-06-09T11:${String(40 + Math.floor(index / 60)).padStart(2, '0')}:${String(index % 60).padStart(2, '0')}Z`,

--- a/web/src/components/usage/OverviewRealtimePanel.tsx
+++ b/web/src/components/usage/OverviewRealtimePanel.tsx
@@ -35,6 +35,7 @@ interface RealtimeMetric {
 }
 
 type ResponseDistributionDatum = number | null | { x: string; y: number; count: number };
+type ResponseDistributionParticleDatum = { x: string; y: number; count: number };
 
 interface OverviewRealtimePanelProps {
   realtime?: OverviewRealtimeBlock;
@@ -50,6 +51,7 @@ interface OverviewRealtimePanelProps {
 
 const REALTIME_WINDOWS: OverviewRealtimeWindow[] = ['15m', '30m', '60m'];
 const DEFAULT_VISIBLE_DIMENSIONS: readonly RealtimeDimensionKey[] = ['models', 'api_keys', 'auth_files', 'ai_providers'];
+const RESPONSE_DISTRIBUTION_MAX_PARTICLES = 1000;
 
 const CHART_COLORS = {
   token: '#3b82f6',
@@ -299,12 +301,22 @@ function responseDistributionValues(points: RealtimeResponseAveragePoint[]): Arr
   return points.map((point) => point.avg_ms == null ? null : safeNumber(point.avg_ms));
 }
 
-function responseDistributionParticleData(particles: RealtimeResponseParticle[], timezone?: string): Array<{ x: string; y: number; count: number }> {
-  return particles.map((point) => ({
+function sampleResponseDistributionParticles(particles: RealtimeResponseParticle[]): RealtimeResponseParticle[] {
+  if (particles.length <= RESPONSE_DISTRIBUTION_MAX_PARTICLES) return particles;
+  const lastIndex = particles.length - 1;
+  const lastSampleIndex = RESPONSE_DISTRIBUTION_MAX_PARTICLES - 1;
+  return Array.from({ length: RESPONSE_DISTRIBUTION_MAX_PARTICLES }, (_, index) => {
+    const sourceIndex = index === lastSampleIndex ? lastIndex : Math.floor((index * lastIndex) / lastSampleIndex);
+    return particles[sourceIndex];
+  });
+}
+
+function responseDistributionParticleData(particles: RealtimeResponseParticle[], timezone?: string): ResponseDistributionParticleDatum[] {
+  return sampleResponseDistributionParticles(particles).map((point) => ({
     x: formatBucketLabel(point.bucket, timezone),
     y: safeNumber(point.ms),
     count: Math.max(1, safeNumber(point.count)),
-  }));
+  })).filter((point) => point.y > 0);
 }
 
 function responseParticleRadius(count: number, isMobile: boolean): number {
@@ -363,10 +375,26 @@ function buildResponseDistributionData(
 function buildResponseDistributionOptions(
   isDark: boolean,
   isMobile: boolean,
+  averageValues: Array<number | null>,
+  particles: RealtimeResponseParticle[],
 ): ChartOptions<'line'> {
   const options = buildRealtimeLineOptions(isDark, isMobile, formatRealtimeDuration, { yMaxTicksLimit: 5 });
+  const yBounds = responseDistributionLogAxisBounds(averageValues, particles);
+  const baseYScale = options.scales?.y;
+  const responseScales = {
+    ...options.scales,
+    y: {
+      type: 'logarithmic' as const,
+      min: yBounds.min,
+      max: yBounds.max,
+      grid: baseYScale?.grid,
+      border: baseYScale?.border,
+      ticks: baseYScale?.ticks,
+    },
+  } as ChartOptions<'line'>['scales'];
   return {
     ...options,
+    animation: false,
     interaction: { mode: 'nearest', intersect: false },
     plugins: {
       ...options.plugins,
@@ -385,6 +413,30 @@ function buildResponseDistributionOptions(
         },
       },
     },
+    scales: responseScales,
+  };
+}
+
+function responseDistributionLogAxisBounds(averageValues: Array<number | null>, particles: RealtimeResponseParticle[]): { min: number; max: number } {
+  let minValue = Number.POSITIVE_INFINITY;
+  let maxValue = 0;
+  for (const value of averageValues) {
+    if (value == null || !Number.isFinite(value) || value <= 0) continue;
+    minValue = Math.min(minValue, value);
+    maxValue = Math.max(maxValue, value);
+  }
+  for (const particle of particles) {
+    const value = safeNumber(particle.ms);
+    if (!Number.isFinite(value) || value <= 0) continue;
+    minValue = Math.min(minValue, value);
+    maxValue = Math.max(maxValue, value);
+  }
+  if (!Number.isFinite(minValue) || maxValue <= 0) {
+    return { min: 1, max: 10 };
+  }
+  return {
+    min: Math.max(1, Math.floor(minValue / 1.35)),
+    max: Math.max(10, Math.ceil(maxValue * 1.18)),
   };
 }
 
@@ -494,7 +546,18 @@ export function OverviewRealtimePanel({ realtime, loading, error, window, onWind
 
   const lineOptions = useMemo(() => buildRealtimeLineOptions(isDark, isMobile, formatCompactNumber), [isDark, isMobile]);
   const percentLineOptions = useMemo(() => buildRealtimeLineOptions(isDark, isMobile, (value) => `${formatFixedTwoDecimals(value)}%`, { yMaxTicksLimit: 5 }), [isDark, isMobile]);
-  const responseDistributionOptions = useMemo(() => buildResponseDistributionOptions(isDark, isMobile), [isDark, isMobile]);
+  const ttftDistributionOptions = useMemo(() => buildResponseDistributionOptions(
+    isDark,
+    isMobile,
+    ttftAverageValues,
+    data.response_distribution.ttft.particles,
+  ), [data.response_distribution.ttft.particles, isDark, isMobile, ttftAverageValues]);
+  const latencyDistributionOptions = useMemo(() => buildResponseDistributionOptions(
+    isDark,
+    isMobile,
+    latencyAverageValues,
+    data.response_distribution.latency.particles,
+  ), [data.response_distribution.latency.particles, isDark, isMobile, latencyAverageValues]);
   const latestLabel = t('usage_stats.overview_realtime_latest');
   const averageLabel = t('usage_stats.overview_realtime_average');
   const trendLabel = t('usage_stats.overview_realtime_trend');
@@ -592,7 +655,7 @@ export function OverviewRealtimePanel({ realtime, loading, error, window, onWind
                 compact
               >
                 <RealtimeChartFrame loading={loading} emptyLabel={ttftEmptyLabel}>
-                  <Chart type="line" data={ttftDistributionChartData} options={responseDistributionOptions} />
+                  <Chart type="line" data={ttftDistributionChartData} options={ttftDistributionOptions} />
                 </RealtimeChartFrame>
               </RealtimeCard>
 
@@ -603,7 +666,7 @@ export function OverviewRealtimePanel({ realtime, loading, error, window, onWind
                 compact
               >
                 <RealtimeChartFrame loading={loading} emptyLabel={latencyEmptyLabel}>
-                  <Chart type="line" data={latencyDistributionChartData} options={responseDistributionOptions} />
+                  <Chart type="line" data={latencyDistributionChartData} options={latencyDistributionOptions} />
                 </RealtimeChartFrame>
               </RealtimeCard>
             </div>

--- a/web/src/components/usage/OverviewRealtimePanel.tsx
+++ b/web/src/components/usage/OverviewRealtimePanel.tsx
@@ -283,35 +283,40 @@ function buildSingleLineData(labels: string[], label: string, values: Array<numb
 }
 
 function responseDistributionAveragePoints(
-  points: RealtimeResponseAveragePoint[],
+  points: RealtimeResponseAveragePoint[] | null | undefined,
   fallbackPoints: Array<{ bucket: string; value?: number | null }>,
 ): RealtimeResponseAveragePoint[] {
-  if (points.length > 0) return points;
+  if (points && points.length > 0) return points;
   return fallbackPoints.map((point) => ({
     bucket: point.bucket,
     avg_ms: point.value ?? null,
   }));
 }
 
-function responseDistributionLabels(points: RealtimeResponseAveragePoint[], timezone?: string): string[] {
-  return points.map((point) => formatBucketLabel(point.bucket, timezone));
+function responseDistributionLabels(points: RealtimeResponseAveragePoint[] | null | undefined, timezone?: string): string[] {
+  return (points ?? []).map((point) => formatBucketLabel(point.bucket, timezone));
 }
 
-function responseDistributionValues(points: RealtimeResponseAveragePoint[]): Array<number | null> {
-  return points.map((point) => point.avg_ms == null ? null : safeNumber(point.avg_ms));
-}
-
-function sampleResponseDistributionParticles(particles: RealtimeResponseParticle[]): RealtimeResponseParticle[] {
-  if (particles.length <= RESPONSE_DISTRIBUTION_MAX_PARTICLES) return particles;
-  const lastIndex = particles.length - 1;
-  const lastSampleIndex = RESPONSE_DISTRIBUTION_MAX_PARTICLES - 1;
-  return Array.from({ length: RESPONSE_DISTRIBUTION_MAX_PARTICLES }, (_, index) => {
-    const sourceIndex = index === lastSampleIndex ? lastIndex : Math.floor((index * lastIndex) / lastSampleIndex);
-    return particles[sourceIndex];
+function responseDistributionValues(points: RealtimeResponseAveragePoint[] | null | undefined): Array<number | null> {
+  return (points ?? []).map((point) => {
+    if (point.avg_ms == null) return null;
+    const value = safeNumber(point.avg_ms);
+    return value > 0 ? value : null;
   });
 }
 
-function responseDistributionParticleData(particles: RealtimeResponseParticle[], timezone?: string): ResponseDistributionParticleDatum[] {
+function sampleResponseDistributionParticles(particles: RealtimeResponseParticle[] | null | undefined): RealtimeResponseParticle[] {
+  const safeParticles = (particles ?? []).filter(Boolean);
+  if (safeParticles.length <= RESPONSE_DISTRIBUTION_MAX_PARTICLES) return safeParticles;
+  const lastIndex = safeParticles.length - 1;
+  const lastSampleIndex = RESPONSE_DISTRIBUTION_MAX_PARTICLES - 1;
+  return Array.from({ length: RESPONSE_DISTRIBUTION_MAX_PARTICLES }, (_, index) => {
+    const sourceIndex = index === lastSampleIndex ? lastIndex : Math.floor((index * lastIndex) / lastSampleIndex);
+    return safeParticles[sourceIndex];
+  });
+}
+
+function responseDistributionParticleData(particles: RealtimeResponseParticle[] | null | undefined, timezone?: string): ResponseDistributionParticleDatum[] {
   return sampleResponseDistributionParticles(particles).map((point) => ({
     x: formatBucketLabel(point.bucket, timezone),
     y: safeNumber(point.ms),
@@ -376,7 +381,7 @@ function buildResponseDistributionOptions(
   isDark: boolean,
   isMobile: boolean,
   averageValues: Array<number | null>,
-  particles: RealtimeResponseParticle[],
+  particles: RealtimeResponseParticle[] | null | undefined,
 ): ChartOptions<'line'> {
   const options = buildRealtimeLineOptions(isDark, isMobile, formatRealtimeDuration, { yMaxTicksLimit: 5 });
   const yBounds = responseDistributionLogAxisBounds(averageValues, particles);
@@ -417,15 +422,16 @@ function buildResponseDistributionOptions(
   };
 }
 
-function responseDistributionLogAxisBounds(averageValues: Array<number | null>, particles: RealtimeResponseParticle[]): { min: number; max: number } {
+function responseDistributionLogAxisBounds(averageValues: Array<number | null> | null | undefined, particles: RealtimeResponseParticle[] | null | undefined): { min: number; max: number } {
   let minValue = Number.POSITIVE_INFINITY;
   let maxValue = 0;
-  for (const value of averageValues) {
+  for (const value of averageValues ?? []) {
     if (value == null || !Number.isFinite(value) || value <= 0) continue;
     minValue = Math.min(minValue, value);
     maxValue = Math.max(maxValue, value);
   }
-  for (const particle of particles) {
+  for (const particle of particles ?? []) {
+    if (!particle) continue;
     const value = safeNumber(particle.ms);
     if (!Number.isFinite(value) || value <= 0) continue;
     minValue = Math.min(minValue, value);


### PR DESCRIPTION
## Summary
- Plot realtime TTFT and latency as per-event distribution points around the rolling average line.
- Keep one rendered point per usage event while capping frontend particles at 1,000 points per distribution chart.
- Use data-driven logarithmic response-axis bounds so long-tail latency values remain visible without flattening the common range.

## Validation
- env GOCACHE=/tmp/cpa-usage-keeper-go-build go test ./internal/...
- npm --prefix ./web run test
- npm --prefix ./web run lint
- npm --prefix ./web run typecheck
- npm --prefix ./web run build