### PR TITLE
Stabilize realtime overview window switching

### DIFF
--- a/web/src/components/usage/hooks/useOverviewRealtimeData.test.ts
+++ b/web/src/components/usage/hooks/useOverviewRealtimeData.test.ts
@@ -25,25 +25,39 @@ describe('resolveDisplayRealtime', () => {
   it('keeps the previous realtime block visible while a new window is loading', () => {
     expect(resolveDisplayRealtime({
       realtime: realtimeForWindow('15m'),
-      loading: true,
       lastRealtimeQueryKey: ':15m',
       realtimeQueryKey: ':60m',
     })?.window).toBe('15m');
   });
 
-  it('hides stale realtime data after loading has finished for a different query', () => {
+  it('keeps the previous realtime block visible before same-scope window loading starts', () => {
     expect(resolveDisplayRealtime({
       realtime: realtimeForWindow('15m'),
-      loading: false,
-      lastRealtimeQueryKey: ':15m',
-      realtimeQueryKey: ':60m',
+      lastRealtimeQueryKey: 'key-a:15m',
+      realtimeQueryKey: 'key-a:60m',
+    })?.window).toBe('15m');
+  });
+
+  it('hides stale realtime data after a same-scope window query fails', () => {
+    expect(resolveDisplayRealtime({
+      realtime: realtimeForWindow('15m'),
+      lastRealtimeErrorQueryKey: 'key-a:60m',
+      lastRealtimeQueryKey: 'key-a:15m',
+      realtimeQueryKey: 'key-a:60m',
     })).toBeNull();
   });
 
   it('hides stale realtime data while loading if the API key changes', () => {
     expect(resolveDisplayRealtime({
       realtime: realtimeForWindow('15m'),
-      loading: true,
+      lastRealtimeQueryKey: 'key-a:15m',
+      realtimeQueryKey: 'key-b:15m',
+    })).toBeNull();
+  });
+
+  it('hides stale realtime data before loading starts if the API key changes', () => {
+    expect(resolveDisplayRealtime({
+      realtime: realtimeForWindow('15m'),
       lastRealtimeQueryKey: 'key-a:15m',
       realtimeQueryKey: 'key-b:15m',
     })).toBeNull();

--- a/web/src/components/usage/hooks/useOverviewRealtimeData.test.ts
+++ b/web/src/components/usage/hooks/useOverviewRealtimeData.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import type { OverviewRealtimeBlock, OverviewRealtimeWindow } from '@/lib/types';
+import { resolveDisplayRealtime } from './useOverviewRealtimeData';
+
+const realtimeForWindow = (window: OverviewRealtimeWindow): OverviewRealtimeBlock => ({
+  window,
+  bucket_seconds: window === '60m' ? 120 : window === '30m' ? 60 : 30,
+  token_velocity: [],
+  response_level: [],
+  response_distribution: {
+    ttft: { average_line: [], particles: [] },
+    latency: { average_line: [], particles: [] },
+  },
+  current_usage: {
+    models: [],
+    api_keys: [],
+    auth_files: [],
+    ai_providers: [],
+  },
+  request_level: [],
+  cache_level: [],
+});
+
+describe('resolveDisplayRealtime', () => {
+  it('keeps the previous realtime block visible while a new window is loading', () => {
+    expect(resolveDisplayRealtime({
+      realtime: realtimeForWindow('15m'),
+      loading: true,
+      lastRealtimeQueryKey: ':15m',
+      realtimeQueryKey: ':60m',
+    })?.window).toBe('15m');
+  });
+
+  it('hides stale realtime data after loading has finished for a different query', () => {
+    expect(resolveDisplayRealtime({
+      realtime: realtimeForWindow('15m'),
+      loading: false,
+      lastRealtimeQueryKey: ':15m',
+      realtimeQueryKey: ':60m',
+    })).toBeNull();
+  });
+});

--- a/web/src/components/usage/hooks/useOverviewRealtimeData.test.ts
+++ b/web/src/components/usage/hooks/useOverviewRealtimeData.test.ts
@@ -39,4 +39,13 @@ describe('resolveDisplayRealtime', () => {
       realtimeQueryKey: ':60m',
     })).toBeNull();
   });
+
+  it('hides stale realtime data while loading if the API key changes', () => {
+    expect(resolveDisplayRealtime({
+      realtime: realtimeForWindow('15m'),
+      loading: true,
+      lastRealtimeQueryKey: 'key-a:15m',
+      realtimeQueryKey: 'key-b:15m',
+    })).toBeNull();
+  });
 });

--- a/web/src/components/usage/hooks/useOverviewRealtimeData.ts
+++ b/web/src/components/usage/hooks/useOverviewRealtimeData.ts
@@ -20,8 +20,8 @@ export interface UseOverviewRealtimeDataOptions {
 
 interface ResolveDisplayRealtimeOptions {
   realtime: OverviewRealtimeBlock | null;
-  loading: boolean;
   lastRealtimeQueryKey: string | null;
+  lastRealtimeErrorQueryKey?: string | null;
   realtimeQueryKey: string;
 }
 
@@ -33,12 +33,13 @@ const realtimeQueryScope = (queryKey: string | null): string | null => {
 
 export function resolveDisplayRealtime({
   realtime,
-  loading,
   lastRealtimeQueryKey,
+  lastRealtimeErrorQueryKey,
   realtimeQueryKey,
 }: ResolveDisplayRealtimeOptions): OverviewRealtimeBlock | null {
   if (lastRealtimeQueryKey === realtimeQueryKey) return realtime;
-  if (loading && realtime && realtimeQueryScope(lastRealtimeQueryKey) === realtimeQueryScope(realtimeQueryKey)) {
+  if (lastRealtimeErrorQueryKey === realtimeQueryKey) return null;
+  if (realtime && realtimeQueryScope(lastRealtimeQueryKey) === realtimeQueryScope(realtimeQueryKey)) {
     return realtime;
   }
   return null;
@@ -56,8 +57,8 @@ export function useOverviewRealtimeData(options: UseOverviewRealtimeDataOptions 
   const realtimeQueryKey = `${apiKeyId ?? ''}:${realtimeWindow ?? ''}`;
   const currentRealtime = resolveDisplayRealtime({
     realtime,
-    loading,
     lastRealtimeQueryKey,
+    lastRealtimeErrorQueryKey,
     realtimeQueryKey,
   });
 

--- a/web/src/components/usage/hooks/useOverviewRealtimeData.ts
+++ b/web/src/components/usage/hooks/useOverviewRealtimeData.ts
@@ -18,6 +18,24 @@ export interface UseOverviewRealtimeDataOptions {
   realtimeWindow?: OverviewRealtimeWindow;
 }
 
+interface ResolveDisplayRealtimeOptions {
+  realtime: OverviewRealtimeBlock | null;
+  loading: boolean;
+  lastRealtimeQueryKey: string | null;
+  realtimeQueryKey: string;
+}
+
+export function resolveDisplayRealtime({
+  realtime,
+  loading,
+  lastRealtimeQueryKey,
+  realtimeQueryKey,
+}: ResolveDisplayRealtimeOptions): OverviewRealtimeBlock | null {
+  if (lastRealtimeQueryKey === realtimeQueryKey) return realtime;
+  if (loading && realtime) return realtime;
+  return null;
+}
+
 export function useOverviewRealtimeData(options: UseOverviewRealtimeDataOptions = {}): UseOverviewRealtimeDataReturn {
   const { onAuthRequired, enabled = true, apiKeyId, realtimeWindow } = options;
   const realtime = useUsageStatsStore((state) => state.realtime);
@@ -28,7 +46,12 @@ export function useOverviewRealtimeData(options: UseOverviewRealtimeDataOptions 
   const lastRefreshedAtTs = useUsageStatsStore((state) => state.lastRealtimeRefreshedAt);
   const loadUsageStatsRealtime = useUsageStatsStore((state) => state.loadUsageStatsRealtime);
   const realtimeQueryKey = `${apiKeyId ?? ''}:${realtimeWindow ?? ''}`;
-  const currentRealtime = lastRealtimeQueryKey === realtimeQueryKey ? realtime : null;
+  const currentRealtime = resolveDisplayRealtime({
+    realtime,
+    loading,
+    lastRealtimeQueryKey,
+    realtimeQueryKey,
+  });
 
   const loadRealtime = useCallback(async () => {
     try {

--- a/web/src/components/usage/hooks/useOverviewRealtimeData.ts
+++ b/web/src/components/usage/hooks/useOverviewRealtimeData.ts
@@ -25,6 +25,12 @@ interface ResolveDisplayRealtimeOptions {
   realtimeQueryKey: string;
 }
 
+const realtimeQueryScope = (queryKey: string | null): string | null => {
+  if (queryKey === null) return null;
+  const separatorIndex = queryKey.lastIndexOf(':');
+  return separatorIndex === -1 ? queryKey : queryKey.slice(0, separatorIndex);
+};
+
 export function resolveDisplayRealtime({
   realtime,
   loading,
@@ -32,7 +38,9 @@ export function resolveDisplayRealtime({
   realtimeQueryKey,
 }: ResolveDisplayRealtimeOptions): OverviewRealtimeBlock | null {
   if (lastRealtimeQueryKey === realtimeQueryKey) return realtime;
-  if (loading && realtime) return realtime;
+  if (loading && realtime && realtimeQueryScope(lastRealtimeQueryKey) === realtimeQueryScope(realtimeQueryKey)) {
+    return realtime;
+  }
   return null;
 }
 


### PR DESCRIPTION
## Summary
- Keep the previous realtime block visible while a newly selected window is loading.
- Add hook-level regression coverage for realtime display-data selection.

## Verification
- npm --prefix ./web run test
- npm --prefix ./web run typecheck
- npm --prefix ./web run lint
- npm --prefix ./web run build