### PR TITLE
Add Codex header quota cache updates

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -108,12 +108,16 @@ func NewWithConfig(cfg config.Config) (*App, error) {
 		recentUsageCache = nil
 	}
 
+	cpaClient := cpa.NewClient(cfg.CPABaseURL, cfg.CPAManagementKey, cfg.RequestTimeout, cfg.TLSSkipVerify)
+	quotaService := quota.NewServiceWithOptions(db, cpaClient, quota.ServiceOptions{RefreshWorkerLimit: cfg.QuotaRefreshWorkerLimit, AutoRefreshInterval: cfg.QuotaAutoRefreshInterval})
 	// syncService 仍然是 metadata 和 usage 处理共享的业务服务入口。
 	syncService := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{
 		BaseURL: cfg.CPABaseURL,
-		Client:  cpa.NewClient(cfg.CPABaseURL, cfg.CPAManagementKey, cfg.RequestTimeout, cfg.TLSSkipVerify),
+		Client:  cpaClient,
 		// usage_events 事务提交后通过这个缓存做非阻塞增量追加，供 Overview realtime 和右边界补偿复用。
 		RecentUsageEvents: recentUsageCache,
+		// Redis usage response_headers 提交后异步 patch quota cache，不参与 usage_events 入库事务。
+		UsageHeaderQuota: quotaService,
 	})
 	// metadataSyncRunner 提前创建，保证控制消息和后台任务使用同一个调度器实例。
 	metadataSyncRunner := NewMetadataSyncRunner(syncService, cfg.MetadataSyncInterval)
@@ -158,7 +162,10 @@ func NewWithConfig(cfg config.Config) (*App, error) {
 	if cfg.BackupEnabled {
 		sqlDB, err := db.DB()
 		if err != nil {
-			recentUsageCache.Close()
+			if recentUsageCache != nil {
+				recentUsageCache.Close()
+			}
+			quotaService.StopRefreshTasks()
 			_ = closeGormDB(db)
 			_ = logCloser.Close()
 			return nil, err
@@ -170,13 +177,11 @@ func NewWithConfig(cfg config.Config) (*App, error) {
 	usageService := service.NewUsageServiceWithRecentCache(db, recentUsageCache)
 	usageIdentityService := service.NewUsageIdentityServiceWithRecentCache(db, recentUsageCache)
 	cpaAPIKeyService := service.NewCPAAPIKeyService(db)
-	cpaClient := cpa.NewClient(cfg.CPABaseURL, cfg.CPAManagementKey, cfg.RequestTimeout, cfg.TLSSkipVerify)
 	authFilesManagementService := service.NewAuthFilesManagementService(cpaClient)
 	if cfg.TLSSkipVerify {
 		logrus.WithField("cpa_base_url", cfg.CPABaseURL).Warn("TLS certificate verification is disabled for CPA and Redis queue connections")
 	}
 	pricingService := service.NewPricingService(db, cpaClient)
-	quotaService := quota.NewServiceWithOptions(db, cpaClient, quota.ServiceOptions{RefreshWorkerLimit: cfg.QuotaRefreshWorkerLimit, AutoRefreshInterval: cfg.QuotaAutoRefreshInterval})
 	sessionManager := auth.NewSessionManager(cfg.AuthSessionTTL)
 	if cfg.AuthEnabled {
 		sessionManager = auth.NewPersistentSessionManager(cfg.AuthSessionTTL, auth.NewGormSessionStore(db))

--- a/internal/benchmark/redis_process_benchmark_test.go
+++ b/internal/benchmark/redis_process_benchmark_test.go
@@ -1,0 +1,227 @@
+package benchmark
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/config"
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/poller"
+	"cpa-usage-keeper/internal/repository"
+	"cpa-usage-keeper/internal/service"
+	servicedto "cpa-usage-keeper/internal/service/dto"
+	"gorm.io/gorm"
+)
+
+const redisProcessBenchmarkIdentityCount = 10_000
+
+func BenchmarkRedisUsageInboxProcessBatch(b *testing.B) {
+	for _, size := range []int{10, 100, 500, 1_000} {
+		b.Run(fmt.Sprintf("rows_%d_identities_%d", size, redisProcessBenchmarkIdentityCount), func(b *testing.B) {
+			benchmarkRedisUsageInboxProcessing(b, size, redisProcessBenchmarkIdentityCount, false)
+		})
+	}
+}
+
+func BenchmarkRedisUsageInboxProcessBatchThousandIdentities(b *testing.B) {
+	for _, size := range []int{100, 500, 999, 1_000} {
+		b.Run(fmt.Sprintf("rows_%d_identities_%d", size, 1_000), func(b *testing.B) {
+			benchmarkRedisUsageInboxProcessing(b, size, 1_000, false)
+		})
+	}
+}
+
+func BenchmarkRedisUsageInboxProcessDrain(b *testing.B) {
+	benchmarkRedisUsageInboxProcessing(b, 10_000, redisProcessBenchmarkIdentityCount, true)
+}
+
+func BenchmarkRedisUsageInboxProcessDrainThousandIdentities(b *testing.B) {
+	benchmarkRedisUsageInboxProcessing(b, 10_000, 1_000, true)
+}
+
+func BenchmarkRedisUsageInboxWriterRefreshFiltered(b *testing.B) {
+	b.ReportAllocs()
+	var totalInserted int
+	var totalElapsed time.Duration
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		db := openRedisProcessBenchmarkDBWithoutSeed(b, i)
+		writer := poller.NewControlAwareRedisInboxWriter(poller.NewRedisInboxWriter(db), &redisProcessBenchmarkRefreshObserver{})
+		messages := redisProcessBenchmarkMessagesWithRefresh(1_000, 1_000, time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC))
+		b.StartTimer()
+
+		startedAt := time.Now()
+		inserted, err := writer.Insert(context.Background(), poller.RedisIngestSourceRedisPull, messages, time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC))
+		elapsed := time.Since(startedAt)
+		if err != nil {
+			b.Fatalf("writer.Insert returned error: %v", err)
+		}
+		b.StopTimer()
+
+		totalInserted += inserted
+		totalElapsed += elapsed
+		closeRedisProcessBenchmarkDB(b, db)
+	}
+	if totalElapsed > 0 {
+		b.ReportMetric(float64(totalInserted)/totalElapsed.Seconds(), "inbox_rows/sec")
+	}
+}
+
+func benchmarkRedisUsageInboxProcessing(b *testing.B, rowCount, identityCount int, drain bool) {
+	b.Helper()
+	b.ReportAllocs()
+
+	var totalInserted int
+	var totalBatches int
+	var totalElapsed time.Duration
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		db := openRedisProcessBenchmarkDB(b, rowCount, identityCount, i)
+		syncService := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{
+			Now: func() time.Time { return time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC) },
+		})
+		b.StartTimer()
+
+		startedAt := time.Now()
+		result, nonEmptyBatches, err := processRedisUsageBenchmarkRows(syncService, drain)
+		elapsed := time.Since(startedAt)
+		if err != nil {
+			b.Fatalf("ProcessRedisUsageInbox returned error: %v", err)
+		}
+		b.StopTimer()
+
+		totalInserted += result.InsertedEvents
+		totalBatches += nonEmptyBatches
+		totalElapsed += elapsed
+		closeRedisProcessBenchmarkDB(b, db)
+	}
+
+	if totalElapsed > 0 {
+		b.ReportMetric(float64(totalInserted)/totalElapsed.Seconds(), "events/sec")
+	}
+	if totalBatches > 0 {
+		b.ReportMetric(float64(totalInserted)/float64(totalBatches), "events/batch")
+	}
+}
+
+func processRedisUsageBenchmarkRows(syncService *service.SyncService, drain bool) (servicedto.RedisBatchSyncResult, int, error) {
+	total := servicedto.RedisBatchSyncResult{}
+	nonEmptyBatches := 0
+	for {
+		result, err := syncService.ProcessRedisUsageInbox(context.Background())
+		if result != nil {
+			total.InsertedEvents += result.InsertedEvents
+			total.DedupedEvents += result.DedupedEvents
+			total.Status = result.Status
+			total.Empty = result.Empty
+			if result.InsertedEvents > 0 {
+				nonEmptyBatches++
+			}
+		}
+		if err != nil {
+			return total, nonEmptyBatches, err
+		}
+		if !drain || result == nil || result.Empty || result.InsertedEvents == 0 {
+			return total, nonEmptyBatches, nil
+		}
+	}
+}
+
+func openRedisProcessBenchmarkDB(b *testing.B, rowCount, identityCount, iteration int) *gorm.DB {
+	b.Helper()
+	db := openRedisProcessBenchmarkDBWithoutSeed(b, iteration)
+	seedRedisProcessBenchmarkIdentities(b, db, identityCount)
+	seedRedisProcessBenchmarkInbox(b, db, rowCount, identityCount)
+	return db
+}
+
+func openRedisProcessBenchmarkDBWithoutSeed(b *testing.B, iteration int) *gorm.DB {
+	b.Helper()
+	db, err := repository.OpenDatabase(config.Config{SQLitePath: filepath.Join(b.TempDir(), fmt.Sprintf("redis-process-%d.db", iteration))})
+	if err != nil {
+		b.Fatalf("OpenDatabase returned error: %v", err)
+	}
+	return db
+}
+
+func seedRedisProcessBenchmarkIdentities(b *testing.B, db *gorm.DB, identityCount int) {
+	b.Helper()
+	now := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	identities := make([]entities.UsageIdentity, 0, identityCount)
+	for i := 0; i < identityCount; i++ {
+		identity := redisProcessBenchmarkAuthIndex(i)
+		identities = append(identities, entities.UsageIdentity{
+			Name:         identity,
+			AuthType:     entities.UsageIdentityAuthTypeAuthFile,
+			AuthTypeName: "auth_file",
+			Identity:     identity,
+			Type:         "codex",
+			Provider:     "codex",
+			LookupKey:    identity,
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		})
+	}
+	if err := db.CreateInBatches(&identities, 20).Error; err != nil {
+		b.Fatalf("seed usage identities returned error: %v", err)
+	}
+}
+
+func seedRedisProcessBenchmarkInbox(b *testing.B, db *gorm.DB, rowCount, identityCount int) {
+	b.Helper()
+	messages := make([]string, 0, rowCount)
+	base := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < rowCount; i++ {
+		messages = append(messages, redisProcessBenchmarkMessage(i, identityCount, base))
+	}
+	if _, err := repository.InsertRedisUsageInboxRawMessages(db, "redis_pull:usage", messages, base); err != nil {
+		b.Fatalf("seed redis usage inbox returned error: %v", err)
+	}
+}
+
+func redisProcessBenchmarkMessage(i, identityCount int, base time.Time) string {
+	authIndex := redisProcessBenchmarkAuthIndex(i % identityCount)
+	timestamp := base.Add(time.Duration(i) * time.Millisecond).Format(time.RFC3339Nano)
+	return fmt.Sprintf(
+		`{"timestamp":%q,"latency_ms":120,"source":"redis","auth_index":%q,"tokens":{"input_tokens":120,"output_tokens":48,"reasoning_tokens":8,"cached_tokens":16,"cache_read_tokens":4,"cache_creation_tokens":2,"total_tokens":176},"provider":"codex","model":"gpt-5","auth_type":"oauth","api_key":"bench-group","request_id":%q}`,
+		timestamp,
+		authIndex,
+		fmt.Sprintf("bench-%08d", i),
+	)
+}
+
+func redisProcessBenchmarkMessagesWithRefresh(totalMessages, identityCount int, base time.Time) []string {
+	messages := make([]string, 0, totalMessages)
+	for i := 0; i < totalMessages; i++ {
+		if i == totalMessages-1 {
+			messages = append(messages, `{"refresh":true}`)
+			continue
+		}
+		messages = append(messages, redisProcessBenchmarkMessage(i, identityCount, base))
+	}
+	return messages
+}
+
+func redisProcessBenchmarkAuthIndex(i int) string {
+	return fmt.Sprintf("auth-%05d", i)
+}
+
+type redisProcessBenchmarkRefreshObserver struct{}
+
+func (o *redisProcessBenchmarkRefreshObserver) MarkRefreshSupported() {}
+
+func (o *redisProcessBenchmarkRefreshObserver) RequestMetadataRefresh() {}
+
+func (o *redisProcessBenchmarkRefreshObserver) MarkRefreshPollingRequired(string) {}
+
+func closeRedisProcessBenchmarkDB(b *testing.B, db *gorm.DB) {
+	b.Helper()
+	sqlDB, err := db.DB()
+	if err == nil {
+		_ = sqlDB.Close()
+	}
+}

