### PR TITLE
Cap realtime distribution particles

### DIFF
--- a/internal/api/usage_overview.go
+++ b/internal/api/usage_overview.go
@@ -83,6 +83,8 @@ type usageOverviewRealtime struct {
 	Window               string                            `json:"window"`
 	Timezone             string                            `json:"timezone"`
 	BucketSeconds        int64                             `json:"bucket_seconds"`
+	WindowStart          *time.Time                        `json:"window_start,omitempty"`
+	WindowEnd            *time.Time                        `json:"window_end,omitempty"`
 	TokenVelocity        []usageOverviewTokenVelocityPoint `json:"token_velocity"`
 	ResponseLevel        []usageOverviewResponseLevelPoint `json:"response_level"`
 	ResponseDistribution usageOverviewResponseDistribution `json:"response_distribution"`
@@ -95,6 +97,8 @@ type keyUsageOverviewRealtime struct {
 	Window               string                               `json:"window"`
 	Timezone             string                               `json:"timezone"`
 	BucketSeconds        int64                                `json:"bucket_seconds"`
+	WindowStart          *time.Time                           `json:"window_start,omitempty"`
+	WindowEnd            *time.Time                           `json:"window_end,omitempty"`
 	TokenVelocity        []usageOverviewTokenVelocityPoint    `json:"token_velocity"`
 	ResponseLevel        []usageOverviewResponseLevelPoint    `json:"response_level"`
 	ResponseDistribution usageOverviewResponseDistribution    `json:"response_distribution"`
@@ -124,14 +128,18 @@ type usageOverviewResponseAveragePoint struct {
 }
 
 type usageOverviewResponseParticle struct {
-	Bucket string `json:"bucket"`
-	MS     int64  `json:"ms"`
-	Count  int64  `json:"count"`
+	Bucket    string `json:"bucket"`
+	Timestamp string `json:"timestamp,omitempty"`
+	MS        int64  `json:"ms"`
+	Count     int64  `json:"count"`
 }
 
 type usageOverviewResponseDistributionSeries struct {
-	AverageLine []usageOverviewResponseAveragePoint `json:"average_line"`
-	Particles   []usageOverviewResponseParticle     `json:"particles"`
+	AverageLine    []usageOverviewResponseAveragePoint `json:"average_line"`
+	Particles      []usageOverviewResponseParticle     `json:"particles"`
+	TotalParticles int64                               `json:"total_particles"`
+	Sampled        bool                                `json:"sampled"`
+	MaxParticles   int                                 `json:"max_particles"`
 }
 
 type usageOverviewResponseDistribution struct {
@@ -154,6 +162,8 @@ type usageOverviewRealtimeBase struct {
 	Window               string
 	Timezone             string
 	BucketSeconds        int64
+	WindowStart          *time.Time
+	WindowEnd            *time.Time
 	TokenVelocity        []usageOverviewTokenVelocityPoint
 	ResponseLevel        []usageOverviewResponseLevelPoint
 	ResponseDistribution usageOverviewResponseDistribution
@@ -465,6 +475,8 @@ func emptyUsageOverviewRealtime(window string) usageOverviewRealtime {
 		Window:               base.Window,
 		Timezone:             base.Timezone,
 		BucketSeconds:        base.BucketSeconds,
+		WindowStart:          base.WindowStart,
+		WindowEnd:            base.WindowEnd,
 		TokenVelocity:        base.TokenVelocity,
 		ResponseLevel:        base.ResponseLevel,
 		ResponseDistribution: base.ResponseDistribution,
@@ -485,6 +497,8 @@ func emptyKeyUsageOverviewRealtime(window string) keyUsageOverviewRealtime {
 		Window:               base.Window,
 		Timezone:             base.Timezone,
 		BucketSeconds:        base.BucketSeconds,
+		WindowStart:          base.WindowStart,
+		WindowEnd:            base.WindowEnd,
 		TokenVelocity:        base.TokenVelocity,
 		ResponseLevel:        base.ResponseLevel,
 		ResponseDistribution: base.ResponseDistribution,
@@ -533,6 +547,14 @@ func realtimeBucketSeconds(window string) int64 {
 	}
 }
 
+func usageOverviewOptionalTime(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	normalized := timeutil.NormalizeStorageTime(value)
+	return &normalized
+}
+
 func buildUsageOverviewRealtime(realtime *servicedto.UsageOverviewRealtime, window string, apiKeyInfos map[string]analysisAPIKeyInfo) usageOverviewRealtime {
 	if realtime == nil {
 		return emptyUsageOverviewRealtime(window)
@@ -541,6 +563,8 @@ func buildUsageOverviewRealtime(realtime *servicedto.UsageOverviewRealtime, wind
 		Window:               realtime.Window,
 		Timezone:             time.Local.String(),
 		BucketSeconds:        realtime.BucketSeconds,
+		WindowStart:          usageOverviewOptionalTime(realtime.WindowStart),
+		WindowEnd:            usageOverviewOptionalTime(realtime.WindowEnd),
 		TokenVelocity:        make([]usageOverviewTokenVelocityPoint, 0, len(realtime.TokenVelocity)),
 		ResponseLevel:        make([]usageOverviewResponseLevelPoint, 0, len(realtime.ResponseLevel)),
 		ResponseDistribution: mapUsageOverviewResponseDistribution(realtime.ResponseDistribution),
@@ -602,6 +626,8 @@ func buildKeyUsageOverviewRealtime(realtime *servicedto.UsageOverviewRealtime, w
 		Window:               realtime.Window,
 		Timezone:             time.Local.String(),
 		BucketSeconds:        realtime.BucketSeconds,
+		WindowStart:          usageOverviewOptionalTime(realtime.WindowStart),
+		WindowEnd:            usageOverviewOptionalTime(realtime.WindowEnd),
 		TokenVelocity:        make([]usageOverviewTokenVelocityPoint, 0, len(realtime.TokenVelocity)),
 		ResponseLevel:        make([]usageOverviewResponseLevelPoint, 0, len(realtime.ResponseLevel)),
 		ResponseDistribution: mapUsageOverviewResponseDistribution(realtime.ResponseDistribution),
@@ -661,8 +687,11 @@ func mapUsageOverviewResponseDistribution(distribution servicedto.RealtimeRespon
 
 func mapUsageOverviewResponseDistributionSeries(series servicedto.RealtimeResponseDistributionSeries) usageOverviewResponseDistributionSeries {
 	return usageOverviewResponseDistributionSeries{
-		AverageLine: mapUsageOverviewResponseAveragePoints(series.AverageLine),
-		Particles:   mapUsageOverviewResponseParticles(series.Particles),
+		AverageLine:    mapUsageOverviewResponseAveragePoints(series.AverageLine),
+		Particles:      mapUsageOverviewResponseParticles(series.Particles),
+		TotalParticles: series.TotalParticles,
+		Sampled:        series.Sampled,
+		MaxParticles:   series.MaxParticles,
 	}
 }
 
@@ -681,9 +710,10 @@ func mapUsageOverviewResponseParticles(points []servicedto.RealtimeResponseParti
 	result := make([]usageOverviewResponseParticle, 0, len(points))
 	for _, point := range points {
 		result = append(result, usageOverviewResponseParticle{
-			Bucket: point.Bucket,
-			MS:     point.MS,
-			Count:  point.Count,
+			Bucket:    point.Bucket,
+			Timestamp: point.Timestamp,
+			MS:        point.MS,
+			Count:     point.Count,
 		})
 	}
 	return result

--- a/internal/api/usage_overview_test.go
+++ b/internal/api/usage_overview_test.go
@@ -308,6 +308,8 @@ func TestUsageOverviewRealtimeAcceptsWindowAndReturnsRealtimeBlock(t *testing.T)
 	provider := &usageFilterStub{realtime: &servicedto.UsageOverviewRealtime{
 		Window:        "30m",
 		BucketSeconds: 60,
+		WindowStart:   time.Date(2026, 4, 22, 11, 0, 0, 0, location),
+		WindowEnd:     time.Date(2026, 4, 22, 11, 30, 0, 0, location),
 		TokenVelocity: []servicedto.RealtimeTokenVelocityPoint{{
 			Bucket:          "2026-04-22T11:00:00Z",
 			TokensPerMinute: 120,
@@ -319,6 +321,21 @@ func TestUsageOverviewRealtimeAcceptsWindowAndReturnsRealtimeBlock(t *testing.T)
 			TTFTP95MS:    int64Ptr(210),
 			LatencyP95MS: int64Ptr(820),
 		}},
+		ResponseDistribution: servicedto.RealtimeResponseDistribution{
+			TTFT: servicedto.RealtimeResponseDistributionSeries{
+				Particles: []servicedto.RealtimeResponseParticle{{
+					Bucket:    "2026-04-22T11:00:00Z",
+					Timestamp: "2026-04-22T11:00:15Z",
+					MS:        120,
+					Count:     1,
+				}},
+				TotalParticles: 1,
+				MaxParticles:   1000,
+			},
+			Latency: servicedto.RealtimeResponseDistributionSeries{
+				MaxParticles: 1000,
+			},
+		},
 		CurrentUsage: servicedto.RealtimeCurrentUsage{
 			Models: []servicedto.RealtimeUsageTopItem{{
 				Key:      "gpt-5",
@@ -362,10 +379,10 @@ func TestUsageOverviewRealtimeAcceptsWindowAndReturnsRealtimeBlock(t *testing.T)
 		t.Fatalf("expected realtime window and anchor to be passed through, got %+v", provider.lastRealtime)
 	}
 	for _, expected := range []string{
-		`"window":"30m","timezone":"Asia/Shanghai","bucket_seconds":60`,
+		`"window":"30m","timezone":"Asia/Shanghai","bucket_seconds":60,"window_start":"2026-04-22T11:00:00+08:00","window_end":"2026-04-22T11:30:00+08:00"`,
 		`"token_velocity":[{"bucket":"2026-04-22T11:00:00Z","tokens_per_minute":120,"tokens":20,"cost":0.123}]`,
 		`"response_level":[{"bucket":"2026-04-22T11:00:00Z","ttft_p95_ms":210,"latency_p95_ms":820}]`,
-		`"response_distribution":{"ttft":{"average_line":[],"particles":[]},"latency":{"average_line":[],"particles":[]}}`,
+		`"response_distribution":{"ttft":{"average_line":[],"particles":[{"bucket":"2026-04-22T11:00:00Z","timestamp":"2026-04-22T11:00:15Z","ms":120,"count":1}],"total_particles":1,"sampled":false,"max_particles":1000},"latency":{"average_line":[],"particles":[],"total_particles":0,"sampled":false,"max_particles":1000}}`,
 		`"current_usage":{"models":[{"key":"gpt-5","label":"gpt-5","tokens":20,"requests":1,"cost":0.123,"share":100}],"api_keys":[{"key":"sk-*********123456","label":"sk-*********123456","tokens":20,"requests":1,"share":100}]`,
 		`"request_level":[{"bucket":"2026-04-22T11:00:00Z","requests_per_minute":6,"requests":1}]`,
 		`"cache_level":[{"bucket":"2026-04-22T11:00:00Z","cache_rate":25,"cached_tokens":5,"input_tokens":20}]`,

--- a/internal/repository/dto/usage_overview.go
+++ b/internal/repository/dto/usage_overview.go
@@ -79,15 +79,19 @@ type RealtimeResponseAveragePointRecord struct {
 
 // RealtimeResponseParticleRecord 是响应分布图的一个聚合粒子点。
 type RealtimeResponseParticleRecord struct {
-	Bucket string
-	MS     int64
-	Count  int64
+	Bucket    string
+	Timestamp string
+	MS        int64
+	Count     int64
 }
 
 // RealtimeResponseDistributionSeriesRecord 是单个响应指标的平均线和粒子分布。
 type RealtimeResponseDistributionSeriesRecord struct {
-	AverageLine []RealtimeResponseAveragePointRecord
-	Particles   []RealtimeResponseParticleRecord
+	AverageLine    []RealtimeResponseAveragePointRecord
+	Particles      []RealtimeResponseParticleRecord
+	TotalParticles int64
+	Sampled        bool
+	MaxParticles   int
 }
 
 // RealtimeResponseDistributionRecord 是 TTFT 和 Latency 的实时响应分布。
@@ -118,6 +122,8 @@ type RealtimeCurrentUsageRecord struct {
 type UsageOverviewRealtimeRecord struct {
 	Window               string
 	BucketSeconds        int64
+	WindowStart          time.Time
+	WindowEnd            time.Time
 	TokenVelocity        []RealtimeTokenVelocityPointRecord
 	ResponseLevel        []RealtimeResponseLevelPointRecord
 	ResponseDistribution RealtimeResponseDistributionRecord

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -1522,7 +1522,11 @@ func usageOverviewHealthBlockIndex(blocks []dto.UsageOverviewHealthBlockRecord, 
 	return -1
 }
 
-const usageOverviewRealtimeBucketCount = 30
+const (
+	usageOverviewRealtimeBucketCount                     = 30
+	usageOverviewRealtimeDistributionMaxParticles        = 1000
+	usageOverviewRealtimeDistributionDefaultParticleSize = 1
+)
 
 type usageOverviewRealtimeBucket struct {
 	bucketStart    time.Time
@@ -1532,8 +1536,13 @@ type usageOverviewRealtimeBucket struct {
 	cachedTokens   int64
 	costUSD        float64
 	costAvailable  bool
-	ttftSamples    []int64
-	latencySamples []int64
+	ttftSamples    []usageOverviewRealtimeResponseSample
+	latencySamples []usageOverviewRealtimeResponseSample
+}
+
+type usageOverviewRealtimeResponseSample struct {
+	timestamp time.Time
+	ms        int64
 }
 
 type usageOverviewRealtimeTopAccumulator struct {
@@ -1613,11 +1622,11 @@ func buildUsageOverviewRealtime(db *gorm.DB, filter dto.UsageQueryFilter, pricin
 		}
 		// TTFT 缺失或非正数时不补 0，避免 log 分布和 percentile 被无效样本拉低。
 		if event.TTFTMS != nil && *event.TTFTMS > 0 {
-			bucket.ttftSamples = append(bucket.ttftSamples, *event.TTFTMS)
+			bucket.ttftSamples = append(bucket.ttftSamples, usageOverviewRealtimeResponseSample{timestamp: timestamp, ms: *event.TTFTMS})
 		}
 		// Latency 只有正数才作为样本。
 		if event.LatencyMS > 0 {
-			bucket.latencySamples = append(bucket.latencySamples, event.LatencyMS)
+			bucket.latencySamples = append(bucket.latencySamples, usageOverviewRealtimeResponseSample{timestamp: timestamp, ms: event.LatencyMS})
 		}
 		// 失败或无 token 的请求不参与 token velocity/cache/current token share。
 		if event.Failed || event.TotalTokens <= 0 {
@@ -1643,7 +1652,7 @@ func buildUsageOverviewRealtime(db *gorm.DB, filter dto.UsageQueryFilter, pricin
 	}
 
 	// 最后统一把 bucket、percentile 和 Top5 accumulator 映射成 API DTO。
-	return finalizeUsageOverviewRealtime(window, span, buckets, warmupBucketCount, modelUsage, apiKeyUsage, authFileUsage, aiProviderUsage), nil
+	return finalizeUsageOverviewRealtime(window, span, start, end, buckets, warmupBucketCount, modelUsage, apiKeyUsage, authFileUsage, aiProviderUsage), nil
 }
 
 func usageOverviewRealtimeWindow(value string) (time.Duration, time.Duration) {
@@ -1937,7 +1946,7 @@ func aggregateUsageOverviewRealtimeBucket(buckets []usageOverviewRealtimeBucket,
 	return aggregated
 }
 
-func finalizeUsageOverviewRealtime(window, span time.Duration, buckets []usageOverviewRealtimeBucket, visibleStartIndex int, modelUsage, apiKeyUsage, authFileUsage, aiProviderUsage map[string]*usageOverviewRealtimeTopAccumulator) dto.UsageOverviewRealtimeRecord {
+func finalizeUsageOverviewRealtime(window, span time.Duration, windowStart, windowEnd time.Time, buckets []usageOverviewRealtimeBucket, visibleStartIndex int, modelUsage, apiKeyUsage, authFileUsage, aiProviderUsage map[string]*usageOverviewRealtimeTopAccumulator) dto.UsageOverviewRealtimeRecord {
 	visibleBucketCount := len(buckets) - visibleStartIndex
 	tokenVelocity := make([]dto.RealtimeTokenVelocityPointRecord, 0, visibleBucketCount)
 	responseLevel := make([]dto.RealtimeResponseLevelPointRecord, 0, visibleBucketCount)
@@ -1997,9 +2006,13 @@ func finalizeUsageOverviewRealtime(window, span time.Duration, buckets []usageOv
 			InputTokens:  rollingBucket.inputTokens,
 		})
 	}
+	responseDistribution.TTFT = finalizeUsageOverviewRealtimeDistributionSeries(responseDistribution.TTFT)
+	responseDistribution.Latency = finalizeUsageOverviewRealtimeDistributionSeries(responseDistribution.Latency)
 	return dto.UsageOverviewRealtimeRecord{
 		Window:               usageOverviewRealtimeWindowLabel(window),
 		BucketSeconds:        int64(span / time.Second),
+		WindowStart:          windowStart,
+		WindowEnd:            windowEnd,
 		TokenVelocity:        tokenVelocity,
 		ResponseLevel:        responseLevel,
 		ResponseDistribution: responseDistribution,
@@ -2014,24 +2027,88 @@ func finalizeUsageOverviewRealtime(window, span time.Duration, buckets []usageOv
 	}
 }
 
-func usageOverviewRealtimeAverage(samples []int64) *float64 {
+func finalizeUsageOverviewRealtimeDistributionSeries(series dto.RealtimeResponseDistributionSeriesRecord) dto.RealtimeResponseDistributionSeriesRecord {
+	series.TotalParticles = usageOverviewRealtimeParticleCountTotal(series.Particles)
+	series.MaxParticles = usageOverviewRealtimeDistributionMaxParticles
+	if len(series.Particles) <= usageOverviewRealtimeDistributionMaxParticles {
+		return series
+	}
+	series.Sampled = true
+	series.Particles = sampleUsageOverviewRealtimeDistributionParticles(series.Particles, usageOverviewRealtimeDistributionMaxParticles)
+	return series
+}
+
+func sampleUsageOverviewRealtimeDistributionParticles(particles []dto.RealtimeResponseParticleRecord, maxParticles int) []dto.RealtimeResponseParticleRecord {
+	if len(particles) <= maxParticles || maxParticles <= 0 {
+		return particles
+	}
+	sortedParticles := append([]dto.RealtimeResponseParticleRecord(nil), particles...)
+	sort.SliceStable(sortedParticles, func(i, j int) bool {
+		leftTime := usageOverviewRealtimeParticleTimeKey(sortedParticles[i])
+		rightTime := usageOverviewRealtimeParticleTimeKey(sortedParticles[j])
+		if leftTime != rightTime {
+			return leftTime < rightTime
+		}
+		if sortedParticles[i].MS != sortedParticles[j].MS {
+			return sortedParticles[i].MS < sortedParticles[j].MS
+		}
+		return sortedParticles[i].Count < sortedParticles[j].Count
+	})
+
+	sampled := make([]dto.RealtimeResponseParticleRecord, 0, maxParticles)
+	for index := 0; index < maxParticles; index++ {
+		start := index * len(sortedParticles) / maxParticles
+		end := (index + 1) * len(sortedParticles) / maxParticles
+		if end <= start {
+			end = start + 1
+		}
+		group := sortedParticles[start:end]
+		// 代表点保持为真实事件坐标，只把该组真实样本数汇总到 count。
+		representative := group[len(group)/2]
+		representative.Count = usageOverviewRealtimeParticleCountTotal(group)
+		sampled = append(sampled, representative)
+	}
+	return sampled
+}
+
+func usageOverviewRealtimeParticleTimeKey(particle dto.RealtimeResponseParticleRecord) string {
+	if particle.Timestamp != "" {
+		return particle.Timestamp
+	}
+	return particle.Bucket
+}
+
+func usageOverviewRealtimeParticleCountTotal(particles []dto.RealtimeResponseParticleRecord) int64 {
+	var total int64
+	for _, particle := range particles {
+		count := particle.Count
+		if count <= 0 {
+			count = usageOverviewRealtimeDistributionDefaultParticleSize
+		}
+		total += count
+	}
+	return total
+}
+
+func usageOverviewRealtimeAverage(samples []usageOverviewRealtimeResponseSample) *float64 {
 	if len(samples) == 0 {
 		return nil
 	}
 	var sum int64
 	for _, sample := range samples {
-		sum += sample
+		sum += sample.ms
 	}
 	value := float64(sum) / float64(len(samples))
 	return &value
 }
 
-func appendUsageOverviewRealtimeDistributionParticles(dst []dto.RealtimeResponseParticleRecord, bucket string, samples []int64) []dto.RealtimeResponseParticleRecord {
+func appendUsageOverviewRealtimeDistributionParticles(dst []dto.RealtimeResponseParticleRecord, bucket string, samples []usageOverviewRealtimeResponseSample) []dto.RealtimeResponseParticleRecord {
 	for _, sample := range samples {
 		dst = append(dst, dto.RealtimeResponseParticleRecord{
-			Bucket: bucket,
-			MS:     sample,
-			Count:  1,
+			Bucket:    bucket,
+			Timestamp: timeutil.FormatStorageTime(sample.timestamp),
+			MS:        sample.ms,
+			Count:     1,
 		})
 	}
 	return dst
@@ -2053,11 +2130,14 @@ func usageOverviewRealtimeCacheRate(cachedTokens, inputTokens int64) *float64 {
 	return &value
 }
 
-func usageOverviewRealtimePercentilePair(samples []int64, first, second float64) (*int64, *int64) {
+func usageOverviewRealtimePercentilePair(samples []usageOverviewRealtimeResponseSample, first, second float64) (*int64, *int64) {
 	if len(samples) == 0 {
 		return nil, nil
 	}
-	sorted := append([]int64(nil), samples...)
+	sorted := make([]int64, 0, len(samples))
+	for _, sample := range samples {
+		sorted = append(sorted, sample.ms)
+	}
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
 	return usageOverviewRealtimeSortedPercentile(sorted, first), usageOverviewRealtimeSortedPercentile(sorted, second)
 }

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -2057,8 +2057,7 @@ func sampleUsageOverviewRealtimeDistributionParticles(particles []dto.RealtimeRe
 
 	sampled := make([]dto.RealtimeResponseParticleRecord, 0, maxParticles)
 	for index := 0; index < maxParticles; index++ {
-		start := index * len(sortedParticles) / maxParticles
-		end := (index + 1) * len(sortedParticles) / maxParticles
+		start, end := usageOverviewRealtimeDistributionParticleRange(index, len(sortedParticles), maxParticles)
 		if end <= start {
 			end = start + 1
 		}
@@ -2069,6 +2068,15 @@ func sampleUsageOverviewRealtimeDistributionParticles(particles []dto.RealtimeRe
 		sampled = append(sampled, representative)
 	}
 	return sampled
+}
+
+func usageOverviewRealtimeDistributionParticleRange(index, particleCount, maxParticles int) (int, int) {
+	if maxParticles <= 0 {
+		return 0, 0
+	}
+	start := int(int64(index) * int64(particleCount) / int64(maxParticles))
+	end := int(int64(index+1) * int64(particleCount) / int64(maxParticles))
+	return start, end
 }
 
 func usageOverviewRealtimeParticleTimeKey(particle dto.RealtimeResponseParticleRecord) string {

--- a/internal/repository/usage_filter_test.go
+++ b/internal/repository/usage_filter_test.go
@@ -1341,6 +1341,9 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 	if realtime.Window != "15m" || realtime.BucketSeconds != 30 {
 		t.Fatalf("unexpected realtime metadata: %+v", realtime)
 	}
+	if !realtime.WindowStart.Equal(now.Add(-15*time.Minute)) || !realtime.WindowEnd.Equal(now) {
+		t.Fatalf("expected realtime window bounds to match the selected range, got start=%s end=%s", realtime.WindowStart, realtime.WindowEnd)
+	}
 	if len(realtime.TokenVelocity) != 30 || len(realtime.ResponseLevel) != 30 || len(realtime.RequestLevel) != 30 || len(realtime.CacheLevel) != 30 {
 		t.Fatalf("expected 30 realtime buckets, got token=%d response=%d request=%d cache=%d", len(realtime.TokenVelocity), len(realtime.ResponseLevel), len(realtime.RequestLevel), len(realtime.CacheLevel))
 	}
@@ -1380,23 +1383,26 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 		realtime.ResponseDistribution.Latency.AverageLine[26].AvgMS == nil || math.Abs(*realtime.ResponseDistribution.Latency.AverageLine[26].AvgMS-900) > 0.000000001 {
 		t.Fatalf("expected failed request latency distribution without ttft after sliding carry, got ttft=%+v latency=%+v", realtime.ResponseDistribution.TTFT.AverageLine[26], realtime.ResponseDistribution.Latency.AverageLine[26])
 	}
-	expectedTTFTParticles := []dto.RealtimeResponseParticleRecord{
-		{Bucket: "2026-06-09T11:55:00Z", MS: 100, Count: 1},
-		{Bucket: "2026-06-09T11:55:00Z", MS: 200, Count: 1},
-	}
-	if !reflect.DeepEqual(realtime.ResponseDistribution.TTFT.Particles, expectedTTFTParticles) {
+	if len(realtime.ResponseDistribution.TTFT.Particles) != 2 {
 		t.Fatalf("expected response distribution TTFT particles to map one usage event to one point, got %+v", realtime.ResponseDistribution.TTFT.Particles)
 	}
-	expectedLatencyParticles := []dto.RealtimeResponseParticleRecord{
-		{Bucket: "2026-06-09T11:55:00Z", MS: 500, Count: 1},
-		{Bucket: "2026-06-09T11:55:00Z", MS: 700, Count: 1},
-		{Bucket: "2026-06-09T11:55:00Z", MS: 650, Count: 1},
-		{Bucket: "2026-06-09T11:55:30Z", MS: 900, Count: 1},
-		{Bucket: "2026-06-09T11:59:30Z", MS: 300, Count: 1},
-	}
-	if !reflect.DeepEqual(realtime.ResponseDistribution.Latency.Particles, expectedLatencyParticles) {
+	assertRealtimeParticleCore(t, realtime.ResponseDistribution.TTFT.Particles[0], "2026-06-09T11:55:00Z", 100, 1)
+	assertRealtimeParticleCore(t, realtime.ResponseDistribution.TTFT.Particles[1], "2026-06-09T11:55:00Z", 200, 1)
+	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.TTFT.Particles[0], "2026-06-09T11:55:10Z")
+	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.TTFT.Particles[1], "2026-06-09T11:55:15Z")
+	if len(realtime.ResponseDistribution.Latency.Particles) != 5 {
 		t.Fatalf("expected response distribution latency particles to map one usage event to one point, got %+v", realtime.ResponseDistribution.Latency.Particles)
 	}
+	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[0], "2026-06-09T11:55:00Z", 500, 1)
+	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[1], "2026-06-09T11:55:00Z", 700, 1)
+	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[2], "2026-06-09T11:55:00Z", 650, 1)
+	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[3], "2026-06-09T11:55:30Z", 900, 1)
+	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[4], "2026-06-09T11:59:30Z", 300, 1)
+	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[0], "2026-06-09T11:55:10Z")
+	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[1], "2026-06-09T11:55:15Z")
+	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[2], "2026-06-09T11:55:20Z")
+	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[3], "2026-06-09T11:55:30Z")
+	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[4], "2026-06-09T11:59:40Z")
 	if realtime.RequestLevel[21].Requests != 4 || math.Abs(realtime.RequestLevel[21].RequestsPerMinute-(4.0/3.0)) > 0.000000001 {
 		t.Fatalf("expected request level to use the 3m sliding window, got %+v", realtime.RequestLevel[21])
 	}
@@ -1436,6 +1442,134 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 		realtime.CurrentUsage.AIProviders[0].Label != "OpenAI Provider" ||
 		realtime.CurrentUsage.AIProviders[0].Tokens != 50 {
 		t.Fatalf("unexpected realtime ai provider usage: %+v", realtime.CurrentUsage.AIProviders)
+	}
+}
+
+func TestBuildUsageOverviewRealtimeWithFilterCapsResponseDistributionParticles(t *testing.T) {
+	withRepositoryTestLocation(t, "UTC")
+	db, err := OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "usage-overview-realtime-particle-cap.db")})
+	if err != nil {
+		t.Fatalf("OpenDatabase returned error: %v", err)
+	}
+	closeTestDatabase(t, db)
+
+	now := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	windowStart := now.Add(-60 * time.Minute)
+	const sampleCount = 1205
+	events := make([]entities.UsageEvent, 0, sampleCount)
+	for index := 0; index < sampleCount; index++ {
+		ttft := int64(80 + index%40)
+		events = append(events, entities.UsageEvent{
+			APIGroupKey: "provider-a",
+			Model:       "gpt-5",
+			Timestamp:   windowStart.Add(time.Duration(index) * 2 * time.Second),
+			LatencyMS:   int64(300 + index%200),
+			TTFTMS:      &ttft,
+		})
+	}
+	cache := newEmptyUsageRecentEventCache(UsageRecentEventCacheOptions{Now: func() time.Time { return now }})
+	t.Cleanup(cache.Close)
+	cache.appendEvents(events)
+	if err := db.Migrator().DropTable(&entities.UsageEvent{}); err != nil {
+		t.Fatalf("drop usage_events returned error: %v", err)
+	}
+
+	realtime, err := BuildUsageOverviewRealtimeWithFilterAndRecentCache(db, dto.UsageQueryFilter{
+		APIGroupKey:     "provider-a",
+		RealtimeWindow:  "60m",
+		RealtimeEndTime: &now,
+	}, cache)
+	if err != nil {
+		t.Fatalf("BuildUsageOverviewRealtimeWithFilterAndRecentCache returned error: %v", err)
+	}
+
+	assertRealtimeDistributionParticleCap(t, realtime.ResponseDistribution.TTFT, sampleCount)
+	assertRealtimeDistributionParticleCap(t, realtime.ResponseDistribution.Latency, sampleCount)
+}
+
+func assertRealtimeDistributionParticleCap(t *testing.T, series dto.RealtimeResponseDistributionSeriesRecord, totalSamples int64) {
+	t.Helper()
+	if len(series.Particles) > 1000 {
+		t.Fatalf("expected response distribution particles to be capped at 1000, got %d", len(series.Particles))
+	}
+	if got := sumRealtimeParticleCounts(series.Particles); got != totalSamples {
+		t.Fatalf("expected sampled particle counts to preserve %d real samples, got %d", totalSamples, got)
+	}
+	var merged bool
+	for _, particle := range series.Particles {
+		if particle.Count > 1 {
+			merged = true
+			break
+		}
+	}
+	if !merged {
+		t.Fatalf("expected capped response distribution to merge at least one particle, got %+v", series.Particles)
+	}
+	assertRealtimeDistributionSamplingMetadata(t, series, totalSamples, true, 1000)
+}
+
+func sumRealtimeParticleCounts(particles []dto.RealtimeResponseParticleRecord) int64 {
+	var total int64
+	for _, particle := range particles {
+		total += particle.Count
+	}
+	return total
+}
+
+func assertRealtimeDistributionSamplingMetadata(t *testing.T, series dto.RealtimeResponseDistributionSeriesRecord, totalParticles int64, sampled bool, maxParticles int64) {
+	t.Helper()
+	value := reflect.ValueOf(series)
+	assertRealtimeDistributionIntField(t, value, "TotalParticles", totalParticles)
+	assertRealtimeDistributionBoolField(t, value, "Sampled", sampled)
+	assertRealtimeDistributionIntField(t, value, "MaxParticles", maxParticles)
+}
+
+func assertRealtimeDistributionIntField(t *testing.T, value reflect.Value, name string, expected int64) {
+	t.Helper()
+	field := value.FieldByName(name)
+	if !field.IsValid() {
+		t.Fatalf("expected response distribution series to carry %s metadata", name)
+	}
+	if field.Kind() != reflect.Int && field.Kind() != reflect.Int64 {
+		t.Fatalf("expected %s metadata to be integer, got %s", name, field.Kind())
+	}
+	if got := field.Int(); got != expected {
+		t.Fatalf("expected %s metadata %d, got %d", name, expected, got)
+	}
+}
+
+func assertRealtimeDistributionBoolField(t *testing.T, value reflect.Value, name string, expected bool) {
+	t.Helper()
+	field := value.FieldByName(name)
+	if !field.IsValid() {
+		t.Fatalf("expected response distribution series to carry %s metadata", name)
+	}
+	if field.Kind() != reflect.Bool {
+		t.Fatalf("expected %s metadata to be bool, got %s", name, field.Kind())
+	}
+	if got := field.Bool(); got != expected {
+		t.Fatalf("expected %s metadata %t, got %t", name, expected, got)
+	}
+}
+
+func assertRealtimeParticleCore(t *testing.T, particle dto.RealtimeResponseParticleRecord, bucket string, ms, count int64) {
+	t.Helper()
+	if particle.Bucket != bucket || particle.MS != ms || particle.Count != count {
+		t.Fatalf("unexpected response distribution particle core fields: got %+v want bucket=%s ms=%d count=%d", particle, bucket, ms, count)
+	}
+}
+
+func assertRealtimeParticleTimestamp(t *testing.T, particle dto.RealtimeResponseParticleRecord, expected string) {
+	t.Helper()
+	field := reflect.ValueOf(particle).FieldByName("Timestamp")
+	if !field.IsValid() {
+		t.Fatalf("expected response distribution particle to carry the usage event timestamp, got %+v", particle)
+	}
+	if field.Kind() != reflect.String {
+		t.Fatalf("expected response distribution particle timestamp to be string, got %s", field.Kind())
+	}
+	if got := field.String(); got != expected {
+		t.Fatalf("expected response distribution particle timestamp %s, got %s", expected, got)
 	}
 }
 

--- a/internal/repository/usage_filter_test.go
+++ b/internal/repository/usage_filter_test.go
@@ -1487,6 +1487,13 @@ func TestBuildUsageOverviewRealtimeWithFilterCapsResponseDistributionParticles(t
 	assertRealtimeDistributionParticleCap(t, realtime.ResponseDistribution.Latency, sampleCount)
 }
 
+func TestUsageOverviewRealtimeDistributionParticleRangeUsesWideArithmetic(t *testing.T) {
+	start, end := usageOverviewRealtimeDistributionParticleRange(999, 2_200_000, 1000)
+	if start != 2_197_800 || end != 2_200_000 {
+		t.Fatalf("expected wide particle range arithmetic, got start=%d end=%d", start, end)
+	}
+}
+
 func assertRealtimeDistributionParticleCap(t *testing.T, series dto.RealtimeResponseDistributionSeriesRecord, totalSamples int64) {
 	t.Helper()
 	if len(series.Particles) > 1000 {

--- a/internal/service/dto/usage.go
+++ b/internal/service/dto/usage.go
@@ -148,15 +148,19 @@ type RealtimeResponseAveragePoint struct {
 
 // RealtimeResponseParticle 是响应分布图的一个聚合粒子点。
 type RealtimeResponseParticle struct {
-	Bucket string
-	MS     int64
-	Count  int64
+	Bucket    string
+	Timestamp string
+	MS        int64
+	Count     int64
 }
 
 // RealtimeResponseDistributionSeries 是单个响应指标的平均线和粒子分布。
 type RealtimeResponseDistributionSeries struct {
-	AverageLine []RealtimeResponseAveragePoint
-	Particles   []RealtimeResponseParticle
+	AverageLine    []RealtimeResponseAveragePoint
+	Particles      []RealtimeResponseParticle
+	TotalParticles int64
+	Sampled        bool
+	MaxParticles   int
 }
 
 // RealtimeResponseDistribution 是 TTFT 和 Latency 的实时响应分布。
@@ -202,6 +206,8 @@ type RealtimeCacheLevelPoint struct {
 type UsageOverviewRealtime struct {
 	Window               string
 	BucketSeconds        int64
+	WindowStart          time.Time
+	WindowEnd            time.Time
 	TokenVelocity        []RealtimeTokenVelocityPoint
 	ResponseLevel        []RealtimeResponseLevelPoint
 	ResponseDistribution RealtimeResponseDistribution

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -133,6 +133,8 @@ func mapUsageOverviewRealtime(realtime repodto.UsageOverviewRealtimeRecord) serv
 	return servicedto.UsageOverviewRealtime{
 		Window:               realtime.Window,
 		BucketSeconds:        realtime.BucketSeconds,
+		WindowStart:          realtime.WindowStart,
+		WindowEnd:            realtime.WindowEnd,
 		TokenVelocity:        mapRealtimeTokenVelocity(realtime.TokenVelocity),
 		ResponseLevel:        mapRealtimeResponseLevel(realtime.ResponseLevel),
 		ResponseDistribution: mapRealtimeResponseDistribution(realtime.ResponseDistribution),
@@ -178,8 +180,11 @@ func mapRealtimeResponseDistribution(distribution repodto.RealtimeResponseDistri
 
 func mapRealtimeResponseDistributionSeries(series repodto.RealtimeResponseDistributionSeriesRecord) servicedto.RealtimeResponseDistributionSeries {
 	return servicedto.RealtimeResponseDistributionSeries{
-		AverageLine: mapRealtimeResponseAveragePoints(series.AverageLine),
-		Particles:   mapRealtimeResponseParticles(series.Particles),
+		AverageLine:    mapRealtimeResponseAveragePoints(series.AverageLine),
+		Particles:      mapRealtimeResponseParticles(series.Particles),
+		TotalParticles: series.TotalParticles,
+		Sampled:        series.Sampled,
+		MaxParticles:   series.MaxParticles,
 	}
 }
 
@@ -198,9 +203,10 @@ func mapRealtimeResponseParticles(points []repodto.RealtimeResponseParticleRecor
 	result := make([]servicedto.RealtimeResponseParticle, 0, len(points))
 	for _, point := range points {
 		result = append(result, servicedto.RealtimeResponseParticle{
-			Bucket: point.Bucket,
-			MS:     point.MS,
-			Count:  point.Count,
+			Bucket:    point.Bucket,
+			Timestamp: point.Timestamp,
+			MS:        point.MS,
+			Count:     point.Count,
 		})
 	}
 	return result

--- a/web/src/components/usage/OverviewRealtimePanel.logic.test.tsx
+++ b/web/src/components/usage/OverviewRealtimePanel.logic.test.tsx
@@ -36,6 +36,8 @@ import { OverviewRealtimePanel } from './OverviewRealtimePanel';
 const realtime: OverviewRealtimeBlock = {
   window: '15m',
   bucket_seconds: 30,
+  window_start: '2026-06-09T11:55:00Z',
+  window_end: '2026-06-09T12:10:00Z',
   token_velocity: [
     { bucket: '2026-06-09T11:55:00Z', tokens_per_minute: 120, tokens: 60, cost: 0.01 },
     { bucket: '2026-06-09T11:55:30Z', tokens_per_minute: 240, tokens: 120, cost: 0.02 },
@@ -51,8 +53,8 @@ const realtime: OverviewRealtimeBlock = {
         { bucket: '2026-06-09T11:55:30Z', avg_ms: 190 },
       ],
       particles: [
-        { bucket: '2026-06-09T11:55:00Z', ms: 120, count: 2 },
-        { bucket: '2026-06-09T11:55:30Z', ms: 230, count: 5 },
+        { bucket: '2026-06-09T11:55:00Z', timestamp: '2026-06-09T11:55:10Z', ms: 120, count: 2 },
+        { bucket: '2026-06-09T11:55:30Z', timestamp: '2026-06-09T11:55:41Z', ms: 230, count: 5 },
       ],
     },
     latency: {
@@ -61,8 +63,8 @@ const realtime: OverviewRealtimeBlock = {
         { bucket: '2026-06-09T11:55:30Z', avg_ms: 780 },
       ],
       particles: [
-        { bucket: '2026-06-09T11:55:00Z', ms: 520, count: 3 },
-        { bucket: '2026-06-09T11:55:30Z', ms: 940, count: 6 },
+        { bucket: '2026-06-09T11:55:00Z', timestamp: '2026-06-09T11:55:11Z', ms: 520, count: 3 },
+        { bucket: '2026-06-09T11:55:30Z', timestamp: '2026-06-09T11:55:44Z', ms: 940, count: 6 },
       ],
     },
   },
@@ -239,14 +241,25 @@ describe('OverviewRealtimePanel', () => {
       'usage_stats.overview_realtime_ttft_average',
       'usage_stats.overview_realtime_ttft_distribution',
     ]);
+    expect(chartCapture.chartCalls[0].data.datasets[0].data).toEqual([
+      { x: Date.parse('2026-06-09T11:55:00Z'), y: 150 },
+      { x: Date.parse('2026-06-09T11:55:30Z'), y: 190 },
+    ]);
     expect(chartCapture.chartCalls[0].data.datasets[1].data).toEqual([
-      { x: '11:55', y: 120, count: 2 },
-      { x: '11:55:30', y: 230, count: 5 },
+      { x: Date.parse('2026-06-09T11:55:10Z'), y: 120, count: 2 },
+      { x: Date.parse('2026-06-09T11:55:41Z'), y: 230, count: 5 },
     ]);
     expect(chartCapture.chartCalls[1].data.datasets.map((dataset) => dataset.label)).toEqual([
       'usage_stats.overview_realtime_latency_average',
       'usage_stats.overview_realtime_latency_distribution',
     ]);
+    const ttftXAxis = chartCapture.chartCalls[0].options.scales?.x as { type?: string; min?: number; max?: number };
+    const latencyXAxis = chartCapture.chartCalls[1].options.scales?.x as { type?: string; min?: number; max?: number };
+    expect(ttftXAxis.type).toBe('linear');
+    expect(ttftXAxis.min).toBe(Date.parse('2026-06-09T11:55:00Z'));
+    expect(ttftXAxis.max).toBe(Date.parse('2026-06-09T12:10:00Z'));
+    expect(latencyXAxis.min).toBe(ttftXAxis.min);
+    expect(latencyXAxis.max).toBe(ttftXAxis.max);
   });
 
   it('uses data-driven logarithmic response axes per distribution chart', () => {
@@ -317,7 +330,7 @@ describe('OverviewRealtimePanel', () => {
           ],
           particles: [
             { bucket: '2026-06-09T11:55:00Z', ms: 0, count: 1 },
-            { bucket: '2026-06-09T11:55:30Z', ms: 900, count: 1 },
+            { bucket: '2026-06-09T11:55:30Z', timestamp: '2026-06-09T11:55:42Z', ms: 900, count: 1 },
           ],
         },
       },
@@ -335,17 +348,26 @@ describe('OverviewRealtimePanel', () => {
       />
     );
 
-    expect(chartCapture.chartCalls[0].data.datasets[0].data).toEqual([null, null, 120]);
+    expect(chartCapture.chartCalls[0].data.datasets[0].data).toEqual([
+      { x: Date.parse('2026-06-09T11:55:00Z'), y: null },
+      { x: Date.parse('2026-06-09T11:55:30Z'), y: null },
+      { x: Date.parse('2026-06-09T11:56:00Z'), y: 120 },
+    ]);
     expect(chartCapture.chartCalls[0].data.datasets[1].data).toEqual([]);
-    expect(chartCapture.chartCalls[1].data.datasets[0].data).toEqual([null, 800]);
+    expect(chartCapture.chartCalls[1].data.datasets[0].data).toEqual([
+      { x: Date.parse('2026-06-09T11:55:00Z'), y: null },
+      { x: Date.parse('2026-06-09T11:55:30Z'), y: 800 },
+    ]);
     expect(chartCapture.chartCalls[1].data.datasets[1].data).toEqual([
-      { x: '11:55:30', y: 900, count: 1 },
+      { x: Date.parse('2026-06-09T11:55:42Z'), y: 900, count: 1 },
     ]);
   });
 
-  it('caps response distribution particles at one thousand points', () => {
+  it('keeps every response distribution particle visible', () => {
+    const start = Date.parse('2026-06-09T11:40:00Z');
     const particles = Array.from({ length: 1_205 }, (_, index) => ({
-      bucket: `2026-06-09T11:${String(40 + Math.floor(index / 60)).padStart(2, '0')}:${String(index % 60).padStart(2, '0')}Z`,
+      bucket: new Date(start + index * 1000).toISOString(),
+      timestamp: new Date(start + index * 1000).toISOString(),
       ms: index + 1,
       count: 1,
     }));
@@ -372,7 +394,7 @@ describe('OverviewRealtimePanel', () => {
 
     const ttftParticleData = chartCapture.chartCalls[0].data.datasets[1].data as Array<{ y: number }>;
 
-    expect(ttftParticleData).toHaveLength(1_000);
+    expect(ttftParticleData).toHaveLength(1_205);
     expect(ttftParticleData[0].y).toBe(1);
     expect(ttftParticleData[ttftParticleData.length - 1].y).toBe(1_205);
   });

--- a/web/src/components/usage/OverviewRealtimePanel.logic.test.tsx
+++ b/web/src/components/usage/OverviewRealtimePanel.logic.test.tsx
@@ -317,6 +317,7 @@ describe('OverviewRealtimePanel', () => {
       response_distribution: {
         ttft: {
           average_line: [
+            null,
             { bucket: '2026-06-09T11:55:00Z', avg_ms: 0 },
             { bucket: '2026-06-09T11:55:30Z', avg_ms: -5 },
             { bucket: '2026-06-09T11:56:00Z', avg_ms: 120 },
@@ -325,6 +326,7 @@ describe('OverviewRealtimePanel', () => {
         },
         latency: {
           average_line: [
+            undefined,
             { bucket: '2026-06-09T11:55:00Z', avg_ms: 0 },
             { bucket: '2026-06-09T11:55:30Z', avg_ms: 800 },
           ],

--- a/web/src/components/usage/OverviewRealtimePanel.tsx
+++ b/web/src/components/usage/OverviewRealtimePanel.tsx
@@ -34,8 +34,9 @@ interface RealtimeMetric {
   tone?: 'up' | 'down' | 'flat';
 }
 
-type ResponseDistributionDatum = number | null | { x: string; y: number; count: number };
-type ResponseDistributionParticleDatum = { x: string; y: number; count: number };
+type ResponseDistributionDatum = { x: number; y: number | null };
+type ResponseDistributionParticleDatum = { x: number; y: number; count: number };
+type ResponseDistributionXBounds = { min: number; max: number };
 
 interface OverviewRealtimePanelProps {
   realtime?: OverviewRealtimeBlock;
@@ -51,7 +52,6 @@ interface OverviewRealtimePanelProps {
 
 const REALTIME_WINDOWS: OverviewRealtimeWindow[] = ['15m', '30m', '60m'];
 const DEFAULT_VISIBLE_DIMENSIONS: readonly RealtimeDimensionKey[] = ['models', 'api_keys', 'auth_files', 'ai_providers'];
-const RESPONSE_DISTRIBUTION_MAX_PARTICLES = 1000;
 
 const CHART_COLORS = {
   token: '#3b82f6',
@@ -293,10 +293,6 @@ function responseDistributionAveragePoints(
   }));
 }
 
-function responseDistributionLabels(points: RealtimeResponseAveragePoint[] | null | undefined, timezone?: string): string[] {
-  return (points ?? []).map((point) => formatBucketLabel(point.bucket, timezone));
-}
-
 function responseDistributionValues(points: RealtimeResponseAveragePoint[] | null | undefined): Array<number | null> {
   return (points ?? []).map((point) => {
     if (point.avg_ms == null) return null;
@@ -305,23 +301,55 @@ function responseDistributionValues(points: RealtimeResponseAveragePoint[] | nul
   });
 }
 
-function sampleResponseDistributionParticles(particles: RealtimeResponseParticle[] | null | undefined): RealtimeResponseParticle[] {
-  const safeParticles = (particles ?? []).filter(Boolean);
-  if (safeParticles.length <= RESPONSE_DISTRIBUTION_MAX_PARTICLES) return safeParticles;
-  const lastIndex = safeParticles.length - 1;
-  const lastSampleIndex = RESPONSE_DISTRIBUTION_MAX_PARTICLES - 1;
-  return Array.from({ length: RESPONSE_DISTRIBUTION_MAX_PARTICLES }, (_, index) => {
-    const sourceIndex = index === lastSampleIndex ? lastIndex : Math.floor((index * lastIndex) / lastSampleIndex);
-    return safeParticles[sourceIndex];
-  });
+function parseResponseDistributionTime(value: string | null | undefined): number | null {
+  const parsed = Date.parse(value ?? '');
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
-function responseDistributionParticleData(particles: RealtimeResponseParticle[] | null | undefined, timezone?: string): ResponseDistributionParticleDatum[] {
-  return sampleResponseDistributionParticles(particles).map((point) => ({
-    x: formatBucketLabel(point.bucket, timezone),
-    y: safeNumber(point.ms),
-    count: Math.max(1, safeNumber(point.count)),
-  })).filter((point) => point.y > 0);
+function responseDistributionAverageData(points: RealtimeResponseAveragePoint[] | null | undefined): ResponseDistributionDatum[] {
+  return (points ?? []).map((point) => {
+    const x = parseResponseDistributionTime(point.bucket);
+    if (x == null) return null;
+    if (point.avg_ms == null) return { x, y: null };
+    const value = safeNumber(point.avg_ms);
+    return { x, y: value > 0 ? value : null };
+  }).filter((point): point is ResponseDistributionDatum => point !== null);
+}
+
+function responseDistributionParticleData(particles: RealtimeResponseParticle[] | null | undefined): ResponseDistributionParticleDatum[] {
+  return (particles ?? []).filter(Boolean).map((point) => {
+    const x = parseResponseDistributionTime(point.timestamp ?? point.bucket);
+    if (x == null) return null;
+    return {
+      x,
+      y: safeNumber(point.ms),
+      count: Math.max(1, safeNumber(point.count)),
+    };
+  }).filter((point): point is ResponseDistributionParticleDatum => Boolean(point && point.y > 0));
+}
+
+function responseDistributionXBounds(data: OverviewRealtimeBlock): ResponseDistributionXBounds | undefined {
+  const min = parseResponseDistributionTime(data.window_start);
+  const max = parseResponseDistributionTime(data.window_end);
+  if (min != null && max != null && max > min) {
+    return { min, max };
+  }
+
+  const bucketSeconds = safeNumber(data.bucket_seconds);
+  if (bucketSeconds <= 0) return undefined;
+  const bucketStarts = [
+    ...data.token_velocity,
+    ...data.response_level,
+    ...data.request_level,
+    ...data.cache_level,
+    ...data.response_distribution.ttft.average_line,
+    ...data.response_distribution.latency.average_line,
+  ].map((point) => parseResponseDistributionTime(point.bucket))
+    .filter((value): value is number => value != null);
+  if (bucketStarts.length === 0) return undefined;
+  const minBucket = Math.min(...bucketStarts);
+  const maxBucket = Math.max(...bucketStarts) + bucketSeconds * 1000;
+  return maxBucket > minBucket ? { min: minBucket, max: maxBucket } : undefined;
 }
 
 function responseParticleRadius(count: number, isMobile: boolean): number {
@@ -331,21 +359,19 @@ function responseParticleRadius(count: number, isMobile: boolean): number {
 }
 
 function buildResponseDistributionData(
-  labels: string[],
   averageLabel: string,
   particleLabel: string,
-  averageValues: Array<number | null>,
-  particles: Array<{ x: string; y: number; count: number }>,
+  averageData: ResponseDistributionDatum[],
+  particles: ResponseDistributionParticleDatum[],
   color: string,
   isMobile: boolean,
-): ChartData<'line', ResponseDistributionDatum[], string> {
+): ChartData<'line', ResponseDistributionDatum[], number> {
   return {
-    labels,
     datasets: [
       {
         type: 'line',
         label: averageLabel,
-        data: averageValues,
+        data: averageData,
         borderColor: color,
         backgroundColor: `${color}12`,
         borderWidth: isMobile ? 1.8 : 2.2,
@@ -380,14 +406,28 @@ function buildResponseDistributionData(
 function buildResponseDistributionOptions(
   isDark: boolean,
   isMobile: boolean,
-  averageValues: Array<number | null>,
+  averageData: ResponseDistributionDatum[],
   particles: RealtimeResponseParticle[] | null | undefined,
+  xBounds: ResponseDistributionXBounds | undefined,
+  timezone?: string,
 ): ChartOptions<'line'> {
   const options = buildRealtimeLineOptions(isDark, isMobile, formatRealtimeDuration, { yMaxTicksLimit: 5 });
-  const yBounds = responseDistributionLogAxisBounds(averageValues, particles);
+  const yBounds = responseDistributionLogAxisBounds(averageData, particles);
+  const baseXScale = options.scales?.x;
   const baseYScale = options.scales?.y;
   const responseScales = {
     ...options.scales,
+    x: {
+      type: 'linear' as const,
+      min: xBounds?.min,
+      max: xBounds?.max,
+      grid: baseXScale?.grid,
+      border: baseXScale?.border,
+      ticks: {
+        ...baseXScale?.ticks,
+        callback: (value) => formatResponseDistributionTick(Number(value), timezone),
+      },
+    },
     y: {
       type: 'logarithmic' as const,
       min: yBounds.min,
@@ -406,6 +446,10 @@ function buildResponseDistributionOptions(
       tooltip: {
         ...options.plugins?.tooltip,
         callbacks: {
+          title: (items) => {
+            const x = Number(items[0]?.parsed.x ?? 0);
+            return Number.isFinite(x) ? formatResponseDistributionTick(x, timezone) : '';
+          },
           label: (context) => {
             const raw = context.raw as { count?: number } | undefined;
             const label = context.dataset.label ? `${context.dataset.label}: ` : '';
@@ -422,10 +466,16 @@ function buildResponseDistributionOptions(
   };
 }
 
-function responseDistributionLogAxisBounds(averageValues: Array<number | null> | null | undefined, particles: RealtimeResponseParticle[] | null | undefined): { min: number; max: number } {
+function formatResponseDistributionTick(value: number, timezone?: string): string {
+  if (!Number.isFinite(value)) return '';
+  return formatBucketLabel(new Date(value).toISOString(), timezone);
+}
+
+function responseDistributionLogAxisBounds(averageData: ResponseDistributionDatum[] | null | undefined, particles: RealtimeResponseParticle[] | null | undefined): { min: number; max: number } {
   let minValue = Number.POSITIVE_INFINITY;
   let maxValue = 0;
-  for (const value of averageValues ?? []) {
+  for (const point of averageData ?? []) {
+    const value = point.y;
     if (value == null || !Number.isFinite(value) || value <= 0) continue;
     minValue = Math.min(minValue, value);
     maxValue = Math.max(maxValue, value);
@@ -538,12 +588,13 @@ export function OverviewRealtimePanel({ realtime, loading, error, window, onWind
     data.response_distribution.latency.average_line,
     data.response_level.map((point) => ({ bucket: point.bucket, value: point.latency_p95_ms })),
   ), [data.response_distribution.latency.average_line, data.response_level]);
-  const ttftDistributionLabels = useMemo(() => responseDistributionLabels(ttftAveragePoints, responseTimezone), [responseTimezone, ttftAveragePoints]);
-  const latencyDistributionLabels = useMemo(() => responseDistributionLabels(latencyAveragePoints, responseTimezone), [latencyAveragePoints, responseTimezone]);
   const ttftAverageValues = useMemo(() => responseDistributionValues(ttftAveragePoints), [ttftAveragePoints]);
   const latencyAverageValues = useMemo(() => responseDistributionValues(latencyAveragePoints), [latencyAveragePoints]);
-  const ttftParticleValues = useMemo(() => responseDistributionParticleData(data.response_distribution.ttft.particles, responseTimezone), [data.response_distribution.ttft.particles, responseTimezone]);
-  const latencyParticleValues = useMemo(() => responseDistributionParticleData(data.response_distribution.latency.particles, responseTimezone), [data.response_distribution.latency.particles, responseTimezone]);
+  const ttftAverageChartData = useMemo(() => responseDistributionAverageData(ttftAveragePoints), [ttftAveragePoints]);
+  const latencyAverageChartData = useMemo(() => responseDistributionAverageData(latencyAveragePoints), [latencyAveragePoints]);
+  const ttftParticleValues = useMemo(() => responseDistributionParticleData(data.response_distribution.ttft.particles), [data.response_distribution.ttft.particles]);
+  const latencyParticleValues = useMemo(() => responseDistributionParticleData(data.response_distribution.latency.particles), [data.response_distribution.latency.particles]);
+  const distributionXBounds = useMemo(() => responseDistributionXBounds(data), [data]);
   const tokenEmptyLabel = data.token_velocity.length === 0 ? t('usage_stats.overview_realtime_token_empty') : undefined;
   const requestEmptyLabel = data.request_level.length === 0 ? t('usage_stats.overview_realtime_request_empty') : undefined;
   const ttftEmptyLabel = !hasFiniteNumber(ttftAverageValues) && ttftParticleValues.length === 0 ? t('usage_stats.overview_realtime_ttft_empty') : undefined;
@@ -555,15 +606,19 @@ export function OverviewRealtimePanel({ realtime, loading, error, window, onWind
   const ttftDistributionOptions = useMemo(() => buildResponseDistributionOptions(
     isDark,
     isMobile,
-    ttftAverageValues,
+    ttftAverageChartData,
     data.response_distribution.ttft.particles,
-  ), [data.response_distribution.ttft.particles, isDark, isMobile, ttftAverageValues]);
+    distributionXBounds,
+    responseTimezone,
+  ), [data.response_distribution.ttft.particles, distributionXBounds, isDark, isMobile, responseTimezone, ttftAverageChartData]);
   const latencyDistributionOptions = useMemo(() => buildResponseDistributionOptions(
     isDark,
     isMobile,
-    latencyAverageValues,
+    latencyAverageChartData,
     data.response_distribution.latency.particles,
-  ), [data.response_distribution.latency.particles, isDark, isMobile, latencyAverageValues]);
+    distributionXBounds,
+    responseTimezone,
+  ), [data.response_distribution.latency.particles, distributionXBounds, isDark, isMobile, latencyAverageChartData, responseTimezone]);
   const latestLabel = t('usage_stats.overview_realtime_latest');
   const averageLabel = t('usage_stats.overview_realtime_average');
   const trendLabel = t('usage_stats.overview_realtime_trend');
@@ -573,23 +628,21 @@ export function OverviewRealtimePanel({ realtime, loading, error, window, onWind
   const requestChartData = useMemo(() => buildSingleLineData(labels, t('usage_stats.overview_realtime_rpm'), requestValues, CHART_COLORS.request), [labels, requestValues, t]);
   const cacheChartData = useMemo(() => buildSingleLineData(labels, t('usage_stats.overview_realtime_cache_rate'), cacheValues, CHART_COLORS.cache), [cacheValues, labels, t]);
   const ttftDistributionChartData = useMemo(() => buildResponseDistributionData(
-    ttftDistributionLabels,
     t('usage_stats.overview_realtime_ttft_average'),
     t('usage_stats.overview_realtime_ttft_distribution'),
-    ttftAverageValues,
+    ttftAverageChartData,
     ttftParticleValues,
     CHART_COLORS.ttft,
     isMobile,
-  ), [isMobile, t, ttftAverageValues, ttftDistributionLabels, ttftParticleValues]);
+  ), [isMobile, t, ttftAverageChartData, ttftParticleValues]);
   const latencyDistributionChartData = useMemo(() => buildResponseDistributionData(
-    latencyDistributionLabels,
     t('usage_stats.overview_realtime_latency_average'),
     t('usage_stats.overview_realtime_latency_distribution'),
-    latencyAverageValues,
+    latencyAverageChartData,
     latencyParticleValues,
     CHART_COLORS.latency,
     isMobile,
-  ), [isMobile, latencyAverageValues, latencyDistributionLabels, latencyParticleValues, t]);
+  ), [isMobile, latencyAverageChartData, latencyParticleValues, t]);
   const ttftMetrics = useMemo(() => metricChips(ttftAverageValues, formatRealtimeDuration, averageLabel, latestLabel, trendLabel, {
       invertTone: true,
     }), [averageLabel, latestLabel, trendLabel, ttftAverageValues]);

--- a/web/src/components/usage/OverviewRealtimePanel.tsx
+++ b/web/src/components/usage/OverviewRealtimePanel.tsx
@@ -294,7 +294,7 @@ function responseDistributionAveragePoints(
 }
 
 function responseDistributionValues(points: RealtimeResponseAveragePoint[] | null | undefined): Array<number | null> {
-  return (points ?? []).map((point) => {
+  return (points ?? []).filter(Boolean).map((point) => {
     if (point.avg_ms == null) return null;
     const value = safeNumber(point.avg_ms);
     return value > 0 ? value : null;
@@ -307,7 +307,7 @@ function parseResponseDistributionTime(value: string | null | undefined): number
 }
 
 function responseDistributionAverageData(points: RealtimeResponseAveragePoint[] | null | undefined): ResponseDistributionDatum[] {
-  return (points ?? []).map((point) => {
+  return (points ?? []).filter(Boolean).map((point) => {
     const x = parseResponseDistributionTime(point.bucket);
     if (x == null) return null;
     if (point.avg_ms == null) return { x, y: null };

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -31,6 +31,10 @@ function realtimeBucketSecondsForWindow(window: OverviewRealtimeWindow): number 
   return 30
 }
 
+function realtimeResponseParticleTotal(particles: OverviewRealtimeBlock['response_distribution']['ttft']['particles']): number {
+  return particles.reduce((total, particle) => total + Math.max(1, Number(particle.count) || 0), 0)
+}
+
 function normalizeOverviewRealtimeBlock(
   block: Partial<OverviewRealtimeBlock> & {
     current_usage?: Partial<OverviewRealtimeBlock['current_usage']>;
@@ -40,21 +44,31 @@ function normalizeOverviewRealtimeBlock(
 ): OverviewRealtimeBlock {
   const currentUsage: Partial<OverviewRealtimeBlock['current_usage']> = block.current_usage ?? {}
   const responseDistribution: Partial<OverviewRealtimeBlock['response_distribution']> = block.response_distribution ?? {}
+  const ttftParticles = responseDistribution.ttft?.particles ?? []
+  const latencyParticles = responseDistribution.latency?.particles ?? []
   const resolvedWindow = block.window ?? fallbackWindow ?? '15m'
   return {
     window: resolvedWindow,
     timezone: block.timezone,
     bucket_seconds: block.bucket_seconds ?? realtimeBucketSecondsForWindow(resolvedWindow),
+    window_start: block.window_start,
+    window_end: block.window_end,
     token_velocity: block.token_velocity ?? [],
     response_level: block.response_level ?? [],
     response_distribution: {
       ttft: {
         average_line: responseDistribution.ttft?.average_line ?? [],
-        particles: responseDistribution.ttft?.particles ?? [],
+        particles: ttftParticles,
+        total_particles: responseDistribution.ttft?.total_particles ?? realtimeResponseParticleTotal(ttftParticles),
+        sampled: responseDistribution.ttft?.sampled ?? false,
+        max_particles: responseDistribution.ttft?.max_particles ?? 1000,
       },
       latency: {
         average_line: responseDistribution.latency?.average_line ?? [],
-        particles: responseDistribution.latency?.particles ?? [],
+        particles: latencyParticles,
+        total_particles: responseDistribution.latency?.total_particles ?? realtimeResponseParticleTotal(latencyParticles),
+        sampled: responseDistribution.latency?.sampled ?? false,
+        max_particles: responseDistribution.latency?.max_particles ?? 1000,
       },
     },
     current_usage: {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -128,6 +128,7 @@ export interface RealtimeResponseAveragePoint {
 
 export interface RealtimeResponseParticle {
   bucket: string
+  timestamp?: string
   ms: number
   count: number
 }
@@ -135,6 +136,9 @@ export interface RealtimeResponseParticle {
 export interface RealtimeResponseDistributionSeries {
   average_line: RealtimeResponseAveragePoint[]
   particles: RealtimeResponseParticle[]
+  total_particles?: number
+  sampled?: boolean
+  max_particles?: number
 }
 
 export interface RealtimeResponseDistribution {
@@ -175,6 +179,8 @@ export interface OverviewRealtimeBlock {
   window: OverviewRealtimeWindow
   timezone?: string
   bucket_seconds: number
+  window_start?: string
+  window_end?: string
   token_velocity: RealtimeTokenVelocityPoint[]
   response_level: RealtimeResponseLevelPoint[]
   response_distribution: RealtimeResponseDistribution


### PR DESCRIPTION
## Summary
- cap Overview realtime TTFT and latency distribution particles at 1000 visual points per series
- preserve full-sample average, p50/p95, current usage, and total represented particle counts
- add response metadata for total particles, sampling state, and max particles

## Validation
- rtk git diff --check
- rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build go test -count=1 ./cmd/... ./internal/...
- rtk npm --prefix ./web run test
- rtk npm --prefix ./web run lint
- rtk npm --prefix ./web run typecheck
- rtk npm --prefix ./web run build
- runtime API check on 60m mock data: TTFT 1000/9828, latency 1000/10485 with count sums preserved