### PR TITLE
Fix overview health timeline calendar-day ranges

### DIFF
--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -2325,11 +2325,25 @@ func isUsageOverviewShortHealthRange(value string) bool {
 	}
 }
 
+func isUsageOverviewCalendarDayHealthRange(value string) bool {
+	switch value {
+	case "today", "yesterday":
+		return true
+	default:
+		return false
+	}
+}
+
 // usageOverviewHealthWindow 返回 health grid 的展示窗口，可能和查询窗口不同。
 func usageOverviewHealthWindow(filter dto.UsageQueryFilter, totalBlocks int, span time.Duration) (time.Time, time.Time) {
 	end := timeutil.NormalizeStorageTime(time.Now())
 	if filter.EndTime != nil {
 		end = timeutil.NormalizeStorageTime(*filter.EndTime)
+	}
+	if isUsageOverviewCalendarDayHealthRange(filter.Range) && filter.StartTime != nil {
+		// today/yesterday 的 health 轴跟随本地自然日展示；统计窗口仍在后续 exact window 中按 queryNow/end 截断。
+		start := timeutil.NormalizeStorageTime(*filter.StartTime)
+		return start, start.AddDate(0, 0, 1)
 	}
 	if isUsageOverviewShortHealthRange(filter.Range) {
 		return end.Add(-usageOverviewHealthPresetWindow), end

--- a/internal/repository/usage_filter_test.go
+++ b/internal/repository/usage_filter_test.go
@@ -845,6 +845,70 @@ func TestBuildUsageOverviewWithFilterBuilds24hHealthGridFor24hRange(t *testing.T
 	}
 }
 
+func TestBuildUsageOverviewWithFilterKeepsCalendarDayHealthWindow(t *testing.T) {
+	withRepositoryTestLocation(t, "Asia/Shanghai")
+
+	db, err := OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "usage-overview-health-calendar-day.db")})
+	if err != nil {
+		t.Fatalf("OpenDatabase returned error: %v", err)
+	}
+	closeTestDatabase(t, db)
+
+	location := time.Local
+	queryNow := time.Date(2026, 6, 22, 15, 30, 0, 0, location)
+	todayStart := time.Date(2026, 6, 22, 0, 0, 0, 0, location)
+	todayEnd := todayStart.AddDate(0, 0, 1).Add(-time.Nanosecond)
+	yesterdayStart := todayStart.AddDate(0, 0, -1)
+	yesterdayEnd := todayStart.Add(-time.Nanosecond)
+
+	for _, tc := range []struct {
+		name        string
+		rangeName   string
+		start       time.Time
+		end         time.Time
+		wantStart   time.Time
+		wantEnd     time.Time
+		wantMinutes int64
+	}{
+		{
+			name:        "today keeps midnight to next midnight after future end clamp",
+			rangeName:   "today",
+			start:       todayStart,
+			end:         todayEnd,
+			wantStart:   todayStart,
+			wantEnd:     todayStart.AddDate(0, 0, 1),
+			wantMinutes: int64(queryNow.Sub(todayStart) / time.Minute),
+		},
+		{
+			name:        "yesterday keeps previous midnight to current midnight",
+			rangeName:   "yesterday",
+			start:       yesterdayStart,
+			end:         yesterdayEnd,
+			wantStart:   yesterdayStart,
+			wantEnd:     todayStart,
+			wantMinutes: 24 * 60,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			overview, err := BuildUsageOverviewWithFilterAndRecentCache(db, dto.UsageQueryFilter{
+				Range:     tc.rangeName,
+				StartTime: &tc.start,
+				EndTime:   &tc.end,
+				QueryNow:  &queryNow,
+			}, nil)
+			if err != nil {
+				t.Fatalf("BuildUsageOverviewWithFilterAndRecentCache returned error: %v", err)
+			}
+			if !overview.Health.WindowStart.Equal(tc.wantStart) || !overview.Health.WindowEnd.Equal(tc.wantEnd) {
+				t.Fatalf("expected %s health window %s - %s, got %s - %s", tc.rangeName, tc.wantStart, tc.wantEnd, overview.Health.WindowStart, overview.Health.WindowEnd)
+			}
+			if overview.Summary.WindowMinutes != tc.wantMinutes {
+				t.Fatalf("expected %s query window minutes %d, got %+v", tc.rangeName, tc.wantMinutes, overview.Summary)
+			}
+		})
+	}
+}
+
 func TestCalculateUsageEventCostDoesNotDoubleChargeReasoningTokens(t *testing.T) {
 	event := entities.UsageEvent{
 		InputTokens:     1_000_000,


### PR DESCRIPTION
## Summary
- make Overview Request Health Timeline use local calendar-day bounds for today and yesterday
- keep rolling ranges and summary query windows unchanged

Fixes #236

## Validation
- rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build go test ./cmd/... ./internal/...
- rtk git diff --check