--- a/internal/quota/codex_header.go
+++ b/internal/quota/codex_header.go
@@ -1,0 +1,177 @@
+package quota
+
+import (
+	"math"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const codexHeaderPrefix = "X-Codex-"
+
+func parseCodexHeaderQuota(headers http.Header) (ProviderOutput, bool) {
+	headers = canonicalQuotaHeaders(headers)
+	usage := &CodexUsagePayload{
+		PlanType: strings.TrimSpace(firstHeaderValue(headers, "X-Codex-Plan-Type")),
+	}
+	usage.RateLimit = parseCodexHeaderRateLimit(headers, codexHeaderPrefix)
+	usage.AdditionalRateLimits = parseCodexAdditionalHeaderLimits(headers)
+	if usage.RateLimit == nil && len(usage.AdditionalRateLimits) == 0 {
+		return ProviderOutput{}, false
+	}
+	return ProviderOutput{Provider: "codex", Result: CodexResult{Usage: usage}}, true
+}
+
+func canonicalQuotaHeaders(headers http.Header) http.Header {
+	if len(headers) == 0 {
+		return nil
+	}
+	canonical := make(http.Header, len(headers))
+	for key, values := range headers {
+		canonicalKey := http.CanonicalHeaderKey(strings.TrimSpace(key))
+		if canonicalKey == "" {
+			continue
+		}
+		for _, value := range values {
+			canonical.Add(canonicalKey, value)
+		}
+	}
+	return canonical
+}
+
+func firstHeaderValue(headers http.Header, key string) string {
+	for _, value := range headers.Values(key) {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func parseCodexHeaderRateLimit(headers http.Header, prefix string) *CodexRateLimitInfo {
+	primary := parseCodexHeaderUsageWindow(headers, prefix+"Primary-")
+	secondary := parseCodexHeaderUsageWindow(headers, prefix+"Secondary-")
+	if primary == nil && secondary == nil {
+		return nil
+	}
+	return &CodexRateLimitInfo{
+		PrimaryWindow:   primary,
+		SecondaryWindow: secondary,
+	}
+}
+
+func parseCodexHeaderUsageWindow(headers http.Header, prefix string) *CodexUsageWindow {
+	usedPercent, ok := parseFloatHeader(headers, prefix+"Used-Percent")
+	if !ok {
+		return nil
+	}
+	windowMinutes, ok := parseIntHeader(headers, prefix+"Window-Minutes")
+	if !ok || windowMinutes <= 0 {
+		return nil
+	}
+	windowSeconds, ok := codexHeaderWindowSecondsFromMinutes(windowMinutes)
+	if !ok {
+		return nil
+	}
+	window := CodexUsageWindow{
+		UsedPercent:        usedPercent,
+		LimitWindowSeconds: windowSeconds,
+	}
+	hasResetBoundary := false
+	if value, ok := parseIntHeader(headers, prefix+"Reset-After-Seconds"); ok && value >= 0 {
+		window.ResetAfterSeconds = value
+		hasResetBoundary = true
+	}
+	if value, ok := parseIntHeader(headers, prefix+"Reset-At"); ok && value > 0 {
+		window.ResetAt = value
+		hasResetBoundary = true
+	}
+	if !hasResetBoundary {
+		return nil
+	}
+	return &window
+}
+
+func codexHeaderWindowSecondsFromMinutes(minutes int64) (int64, bool) {
+	switch minutes {
+	case quotaWindowFiveHourSeconds / 60:
+		return quotaWindowFiveHourSeconds, true
+	case quotaWindowSevenDaySeconds / 60:
+		return quotaWindowSevenDaySeconds, true
+	case quotaWindowThirtyDaySeconds / 60:
+		return quotaWindowThirtyDaySeconds, true
+	case quotaWindowAverageMonthSeconds / 60:
+		return quotaWindowAverageMonthSeconds, true
+	default:
+		return 0, false
+	}
+}
+
+func parseCodexAdditionalHeaderLimits(headers http.Header) []CodexAdditionalRateLimit {
+	type additionalGroup struct {
+		group     string
+		limitName string
+	}
+	groups := make([]additionalGroup, 0)
+	for key := range headers {
+		if !strings.HasPrefix(key, codexHeaderPrefix) || !strings.HasSuffix(key, "-Limit-Name") {
+			continue
+		}
+		group := strings.TrimSuffix(strings.TrimPrefix(key, codexHeaderPrefix), "-Limit-Name")
+		if group == "" {
+			continue
+		}
+		limitName := firstHeaderValue(headers, key)
+		if limitName == "" {
+			continue
+		}
+		groups = append(groups, additionalGroup{group: group, limitName: limitName})
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		if groups[i].limitName == groups[j].limitName {
+			return groups[i].group < groups[j].group
+		}
+		return groups[i].limitName < groups[j].limitName
+	})
+	limits := make([]CodexAdditionalRateLimit, 0, len(groups))
+	for _, group := range groups {
+		rateLimit := parseCodexHeaderRateLimit(headers, codexHeaderPrefix+group.group+"-")
+		if rateLimit == nil {
+			continue
+		}
+		limits = append(limits, CodexAdditionalRateLimit{
+			LimitName:      group.limitName,
+			MeteredFeature: group.limitName,
+			RateLimit:      rateLimit,
+		})
+	}
+	return limits
+}
+
+func parseFloatHeader(headers http.Header, key string) (float64, bool) {
+	value := firstHeaderValue(headers, key)
+	if value == "" {
+		return 0, false
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, false
+	}
+	if math.IsNaN(parsed) || math.IsInf(parsed, 0) || parsed < 0 {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func parseIntHeader(headers http.Header, key string) (int64, bool) {
+	value := firstHeaderValue(headers, key)
+	if value == "" {
+		return 0, false
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return parsed, true
+}

--- a/internal/quota/codex_header_test.go
+++ b/internal/quota/codex_header_test.go
@@ -1,0 +1,206 @@
+package quota
+
+import (
+	"math"
+	"net/http"
+	"strconv"
+	"testing"
+)
+
+func TestParseCodexHeaderQuotaParsesPrimarySecondaryAndAdditionalWindows(t *testing.T) {
+	headers := http.Header{
+		"X-Codex-Plan-Type":                                      []string{"pro"},
+		"X-Codex-Primary-Used-Percent":                           []string{"4"},
+		"X-Codex-Primary-Window-Minutes":                         []string{"300"},
+		"X-Codex-Primary-Reset-After-Seconds":                    []string{"7404"},
+		"X-Codex-Primary-Reset-At":                               []string{"1782105247"},
+		"X-Codex-Secondary-Used-Percent":                         []string{"22"},
+		"X-Codex-Secondary-Window-Minutes":                       []string{"10080"},
+		"X-Codex-Secondary-Reset-After-Seconds":                  []string{"303127"},
+		"X-Codex-Secondary-Reset-At":                             []string{"1782400970"},
+		"X-Codex-Bengalfox-Limit-Name":                           []string{"GPT-5.3-Codex-Spark"},
+		"X-Codex-Bengalfox-Primary-Used-Percent":                 []string{"0"},
+		"X-Codex-Bengalfox-Primary-Window-Minutes":               []string{"300"},
+		"X-Codex-Bengalfox-Primary-Reset-After-Seconds":          []string{"18000"},
+		"X-Codex-Bengalfox-Primary-Reset-At":                     []string{"1782115844"},
+		"X-Codex-Bengalfox-Secondary-Used-Percent":               []string{"0"},
+		"X-Codex-Bengalfox-Secondary-Window-Minutes":             []string{"10080"},
+		"X-Codex-Bengalfox-Secondary-Reset-After-Seconds":        []string{"604800"},
+		"X-Codex-Bengalfox-Secondary-Reset-At":                   []string{"1782702643"},
+		"X-Codex-Bengalfox-Primary-Over-Secondary-Limit-Percent": []string{"0"},
+		"X-Codex-Credits-Has-Credits":                            []string{"False"},
+	}
+
+	output, ok := parseCodexHeaderQuota(headers)
+	if !ok {
+		t.Fatal("expected codex header quota to parse")
+	}
+	rows := NormalizeQuotaRows(output)
+	if len(rows) != 4 {
+		t.Fatalf("expected 4 rows, got %#v", rows)
+	}
+	if rows[0].Key != "rate_limit.primary_window" || rows[0].PlanType != "pro" || rows[0].Window == nil || rows[0].Window.Seconds == nil || *rows[0].Window.Seconds != quotaWindowFiveHourSeconds {
+		t.Fatalf("unexpected primary row: %#v", rows[0])
+	}
+	if rows[0].UsedPercent == nil || *rows[0].UsedPercent != 4 || rows[0].ResetAfterSeconds == nil || *rows[0].ResetAfterSeconds != 7404 {
+		t.Fatalf("unexpected primary usage fields: %#v", rows[0])
+	}
+	if rows[1].Key != "rate_limit.secondary_window" || rows[1].Window == nil || rows[1].Window.Seconds == nil || *rows[1].Window.Seconds != quotaWindowSevenDaySeconds {
+		t.Fatalf("unexpected secondary row: %#v", rows[1])
+	}
+	if rows[2].Key != "additional_rate_limits.GPT-5.3-Codex-Spark.primary_window" || rows[2].Scope != "additional" || rows[2].Metric != "GPT-5.3-Codex-Spark" {
+		t.Fatalf("unexpected additional primary row: %#v", rows[2])
+	}
+	if rows[3].Key != "additional_rate_limits.GPT-5.3-Codex-Spark.secondary_window" {
+		t.Fatalf("unexpected additional secondary row: %#v", rows[3])
+	}
+}
+
+func TestParseCodexHeaderQuotaMapsMonthlyWindowMinutes(t *testing.T) {
+	output, ok := parseCodexHeaderQuota(http.Header{
+		"X-Codex-Primary-Used-Percent":   []string{"33"},
+		"X-Codex-Primary-Window-Minutes": []string{"43800"},
+		"X-Codex-Primary-Reset-At":       []string{"1782702643"},
+	})
+	if !ok {
+		t.Fatal("expected monthly window to parse")
+	}
+	rows := NormalizeQuotaRows(output)
+	if len(rows) != 1 || rows[0].Window == nil || rows[0].Window.Seconds == nil || *rows[0].Window.Seconds != quotaWindowAverageMonthSeconds || rows[0].Label != "Monthly" {
+		t.Fatalf("unexpected monthly rows: %#v", rows)
+	}
+}
+
+func TestBuildCodexUsageHeaderSnapshotKeepsOnlyQuotaHeaders(t *testing.T) {
+	snapshot, ok := BuildUsageHeaderSnapshot(UsageHeaderSnapshotInput{
+		AuthType:  "oauth",
+		AuthIndex: "codex-auth",
+		Provider:  "codex",
+		Headers: http.Header{
+			"Date":                                      []string{"Mon, 22 Jun 2026 03:10:44 GMT"},
+			"Set-Cookie":                                []string{"session=secret"},
+			"X-Codex-Credits-Has-Credits":               []string{"False"},
+			"X-Codex-Plan-Type":                         []string{"pro"},
+			"X-Codex-Primary-Used-Percent":              []string{"", "4", "99"},
+			"X-Codex-Primary-Window-Minutes":            []string{"300"},
+			"X-Codex-Primary-Reset-At":                  []string{"1782105247"},
+			"X-Codex-Bengalfox-Limit-Name":              []string{"GPT-5.3-Codex-Spark"},
+			"X-Codex-Bengalfox-Primary-Used-Percent":    []string{"8"},
+			"X-Codex-Bengalfox-Primary-Window-Minutes":  []string{"300"},
+			"X-Codex-Bengalfox-Primary-Reset-At":        []string{"1782105247"},
+			"X-Codex-Bengalfox-Primary-Unrelated-Field": []string{"ignored"},
+		},
+	})
+	if !ok {
+		t.Fatal("expected codex header snapshot to build")
+	}
+	for _, key := range []string{"Date", "Set-Cookie", "X-Codex-Credits-Has-Credits", "X-Codex-Bengalfox-Primary-Unrelated-Field"} {
+		if snapshot.Headers.Get(key) != "" {
+			t.Fatalf("expected %s to be filtered out, got %#v", key, snapshot.Headers.Values(key))
+		}
+	}
+	if values := snapshot.Headers.Values("X-Codex-Primary-Used-Percent"); len(values) != 1 || values[0] != "4" {
+		t.Fatalf("expected first non-empty used percent value to be kept, got %#v", values)
+	}
+	for _, key := range []string{
+		"X-Codex-Plan-Type",
+		"X-Codex-Primary-Window-Minutes",
+		"X-Codex-Primary-Reset-At",
+		"X-Codex-Bengalfox-Limit-Name",
+		"X-Codex-Bengalfox-Primary-Used-Percent",
+		"X-Codex-Bengalfox-Primary-Window-Minutes",
+		"X-Codex-Bengalfox-Primary-Reset-At",
+	} {
+		if snapshot.Headers.Get(key) == "" {
+			t.Fatalf("expected quota header %s to be retained, got %#v", key, snapshot.Headers)
+		}
+	}
+}
+
+func TestParseCodexHeaderQuotaRejectsOverflowWindowMinutes(t *testing.T) {
+	overflowToFiveHourMinutes := strconv.FormatInt(300+(math.MaxInt64/2+1), 10)
+	output, ok := parseCodexHeaderQuota(http.Header{
+		"X-Codex-Primary-Used-Percent":   []string{"33"},
+		"X-Codex-Primary-Window-Minutes": []string{overflowToFiveHourMinutes},
+		"X-Codex-Primary-Reset-At":       []string{"1782702643"},
+	})
+	if ok {
+		t.Fatalf("expected overflow-sized window minutes to be ignored, got %#v", output)
+	}
+}
+
+func TestParseCodexHeaderQuotaIgnoresCreditsAndInvalidNumbers(t *testing.T) {
+	output, ok := parseCodexHeaderQuota(http.Header{
+		"X-Codex-Credits-Has-Credits":    []string{"False"},
+		"X-Codex-Primary-Used-Percent":   []string{"bad"},
+		"X-Codex-Primary-Window-Minutes": []string{"also-bad"},
+	})
+	if ok {
+		t.Fatalf("expected invalid/incomplete header to be ignored, got %#v", output)
+	}
+}
+
+func TestParseCodexHeaderQuotaRequiresValidUsedPercentPerWindow(t *testing.T) {
+	output, ok := parseCodexHeaderQuota(http.Header{
+		"X-Codex-Primary-Window-Minutes":           []string{"300"},
+		"X-Codex-Primary-Reset-After-Seconds":      []string{"60"},
+		"X-Codex-Secondary-Used-Percent":           []string{"22"},
+		"X-Codex-Secondary-Window-Minutes":         []string{"10080"},
+		"X-Codex-Secondary-Reset-After-Seconds":    []string{"120"},
+		"X-Codex-Bengalfox-Limit-Name":             []string{"GPT-5.3-Codex-Spark"},
+		"X-Codex-Bengalfox-Primary-Window-Minutes": []string{"300"},
+	})
+	if !ok {
+		t.Fatal("expected secondary window with valid used percent to parse")
+	}
+	rows := NormalizeQuotaRows(output)
+	if len(rows) != 1 {
+		t.Fatalf("expected only windows with valid used percent to parse, got %#v", rows)
+	}
+	if rows[0].Key != "rate_limit.secondary_window" || rows[0].UsedPercent == nil || *rows[0].UsedPercent != 22 {
+		t.Fatalf("unexpected parsed row: %#v", rows[0])
+	}
+}
+
+func TestParseCodexHeaderQuotaRequiresWindowMinutesAndResetBoundary(t *testing.T) {
+	output, ok := parseCodexHeaderQuota(http.Header{
+		"X-Codex-Primary-Used-Percent":        []string{"4"},
+		"X-Codex-Primary-Reset-After-Seconds": []string{"60"},
+		"X-Codex-Secondary-Used-Percent":      []string{"22"},
+		"X-Codex-Secondary-Window-Minutes":    []string{"10080"},
+	})
+	if ok {
+		t.Fatalf("expected quota header without complete window/reset data to be ignored, got %#v", output)
+	}
+}
+
+func TestParseCodexHeaderQuotaIgnoresWindowWithoutUsedPercent(t *testing.T) {
+	output, ok := parseCodexHeaderQuota(http.Header{
+		"X-Codex-Primary-Window-Minutes":      []string{"300"},
+		"X-Codex-Primary-Reset-After-Seconds": []string{"60"},
+		"X-Codex-Bengalfox-Limit-Name":        []string{"GPT-5.3-Codex-Spark"},
+		"X-Codex-Bengalfox-Reset-At":          []string{"1782115844"},
+	})
+	if ok {
+		t.Fatalf("expected quota header without valid used percent to be ignored, got %#v", output)
+	}
+}
+
+func TestParseCodexHeaderQuotaAcceptsLowercaseHeaderKeys(t *testing.T) {
+	output, ok := parseCodexHeaderQuota(http.Header{
+		"x-codex-plan-type":                     []string{"pro"},
+		"x-codex-primary-used-percent":          []string{"12"},
+		"x-codex-primary-window-minutes":        []string{"300"},
+		"x-codex-primary-reset-after-seconds":   []string{"60"},
+		"x-codex-secondary-used-percent":        []string{"24"},
+		"x-codex-secondary-window-minutes":      []string{"43200"},
+		"x-codex-secondary-reset-after-seconds": []string{"120"},
+	})
+	if !ok {
+		t.Fatal("expected lowercase codex headers to parse")
+	}
+	rows := NormalizeQuotaRows(output)
+	if len(rows) != 2 || rows[1].Window == nil || rows[1].Window.Seconds == nil || *rows[1].Window.Seconds != quotaWindowThirtyDaySeconds {
+		t.Fatalf("unexpected rows: %#v", rows)
+	}
+}

--- a/internal/quota/header_cache_worker.go
+++ b/internal/quota/header_cache_worker.go
@@ -167,6 +167,10 @@ func (s *Service) applyUsageHeaderSnapshots(ctx context.Context, snapshots []Usa
 		return
 	}
 	statsProvider := s.usageHeaderWindowStatsProvider(ctx)
+	if statsProvider == nil {
+		// 批量 header 更新必须与窗口 token/cost 使用同一统计基础；统计器不可用时整批跳过，避免写入半套 cache。
+		return
+	}
 	for _, snapshot := range snapshots {
 		authIndex := strings.TrimSpace(snapshot.AuthIndex)
 		identity, ok := identityByAuthIndex[authIndex]

--- a/internal/quota/header_cache_worker.go
+++ b/internal/quota/header_cache_worker.go
@@ -1,0 +1,493 @@
+package quota
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+	"cpa-usage-keeper/internal/timeutil"
+
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+const (
+	usageHeaderSnapshotFlushInterval = 30 * time.Second
+)
+
+func (s *Service) TryAppendUsageHeaderSnapshots(snapshots []UsageHeaderSnapshot) bool {
+	if s == nil || len(snapshots) == 0 {
+		return true
+	}
+	s.usageHeaderMu.Lock()
+	defer s.usageHeaderMu.Unlock()
+	if s.usageHeaderClosing {
+		return false
+	}
+	if !s.acquireUsageHeaderSlot() {
+		return false
+	}
+	cloned := cloneUsageHeaderSnapshots(snapshots)
+	select {
+	case s.usageHeaderCh <- cloned:
+		return true
+	default:
+		s.releaseUsageHeaderSlot()
+		return false
+	}
+}
+
+func (s *Service) acquireUsageHeaderSlot() bool {
+	if s == nil || s.usageHeaderSlots == nil {
+		return false
+	}
+	select {
+	case <-s.usageHeaderSlots:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Service) releaseUsageHeaderSlot() {
+	if s == nil || s.usageHeaderSlots == nil {
+		return
+	}
+	select {
+	case s.usageHeaderSlots <- struct{}{}:
+	default:
+	}
+}
+
+func (s *Service) runUsageHeaderSnapshotWorker() {
+	defer close(s.usageHeaderDoneCh)
+	flushInterval := s.usageHeaderFlushInterval
+	if flushInterval <= 0 {
+		flushInterval = usageHeaderSnapshotFlushInterval
+	}
+	ticker := time.NewTicker(flushInterval)
+	defer ticker.Stop()
+	pending := make(map[string]UsageHeaderSnapshot)
+	for {
+		select {
+		case snapshots := <-s.usageHeaderCh:
+			s.releaseUsageHeaderSlot()
+			mergePendingUsageHeaderSnapshots(pending, snapshots)
+		case <-ticker.C:
+			s.flushPendingUsageHeaderSnapshots(pending)
+		case <-s.usageHeaderStopCh:
+			s.drainUsageHeaderSnapshots(pending)
+			s.flushPendingUsageHeaderSnapshots(pending)
+			return
+		}
+	}
+}
+
+func (s *Service) drainUsageHeaderSnapshots(pending map[string]UsageHeaderSnapshot) {
+	for {
+		select {
+		case snapshots := <-s.usageHeaderCh:
+			s.releaseUsageHeaderSlot()
+			mergePendingUsageHeaderSnapshots(pending, snapshots)
+		default:
+			return
+		}
+	}
+}
+
+func (s *Service) flushPendingUsageHeaderSnapshots(pending map[string]UsageHeaderSnapshot) {
+	if len(pending) == 0 {
+		return
+	}
+	snapshots := pendingUsageHeaderSnapshots(pending)
+	clear(pending)
+	s.applyUsageHeaderSnapshots(context.Background(), snapshots)
+}
+
+func mergePendingUsageHeaderSnapshots(pending map[string]UsageHeaderSnapshot, snapshots []UsageHeaderSnapshot) {
+	for _, snapshot := range snapshots {
+		authIndex := strings.TrimSpace(snapshot.AuthIndex)
+		if authIndex == "" {
+			authIndex = snapshot.Provider + "\x00" + snapshot.AuthType
+		}
+		if existing, ok := pending[authIndex]; !ok || usageHeaderSnapshotIsNewer(snapshot, existing) {
+			pending[authIndex] = snapshot
+		}
+	}
+}
+
+func usageHeaderSnapshotIsNewer(candidate UsageHeaderSnapshot, existing UsageHeaderSnapshot) bool {
+	if candidate.ObservedAt.IsZero() {
+		return existing.ObservedAt.IsZero()
+	}
+	if existing.ObservedAt.IsZero() {
+		return true
+	}
+	return !candidate.ObservedAt.Before(existing.ObservedAt)
+}
+
+func pendingUsageHeaderSnapshots(pending map[string]UsageHeaderSnapshot) []UsageHeaderSnapshot {
+	keys := make([]string, 0, len(pending))
+	for key := range pending {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	snapshots := make([]UsageHeaderSnapshot, 0, len(keys))
+	for _, key := range keys {
+		snapshots = append(snapshots, pending[key])
+	}
+	return snapshots
+}
+
+func (s *Service) stopUsageHeaderSnapshotWorker() {
+	if s == nil || s.usageHeaderStopCh == nil || s.usageHeaderDoneCh == nil {
+		return
+	}
+	s.usageHeaderCloseOnce.Do(func() {
+		s.usageHeaderMu.Lock()
+		s.usageHeaderClosing = true
+		close(s.usageHeaderStopCh)
+		s.usageHeaderMu.Unlock()
+		<-s.usageHeaderDoneCh
+	})
+}
+
+func (s *Service) applyUsageHeaderSnapshots(ctx context.Context, snapshots []UsageHeaderSnapshot) {
+	if len(snapshots) == 0 {
+		return
+	}
+	identityByAuthIndex, err := s.usageHeaderIdentityLookup(ctx, snapshots)
+	if err != nil {
+		logrus.WithError(err).WithField("snapshot_count", len(snapshots)).Warn("usage header quota identity lookup failed")
+		return
+	}
+	statsProvider := s.usageHeaderWindowStatsProvider(ctx)
+	for _, snapshot := range snapshots {
+		authIndex := strings.TrimSpace(snapshot.AuthIndex)
+		identity, ok := identityByAuthIndex[authIndex]
+		if !ok {
+			logUsageHeaderSnapshotIgnored(snapshot)
+			continue
+		}
+		if !s.applyUsageHeaderSnapshotWithIdentity(ctx, snapshot, identity, statsProvider) {
+			logUsageHeaderSnapshotIgnored(snapshot)
+		}
+	}
+}
+
+func logUsageHeaderSnapshotIgnored(snapshot UsageHeaderSnapshot) {
+	logrus.WithFields(logrus.Fields{
+		"auth_index": snapshot.AuthIndex,
+		"provider":   snapshot.Provider,
+	}).Debug("usage header quota snapshot ignored")
+}
+
+func (s *Service) usageHeaderIdentityLookup(ctx context.Context, snapshots []UsageHeaderSnapshot) (map[string]entities.UsageIdentity, error) {
+	authIndexes := usageHeaderSnapshotAuthIndexes(snapshots)
+	if len(authIndexes) == 0 {
+		return map[string]entities.UsageIdentity{}, nil
+	}
+	identities, err := repository.ListActiveAuthFileUsageIdentitiesByAuthIndexes(ctx, s.db, authIndexes)
+	if err != nil {
+		return nil, err
+	}
+	identityByAuthIndex := make(map[string]entities.UsageIdentity, len(identities))
+	for _, identity := range identities {
+		authIndex := strings.TrimSpace(identity.Identity)
+		if authIndex == "" || !usageHeaderIdentityIsCodex(identity) {
+			continue
+		}
+		identityByAuthIndex[authIndex] = identity
+	}
+	return identityByAuthIndex, nil
+}
+
+func usageHeaderSnapshotAuthIndexes(snapshots []UsageHeaderSnapshot) []string {
+	authIndexes := make([]string, 0, len(snapshots))
+	seen := make(map[string]struct{}, len(snapshots))
+	for _, snapshot := range snapshots {
+		authType := strings.ToLower(strings.TrimSpace(snapshot.AuthType))
+		authIndex := strings.TrimSpace(snapshot.AuthIndex)
+		if authType != "oauth" || authIndex == "" {
+			continue
+		}
+		if _, ok := seen[authIndex]; ok {
+			continue
+		}
+		seen[authIndex] = struct{}{}
+		authIndexes = append(authIndexes, authIndex)
+	}
+	return authIndexes
+}
+
+func (s *Service) usageHeaderWindowStatsProvider(ctx context.Context) usageWindowStatsProvider {
+	calculator, err := repository.NewUsageWindowStatsCalculator(ctx, s.db)
+	if err != nil {
+		logrus.WithError(err).Debug("usage header quota window stats calculator unavailable")
+		return nil
+	}
+	return calculator
+}
+
+func (s *Service) applyUsageHeaderSnapshot(ctx context.Context, snapshot UsageHeaderSnapshot) bool {
+	if s == nil {
+		return false
+	}
+	authType := strings.ToLower(strings.TrimSpace(snapshot.AuthType))
+	authIndex := strings.TrimSpace(snapshot.AuthIndex)
+	if authType != "oauth" || authIndex == "" {
+		return false
+	}
+	identity, err := repository.GetActiveAuthFileUsageIdentityByAuthIndex(ctx, s.db, authIndex)
+	if err != nil {
+		logUsageHeaderIdentityLookupError(authIndex, err)
+		return false
+	}
+	if !usageHeaderIdentityIsCodex(identity) {
+		return false
+	}
+	return s.applyUsageHeaderSnapshotWithIdentity(ctx, snapshot, identity, nil)
+}
+
+func logUsageHeaderIdentityLookupError(authIndex string, err error) {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return
+	}
+	logrus.WithError(err).WithField("auth_index", authIndex).Warn("usage header quota identity lookup failed")
+}
+
+func (s *Service) applyUsageHeaderSnapshotWithIdentity(ctx context.Context, snapshot UsageHeaderSnapshot, identity entities.UsageIdentity, statsProvider usageWindowStatsProvider) bool {
+	if s == nil {
+		return false
+	}
+	authType := strings.ToLower(strings.TrimSpace(snapshot.AuthType))
+	authIndex := strings.TrimSpace(snapshot.AuthIndex)
+	if authType != "oauth" || authIndex == "" || strings.TrimSpace(identity.Identity) != authIndex {
+		return false
+	}
+	if !usageHeaderIdentityIsCodex(identity) {
+		return false
+	}
+	output, ok := parseCodexHeaderQuota(snapshot.Headers)
+	if !ok {
+		return false
+	}
+	response := CheckResponse{
+		ID:    authIndex,
+		Quota: NormalizeQuotaRows(output),
+	}
+	if len(response.Quota) == 0 {
+		return false
+	}
+	if count, ok := rateLimitResetCreditsAvailableCount(output); ok {
+		response.RateLimitResetCreditsAvailableCount = count
+	}
+	observedAt := timeutil.NormalizeStorageTime(snapshot.ObservedAt)
+	if observedAt.IsZero() {
+		observedAt = timeutil.NormalizeStorageTime(time.Now())
+	}
+	if !s.shouldProcessUsageHeaderQuotaSnapshot(authIndex, observedAt) {
+		return false
+	}
+	if statsProvider != nil {
+		response = s.attachWindowUsageStatsWithProvider(ctx, authIndex, response, observedAt, statsProvider)
+	} else {
+		response = s.attachWindowUsageStats(ctx, authIndex, response, observedAt)
+	}
+	return s.mergeUsageHeaderQuotaCache(authIndex, response, observedAt, identity)
+}
+
+func usageHeaderIdentityIsCodex(identity entities.UsageIdentity) bool {
+	return normalizeIdentityType(identity.Type) == "codex"
+}
+
+func (s *Service) shouldProcessUsageHeaderQuotaSnapshot(authIndex string, observedAt time.Time) bool {
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+	existing, ok := s.refreshTasks[authIndex]
+	if !ok {
+		return true
+	}
+	if existing.isActive() {
+		return false
+	}
+	if usageHeaderCompletedCacheIsCurrentOrNewer(existing, observedAt) {
+		return false
+	}
+	return true
+}
+
+func (s *Service) mergeUsageHeaderQuotaCache(authIndex string, response CheckResponse, observedAt time.Time, identity entities.UsageIdentity) bool {
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+	existing, ok := s.refreshTasks[authIndex]
+	if ok {
+		if existing.isActive() {
+			return false
+		}
+		if usageHeaderCompletedCacheIsCurrentOrNewer(existing, observedAt) {
+			return false
+		}
+		if existing.Quota != nil {
+			response = mergeUsageHeaderQuotaResponse(*existing.Quota, response)
+		}
+	}
+	s.refreshTasks[authIndex] = &RefreshTaskRecord{
+		AuthIndex:   authIndex,
+		Name:        identity.Name,
+		Type:        identity.Type,
+		FileName:    identity.FileName,
+		Status:      RefreshTaskStatusCompleted,
+		Quota:       &response,
+		Source:      RefreshSourceUsageHeader,
+		CreatedAt:   observedAt,
+		RefreshedAt: observedAt,
+	}
+	return true
+}
+
+func usageHeaderCompletedCacheIsCurrentOrNewer(existing *RefreshTaskRecord, observedAt time.Time) bool {
+	return existing != nil &&
+		existing.Status == RefreshTaskStatusCompleted &&
+		!existing.RefreshedAt.IsZero() &&
+		!existing.RefreshedAt.Before(observedAt)
+}
+
+func mergeUsageHeaderQuotaResponse(existing CheckResponse, header CheckResponse) CheckResponse {
+	merged := header
+	if merged.ID == "" {
+		merged.ID = existing.ID
+	}
+	if merged.RateLimitResetCreditsAvailableCount == nil {
+		merged.RateLimitResetCreditsAvailableCount = existing.RateLimitResetCreditsAvailableCount
+	}
+	merged.Quota = mergeUsageHeaderQuotaRows(existing.Quota, header.Quota)
+	return merged
+}
+
+func mergeUsageHeaderQuotaRows(existing []QuotaRow, header []QuotaRow) []QuotaRow {
+	headerByKey := make(map[string]QuotaRow, len(header))
+	headerOrder := make([]string, 0, len(header))
+	for _, row := range header {
+		if strings.TrimSpace(row.Key) == "" {
+			continue
+		}
+		if _, ok := headerByKey[row.Key]; !ok {
+			headerOrder = append(headerOrder, row.Key)
+		}
+		headerByKey[row.Key] = row
+	}
+	merged := make([]QuotaRow, 0, len(existing)+len(header))
+	seen := make(map[string]struct{}, len(existing)+len(header))
+	for _, row := range existing {
+		if replacement, ok := headerByKey[row.Key]; ok {
+			merged = append(merged, mergeUsageHeaderQuotaRow(row, replacement))
+			seen[row.Key] = struct{}{}
+			continue
+		}
+		merged = append(merged, row)
+		if strings.TrimSpace(row.Key) != "" {
+			seen[row.Key] = struct{}{}
+		}
+	}
+	for _, key := range headerOrder {
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		merged = append(merged, headerByKey[key])
+	}
+	return merged
+}
+
+func mergeUsageHeaderQuotaRow(existing QuotaRow, header QuotaRow) QuotaRow {
+	merged := existing
+	if strings.TrimSpace(header.Key) != "" {
+		merged.Key = header.Key
+	}
+	if strings.TrimSpace(header.Label) != "" {
+		merged.Label = header.Label
+	}
+	if strings.TrimSpace(header.Scope) != "" {
+		merged.Scope = header.Scope
+	}
+	if strings.TrimSpace(header.Metric) != "" {
+		merged.Metric = header.Metric
+	}
+	if strings.TrimSpace(header.PlanType) != "" {
+		merged.PlanType = header.PlanType
+	}
+	if header.Used != nil {
+		merged.Used = header.Used
+	}
+	if header.Limit != nil {
+		merged.Limit = header.Limit
+	}
+	if header.Remaining != nil {
+		merged.Remaining = header.Remaining
+	}
+	if header.RemainingFraction != nil {
+		merged.RemainingFraction = header.RemainingFraction
+	}
+	if header.UsedPercent != nil {
+		merged.UsedPercent = header.UsedPercent
+	}
+	if header.Allowed != nil {
+		merged.Allowed = header.Allowed
+	}
+	if header.LimitReached != nil {
+		merged.LimitReached = header.LimitReached
+	}
+	if header.Window != nil {
+		merged.Window = header.Window
+	}
+	if strings.TrimSpace(header.ResetAt) != "" {
+		merged.ResetAt = header.ResetAt
+	}
+	if header.ResetAfterSeconds != nil {
+		merged.ResetAfterSeconds = header.ResetAfterSeconds
+	}
+	if usageHeaderQuotaRowIsWindow(header) {
+		// Header 只负责刷新普通 window 进度条；token/cost 跟随同一窗口重新计算，即使为空也要清掉旧值。
+		merged.WindowUsageTokens = header.WindowUsageTokens
+		merged.WindowUsageCost = header.WindowUsageCost
+	} else {
+		if header.WindowUsageTokens != nil {
+			merged.WindowUsageTokens = header.WindowUsageTokens
+		}
+		if header.WindowUsageCost != nil {
+			merged.WindowUsageCost = header.WindowUsageCost
+		}
+	}
+	return merged
+}
+
+func usageHeaderQuotaRowIsWindow(row QuotaRow) bool {
+	return strings.EqualFold(strings.TrimSpace(row.Scope), "window")
+}
+
+func cloneUsageHeaderSnapshots(snapshots []UsageHeaderSnapshot) []UsageHeaderSnapshot {
+	cloned := make([]UsageHeaderSnapshot, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		snapshot.Headers = cloneUsageHeaderHTTPHeaders(snapshot.Headers)
+		cloned = append(cloned, snapshot)
+	}
+	return cloned
+}
+
+func cloneUsageHeaderHTTPHeaders(headers http.Header) http.Header {
+	if len(headers) == 0 {
+		return nil
+	}
+	cloned := make(http.Header, len(headers))
+	for key, values := range headers {
+		copied := make([]string, len(values))
+		copy(copied, values)
+		cloned[key] = copied
+	}
+	return cloned
+}

--- a/internal/quota/header_cache_worker_test.go
+++ b/internal/quota/header_cache_worker_test.go
@@ -1,0 +1,716 @@
+package quota
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"gorm.io/gorm"
+)
+
+func TestApplyUsageHeaderSnapshotWritesCompletedCacheWithWindowUsageStats(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	seedUsageEvent(t, db, entities.UsageEvent{
+		AuthType:     "oauth",
+		AuthIndex:    "codex-auth",
+		Model:        "gpt-5.5",
+		Timestamp:    time.Date(2026, 6, 22, 10, 0, 0, 0, time.Local),
+		TotalTokens:  123,
+		InputTokens:  100,
+		OutputTokens: 23,
+	})
+	service := NewServiceWithRegistry(db, NewProviderRegistry(nil))
+	defer service.StopRefreshTasks()
+
+	applied := service.applyUsageHeaderSnapshot(context.Background(), UsageHeaderSnapshot{
+		AuthType:   "oauth",
+		AuthIndex:  "codex-auth",
+		Provider:   "codex",
+		ObservedAt: time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local),
+		Headers: http.Header{
+			"X-Codex-Plan-Type":              []string{"pro"},
+			"X-Codex-Primary-Used-Percent":   []string{"4"},
+			"X-Codex-Primary-Window-Minutes": []string{"300"},
+			"X-Codex-Primary-Reset-At":       []string{strconv.FormatInt(time.Date(2026, 6, 22, 15, 0, 0, 0, time.Local).Unix(), 10)},
+		},
+	})
+	if !applied {
+		t.Fatal("expected header snapshot to apply")
+	}
+	task, err := service.GetRefreshTaskByAuthIndex(context.Background(), "codex-auth")
+	if err != nil {
+		t.Fatalf("GetRefreshTaskByAuthIndex returned error: %v", err)
+	}
+	if task.Status != RefreshTaskStatusCompleted || task.Quota == nil || len(task.Quota.Quota) != 1 {
+		t.Fatalf("unexpected task: %+v", task)
+	}
+	row := task.Quota.Quota[0]
+	if row.WindowUsageTokens == nil || *row.WindowUsageTokens != 123 || row.WindowUsageCost == nil {
+		t.Fatalf("expected local token/cost fallback, got %#v", row)
+	}
+	if task.RefreshedAt == nil || !task.RefreshedAt.Equal(time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local)) {
+		t.Fatalf("expected refreshed_at from observed_at, got %+v", task.RefreshedAt)
+	}
+}
+
+func TestApplyUsageHeaderSnapshotUsesObservedAtAsWindowUsageStatsEnd(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	observedAt := time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local)
+	seedUsageEvent(t, db, entities.UsageEvent{
+		AuthType:    "oauth",
+		AuthIndex:   "codex-auth",
+		Model:       "gpt-5.5",
+		Timestamp:   observedAt.Add(-time.Nanosecond),
+		TotalTokens: 50,
+	})
+	seedUsageEvent(t, db, entities.UsageEvent{
+		AuthType:    "oauth",
+		AuthIndex:   "codex-auth",
+		Model:       "gpt-5.5",
+		Timestamp:   observedAt,
+		TotalTokens: 123,
+	})
+	service := NewServiceWithRegistry(db, NewProviderRegistry(nil))
+	defer service.StopRefreshTasks()
+
+	applied := service.applyUsageHeaderSnapshot(context.Background(), UsageHeaderSnapshot{
+		AuthType:   "oauth",
+		AuthIndex:  "codex-auth",
+		Provider:   "codex",
+		ObservedAt: observedAt,
+		Headers: http.Header{
+			"X-Codex-Plan-Type":              []string{"pro"},
+			"X-Codex-Primary-Used-Percent":   []string{"4"},
+			"X-Codex-Primary-Window-Minutes": []string{"300"},
+			"X-Codex-Primary-Reset-At":       []string{strconv.FormatInt(observedAt.Add(4*time.Hour).Unix(), 10)},
+		},
+	})
+	if !applied {
+		t.Fatal("expected header snapshot to apply")
+	}
+	task, err := service.GetRefreshTaskByAuthIndex(context.Background(), "codex-auth")
+	if err != nil {
+		t.Fatalf("GetRefreshTaskByAuthIndex returned error: %v", err)
+	}
+	if task.Quota == nil || len(task.Quota.Quota) != 1 {
+		t.Fatalf("unexpected task quota: %+v", task)
+	}
+	row := task.Quota.Quota[0]
+	if row.WindowUsageTokens == nil || *row.WindowUsageTokens != 50 {
+		t.Fatalf("expected local token fallback to use observed_at as half-open window end, got %#v", row)
+	}
+}
+
+func TestApplyUsageHeaderSnapshotMatchesUsageIdentityTypeByAuthIndex(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "Codex Team", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	service := NewServiceWithRegistry(db, NewProviderRegistry(nil))
+	defer service.StopRefreshTasks()
+
+	snapshot := codexUsageHeaderSnapshot("codex-auth", time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local), "4")
+	snapshot.Provider = "claude"
+	applied := service.applyUsageHeaderSnapshot(context.Background(), snapshot)
+	if !applied {
+		t.Fatal("expected auth_index usage identity type to drive codex header matching")
+	}
+	task, err := service.GetRefreshTaskByAuthIndex(context.Background(), "codex-auth")
+	if err != nil {
+		t.Fatalf("GetRefreshTaskByAuthIndex returned error: %v", err)
+	}
+	if task.Quota == nil || len(task.Quota.Quota) != 1 || task.Quota.Quota[0].UsedPercent == nil || *task.Quota.Quota[0].UsedPercent != 4 {
+		t.Fatalf("expected codex quota cache from identity type, got %+v", task)
+	}
+}
+
+func TestApplyUsageHeaderSnapshotIgnoresProviderOnlyCodexWhenIdentityTypeDiffers(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "claude-auth", Provider: "codex", Type: "claude", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	service := NewServiceWithRegistry(db, NewProviderRegistry(nil))
+	defer service.StopRefreshTasks()
+
+	applied := service.applyUsageHeaderSnapshot(context.Background(), codexUsageHeaderSnapshot("claude-auth", time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local), "4"))
+	if applied {
+		t.Fatal("expected non-codex usage identity type to ignore codex-looking headers")
+	}
+	if len(service.refreshTasks) != 0 {
+		t.Fatalf("expected no quota cache task, got %+v", service.refreshTasks)
+	}
+}
+
+func TestApplyUsageHeaderSnapshotSkipsActiveRefreshTask(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	service := NewServiceWithRegistry(db, NewProviderRegistry(nil))
+	defer service.StopRefreshTasks()
+	service.refreshTasks["codex-auth"] = &RefreshTaskRecord{AuthIndex: "codex-auth", Status: RefreshTaskStatusQueued, Source: RefreshSourceManual}
+
+	applied := service.applyUsageHeaderSnapshot(context.Background(), codexUsageHeaderSnapshot("codex-auth", time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local), "4"))
+	if applied {
+		t.Fatal("expected active refresh task to win over header snapshot")
+	}
+	if task := service.refreshTasks["codex-auth"]; task.Status != RefreshTaskStatusQueued || task.Quota != nil {
+		t.Fatalf("expected queued task to remain unchanged, got %+v", task)
+	}
+}
+
+func TestApplyUsageHeaderSnapshotUpdatesRecentCompletedCacheAndCreatesMissingCache(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "new-codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	service := NewServiceWithRegistry(db, NewProviderRegistry(nil))
+	defer service.StopRefreshTasks()
+	refreshedAt := time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local)
+	service.refreshTasks["codex-auth"] = &RefreshTaskRecord{
+		AuthIndex:   "codex-auth",
+		Status:      RefreshTaskStatusCompleted,
+		Source:      RefreshSourceManual,
+		RefreshedAt: refreshedAt,
+		Quota:       &CheckResponse{ID: "codex-auth", Quota: []QuotaRow{{Key: "rate_limit.primary_window", Label: "5h", Scope: "window", UsedPercent: floatPtr(90)}}},
+	}
+
+	applied := service.applyUsageHeaderSnapshot(context.Background(), codexUsageHeaderSnapshot("codex-auth", refreshedAt.Add(20*time.Second), "4"))
+	if !applied {
+		t.Fatal("expected recent newer header to update completed cache")
+	}
+	task := service.refreshTasks["codex-auth"]
+	if task.Quota == nil || len(task.Quota.Quota) != 1 || task.Quota.Quota[0].UsedPercent == nil || *task.Quota.Quota[0].UsedPercent != 4 {
+		t.Fatalf("expected recent header progress to update cache, got %+v", task)
+	}
+
+	applied = service.applyUsageHeaderSnapshot(context.Background(), codexUsageHeaderSnapshot("new-codex-auth", refreshedAt.Add(20*time.Second), "8"))
+	if !applied {
+		t.Fatal("expected missing cache to be created despite debounce window")
+	}
+	created := service.refreshTasks["new-codex-auth"]
+	if created == nil || created.Quota == nil || len(created.Quota.Quota) != 1 || created.Quota.Quota[0].UsedPercent == nil || *created.Quota.Quota[0].UsedPercent != 8 {
+		t.Fatalf("expected header quota cache creation for missing cache, got %+v", created)
+	}
+}
+
+func TestApplyUsageHeaderSnapshotUpdatesRecentCompletedCacheAndRefreshesWindowUsageStats(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	seedUsageEvent(t, db, entities.UsageEvent{
+		AuthType:    "oauth",
+		AuthIndex:   "codex-auth",
+		Model:       "gpt-5.5",
+		Timestamp:   time.Date(2026, 6, 22, 10, 30, 0, 0, time.Local),
+		TotalTokens: 123,
+	})
+	service := NewServiceWithRegistry(db, NewProviderRegistry(nil))
+	defer service.StopRefreshTasks()
+	refreshedAt := time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local)
+	service.refreshTasks["codex-auth"] = &RefreshTaskRecord{
+		AuthIndex:   "codex-auth",
+		Status:      RefreshTaskStatusCompleted,
+		Source:      RefreshSourceManual,
+		RefreshedAt: refreshedAt,
+		Quota: &CheckResponse{ID: "codex-auth", Quota: []QuotaRow{{
+			Key:         "rate_limit.primary_window",
+			Label:       "5h",
+			Scope:       "window",
+			UsedPercent: floatPtr(90),
+		}}},
+	}
+	windowStatsQueries := 0
+	callbackName := "test:count_header_recent_update_window_stats_queries"
+	if err := db.Callback().Query().After("gorm:query").Register(callbackName, func(tx *gorm.DB) {
+		sql := tx.Statement.SQL.String()
+		if queryMentionsTable(sql, "usage_events") || queryMentionsTable(sql, "usage_overview_hourly_stats") || queryMentionsTable(sql, "model_price_settings") {
+			windowStatsQueries++
+		}
+	}); err != nil {
+		t.Fatalf("register query callback returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Callback().Query().Remove(callbackName) })
+
+	applied := service.applyUsageHeaderSnapshot(context.Background(), codexUsageHeaderSnapshot("codex-auth", refreshedAt.Add(20*time.Second), "4"))
+	if !applied {
+		t.Fatal("expected recent newer header to update completed cache")
+	}
+	if windowStatsQueries == 0 {
+		t.Fatal("expected recent header update to refresh window stats")
+	}
+	task := service.refreshTasks["codex-auth"]
+	if task.Quota == nil || len(task.Quota.Quota) != 1 || task.Quota.Quota[0].UsedPercent == nil || *task.Quota.Quota[0].UsedPercent != 4 {
+		t.Fatalf("expected recent header progress to update cache, got %+v", task)
+	}
+}
+
+func TestApplyUsageHeaderSnapshotWarnsOnIdentityDatabaseError(t *testing.T) {
+	hook := logrustest.NewGlobal()
+	defer hook.Reset()
+	previousLevel := logrus.GetLevel()
+	logrus.SetLevel(logrus.WarnLevel)
+	t.Cleanup(func() { logrus.SetLevel(previousLevel) })
+
+	service := NewServiceWithRegistry(nil, NewProviderRegistry(nil))
+	defer service.StopRefreshTasks()
+
+	if service.applyUsageHeaderSnapshot(context.Background(), codexUsageHeaderSnapshot("codex-auth", time.Now(), "4")) {
+		t.Fatal("expected snapshot with database error to be ignored")
+	}
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == logrus.WarnLevel && entry.Message == "usage header quota identity lookup failed" && entry.Data["auth_index"] == "codex-auth" {
+			return
+		}
+	}
+	t.Fatalf("expected warning log for identity database error, got %#v", hook.AllEntries())
+}
+
+func TestApplyUsageHeaderSnapshotRecoversFailedCacheWithinDebounceAndClearsFailureFields(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	service := NewServiceWithRegistry(db, NewProviderRegistry(nil))
+	defer service.StopRefreshTasks()
+	httpStatus := 429
+	refreshedAt := time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local)
+	service.refreshTasks["codex-auth"] = &RefreshTaskRecord{
+		AuthIndex:      "codex-auth",
+		Status:         RefreshTaskStatusFailed,
+		Error:          "rate limited",
+		HTTPStatusCode: &httpStatus,
+		Source:         RefreshSourceManual,
+		RefreshedAt:    refreshedAt,
+		ExpiresAt:      time.Now().Add(time.Hour),
+		Quota:          &CheckResponse{ID: "codex-auth", Quota: []QuotaRow{{Key: "rate_limit.primary_window", Label: "5h", Scope: "window", UsedPercent: floatPtr(90)}}},
+	}
+
+	applied := service.applyUsageHeaderSnapshot(context.Background(), codexUsageHeaderSnapshot("codex-auth", refreshedAt.Add(20*time.Second), "4"))
+	if !applied {
+		t.Fatal("expected failed cache to be recovered by complete header inside debounce window")
+	}
+	task := service.refreshTasks["codex-auth"]
+	if task.Status != RefreshTaskStatusCompleted || task.Error != "" || task.HTTPStatusCode != nil || !task.ExpiresAt.IsZero() {
+		t.Fatalf("expected failed fields to be cleared after header recovery, got %+v", task)
+	}
+	if task.Quota == nil || len(task.Quota.Quota) != 1 || task.Quota.Quota[0].UsedPercent == nil || *task.Quota.Quota[0].UsedPercent != 4 {
+		t.Fatalf("expected recovered header quota, got %+v", task)
+	}
+}
+
+func TestApplyUsageHeaderSnapshotDoesNotOverwriteNewerCompletedCache(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	service := NewServiceWithRegistry(db, NewProviderRegistry(nil))
+	defer service.StopRefreshTasks()
+	newerAt := time.Date(2026, 6, 22, 12, 0, 0, 0, time.Local)
+	service.refreshTasks["codex-auth"] = &RefreshTaskRecord{
+		AuthIndex:   "codex-auth",
+		Status:      RefreshTaskStatusCompleted,
+		Source:      RefreshSourceManual,
+		RefreshedAt: newerAt,
+		Quota:       &CheckResponse{ID: "codex-auth", Quota: []QuotaRow{{Key: "rate_limit.primary_window", Label: "5h", UsedPercent: floatPtr(90)}}},
+	}
+
+	applied := service.applyUsageHeaderSnapshot(context.Background(), codexUsageHeaderSnapshot("codex-auth", newerAt.Add(-time.Hour), "4"))
+	if applied {
+		t.Fatal("expected older header snapshot to be ignored")
+	}
+	task := service.refreshTasks["codex-auth"]
+	if task.Quota == nil || len(task.Quota.Quota) != 1 || task.Quota.Quota[0].UsedPercent == nil || *task.Quota.Quota[0].UsedPercent != 90 {
+		t.Fatalf("expected newer cache to remain unchanged, got %+v", task)
+	}
+}
+
+func TestApplyUsageHeaderSnapshotIgnoresIncompleteWindowWithoutClearingExistingUsage(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	service := NewServiceWithRegistry(db, NewProviderRegistry(nil))
+	defer service.StopRefreshTasks()
+	oldPercent := 80.0
+	oldTokens := int64(999)
+	oldCost := 9.9
+	service.refreshTasks["codex-auth"] = &RefreshTaskRecord{
+		AuthIndex:   "codex-auth",
+		Status:      RefreshTaskStatusCompleted,
+		Source:      RefreshSourceManual,
+		RefreshedAt: time.Date(2026, 6, 22, 10, 0, 0, 0, time.Local),
+		Quota: &CheckResponse{ID: "codex-auth", Quota: []QuotaRow{{
+			Key:               "rate_limit.primary_window",
+			Label:             "5h",
+			Scope:             "window",
+			UsedPercent:       &oldPercent,
+			Window:            &QuotaWindow{Seconds: intPtr(quotaWindowFiveHourSeconds)},
+			ResetAfterSeconds: intPtr(3600),
+			WindowUsageTokens: &oldTokens,
+			WindowUsageCost:   &oldCost,
+		}}},
+	}
+
+	applied := service.applyUsageHeaderSnapshot(context.Background(), UsageHeaderSnapshot{
+		AuthType:   "oauth",
+		AuthIndex:  "codex-auth",
+		Provider:   "codex",
+		ObservedAt: time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local),
+		Headers: http.Header{
+			"X-Codex-Primary-Used-Percent": []string{"4"},
+		},
+	})
+	if applied {
+		t.Fatal("expected incomplete header window to be ignored")
+	}
+	task := service.refreshTasks["codex-auth"]
+	row := task.Quota.Quota[0]
+	if row.UsedPercent == nil || *row.UsedPercent != oldPercent || row.WindowUsageTokens == nil || *row.WindowUsageTokens != oldTokens || row.WindowUsageCost == nil || *row.WindowUsageCost != oldCost {
+		t.Fatalf("expected existing cache usage fields to remain unchanged, got %#v", row)
+	}
+}
+
+func TestApplyUsageHeaderSnapshotMergesProgressWithManualAuthoritativeFields(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	seedUsageEvent(t, db, entities.UsageEvent{
+		AuthType:    "oauth",
+		AuthIndex:   "codex-auth",
+		Model:       "gpt-5.5",
+		Timestamp:   time.Date(2026, 6, 22, 10, 30, 0, 0, time.Local),
+		TotalTokens: 123,
+	})
+	service := NewServiceWithRegistry(db, NewProviderRegistry(nil))
+	defer service.StopRefreshTasks()
+	oldUsed := 8.0
+	oldLimit := 10.0
+	oldRemaining := 2.0
+	oldRemainingFraction := 0.2
+	oldPercent := 80.0
+	oldTokens := int64(999)
+	oldCost := 9.9
+	service.refreshTasks["codex-auth"] = &RefreshTaskRecord{
+		AuthIndex:   "codex-auth",
+		Status:      RefreshTaskStatusCompleted,
+		Source:      RefreshSourceManual,
+		RefreshedAt: time.Date(2026, 6, 22, 10, 0, 0, 0, time.Local),
+		Quota: &CheckResponse{ID: "codex-auth", Quota: []QuotaRow{{
+			Key:               "rate_limit.primary_window",
+			Label:             "Manual 5h",
+			Scope:             "window",
+			Metric:            "manual",
+			PlanType:          "pro",
+			Used:              &oldUsed,
+			Limit:             &oldLimit,
+			Remaining:         &oldRemaining,
+			RemainingFraction: &oldRemainingFraction,
+			UsedPercent:       &oldPercent,
+			Window:            &QuotaWindow{Seconds: intPtr(quotaWindowFiveHourSeconds)},
+			WindowUsageTokens: &oldTokens,
+			WindowUsageCost:   &oldCost,
+		}}},
+	}
+
+	applied := service.applyUsageHeaderSnapshot(context.Background(), codexUsageHeaderSnapshot("codex-auth", time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local), "4"))
+	if !applied {
+		t.Fatal("expected header snapshot to update stale cache")
+	}
+	task := service.refreshTasks["codex-auth"]
+	if task.Quota == nil || len(task.Quota.Quota) != 1 {
+		t.Fatalf("unexpected merged task: %+v", task)
+	}
+	row := task.Quota.Quota[0]
+	if row.Used == nil || *row.Used != oldUsed || row.Limit == nil || *row.Limit != oldLimit || row.Remaining == nil || *row.Remaining != oldRemaining || row.RemainingFraction == nil || *row.RemainingFraction != oldRemainingFraction {
+		t.Fatalf("expected manual absolute fields to be preserved, got %#v", row)
+	}
+	if row.UsedPercent == nil || *row.UsedPercent != 4 {
+		t.Fatalf("expected header used percent to update progress, got %#v", row.UsedPercent)
+	}
+	if row.WindowUsageTokens == nil || *row.WindowUsageTokens != 123 || row.WindowUsageCost == nil {
+		t.Fatalf("expected window token/cost fallback to follow header progress, got %#v", row)
+	}
+}
+
+func TestApplyUsageHeaderSnapshotMergesRowsAndPreservesResetCredits(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	service := NewServiceWithRegistry(db, NewProviderRegistry(nil))
+	defer service.StopRefreshTasks()
+	credits := 2
+	oldPercent := 61.0
+	service.refreshTasks["codex-auth"] = &RefreshTaskRecord{
+		AuthIndex:   "codex-auth",
+		Status:      RefreshTaskStatusCompleted,
+		Source:      RefreshSourceManual,
+		RefreshedAt: time.Date(2026, 6, 22, 10, 0, 0, 0, time.Local),
+		Quota: &CheckResponse{
+			ID:                                  "codex-auth",
+			RateLimitResetCreditsAvailableCount: &credits,
+			Quota: []QuotaRow{
+				{Key: "rate_limit.primary_window", Label: "5h", UsedPercent: &oldPercent},
+				{Key: "rate_limit.secondary_window", Label: "Weekly", UsedPercent: floatPtr(22)},
+				{Key: "manual_only", Label: "Manual Only", Scope: "extra"},
+			},
+		},
+	}
+
+	applied := service.applyUsageHeaderSnapshot(context.Background(), codexUsageHeaderSnapshot("codex-auth", time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local), "4"))
+	if !applied {
+		t.Fatal("expected newer header snapshot to apply")
+	}
+	task := service.refreshTasks["codex-auth"]
+	if task.Quota == nil || task.Quota.RateLimitResetCreditsAvailableCount == nil || *task.Quota.RateLimitResetCreditsAvailableCount != 2 {
+		t.Fatalf("expected reset credits to be preserved, got %+v", task.Quota)
+	}
+	if len(task.Quota.Quota) != 3 {
+		t.Fatalf("expected merged rows to preserve non-header rows, got %#v", task.Quota.Quota)
+	}
+	if task.Quota.Quota[0].Key != "rate_limit.primary_window" || task.Quota.Quota[0].UsedPercent == nil || *task.Quota.Quota[0].UsedPercent != 4 {
+		t.Fatalf("expected primary row to be replaced by header row, got %#v", task.Quota.Quota[0])
+	}
+	if task.Quota.Quota[1].Key != "rate_limit.secondary_window" || task.Quota.Quota[2].Key != "manual_only" {
+		t.Fatalf("expected untouched rows to keep their order, got %#v", task.Quota.Quota)
+	}
+}
+
+func TestApplyUsageHeaderSnapshotDoesNotBackfillAdditionalLimitUsageStats(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	seedUsageEvent(t, db, entities.UsageEvent{
+		AuthType:    "oauth",
+		AuthIndex:   "codex-auth",
+		Model:       "gpt-5.5",
+		Timestamp:   time.Date(2026, 6, 22, 10, 0, 0, 0, time.Local),
+		TotalTokens: 123,
+	})
+	service := NewServiceWithRegistry(db, NewProviderRegistry(nil))
+	defer service.StopRefreshTasks()
+
+	applied := service.applyUsageHeaderSnapshot(context.Background(), UsageHeaderSnapshot{
+		AuthType:   "oauth",
+		AuthIndex:  "codex-auth",
+		Provider:   "codex",
+		ObservedAt: time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local),
+		Headers: http.Header{
+			"X-Codex-Bengalfox-Limit-Name":                  []string{"GPT-5.3-Codex-Spark"},
+			"X-Codex-Bengalfox-Primary-Used-Percent":        []string{"5"},
+			"X-Codex-Bengalfox-Primary-Window-Minutes":      []string{"300"},
+			"X-Codex-Bengalfox-Primary-Reset-After-Seconds": []string{"60"},
+		},
+	})
+	if !applied {
+		t.Fatal("expected additional header snapshot to apply")
+	}
+	task, err := service.GetRefreshTaskByAuthIndex(context.Background(), "codex-auth")
+	if err != nil {
+		t.Fatalf("GetRefreshTaskByAuthIndex returned error: %v", err)
+	}
+	if task.Quota == nil || len(task.Quota.Quota) != 1 {
+		t.Fatalf("unexpected task quota: %+v", task)
+	}
+	row := task.Quota.Quota[0]
+	if row.Scope != "additional" || row.WindowUsageTokens != nil || row.WindowUsageCost != nil {
+		t.Fatalf("expected additional limit to skip auth-wide usage fallback, got %#v", row)
+	}
+}
+
+func TestApplyUsageHeaderSnapshotIgnoresUnsupportedSnapshots(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "provider-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAIProvider})
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "deleted-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile, IsDeleted: true})
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "claude-auth", Provider: "claude", Type: "claude", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	service := NewServiceWithRegistry(db, NewProviderRegistry(map[string]ProviderHandler{"codex": nil}))
+	defer service.StopRefreshTasks()
+
+	tests := []UsageHeaderSnapshot{
+		{AuthType: "apikey", AuthIndex: "codex-auth", Provider: "codex", ObservedAt: time.Now(), Headers: codexUsageHeader("4")},
+		{AuthType: "oauth", Provider: "codex", ObservedAt: time.Now(), Headers: codexUsageHeader("4")},
+		{AuthType: "oauth", AuthIndex: "provider-auth", Provider: "codex", ObservedAt: time.Now(), Headers: codexUsageHeader("4")},
+		{AuthType: "oauth", AuthIndex: "deleted-auth", Provider: "codex", ObservedAt: time.Now(), Headers: codexUsageHeader("4")},
+		{AuthType: "oauth", AuthIndex: "claude-auth", Provider: "codex", ObservedAt: time.Now(), Headers: codexUsageHeader("4")},
+		{AuthType: "oauth", AuthIndex: "codex-auth", Provider: "codex", ObservedAt: time.Now(), Headers: http.Header{"X-Codex-Credits-Has-Credits": []string{"False"}}},
+	}
+	for _, snapshot := range tests {
+		if service.applyUsageHeaderSnapshot(context.Background(), snapshot) {
+			t.Fatalf("expected snapshot to be ignored: %+v", snapshot)
+		}
+	}
+	if len(service.refreshTasks) != 0 {
+		t.Fatalf("expected no header cache tasks, got %+v", service.refreshTasks)
+	}
+}
+
+func TestStopRefreshTasksStopsUsageHeaderWorker(t *testing.T) {
+	service := NewServiceWithRegistry(openQuotaTestDatabase(t), NewProviderRegistry(nil))
+	service.StopRefreshTasks()
+
+	if service.TryAppendUsageHeaderSnapshots([]UsageHeaderSnapshot{codexUsageHeaderSnapshot("codex-auth", time.Now(), "4")}) {
+		t.Fatal("expected stopped usage header worker to reject new snapshots")
+	}
+}
+
+func TestTryAppendUsageHeaderSnapshotsWaitsForFlushBeforeApplyingOrQueryingIdentity(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	service := NewServiceWithRegistryAndOptions(db, NewProviderRegistry(nil), ServiceOptions{UsageHeaderSnapshotFlushInterval: time.Hour})
+	defer service.StopRefreshTasks()
+	identityQueries := 0
+	callbackName := "test:count_header_flush_identity_queries"
+	if err := db.Callback().Query().After("gorm:query").Register(callbackName, func(tx *gorm.DB) {
+		if queryMentionsTable(tx.Statement.SQL.String(), "usage_identities") {
+			identityQueries++
+		}
+	}); err != nil {
+		t.Fatalf("register query callback returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Callback().Query().Remove(callbackName) })
+
+	snapshot := codexUsageHeaderSnapshot("codex-auth", time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local), "4")
+	if !service.TryAppendUsageHeaderSnapshots([]UsageHeaderSnapshot{snapshot}) {
+		t.Fatal("expected snapshot append to be accepted")
+	}
+	snapshot.Headers.Set("X-Codex-Primary-Used-Percent", "99")
+
+	time.Sleep(30 * time.Millisecond)
+	if _, err := service.GetRefreshTaskByAuthIndex(context.Background(), "codex-auth"); err == nil {
+		t.Fatal("expected snapshot to remain pending before flush interval")
+	}
+	if identityQueries != 0 {
+		t.Fatalf("expected no identity query before header flush, got %d", identityQueries)
+	}
+
+	service.StopRefreshTasks()
+	task, err := service.GetRefreshTaskByAuthIndex(context.Background(), "codex-auth")
+	if err != nil {
+		t.Fatalf("GetRefreshTaskByAuthIndex returned error: %v", err)
+	}
+	if task.Quota == nil || len(task.Quota.Quota) != 1 || task.Quota.Quota[0].UsedPercent == nil || *task.Quota.Quota[0].UsedPercent != 4 {
+		t.Fatalf("expected stopped worker to flush cloned header snapshot, got %+v", task)
+	}
+}
+
+func TestTryAppendUsageHeaderSnapshotsFlushesPendingSnapshotsOnInterval(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	service := NewServiceWithRegistryAndOptions(db, NewProviderRegistry(nil), ServiceOptions{UsageHeaderSnapshotFlushInterval: 20 * time.Millisecond})
+	defer service.StopRefreshTasks()
+
+	if !service.TryAppendUsageHeaderSnapshots([]UsageHeaderSnapshot{codexUsageHeaderSnapshot("codex-auth", time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local), "4")}) {
+		t.Fatal("expected snapshot append to be accepted")
+	}
+
+	task := waitForRefreshTask(t, service, "codex-auth", RefreshTaskStatusCompleted)
+	if task.Quota == nil || len(task.Quota.Quota) != 1 || task.Quota.Quota[0].UsedPercent == nil || *task.Quota.Quota[0].UsedPercent != 4 {
+		t.Fatalf("expected interval flush to apply header snapshot, got %+v", task)
+	}
+}
+
+func TestTryAppendUsageHeaderSnapshotsKeepsLatestPendingSnapshotPerAuthIndex(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	service := NewServiceWithRegistryAndOptions(db, NewProviderRegistry(nil), ServiceOptions{UsageHeaderSnapshotFlushInterval: time.Hour})
+	defer service.StopRefreshTasks()
+	older := codexUsageHeaderSnapshot("codex-auth", time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local), "4")
+	newer := codexUsageHeaderSnapshot("codex-auth", time.Date(2026, 6, 22, 11, 0, 10, 0, time.Local), "9")
+
+	if !service.TryAppendUsageHeaderSnapshots([]UsageHeaderSnapshot{older}) {
+		t.Fatal("expected older snapshot append to be accepted")
+	}
+	if !service.TryAppendUsageHeaderSnapshots([]UsageHeaderSnapshot{newer}) {
+		t.Fatal("expected newer snapshot append to be accepted")
+	}
+	service.StopRefreshTasks()
+
+	task, err := service.GetRefreshTaskByAuthIndex(context.Background(), "codex-auth")
+	if err != nil {
+		t.Fatalf("GetRefreshTaskByAuthIndex returned error: %v", err)
+	}
+	if task.Quota == nil || len(task.Quota.Quota) != 1 || task.Quota.Quota[0].UsedPercent == nil || *task.Quota.Quota[0].UsedPercent != 9 {
+		t.Fatalf("expected latest pending snapshot to win, got %+v", task)
+	}
+}
+
+func TestTryAppendUsageHeaderSnapshotsFlushesDifferentAuthIndexesTogether(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth-1", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth-2", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	identityQueries := 0
+	priceQueries := 0
+	callbackName := "test:count_header_flush_batch_queries"
+	if err := db.Callback().Query().After("gorm:query").Register(callbackName, func(tx *gorm.DB) {
+		sql := tx.Statement.SQL.String()
+		if queryMentionsTable(sql, "usage_identities") {
+			identityQueries++
+		}
+		if queryMentionsTable(sql, "model_price_settings") {
+			priceQueries++
+		}
+	}); err != nil {
+		t.Fatalf("register query callback returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Callback().Query().Remove(callbackName) })
+	service := NewServiceWithRegistryAndOptions(db, NewProviderRegistry(nil), ServiceOptions{UsageHeaderSnapshotFlushInterval: time.Hour})
+	defer service.StopRefreshTasks()
+
+	if !service.TryAppendUsageHeaderSnapshots([]UsageHeaderSnapshot{
+		codexUsageHeaderSnapshot("codex-auth-1", time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local), "4"),
+		codexUsageHeaderSnapshot("codex-auth-2", time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local), "8"),
+	}) {
+		t.Fatal("expected snapshot append to be accepted")
+	}
+	service.StopRefreshTasks()
+
+	first, err := service.GetRefreshTaskByAuthIndex(context.Background(), "codex-auth-1")
+	if err != nil {
+		t.Fatalf("GetRefreshTaskByAuthIndex auth-1 returned error: %v", err)
+	}
+	second, err := service.GetRefreshTaskByAuthIndex(context.Background(), "codex-auth-2")
+	if err != nil {
+		t.Fatalf("GetRefreshTaskByAuthIndex auth-2 returned error: %v", err)
+	}
+	if first.Quota == nil || len(first.Quota.Quota) != 1 || first.Quota.Quota[0].UsedPercent == nil || *first.Quota.Quota[0].UsedPercent != 4 {
+		t.Fatalf("expected first auth header quota, got %+v", first)
+	}
+	if second.Quota == nil || len(second.Quota.Quota) != 1 || second.Quota.Quota[0].UsedPercent == nil || *second.Quota.Quota[0].UsedPercent != 8 {
+		t.Fatalf("expected second auth header quota, got %+v", second)
+	}
+	if identityQueries != 1 {
+		t.Fatalf("expected flush to batch identity lookup into 1 query, got %d", identityQueries)
+	}
+	if priceQueries != 1 {
+		t.Fatalf("expected flush to reuse one price settings query, got %d", priceQueries)
+	}
+}
+
+func seedUsageEvent(t *testing.T, db *gorm.DB, event entities.UsageEvent) {
+	t.Helper()
+	if event.EventKey == "" {
+		event.EventKey = "event-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	}
+	if err := db.Create(&event).Error; err != nil {
+		t.Fatalf("seed usage event: %v", err)
+	}
+}
+
+func codexUsageHeaderSnapshot(authIndex string, observedAt time.Time, usedPercent string) UsageHeaderSnapshot {
+	return UsageHeaderSnapshot{
+		AuthType:   "oauth",
+		AuthIndex:  authIndex,
+		Provider:   "codex",
+		ObservedAt: observedAt,
+		Headers:    codexUsageHeader(usedPercent),
+	}
+}
+
+func codexUsageHeader(usedPercent string) http.Header {
+	return http.Header{
+		"X-Codex-Primary-Used-Percent":   []string{usedPercent},
+		"X-Codex-Primary-Window-Minutes": []string{"300"},
+		"X-Codex-Primary-Reset-At":       []string{strconv.FormatInt(time.Date(2026, 6, 22, 15, 0, 0, 0, time.Local).Unix(), 10)},
+	}
+}
+
+func queryMentionsTable(sql string, table string) bool {
+	lowerSQL := strings.ToLower(sql)
+	table = strings.ToLower(table)
+	return strings.Contains(lowerSQL, "from `"+table+"`") ||
+		strings.Contains(lowerSQL, `from "`+table+`"`) ||
+		strings.Contains(lowerSQL, "from "+table)
+}

--- a/internal/quota/header_cache_worker_test.go
+++ b/internal/quota/header_cache_worker_test.go
@@ -2,6 +2,8 @@ package quota
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -243,6 +245,30 @@ func TestApplyUsageHeaderSnapshotUpdatesRecentCompletedCacheAndRefreshesWindowUs
 	task := service.refreshTasks["codex-auth"]
 	if task.Quota == nil || len(task.Quota.Quota) != 1 || task.Quota.Quota[0].UsedPercent == nil || *task.Quota.Quota[0].UsedPercent != 4 {
 		t.Fatalf("expected recent header progress to update cache, got %+v", task)
+	}
+}
+
+func TestApplyUsageHeaderSnapshotsSkipsBatchWhenWindowStatsProviderUnavailable(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	callbackName := "test:fail_header_batch_window_stats_provider"
+	if err := db.Callback().Query().After("gorm:query").Register(callbackName, func(tx *gorm.DB) {
+		if queryMentionsTable(tx.Statement.SQL.String(), "model_price_settings") {
+			tx.AddError(fmt.Errorf("forced model price settings failure"))
+		}
+	}); err != nil {
+		t.Fatalf("register query callback returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Callback().Query().Remove(callbackName) })
+	service := NewServiceWithRegistry(db, NewProviderRegistry(nil))
+	defer service.StopRefreshTasks()
+
+	service.applyUsageHeaderSnapshots(context.Background(), []UsageHeaderSnapshot{
+		codexUsageHeaderSnapshot("codex-auth", time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local), "4"),
+	})
+
+	if _, err := service.GetRefreshTaskByAuthIndex(context.Background(), "codex-auth"); !errors.Is(err, ErrTaskNotFound) {
+		t.Fatalf("expected provider failure to skip the whole header batch, got err=%v", err)
 	}
 }
 

--- a/internal/quota/header_snapshot.go
+++ b/internal/quota/header_snapshot.go
@@ -1,0 +1,116 @@
+package quota
+
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+const codexHeaderSnapshotValueMaxLength = 4096
+
+type UsageHeaderSnapshotInput struct {
+	AuthType   string
+	AuthIndex  string
+	Provider   string
+	ObservedAt time.Time
+	Headers    http.Header
+}
+
+type UsageHeaderSnapshot struct {
+	AuthType   string
+	AuthIndex  string
+	Provider   string
+	ObservedAt time.Time
+	Headers    http.Header
+}
+
+type UsageHeaderSnapshotAppender interface {
+	TryAppendUsageHeaderSnapshots([]UsageHeaderSnapshot) bool
+}
+
+type usageHeaderSnapshotProcessor interface {
+	TryBuildUsageHeaderSnapshot(UsageHeaderSnapshotInput) (*UsageHeaderSnapshot, bool)
+}
+
+var usageHeaderSnapshotProcessors = []usageHeaderSnapshotProcessor{
+	codexUsageHeaderSnapshotProcessor{},
+}
+
+func BuildUsageHeaderSnapshot(input UsageHeaderSnapshotInput) (*UsageHeaderSnapshot, bool) {
+	for _, processor := range usageHeaderSnapshotProcessors {
+		if snapshot, ok := processor.TryBuildUsageHeaderSnapshot(input); ok {
+			return snapshot, true
+		}
+	}
+	return nil, false
+}
+
+type codexUsageHeaderSnapshotProcessor struct{}
+
+func (codexUsageHeaderSnapshotProcessor) TryBuildUsageHeaderSnapshot(input UsageHeaderSnapshotInput) (*UsageHeaderSnapshot, bool) {
+	authType := strings.ToLower(strings.TrimSpace(input.AuthType))
+	authIndex := strings.TrimSpace(input.AuthIndex)
+	if authType != "oauth" || authIndex == "" || len(input.Headers) == 0 {
+		return nil, false
+	}
+	headers := codexQuotaSnapshotHeaders(input.Headers)
+	if _, ok := parseCodexHeaderQuota(headers); !ok {
+		return nil, false
+	}
+	return &UsageHeaderSnapshot{
+		AuthType:   authType,
+		AuthIndex:  authIndex,
+		Provider:   strings.TrimSpace(input.Provider),
+		ObservedAt: input.ObservedAt,
+		Headers:    headers,
+	}, true
+}
+
+func codexQuotaSnapshotHeaders(headers http.Header) http.Header {
+	canonical := canonicalQuotaHeaders(headers)
+	if len(canonical) == 0 {
+		return nil
+	}
+	filtered := make(http.Header)
+	for key, values := range canonical {
+		if !isCodexQuotaHeaderKey(key) {
+			continue
+		}
+		if value, ok := firstBoundedHeaderValue(values); ok {
+			filtered.Set(key, value)
+		}
+	}
+	return filtered
+}
+
+func isCodexQuotaHeaderKey(key string) bool {
+	if key == "X-Codex-Plan-Type" {
+		return true
+	}
+	if !strings.HasPrefix(key, codexHeaderPrefix) {
+		return false
+	}
+	for _, suffix := range []string{
+		"-Limit-Name",
+		"-Used-Percent",
+		"-Window-Minutes",
+		"-Reset-At",
+		"-Reset-After-Seconds",
+	} {
+		if strings.HasSuffix(key, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func firstBoundedHeaderValue(values []string) (string, bool) {
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" || len(trimmed) > codexHeaderSnapshotValueMaxLength {
+			continue
+		}
+		return trimmed, true
+	}
+	return "", false
+}

--- a/internal/quota/refresh.go
+++ b/internal/quota/refresh.go
@@ -22,6 +22,7 @@ const (
 	RefreshSourceInspection    RefreshSource = "inspection"
 	RefreshSourceScheduled     RefreshSource = "scheduled"
 	RefreshSourceCacheBackfill RefreshSource = "cache_backfill"
+	RefreshSourceUsageHeader   RefreshSource = "usage_header"
 )
 
 type RefreshTaskStatus string

--- a/internal/quota/service.go
+++ b/internal/quota/service.go
@@ -18,9 +18,12 @@ import (
 )
 
 type ServiceOptions struct {
-	RefreshWorkerLimit  int
-	AutoRefreshInterval time.Duration
+	RefreshWorkerLimit               int
+	AutoRefreshInterval              time.Duration
+	UsageHeaderSnapshotFlushInterval time.Duration
 }
+
+const usageHeaderSnapshotQueueSize = 100
 
 type Service struct {
 	db       *gorm.DB
@@ -62,6 +65,15 @@ type Service struct {
 	refreshClosing bool
 	// refreshWG 跟踪 service 派生的 dispatcher/worker/heartbeat goroutine，App 关闭 DB 前会等待它们退出。
 	refreshWG sync.WaitGroup
+
+	usageHeaderCh            chan []UsageHeaderSnapshot
+	usageHeaderSlots         chan struct{}
+	usageHeaderStopCh        chan struct{}
+	usageHeaderDoneCh        chan struct{}
+	usageHeaderFlushInterval time.Duration
+	usageHeaderMu            sync.Mutex
+	usageHeaderClosing       bool
+	usageHeaderCloseOnce     sync.Once
 }
 
 type CheckRequest struct {
@@ -98,20 +110,34 @@ func NewServiceWithRegistryAndOptions(db *gorm.DB, registry ProviderRegistry, op
 	if autoRefreshInterval <= 0 {
 		autoRefreshInterval = AutoRefreshInterval
 	}
-	refreshContext, refreshCancel := context.WithCancel(context.Background())
-	return &Service{
-		db:                   db,
-		registry:             registry,
-		refreshTasks:         make(map[string]*RefreshTaskRecord),
-		resetInFlight:        make(map[string]struct{}),
-		refreshWorkerTokens:  make(chan struct{}, workerLimit),
-		refreshTaskTTL:       RefreshTransientTaskTTL,
-		refreshCooldown:      time.Sleep,
-		refreshContext:       refreshContext,
-		refreshCancel:        refreshCancel,
-		autoRefreshInterval:  autoRefreshInterval,
-		autoRefreshActiveTTL: AutoRefreshActiveTTL,
+	usageHeaderFlushInterval := options.UsageHeaderSnapshotFlushInterval
+	if usageHeaderFlushInterval <= 0 {
+		usageHeaderFlushInterval = usageHeaderSnapshotFlushInterval
 	}
+	refreshContext, refreshCancel := context.WithCancel(context.Background())
+	service := &Service{
+		db:                       db,
+		registry:                 registry,
+		refreshTasks:             make(map[string]*RefreshTaskRecord),
+		resetInFlight:            make(map[string]struct{}),
+		refreshWorkerTokens:      make(chan struct{}, workerLimit),
+		refreshTaskTTL:           RefreshTransientTaskTTL,
+		refreshCooldown:          time.Sleep,
+		refreshContext:           refreshContext,
+		refreshCancel:            refreshCancel,
+		autoRefreshInterval:      autoRefreshInterval,
+		autoRefreshActiveTTL:     AutoRefreshActiveTTL,
+		usageHeaderCh:            make(chan []UsageHeaderSnapshot, usageHeaderSnapshotQueueSize),
+		usageHeaderSlots:         make(chan struct{}, usageHeaderSnapshotQueueSize),
+		usageHeaderStopCh:        make(chan struct{}),
+		usageHeaderDoneCh:        make(chan struct{}),
+		usageHeaderFlushInterval: usageHeaderFlushInterval,
+	}
+	for i := 0; i < usageHeaderSnapshotQueueSize; i++ {
+		service.usageHeaderSlots <- struct{}{}
+	}
+	go service.runUsageHeaderSnapshotWorker()
+	return service
 }
 
 func (s *Service) SetRefreshContext(ctx context.Context) {
@@ -212,6 +238,7 @@ func (s *Service) StopRefreshTasks() {
 	if cancel != nil {
 		cancel()
 	}
+	s.stopUsageHeaderSnapshotWorker()
 	s.refreshWG.Wait()
 }
 

--- a/internal/quota/usage_stats.go
+++ b/internal/quota/usage_stats.go
@@ -19,6 +19,9 @@ type usageWindowStatsProvider interface {
 }
 
 func (s *Service) attachWindowUsageStats(ctx context.Context, authIndex string, response CheckResponse, now time.Time) CheckResponse {
+	if s == nil {
+		return response
+	}
 	calculator, err := repository.NewUsageWindowStatsCalculator(ctx, s.db)
 	if err != nil {
 		return response

--- a/internal/quota/usage_stats.go
+++ b/internal/quota/usage_stats.go
@@ -14,9 +14,21 @@ type quotaUsageWindowKey struct {
 	end   time.Time
 }
 
+type usageWindowStatsProvider interface {
+	SumByAuthIndex(context.Context, string, time.Time, *time.Time) (repository.UsageWindowStats, error)
+}
+
 func (s *Service) attachWindowUsageStats(ctx context.Context, authIndex string, response CheckResponse, now time.Time) CheckResponse {
+	calculator, err := repository.NewUsageWindowStatsCalculator(ctx, s.db)
+	if err != nil {
+		return response
+	}
+	return s.attachWindowUsageStatsWithProvider(ctx, authIndex, response, now, calculator)
+}
+
+func (s *Service) attachWindowUsageStatsWithProvider(ctx context.Context, authIndex string, response CheckResponse, now time.Time, statsProvider usageWindowStatsProvider) CheckResponse {
 	// quota 为空时没有可补充的窗口用量，直接返回原响应。
-	if len(response.Quota) == 0 {
+	if len(response.Quota) == 0 || statsProvider == nil {
 		// 返回原响应，避免后续 map 和数据库查询开销。
 		return response
 	}
@@ -48,7 +60,7 @@ func (s *Service) attachWindowUsageStats(ctx context.Context, authIndex string, 
 			// repository 内部会按窗口长度选择 raw group by 或 hourly rollup。
 			var err error
 			// 调用窗口统计查询，end 使用半开区间避免重复累计边界事件。
-			stats, err = repository.SumUsageWindowStatsByAuthIndex(ctx, s.db, authIndex, windowStart, &windowEnd)
+			stats, err = statsProvider.SumByAuthIndex(ctx, authIndex, windowStart, &windowEnd)
 			// 统计失败不影响 quota 主结果，只跳过当前窗口用量展示。
 			if err != nil {
 				// 当前 row 不写 token/cost，继续处理其它 row。

--- a/internal/quota/usage_stats_test.go
+++ b/internal/quota/usage_stats_test.go
@@ -68,6 +68,20 @@ func TestQuotaRowUsageWindowRejectsNegativeResetAfterSeconds(t *testing.T) {
 	}
 }
 
+func TestAttachWindowUsageStatsNilServiceReturnsOriginalResponse(t *testing.T) {
+	var service *Service
+	response := CheckResponse{ID: "auth-nil", Quota: []QuotaRow{{
+		Key:   "rate_limit.primary_window",
+		Label: "5h",
+	}}}
+
+	got := service.attachWindowUsageStats(context.Background(), "auth-nil", response, time.Now())
+
+	if got.ID != response.ID || len(got.Quota) != 1 || got.Quota[0].Key != response.Quota[0].Key {
+		t.Fatalf("expected nil service to return original response, got %#v", got)
+	}
+}
+
 func TestAttachWindowUsageStatsOnlyBackfillsMissingKnownWindowScopeRows(t *testing.T) {
 	db := openQuotaUsageStatsTestDB(t)
 	service := &Service{db: db}

--- a/internal/repository/usage_identities.go
+++ b/internal/repository/usage_identities.go
@@ -97,6 +97,8 @@ const usageIdentityReadColumns = "id, name, auth_type, auth_type_name, identity,
 
 const usageIdentityAggregationColumns = "id, auth_type, identity, total_requests, success_count, failure_count, input_tokens, output_tokens, reasoning_tokens, cached_tokens, total_tokens, last_aggregated_usage_event_id, first_used_at, last_used_at"
 
+const activeAuthFileUsageIdentityLookupBatchSize = 500
+
 func ListUsageIdentities(ctx context.Context, db *gorm.DB) ([]entities.UsageIdentity, error) {
 	if db == nil {
 		return nil, fmt.Errorf("database is nil")
@@ -232,6 +234,50 @@ func GetActiveAuthFileUsageIdentityByAuthIndex(ctx context.Context, db *gorm.DB,
 		return identity, fmt.Errorf("get active auth file usage identity by auth index: %w", err)
 	}
 	return identity, nil
+}
+
+func ListActiveAuthFileUsageIdentitiesByAuthIndexes(ctx context.Context, db *gorm.DB, authIndexes []string) ([]entities.UsageIdentity, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database is nil")
+	}
+	authIndexes = normalizeUniqueAuthIndexes(authIndexes)
+	if len(authIndexes) == 0 {
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	identities := make([]entities.UsageIdentity, 0, len(authIndexes))
+	queryDB := db.WithContext(ctx)
+	for start := 0; start < len(authIndexes); start += activeAuthFileUsageIdentityLookupBatchSize {
+		end := min(start+activeAuthFileUsageIdentityLookupBatchSize, len(authIndexes))
+		var batch []entities.UsageIdentity
+		if err := queryDB.
+			Select(usageIdentityReadColumns).
+			Where("auth_type = ? AND identity IN ? AND is_deleted = ?", entities.UsageIdentityAuthTypeAuthFile, authIndexes[start:end], false).
+			Find(&batch).Error; err != nil {
+			return nil, fmt.Errorf("list active auth file usage identities by auth indexes: %w", err)
+		}
+		identities = append(identities, batch...)
+	}
+	return identities, nil
+}
+
+func normalizeUniqueAuthIndexes(authIndexes []string) []string {
+	normalized := make([]string, 0, len(authIndexes))
+	seen := make(map[string]struct{}, len(authIndexes))
+	for _, authIndex := range authIndexes {
+		authIndex = strings.TrimSpace(authIndex)
+		if authIndex == "" {
+			continue
+		}
+		if _, ok := seen[authIndex]; ok {
+			continue
+		}
+		seen[authIndex] = struct{}{}
+		normalized = append(normalized, authIndex)
+	}
+	return normalized
 }
 
 func AggregateUsageIdentityStats(ctx context.Context, db *gorm.DB, now time.Time) error {

--- a/internal/repository/usage_window_stats.go
+++ b/internal/repository/usage_window_stats.go
@@ -20,6 +20,11 @@ type UsageWindowStats struct {
 	Cost   float64
 }
 
+type UsageWindowStatsCalculator struct {
+	db             *gorm.DB
+	pricingByModel map[string]entities.ModelPriceSetting
+}
+
 type usageWindowTokenStats struct {
 	Model               string `gorm:"column:model"`
 	TotalTokens         int64  `gorm:"column:total_tokens"`
@@ -28,6 +33,39 @@ type usageWindowTokenStats struct {
 	CachedTokens        int64  `gorm:"column:cached_tokens"`
 	CacheReadTokens     int64  `gorm:"column:cache_read_tokens"`
 	CacheCreationTokens int64  `gorm:"column:cache_creation_tokens"`
+}
+
+func NewUsageWindowStatsCalculator(ctx context.Context, db *gorm.DB) (*UsageWindowStatsCalculator, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	queryDB := db.WithContext(ctx)
+	pricingByModel, err := loadPriceSettingsByModel(queryDB)
+	if err != nil {
+		return nil, err
+	}
+	return &UsageWindowStatsCalculator{db: db, pricingByModel: pricingByModel}, nil
+}
+
+func (c *UsageWindowStatsCalculator) SumByAuthIndex(ctx context.Context, authIndex string, start time.Time, end *time.Time) (UsageWindowStats, error) {
+	if c == nil || c.db == nil {
+		return UsageWindowStats{}, fmt.Errorf("usage window stats calculator is nil")
+	}
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex == "" {
+		return UsageWindowStats{}, fmt.Errorf("auth_index is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	rows, err := loadUsageWindowTokenStats(c.db.WithContext(ctx), authIndex, start, end)
+	if err != nil {
+		return UsageWindowStats{}, err
+	}
+	return usageWindowStatsFromTokenStats(rows, c.pricingByModel), nil
 }
 
 func SumUsageWindowStatsByAuthIndex(ctx context.Context, db *gorm.DB, authIndex string, start time.Time, end *time.Time) (UsageWindowStats, error) {

--- a/internal/service/redis_usage.go
+++ b/internal/service/redis_usage.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -132,8 +133,7 @@ func (d queuedUsageDetail) toUsageHeaderSnapshot(event entities.UsageEvent) *quo
 }
 
 func decodeRedisUsageResponseHeaders(raw json.RawMessage) (http.Header, bool) {
-	trimmed := strings.TrimSpace(string(raw))
-	if trimmed == "" || trimmed == "null" {
+	if rawJSONMessageIsEmptyOrNull(raw) {
 		return nil, false
 	}
 	var headers http.Header
@@ -154,6 +154,11 @@ func decodeRedisUsageResponseHeaders(raw json.RawMessage) (http.Header, bool) {
 		return nil, false
 	}
 	return headers, true
+}
+
+func rawJSONMessageIsEmptyOrNull(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) == 0 || (len(trimmed) == 4 && trimmed[0] == 'n' && trimmed[1] == 'u' && trimmed[2] == 'l' && trimmed[3] == 'l')
 }
 
 func decodeRedisUsageHeaderValues(raw json.RawMessage) []string {

--- a/internal/service/redis_usage.go
+++ b/internal/service/redis_usage.go
@@ -3,46 +3,56 @@ package service
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
 	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/quota"
 	"cpa-usage-keeper/internal/repository/dto"
 	"cpa-usage-keeper/internal/timeutil"
 )
 
 // DecodeRedisUsageMessage 将 redis_inboxes.raw_message 原样解码为 usage_events 入库实体。
 func DecodeRedisUsageMessage(message string, fetchedAt time.Time) (entities.UsageEvent, json.RawMessage, error) {
+	event, raw, _, err := DecodeRedisUsageMessageWithHeaders(message, fetchedAt)
+	return event, raw, err
+}
+
+// DecodeRedisUsageMessageWithHeaders 解码 usage event，并在 OAuth 响应携带 headers 时抽取 quota cache 更新快照。
+func DecodeRedisUsageMessageWithHeaders(message string, fetchedAt time.Time) (entities.UsageEvent, json.RawMessage, *quota.UsageHeaderSnapshot, error) {
 	raw := json.RawMessage(message)
 	var payload queuedUsageDetail
 	if err := json.Unmarshal(raw, &payload); err != nil {
-		return entities.UsageEvent{}, nil, fmt.Errorf("decode redis usage message: %w", err)
+		return entities.UsageEvent{}, nil, nil, fmt.Errorf("decode redis usage message: %w", err)
 	}
 	if strings.TrimSpace(payload.RequestID) == "" {
-		return entities.UsageEvent{}, raw, fmt.Errorf("decode redis usage message: request_id is required")
+		return entities.UsageEvent{}, raw, nil, fmt.Errorf("decode redis usage message: request_id is required")
 	}
-	return payload.toUsageEvent(fetchedAt), raw, nil
+	event := payload.toUsageEvent(fetchedAt)
+	return event, raw, payload.toUsageHeaderSnapshot(event), nil
 }
 
 // queuedUsageDetail 对应 CPA Redis 队列中的单条 usage JSON payload。
 type queuedUsageDetail struct {
-	Timestamp       time.Time      `json:"timestamp"`
-	LatencyMS       int64          `json:"latency_ms"`
-	TTFTMS          *int64         `json:"ttft_ms"`
-	Source          string         `json:"source"`
-	AuthIndex       string         `json:"auth_index"`
-	Tokens          dto.TokenStats `json:"tokens"`
-	Failed          bool           `json:"failed"`
-	Provider        string         `json:"provider"`
-	Model           string         `json:"model"`
-	Alias           *string        `json:"alias"`
-	ReasoningEffort string         `json:"reasoning_effort"`
-	ServiceTier     string         `json:"service_tier"`
-	ExecutorType    string         `json:"executor_type"`
-	Endpoint        string         `json:"endpoint"`
-	AuthType        string         `json:"auth_type"`
-	APIKey          string         `json:"api_key"`
-	RequestID       string         `json:"request_id"`
+	Timestamp       time.Time       `json:"timestamp"`
+	LatencyMS       int64           `json:"latency_ms"`
+	TTFTMS          *int64          `json:"ttft_ms"`
+	Source          string          `json:"source"`
+	AuthIndex       string          `json:"auth_index"`
+	Tokens          dto.TokenStats  `json:"tokens"`
+	Failed          bool            `json:"failed"`
+	Provider        string          `json:"provider"`
+	Model           string          `json:"model"`
+	Alias           *string         `json:"alias"`
+	ReasoningEffort string          `json:"reasoning_effort"`
+	ServiceTier     string          `json:"service_tier"`
+	ExecutorType    string          `json:"executor_type"`
+	Endpoint        string          `json:"endpoint"`
+	AuthType        string          `json:"auth_type"`
+	APIKey          string          `json:"api_key"`
+	RequestID       string          `json:"request_id"`
+	ResponseHeaders json.RawMessage `json:"response_headers"`
 }
 
 func normalizeRedisAuthType(value string) string {
@@ -101,4 +111,69 @@ func (d queuedUsageDetail) toUsageEvent(fetchedAt time.Time) entities.UsageEvent
 		CacheCreationTokens: d.Tokens.CacheCreationTokens,
 		TotalTokens:         d.Tokens.TotalTokens,
 	}
+}
+
+func (d queuedUsageDetail) toUsageHeaderSnapshot(event entities.UsageEvent) *quota.UsageHeaderSnapshot {
+	headers, ok := decodeRedisUsageResponseHeaders(d.ResponseHeaders)
+	if !ok {
+		return nil
+	}
+	snapshot, ok := quota.BuildUsageHeaderSnapshot(quota.UsageHeaderSnapshotInput{
+		AuthType:   event.AuthType,
+		AuthIndex:  event.AuthIndex,
+		Provider:   event.Provider,
+		ObservedAt: event.Timestamp,
+		Headers:    headers,
+	})
+	if !ok {
+		return nil
+	}
+	return snapshot
+}
+
+func decodeRedisUsageResponseHeaders(raw json.RawMessage) (http.Header, bool) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return nil, false
+	}
+	var headers http.Header
+	if err := json.Unmarshal(raw, &headers); err == nil && len(headers) > 0 {
+		return headers, true
+	}
+	var rawHeaders map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &rawHeaders); err != nil || len(rawHeaders) == 0 {
+		return nil, false
+	}
+	headers = make(http.Header, len(rawHeaders))
+	for key, rawValue := range rawHeaders {
+		for _, value := range decodeRedisUsageHeaderValues(rawValue) {
+			headers.Add(key, value)
+		}
+	}
+	if len(headers) == 0 {
+		return nil, false
+	}
+	return headers, true
+}
+
+func decodeRedisUsageHeaderValues(raw json.RawMessage) []string {
+	var value string
+	if err := json.Unmarshal(raw, &value); err == nil {
+		return []string{value}
+	}
+	var values []string
+	if err := json.Unmarshal(raw, &values); err == nil {
+		return values
+	}
+	var rawValues []json.RawMessage
+	if err := json.Unmarshal(raw, &rawValues); err != nil {
+		return nil
+	}
+	values = make([]string, 0, len(rawValues))
+	for _, rawValue := range rawValues {
+		if err := json.Unmarshal(rawValue, &value); err == nil {
+			values = append(values, value)
+		}
+	}
+	return values
 }

--- a/internal/service/redis_usage_test.go
+++ b/internal/service/redis_usage_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -124,6 +125,19 @@ func TestDecodeRedisUsageMessageWithHeadersSkipsMalformedHeadersWithoutBlockingE
 	}
 	if snapshot != nil {
 		t.Fatalf("expected malformed headers to skip quota snapshot, got %+v", snapshot)
+	}
+}
+
+func TestDecodeRedisUsageResponseHeadersSkipsNullWithoutAllocating(t *testing.T) {
+	raw := json.RawMessage(" \nnull\t")
+	allocs := testing.AllocsPerRun(1000, func() {
+		headers, ok := decodeRedisUsageResponseHeaders(raw)
+		if ok || headers != nil {
+			t.Fatalf("expected null response_headers to be skipped, got ok=%v headers=%+v", ok, headers)
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("expected null response_headers check to avoid allocations, got %.2f", allocs)
 	}
 }
 

--- a/internal/service/redis_usage_test.go
+++ b/internal/service/redis_usage_test.go
@@ -71,6 +71,100 @@ func TestDecodeRedisUsageMessageRequiresRequestID(t *testing.T) {
 	}
 }
 
+func TestDecodeRedisUsageMessageWithHeadersExtractsQuotaSnapshot(t *testing.T) {
+	fetchedAt := time.Date(2026, 6, 22, 11, 10, 43, 0, time.Local)
+	event, _, snapshot, err := DecodeRedisUsageMessageWithHeaders(`{
+		"timestamp":"2026-06-22T11:10:43+08:00",
+		"auth_type":"oauth",
+		"auth_index":"codex-auth",
+		"provider":"codex",
+		"request_id":"req-header",
+		"response_headers":{
+			"X-Codex-Plan-Type":["pro"],
+			"X-Codex-Primary-Used-Percent":["4"],
+			"X-Codex-Primary-Window-Minutes":["300"],
+			"X-Codex-Primary-Reset-After-Seconds":["60"]
+		}
+	}`, fetchedAt)
+	if err != nil {
+		t.Fatalf("DecodeRedisUsageMessageWithHeaders returned error: %v", err)
+	}
+	if event.AuthType != "oauth" || event.AuthIndex != "codex-auth" {
+		t.Fatalf("unexpected event identity: %+v", event)
+	}
+	if snapshot == nil {
+		t.Fatal("expected quota header snapshot")
+	}
+	if snapshot.AuthType != "oauth" || snapshot.AuthIndex != "codex-auth" || snapshot.Provider != "codex" {
+		t.Fatalf("unexpected snapshot identity: %+v", snapshot)
+	}
+	if snapshot.Headers.Get("X-Codex-Plan-Type") != "pro" {
+		t.Fatalf("expected codex plan header, got %#v", snapshot.Headers)
+	}
+	if snapshot.ObservedAt.IsZero() {
+		t.Fatalf("expected observed timestamp")
+	}
+}
+
+func TestDecodeRedisUsageMessageWithHeadersSkipsMalformedHeadersWithoutBlockingEvent(t *testing.T) {
+	fetchedAt := time.Date(2026, 6, 22, 11, 10, 43, 0, time.Local)
+	event, _, snapshot, err := DecodeRedisUsageMessageWithHeaders(`{
+		"timestamp":"2026-06-22T11:10:43+08:00",
+		"auth_type":"oauth",
+		"auth_index":"codex-auth",
+		"provider":"codex",
+		"request_id":"req-header-malformed",
+		"response_headers":"not-a-header-map"
+	}`, fetchedAt)
+	if err != nil {
+		t.Fatalf("DecodeRedisUsageMessageWithHeaders returned error: %v", err)
+	}
+	if event.RequestID != "req-header-malformed" || event.AuthIndex != "codex-auth" {
+		t.Fatalf("expected usage event to decode despite malformed headers, got %+v", event)
+	}
+	if snapshot != nil {
+		t.Fatalf("expected malformed headers to skip quota snapshot, got %+v", snapshot)
+	}
+}
+
+func TestDecodeRedisUsageMessageWithHeadersSkipsHeadersWithoutCompleteCodexQuota(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers string
+	}{
+		{
+			name:    "ordinary response headers",
+			headers: `"Date":["Mon, 22 Jun 2026 03:10:44 GMT"]`,
+		},
+		{
+			name:    "codex quota without reset boundary",
+			headers: `"X-Codex-Primary-Used-Percent":["4"],"X-Codex-Primary-Window-Minutes":["300"]`,
+		},
+		{
+			name:    "codex quota without window minutes",
+			headers: `"X-Codex-Primary-Used-Percent":["4"],"X-Codex-Primary-Reset-After-Seconds":["60"]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, snapshot, err := DecodeRedisUsageMessageWithHeaders(`{
+				"timestamp":"2026-06-22T11:10:43+08:00",
+				"auth_type":"oauth",
+				"auth_index":"codex-auth",
+				"provider":"codex",
+				"request_id":"req-header-ignored",
+				"response_headers":{`+tt.headers+`}
+			}`, time.Date(2026, 6, 22, 11, 10, 43, 0, time.Local))
+			if err != nil {
+				t.Fatalf("DecodeRedisUsageMessageWithHeaders returned error: %v", err)
+			}
+			if snapshot != nil {
+				t.Fatalf("expected incomplete/non-codex headers to skip quota snapshot, got %+v", snapshot)
+			}
+		})
+	}
+}
+
 func TestDecodeRedisUsageMessageFallsBackToProviderWhenAPIKeyIsBlank(t *testing.T) {
 	event, _, err := DecodeRedisUsageMessage(`{"api_key":"   ","provider":"claude","endpoint":"/v1/messages","request_id":"req-blank-key"}`, time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC))
 	if err != nil {

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -9,6 +9,7 @@ import (
 	"cpa-usage-keeper/internal/config"
 	"cpa-usage-keeper/internal/cpa"
 	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/quota"
 	"cpa-usage-keeper/internal/repository"
 	"cpa-usage-keeper/internal/timeutil"
 
@@ -53,12 +54,13 @@ const (
 
 // SyncService 负责同步 CPA metadata，并处理已经落入本地 inbox 的 usage 原始消息。
 type SyncService struct {
-	db              *gorm.DB
-	client          CPAClientFetcher
-	metadataFetcher MetadataFetcher
-	baseURL         string
-	now             func() time.Time
-	recentUsage     RecentUsageEventAppender
+	db               *gorm.DB
+	client           CPAClientFetcher
+	metadataFetcher  MetadataFetcher
+	baseURL          string
+	now              func() time.Time
+	recentUsage      RecentUsageEventAppender
+	usageHeaderQuota quota.UsageHeaderSnapshotAppender
 }
 
 // NewSyncService 按生产配置组装 CPA metadata client；远端 usage 拉取由 poller 独立负责。
@@ -76,6 +78,7 @@ type SyncServiceOptions struct {
 	MetadataFetcher   MetadataFetcher
 	Now               func() time.Time
 	RecentUsageEvents RecentUsageEventAppender
+	UsageHeaderQuota  quota.UsageHeaderSnapshotAppender
 }
 
 // NewSyncServiceWithOptions 是统一构造入口，负责填充默认时钟和 metadata fetcher。
@@ -89,12 +92,13 @@ func NewSyncServiceWithOptions(db *gorm.DB, opts SyncServiceOptions) *SyncServic
 		metadataFetcher = opts.Client
 	}
 	return &SyncService{
-		db:              db,
-		client:          opts.Client,
-		metadataFetcher: metadataFetcher,
-		baseURL:         strings.TrimSpace(opts.BaseURL),
-		now:             now,
-		recentUsage:     opts.RecentUsageEvents,
+		db:               db,
+		client:           opts.Client,
+		metadataFetcher:  metadataFetcher,
+		baseURL:          strings.TrimSpace(opts.BaseURL),
+		now:              now,
+		recentUsage:      opts.RecentUsageEvents,
+		usageHeaderQuota: opts.UsageHeaderQuota,
 	}
 }
 
@@ -201,10 +205,11 @@ func (s *SyncService) processRedisInboxRows(ctx context.Context, inboxRows []ent
 	logrus.WithField("row_count", len(inboxRows)).Debug("redis usage inbox processing started")
 	validRows := make([]entities.RedisUsageInbox, 0, len(inboxRows))
 	events := make([]entities.UsageEvent, 0, len(inboxRows))
+	headerSnapshots := make([]quota.UsageHeaderSnapshot, 0)
 	decodeErrs := make([]error, 0)
 	// 先完整解码本批数据，坏消息单独标记，不阻断同批其它可用消息。
 	for _, row := range inboxRows {
-		event, _, decodeErr := DecodeRedisUsageMessage(row.RawMessage, fetchedAt)
+		event, _, snapshot, decodeErr := DecodeRedisUsageMessageWithHeaders(row.RawMessage, fetchedAt)
 		if decodeErr != nil {
 			logrus.WithError(decodeErr).WithField("inbox_id", row.ID).Error("redis usage message decode failed")
 			if markErr := repository.MarkRedisUsageInboxDecodeFailed(s.db, row.ID, decodeErr); markErr != nil {
@@ -215,6 +220,9 @@ func (s *SyncService) processRedisInboxRows(ctx context.Context, inboxRows []ent
 		}
 		validRows = append(validRows, row)
 		events = append(events, event)
+		if snapshot != nil {
+			headerSnapshots = append(headerSnapshots, *snapshot)
+		}
 	}
 	decodeErr := joinErrors(decodeErrs...)
 	logrus.WithFields(logrus.Fields{
@@ -272,6 +280,12 @@ func (s *SyncService) processRedisInboxRows(ctx context.Context, inboxRows []ent
 		if err := s.aggregateUsageEventStats(ctx, timeutil.NormalizeStorageTime(s.now())); err != nil {
 			return &servicedto.RedisBatchSyncResult{Status: "failed"}, err
 		}
+		// header quota 需要复用窗口 token/cost 兜底统计，因此必须在 usage overview 聚合追平后再通知 worker。
+		headerSnapshots = coalesceUsageHeaderSnapshotsByAuthIndex(headerSnapshots)
+		if s.usageHeaderQuota != nil && len(headerSnapshots) > 0 && !s.usageHeaderQuota.TryAppendUsageHeaderSnapshots(headerSnapshots) {
+			// header worker 队列满只影响 quota cache 新鲜度，不能影响 usage_events 写入成功。
+			logrus.WithField("snapshot_count", len(headerSnapshots)).Warn("usage header quota cache append skipped")
+		}
 	}
 	logrus.WithFields(logrus.Fields{
 		"processed_rows":  len(validRows),
@@ -296,6 +310,30 @@ func (s *SyncService) processRedisInboxRows(ctx context.Context, inboxRows []ent
 		InsertedEvents: result.InsertedEvents,
 		DedupedEvents:  result.DedupedEvents,
 	}, returnErr
+}
+
+func coalesceUsageHeaderSnapshotsByAuthIndex(snapshots []quota.UsageHeaderSnapshot) []quota.UsageHeaderSnapshot {
+	if len(snapshots) <= 1 {
+		return snapshots
+	}
+	indexByAuthIndex := make(map[string]int, len(snapshots))
+	coalesced := make([]quota.UsageHeaderSnapshot, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		authIndex := strings.TrimSpace(snapshot.AuthIndex)
+		if authIndex == "" {
+			continue
+		}
+		snapshot.AuthIndex = authIndex
+		if index, ok := indexByAuthIndex[authIndex]; ok {
+			if !snapshot.ObservedAt.Before(coalesced[index].ObservedAt) {
+				coalesced[index] = snapshot
+			}
+			continue
+		}
+		indexByAuthIndex[authIndex] = len(coalesced)
+		coalesced = append(coalesced, snapshot)
+	}
+	return coalesced
 }
 
 type usageEventTypeResolver struct {

--- a/internal/service/sync_test.go
+++ b/internal/service/sync_test.go
@@ -18,6 +18,7 @@ import (
 	"cpa-usage-keeper/internal/cpa/dto/providerconfig"
 	"cpa-usage-keeper/internal/cpa/dto/response"
 	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/quota"
 	"cpa-usage-keeper/internal/repository"
 	"cpa-usage-keeper/internal/repository/dto"
 	servicedto "cpa-usage-keeper/internal/service/dto"
@@ -67,10 +68,37 @@ type recordingRecentUsageAppender struct {
 	allowed bool
 }
 
+type recordingUsageHeaderQuotaAppender struct {
+	calls     int
+	snapshots []quota.UsageHeaderSnapshot
+	allowed   bool
+}
+
+type aggregationAwareUsageHeaderQuotaAppender struct {
+	db                  *gorm.DB
+	calls               int
+	snapshots           []quota.UsageHeaderSnapshot
+	hourlyStatsAtAppend int64
+	countErr            error
+}
+
 func (r *recordingRecentUsageAppender) TryAppend(events []entities.UsageEvent) bool {
 	r.calls++
 	r.events = append(r.events, events...)
 	return r.allowed
+}
+
+func (r *recordingUsageHeaderQuotaAppender) TryAppendUsageHeaderSnapshots(snapshots []quota.UsageHeaderSnapshot) bool {
+	r.calls++
+	r.snapshots = append(r.snapshots, snapshots...)
+	return r.allowed
+}
+
+func (r *aggregationAwareUsageHeaderQuotaAppender) TryAppendUsageHeaderSnapshots(snapshots []quota.UsageHeaderSnapshot) bool {
+	r.calls++
+	r.snapshots = append(r.snapshots, snapshots...)
+	r.countErr = r.db.Model(&entities.UsageOverviewHourlyStat{}).Where("auth_index = ?", "codex-auth").Count(&r.hourlyStatsAtAppend).Error
+	return true
 }
 
 func (s stubMetadataFetcher) FetchAuthFiles(context.Context) (*response.AuthFilesResult, error) {
@@ -328,6 +356,358 @@ func TestProcessRedisUsageInboxIgnoresRecentCacheOverflow(t *testing.T) {
 	}
 	if cache.calls != 1 {
 		t.Fatalf("expected cache append attempt, got %d", cache.calls)
+	}
+}
+
+func TestProcessRedisUsageInboxNotifiesUsageHeaderQuotaAfterTransactionCommit(t *testing.T) {
+	db := openSyncTestDatabase(t)
+	if _, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
+		Source: redisUsageInboxTestSource,
+		RawMessage: `{
+			"timestamp":"2026-06-22T11:10:43+08:00",
+			"provider":"codex",
+			"auth_type":"oauth",
+			"auth_index":"codex-auth",
+			"model":"gpt-5.5",
+			"request_id":"header-quota-commit",
+			"tokens":{"input_tokens":1,"output_tokens":2},
+			"response_headers":{
+				"X-Codex-Plan-Type":["pro"],
+				"X-Codex-Primary-Used-Percent":["4"],
+				"X-Codex-Primary-Window-Minutes":["300"],
+				"X-Codex-Primary-Reset-After-Seconds":["60"]
+			}
+		}`,
+		PoppedAt: time.Date(2026, 6, 22, 11, 10, 43, 0, time.Local),
+	}}); err != nil {
+		t.Fatalf("seed inbox row: %v", err)
+	}
+	appender := &recordingUsageHeaderQuotaAppender{allowed: true}
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
+		BaseURL:          "https://cpa.example.com",
+		UsageHeaderQuota: appender,
+	})
+
+	result, err := service.ProcessRedisUsageInbox(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessRedisUsageInbox returned error: %v", err)
+	}
+	if result == nil || result.InsertedEvents != 1 {
+		t.Fatalf("unexpected process result: %+v", result)
+	}
+	if appender.calls != 1 || len(appender.snapshots) != 1 {
+		t.Fatalf("expected one usage header quota notification, got calls=%d snapshots=%+v", appender.calls, appender.snapshots)
+	}
+	snapshot := appender.snapshots[0]
+	if snapshot.AuthType != "oauth" || snapshot.AuthIndex != "codex-auth" || snapshot.Provider != "codex" {
+		t.Fatalf("unexpected snapshot identity: %+v", snapshot)
+	}
+	if snapshot.Headers.Get("X-Codex-Plan-Type") != "pro" {
+		t.Fatalf("expected codex header snapshot, got %#v", snapshot.Headers)
+	}
+}
+
+func TestProcessRedisUsageInboxNotifiesUsageHeaderQuotaAfterOverviewAggregation(t *testing.T) {
+	db := openSyncTestDatabase(t)
+	if _, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
+		Source: redisUsageInboxTestSource,
+		RawMessage: `{
+			"timestamp":"2026-06-22T11:10:43+08:00",
+			"provider":"codex",
+			"auth_type":"oauth",
+			"auth_index":"codex-auth",
+			"model":"gpt-5.5",
+			"request_id":"header-quota-after-aggregation",
+			"tokens":{"input_tokens":10,"output_tokens":20,"total_tokens":30},
+			"response_headers":{
+				"X-Codex-Primary-Used-Percent":["4"],
+				"X-Codex-Primary-Window-Minutes":["300"],
+				"X-Codex-Primary-Reset-After-Seconds":["60"]
+			}
+		}`,
+		PoppedAt: time.Date(2026, 6, 22, 11, 10, 43, 0, time.Local),
+	}}); err != nil {
+		t.Fatalf("seed inbox row: %v", err)
+	}
+	appender := &aggregationAwareUsageHeaderQuotaAppender{db: db}
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
+		BaseURL:          "https://cpa.example.com",
+		UsageHeaderQuota: appender,
+		Now:              func() time.Time { return time.Date(2026, 6, 22, 11, 15, 0, 0, time.Local) },
+	})
+
+	result, err := service.ProcessRedisUsageInbox(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessRedisUsageInbox returned error: %v", err)
+	}
+	if result == nil || result.InsertedEvents != 1 {
+		t.Fatalf("unexpected process result: %+v", result)
+	}
+	if appender.calls != 1 || len(appender.snapshots) != 1 {
+		t.Fatalf("expected one usage header quota notification, got calls=%d snapshots=%+v", appender.calls, appender.snapshots)
+	}
+	if appender.countErr != nil {
+		t.Fatalf("count hourly stats during header notification: %v", appender.countErr)
+	}
+	if appender.hourlyStatsAtAppend == 0 {
+		t.Fatal("expected usage overview hourly stats to be aggregated before header quota notification")
+	}
+}
+
+func TestProcessRedisUsageInboxCoalescesUsageHeaderQuotaSnapshotsByAuthIndex(t *testing.T) {
+	db := openSyncTestDatabase(t)
+	if _, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{
+		{
+			Source: redisUsageInboxTestSource,
+			RawMessage: `{
+				"timestamp":"2026-06-22T11:00:00+08:00",
+				"provider":"codex",
+				"auth_type":"oauth",
+				"auth_index":"codex-auth",
+				"model":"gpt-5.5",
+				"request_id":"header-quota-old",
+				"tokens":{"input_tokens":1,"output_tokens":2},
+				"response_headers":{
+					"X-Codex-Primary-Used-Percent":["4"],
+					"X-Codex-Primary-Window-Minutes":["300"],
+					"X-Codex-Primary-Reset-After-Seconds":["60"]
+				}
+			}`,
+			PoppedAt: time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local),
+		},
+		{
+			Source: redisUsageInboxTestSource,
+			RawMessage: `{
+				"timestamp":"2026-06-22T11:02:00+08:00",
+				"provider":"codex",
+				"auth_type":"oauth",
+				"auth_index":"codex-auth",
+				"model":"gpt-5.5",
+				"request_id":"header-quota-new",
+				"tokens":{"input_tokens":1,"output_tokens":2},
+				"response_headers":{
+					"X-Codex-Primary-Used-Percent":["8"],
+					"X-Codex-Primary-Window-Minutes":["300"],
+					"X-Codex-Primary-Reset-After-Seconds":["60"]
+				}
+			}`,
+			PoppedAt: time.Date(2026, 6, 22, 11, 2, 0, 0, time.Local),
+		},
+		{
+			Source: redisUsageInboxTestSource,
+			RawMessage: `{
+				"timestamp":"2026-06-22T11:01:00+08:00",
+				"provider":"codex",
+				"auth_type":"oauth",
+				"auth_index":"other-codex-auth",
+				"model":"gpt-5.5",
+				"request_id":"header-quota-other",
+				"tokens":{"input_tokens":1,"output_tokens":2},
+				"response_headers":{
+					"X-Codex-Primary-Used-Percent":["20"],
+					"X-Codex-Primary-Window-Minutes":["300"],
+					"X-Codex-Primary-Reset-After-Seconds":["60"]
+				}
+			}`,
+			PoppedAt: time.Date(2026, 6, 22, 11, 1, 0, 0, time.Local),
+		},
+	}); err != nil {
+		t.Fatalf("seed inbox rows: %v", err)
+	}
+	appender := &recordingUsageHeaderQuotaAppender{allowed: true}
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
+		BaseURL:          "https://cpa.example.com",
+		UsageHeaderQuota: appender,
+	})
+
+	result, err := service.ProcessRedisUsageInbox(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessRedisUsageInbox returned error: %v", err)
+	}
+	if result == nil || result.InsertedEvents != 3 {
+		t.Fatalf("unexpected process result: %+v", result)
+	}
+	if appender.calls != 1 || len(appender.snapshots) != 2 {
+		t.Fatalf("expected latest snapshot per auth_index, got calls=%d snapshots=%+v", appender.calls, appender.snapshots)
+	}
+	snapshotsByAuthIndex := map[string]quota.UsageHeaderSnapshot{}
+	for _, snapshot := range appender.snapshots {
+		snapshotsByAuthIndex[snapshot.AuthIndex] = snapshot
+	}
+	if snapshotsByAuthIndex["codex-auth"].Headers.Get("X-Codex-Primary-Used-Percent") != "8" {
+		t.Fatalf("expected latest codex-auth header snapshot, got %+v", snapshotsByAuthIndex["codex-auth"])
+	}
+	if snapshotsByAuthIndex["other-codex-auth"].Headers.Get("X-Codex-Primary-Used-Percent") != "20" {
+		t.Fatalf("expected other auth header snapshot, got %+v", snapshotsByAuthIndex["other-codex-auth"])
+	}
+}
+
+func TestProcessRedisUsageInboxIgnoresIncompleteUsageHeaderQuotaSnapshotDuringCoalesce(t *testing.T) {
+	db := openSyncTestDatabase(t)
+	if _, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{
+		{
+			Source: redisUsageInboxTestSource,
+			RawMessage: `{
+				"timestamp":"2026-06-22T11:00:00+08:00",
+				"provider":"codex",
+				"auth_type":"oauth",
+				"auth_index":"codex-auth",
+				"model":"gpt-5.5",
+				"request_id":"header-quota-valid-earlier",
+				"tokens":{"input_tokens":1,"output_tokens":2},
+				"response_headers":{
+					"X-Codex-Primary-Used-Percent":["4"],
+					"X-Codex-Primary-Window-Minutes":["300"],
+					"X-Codex-Primary-Reset-After-Seconds":["60"]
+				}
+			}`,
+			PoppedAt: time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local),
+		},
+		{
+			Source: redisUsageInboxTestSource,
+			RawMessage: `{
+				"timestamp":"2026-06-22T11:02:00+08:00",
+				"provider":"codex",
+				"auth_type":"oauth",
+				"auth_index":"codex-auth",
+				"model":"gpt-5.5",
+				"request_id":"header-quota-incomplete-later",
+				"tokens":{"input_tokens":1,"output_tokens":2},
+				"response_headers":{
+					"X-Codex-Primary-Used-Percent":["8"],
+					"X-Codex-Primary-Window-Minutes":["300"]
+				}
+			}`,
+			PoppedAt: time.Date(2026, 6, 22, 11, 2, 0, 0, time.Local),
+		},
+	}); err != nil {
+		t.Fatalf("seed inbox rows: %v", err)
+	}
+	appender := &recordingUsageHeaderQuotaAppender{allowed: true}
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
+		BaseURL:          "https://cpa.example.com",
+		UsageHeaderQuota: appender,
+	})
+
+	result, err := service.ProcessRedisUsageInbox(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessRedisUsageInbox returned error: %v", err)
+	}
+	if result == nil || result.InsertedEvents != 2 {
+		t.Fatalf("unexpected process result: %+v", result)
+	}
+	if appender.calls != 1 || len(appender.snapshots) != 1 {
+		t.Fatalf("expected only one complete usage header snapshot, got calls=%d snapshots=%+v", appender.calls, appender.snapshots)
+	}
+	if appender.snapshots[0].Headers.Get("X-Codex-Primary-Used-Percent") != "4" {
+		t.Fatalf("expected incomplete later header to be filtered before coalesce, got %+v", appender.snapshots[0])
+	}
+}
+
+func TestProcessRedisUsageInboxDoesNotNotifyUsageHeaderQuotaOnRollback(t *testing.T) {
+	db := openSyncTestDatabase(t)
+	if _, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
+		Source: redisUsageInboxTestSource,
+		RawMessage: `{
+			"timestamp":"2026-06-22T11:10:43+08:00",
+			"provider":"codex",
+			"auth_type":"oauth",
+			"auth_index":"codex-auth",
+			"model":"gpt-5.5",
+			"request_id":"header-quota-rollback",
+			"tokens":{"input_tokens":1,"output_tokens":2},
+			"response_headers":{
+				"X-Codex-Primary-Used-Percent":["4"],
+				"X-Codex-Primary-Window-Minutes":["300"],
+				"X-Codex-Primary-Reset-After-Seconds":["60"]
+			}
+		}`,
+		PoppedAt: time.Date(2026, 6, 22, 11, 10, 43, 0, time.Local),
+	}}); err != nil {
+		t.Fatalf("seed inbox row: %v", err)
+	}
+	if err := db.Exec(`CREATE TRIGGER fail_header_quota_mark BEFORE UPDATE OF status ON redis_usage_inboxes WHEN NEW.status = 'processed' BEGIN SELECT RAISE(ABORT, 'processed mark failed'); END;`).Error; err != nil {
+		t.Fatalf("create failure trigger: %v", err)
+	}
+	appender := &recordingUsageHeaderQuotaAppender{allowed: true}
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
+		BaseURL:          "https://cpa.example.com",
+		UsageHeaderQuota: appender,
+	})
+
+	_, err := service.ProcessRedisUsageInbox(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "processed mark failed") {
+		t.Fatalf("expected transaction failure, got %v", err)
+	}
+	if appender.calls != 0 || len(appender.snapshots) != 0 {
+		t.Fatalf("expected no usage header quota notification on rollback, got calls=%d snapshots=%+v", appender.calls, appender.snapshots)
+	}
+}
+
+func TestProcessRedisUsageInboxIgnoresUsageHeaderQuotaOverflow(t *testing.T) {
+	db := openSyncTestDatabase(t)
+	if _, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
+		Source: redisUsageInboxTestSource,
+		RawMessage: `{
+			"timestamp":"2026-06-22T11:10:43+08:00",
+			"provider":"codex",
+			"auth_type":"oauth",
+			"auth_index":"codex-auth",
+			"model":"gpt-5.5",
+			"request_id":"header-quota-overflow",
+			"tokens":{"input_tokens":1,"output_tokens":2},
+			"response_headers":{
+				"X-Codex-Primary-Used-Percent":["4"],
+				"X-Codex-Primary-Window-Minutes":["300"],
+				"X-Codex-Primary-Reset-After-Seconds":["60"]
+			}
+		}`,
+		PoppedAt: time.Date(2026, 6, 22, 11, 10, 43, 0, time.Local),
+	}}); err != nil {
+		t.Fatalf("seed inbox row: %v", err)
+	}
+	appender := &recordingUsageHeaderQuotaAppender{allowed: false}
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
+		BaseURL:          "https://cpa.example.com",
+		UsageHeaderQuota: appender,
+	})
+
+	result, err := service.ProcessRedisUsageInbox(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessRedisUsageInbox should ignore usage header quota overflow, got %v", err)
+	}
+	if result == nil || result.Status != "completed" || result.InsertedEvents != 1 {
+		t.Fatalf("unexpected process result: %+v", result)
+	}
+	if appender.calls != 1 {
+		t.Fatalf("expected overflow appender to be attempted once, got %d", appender.calls)
+	}
+}
+
+func TestProcessRedisUsageInboxSkipsRowsWithoutUsageHeaderQuotaSnapshot(t *testing.T) {
+	db := openSyncTestDatabase(t)
+	if _, err := repository.InsertRedisUsageInboxMessages(db, []dto.RedisInboxInsert{{
+		Source:     redisUsageInboxTestSource,
+		RawMessage: `{"timestamp":"2026-06-22T11:10:43+08:00","provider":"codex","auth_type":"oauth","auth_index":"codex-auth","model":"gpt-5.5","request_id":"header-quota-missing","tokens":{"input_tokens":1,"output_tokens":2}}`,
+		PoppedAt:   time.Date(2026, 6, 22, 11, 10, 43, 0, time.Local),
+	}}); err != nil {
+		t.Fatalf("seed inbox row: %v", err)
+	}
+	appender := &recordingUsageHeaderQuotaAppender{allowed: true}
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{
+		BaseURL:          "https://cpa.example.com",
+		UsageHeaderQuota: appender,
+	})
+
+	result, err := service.ProcessRedisUsageInbox(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessRedisUsageInbox returned error: %v", err)
+	}
+	if result == nil || result.InsertedEvents != 1 {
+		t.Fatalf("unexpected process result: %+v", result)
+	}
+	if appender.calls != 0 || len(appender.snapshots) != 0 {
+		t.Fatalf("expected rows without response_headers to skip quota notification, got calls=%d snapshots=%+v", appender.calls, appender.snapshots)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Parse Codex quota response headers from Redis usage payloads after usage_events persistence.
- Add an asynchronous header snapshot worker that updates or creates quota cache entries without blocking the write path.
- Backfill quota window token/cost from existing usage statistics and preserve manual authoritative fields where appropriate.

## Validation
- git diff --check
- rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build go test ./internal/... -count=1