### PR TITLE
Improve Redis inbox process draining

### DIFF
--- a/internal/poller/redis_process_runner.go
+++ b/internal/poller/redis_process_runner.go
@@ -12,8 +12,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// redisInboxProcessInterval 控制本地 inbox 解码处理频率；远端 ingest 负责写 inbox，本 runner 只处理本地积压。
-const redisInboxProcessInterval = 3 * time.Second
+// redisInboxProcessInterval 控制本地 inbox 空闲或非满批时的检查频率；满批积压会立即继续处理。
+const redisInboxProcessInterval = time.Second
 
 // RedisProcessSyncer 抽象已有 service.ProcessRedisUsageInbox，避免 process runner 依赖完整 SyncService 类型。
 type RedisProcessSyncer interface {
@@ -77,11 +77,36 @@ func (r *RedisProcessRunner) Run(ctx context.Context) error {
 				r.logBatchFailure(result, err)
 			}
 		}
-		// 固定间隔等待下一轮处理，关停时可被 context 打断。
+		// 满批成功或满批 warning 说明本地 inbox 大概率仍有积压，立即进入下一轮 drain。
+		if shouldContinueRedisProcessImmediately(result, err) {
+			// 跳过 sleep 可以避免持续 backlog 被固定等待时间限制吞吐。
+			continue
+		}
+		// 空批、非满批或真正失败时等待下一轮处理，关停时可被 context 打断。
 		if !r.sleep(ctx, redisInboxProcessInterval) {
 			return nil
 		}
 	}
+}
+
+func shouldContinueRedisProcessImmediately(result *servicedto.RedisBatchSyncResult, err error) bool {
+	// 没有结果时无法确认 backlog，runner 保守进入 sleep。
+	if result == nil {
+		// nil result 多见于依赖错误或事务异常，不应忙循环。
+		return false
+	}
+	// 非满批说明本轮已经接近追平，runner 按 1 秒间隔低占用轮询。
+	if !result.BatchFull {
+		// 只在 service 明确报告满批时才跳过 sleep。
+		return false
+	}
+	// 真正失败时立即重试容易形成 busy loop，必须保留 sleep/backoff 空间。
+	if err != nil && !errors.Is(err, ErrSyncCompletedWithWarnings) {
+		// completed_with_warnings 代表部分成功，仍允许满批 drain 继续。
+		return false
+	}
+	// 满批且非真正失败时立即处理下一批，提升持续 backlog 吞吐。
+	return true
 }
 
 func (r *RedisProcessRunner) ProcessOnce(ctx context.Context) (*servicedto.RedisBatchSyncResult, error) {
@@ -171,7 +196,7 @@ func (r *RedisProcessRunner) recordProcessResult(result *servicedto.RedisBatchSy
 
 func (r *RedisProcessRunner) logBatchFailure(result *servicedto.RedisBatchSyncResult, err error) {
 	// 失败日志只包含聚合统计字段，避免输出原始 usage 消息。
-	fields := logrus.Fields{"status": "", "empty": false, "inserted_events": 0, "deduped_events": 0}
+	fields := logrus.Fields{"status": "", "empty": false, "inserted_events": 0, "deduped_events": 0, "processed_rows": 0, "batch_full": false}
 	if result != nil {
 		// result 存在时补充批次状态。
 		fields["status"] = result.Status
@@ -181,6 +206,10 @@ func (r *RedisProcessRunner) logBatchFailure(result *servicedto.RedisBatchSyncRe
 		fields["inserted_events"] = result.InsertedEvents
 		// deduped_events 方便判断是否大部分数据已去重。
 		fields["deduped_events"] = result.DedupedEvents
+		// processed_rows 方便判断本轮失败是否发生在满批处理场景。
+		fields["processed_rows"] = result.ProcessedRows
+		// batch_full 方便判断失败轮次是否本来应该进入连续 drain。
+		fields["batch_full"] = result.BatchFull
 	}
 	// 本地处理失败使用 error 日志级别。
 	logrus.WithError(err).WithFields(fields).Error("redis process batch failed")

--- a/internal/poller/redis_process_runner_internal_test.go
+++ b/internal/poller/redis_process_runner_internal_test.go
@@ -1,0 +1,209 @@
+package poller
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	servicedto "cpa-usage-keeper/internal/service/dto"
+)
+
+func TestRedisProcessRunnerSleepsOneSecondAfterNonFullBatch(t *testing.T) {
+	// 准备一个非满批结果，模拟本地 inbox 已接近追平。
+	syncer := &sequenceRedisProcessSyncer{results: []redisProcessSyncerResult{{
+		// 非满批结果不应触发连续 drain。
+		result: &servicedto.RedisBatchSyncResult{Status: "completed", ProcessedRows: 999},
+	}}}
+	// 构造真实 runner，只替换 syncer 和 sleep 以观察调度行为。
+	runner := NewRedisProcessRunner(syncer)
+	// 创建可取消 context，让测试在捕获 sleep 后退出。
+	ctx, cancel := context.WithCancel(context.Background())
+	// 测试结束兜底取消 context，避免循环泄漏。
+	defer cancel()
+	// delays 保存 runner 实际请求的 sleep 间隔。
+	var delays []time.Duration
+	// 替换 sleep，以便捕获等待时间并停止 runner。
+	runner.sleep = func(_ context.Context, delay time.Duration) bool {
+		// 记录 runner 选择的等待时间。
+		delays = append(delays, delay)
+		// 取消 context，防止 runner 进入额外轮次。
+		cancel()
+		// 返回 false 表示等待被打断，runner 应正常退出。
+		return false
+	}
+
+	// 执行 runner 主循环，验证非满批路径会等待。
+	if err := runner.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	// 非满批应该只处理一次，然后进入 sleep。
+	if syncer.calls != 1 {
+		t.Fatalf("expected one process call before sleep, got %d", syncer.calls)
+	}
+	// 新的空闲/非满批等待间隔应该是 1 秒。
+	want := []time.Duration{time.Second}
+	// 校验 runner 按 1 秒等待，而不是立即继续。
+	if !reflect.DeepEqual(delays, want) {
+		t.Fatalf("unexpected redis process sleep delays: got %v want %v", delays, want)
+	}
+}
+
+func TestRedisProcessRunnerSkipsSleepAfterFullBatch(t *testing.T) {
+	// 准备第一轮满批、第二轮空批的结果序列。
+	syncer := &sequenceRedisProcessSyncer{results: []redisProcessSyncerResult{
+		// 满批成功代表本地 inbox 可能仍有 backlog。
+		{result: &servicedto.RedisBatchSyncResult{Status: "completed", ProcessedRows: 1000, BatchFull: true}},
+		// 第二轮空批用于让 runner 进入 sleep 并退出测试。
+		{result: &servicedto.RedisBatchSyncResult{Empty: true, Status: "empty"}},
+	}}
+	// 构造真实 runner，只替换 syncer 和 sleep 以观察调度行为。
+	runner := NewRedisProcessRunner(syncer)
+	// 创建可取消 context，让测试在捕获 sleep 后退出。
+	ctx, cancel := context.WithCancel(context.Background())
+	// 测试结束兜底取消 context，避免循环泄漏。
+	defer cancel()
+	// delays 保存 runner 实际请求的 sleep 间隔。
+	var delays []time.Duration
+	// 替换 sleep，以便捕获等待时间并停止 runner。
+	runner.sleep = func(_ context.Context, delay time.Duration) bool {
+		// 记录空批后的等待时间。
+		delays = append(delays, delay)
+		// 取消 context，防止 runner 进入额外轮次。
+		cancel()
+		// 返回 false 表示等待被打断，runner 应正常退出。
+		return false
+	}
+
+	// 执行 runner 主循环，验证满批后会立即进入下一轮。
+	if err := runner.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	// 满批成功应该触发第二次处理，而不是先 sleep。
+	if syncer.calls != 2 {
+		t.Fatalf("expected full batch to process again before sleeping, got %d calls", syncer.calls)
+	}
+	// 只有第二轮空批后才应该产生一次 1 秒 sleep。
+	want := []time.Duration{time.Second}
+	// 校验满批路径确实跳过了第一轮 sleep。
+	if !reflect.DeepEqual(delays, want) {
+		t.Fatalf("unexpected redis process sleep delays: got %v want %v", delays, want)
+	}
+}
+
+func TestRedisProcessRunnerSkipsSleepAfterWarningFullBatch(t *testing.T) {
+	// 准备第一轮满批 warning、第二轮空批的结果序列。
+	syncer := &sequenceRedisProcessSyncer{results: []redisProcessSyncerResult{
+		// completed_with_warnings 表示部分成功，不应按真正失败处理。
+		{result: &servicedto.RedisBatchSyncResult{Status: "completed_with_warnings", ProcessedRows: 1000, BatchFull: true}, err: errors.New("decode warning")},
+		// 第二轮空批用于让 runner 进入 sleep 并退出测试。
+		{result: &servicedto.RedisBatchSyncResult{Empty: true, Status: "empty"}},
+	}}
+	// 构造真实 runner，只替换 syncer 和 sleep 以观察调度行为。
+	runner := NewRedisProcessRunner(syncer)
+	// 创建可取消 context，让测试在捕获 sleep 后退出。
+	ctx, cancel := context.WithCancel(context.Background())
+	// 测试结束兜底取消 context，避免循环泄漏。
+	defer cancel()
+	// delays 保存 runner 实际请求的 sleep 间隔。
+	var delays []time.Duration
+	// 替换 sleep，以便捕获等待时间并停止 runner。
+	runner.sleep = func(_ context.Context, delay time.Duration) bool {
+		// 记录空批后的等待时间。
+		delays = append(delays, delay)
+		// 取消 context，防止 runner 进入额外轮次。
+		cancel()
+		// 返回 false 表示等待被打断，runner 应正常退出。
+		return false
+	}
+
+	// 执行 runner 主循环，验证 warning 满批后会立即进入下一轮。
+	if err := runner.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	// warning 满批仍然代表本轮消耗了完整批次，应继续 drain。
+	if syncer.calls != 2 {
+		t.Fatalf("expected warning full batch to process again before sleeping, got %d calls", syncer.calls)
+	}
+	// 只有第二轮空批后才应该产生一次 1 秒 sleep。
+	want := []time.Duration{time.Second}
+	// 校验 warning 满批路径没有被误判为真正失败。
+	if !reflect.DeepEqual(delays, want) {
+		t.Fatalf("unexpected redis process sleep delays: got %v want %v", delays, want)
+	}
+}
+
+func TestRedisProcessRunnerSleepsAfterFailedFullBatch(t *testing.T) {
+	// 准备一个满批但真正失败的结果，模拟 SQLite 锁等不可立即重试的错误。
+	syncer := &sequenceRedisProcessSyncer{results: []redisProcessSyncerResult{{
+		// Status failed 代表本轮没有安全完成，runner 不能立即重试。
+		result: &servicedto.RedisBatchSyncResult{Status: "failed", ProcessedRows: 1000, BatchFull: true},
+		// err 是真正失败，不会被 ErrSyncCompletedWithWarnings 包装。
+		err: errors.New("sqlite locked"),
+	}}}
+	// 构造真实 runner，只替换 syncer 和 sleep 以观察调度行为。
+	runner := NewRedisProcessRunner(syncer)
+	// 创建可取消 context，让测试在捕获 sleep 后退出。
+	ctx, cancel := context.WithCancel(context.Background())
+	// 测试结束兜底取消 context，避免循环泄漏。
+	defer cancel()
+	// delays 保存 runner 实际请求的 sleep 间隔。
+	var delays []time.Duration
+	// 替换 sleep，以便捕获等待时间并停止 runner。
+	runner.sleep = func(_ context.Context, delay time.Duration) bool {
+		// 记录失败后的等待时间。
+		delays = append(delays, delay)
+		// 取消 context，防止 runner 进入额外轮次。
+		cancel()
+		// 返回 false 表示等待被打断，runner 应正常退出。
+		return false
+	}
+
+	// 执行 runner 主循环，验证真正失败不会立即继续。
+	if err := runner.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	// 真正失败应该只处理一次，然后进入 sleep。
+	if syncer.calls != 1 {
+		t.Fatalf("expected failed batch to sleep before retrying, got %d calls", syncer.calls)
+	}
+	// 失败路径应该保留 1 秒等待，避免 busy loop。
+	want := []time.Duration{time.Second}
+	// 校验满批失败没有跳过 sleep。
+	if !reflect.DeepEqual(delays, want) {
+		t.Fatalf("unexpected redis process sleep delays: got %v want %v", delays, want)
+	}
+}
+
+// redisProcessSyncerResult 表示 fake syncer 单轮返回的结果和错误。
+type redisProcessSyncerResult struct {
+	// result 是本轮 ProcessRedisUsageInbox 的返回结果。
+	result *servicedto.RedisBatchSyncResult
+	// err 是本轮 ProcessRedisUsageInbox 的返回错误。
+	err error
+}
+
+// sequenceRedisProcessSyncer 按顺序返回预设结果，便于测试 runner 循环。
+type sequenceRedisProcessSyncer struct {
+	// results 保存每轮 fake syncer 应返回的结果。
+	results []redisProcessSyncerResult
+	// calls 记录 runner 已调用 fake syncer 的次数。
+	calls int
+}
+
+func (s *sequenceRedisProcessSyncer) ProcessRedisUsageInbox(context.Context) (*servicedto.RedisBatchSyncResult, error) {
+	// 如果预设结果已经用完，返回空批，防止测试意外无限循环。
+	if s.calls >= len(s.results) {
+		// 递增调用次数，方便测试定位额外调用。
+		s.calls++
+		// 返回空批结果，模拟本地 inbox 已追平。
+		return &servicedto.RedisBatchSyncResult{Empty: true, Status: "empty"}, nil
+	}
+	// 读取当前调用应该返回的结果。
+	result := s.results[s.calls]
+	// 递增调用次数，准备下一轮返回。
+	s.calls++
+	// 返回当前预设结果和错误。
+	return result.result, result.err
+}

--- a/internal/service/dto/sync.go
+++ b/internal/service/dto/sync.go
@@ -9,10 +9,18 @@ type SyncResult struct {
 
 // RedisBatchSyncResult 是 Redis 批次同步的结果。
 type RedisBatchSyncResult struct {
-	Empty          bool
-	Status         string
+	// Empty 表示本轮没有从 Redis inbox 取到可处理行。
+	Empty bool
+	// Status 表示本轮 Redis inbox 处理的最终状态。
+	Status string
+	// InsertedEvents 表示本轮新写入 usage_events 的事件数量。
 	InsertedEvents int
-	DedupedEvents  int
+	// DedupedEvents 表示本轮被 usage_events 去重保护拦下的事件数量。
+	DedupedEvents int
+	// ProcessedRows 表示本轮从 Redis inbox 取出的原始行数。
+	ProcessedRows int
+	// BatchFull 表示本轮取到的 inbox 行数已经达到 service 批次上限。
+	BatchFull bool
 }
 
 // RedisInboxPullResult 是 Redis inbox 拉取结果。

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -157,20 +157,36 @@ func (s *SyncService) ProcessRedisUsageInbox(ctx context.Context) (*servicedto.R
 	// process_failed 也在这里重试，避免临时 SQLite 锁或短暂解析外问题导致数据永久卡住。
 	processableRows, err := repository.ListProcessableRedisUsageInbox(s.db, redisInboxProcessLimit)
 	if err != nil {
-		return &servicedto.RedisBatchSyncResult{Status: "failed"}, fmt.Errorf("list processable redis usage inbox: %w", err)
+		// 列表失败时没有可靠取出行，返回 0 行失败结果供 runner 保守等待。
+		return newRedisBatchSyncResult("failed", 0), fmt.Errorf("list processable redis usage inbox: %w", err)
 	}
 	if len(processableRows) == 0 {
 		// 空轮次先做轻量 cursor 检查，只有发现 usage_events 尚未聚合时才写派生统计。
 		pendingAggregation, err := repository.HasPendingUsageOverviewAggregation(ctx, s.db)
 		if err != nil {
-			return &servicedto.RedisBatchSyncResult{Empty: true, Status: "failed"}, err
+			// 空批聚合检查失败仍然是空结果，runner 需要按失败路径等待。
+			result := newRedisBatchSyncResult("failed", 0)
+			// Empty 明确告诉调用方本轮没有 inbox 行参与处理。
+			result.Empty = true
+			// 返回失败结果和原始错误，保持既有错误语义。
+			return result, err
 		}
 		if pendingAggregation {
 			if err := s.aggregateUsageEventStats(ctx, fetchedAt); err != nil {
-				return &servicedto.RedisBatchSyncResult{Empty: true, Status: "failed"}, err
+				// 空批补聚合失败仍然不代表 inbox 有积压，runner 保守等待下一轮。
+				result := newRedisBatchSyncResult("failed", 0)
+				// Empty 明确告诉调用方本轮没有 inbox 行参与处理。
+				result.Empty = true
+				// 返回失败结果和原始错误，保持既有错误语义。
+				return result, err
 			}
 		}
-		return &servicedto.RedisBatchSyncResult{Empty: true, Status: "empty"}, nil
+		// 空批成功时返回 0 行结果，避免 runner 误判为需要连续 drain。
+		result := newRedisBatchSyncResult("empty", 0)
+		// Empty 明确告诉调用方本轮没有 inbox 行参与处理。
+		result.Empty = true
+		// 返回空批结果，保持既有空轮次语义。
+		return result, nil
 	}
 	logrus.WithField("row_count", len(processableRows)).Debug("redis usage inbox rows found for processing")
 	return s.processRedisInboxRows(ctx, processableRows, fetchedAt)
@@ -203,6 +219,8 @@ func (s *SyncService) CleanupStorage(ctx context.Context) error {
 // 可解码但入库失败的消息标记为 process_failed，后续 ProcessRedisUsageInbox 会按 id 顺序重试。
 func (s *SyncService) processRedisInboxRows(ctx context.Context, inboxRows []entities.RedisUsageInbox, fetchedAt time.Time) (*servicedto.RedisBatchSyncResult, error) {
 	logrus.WithField("row_count", len(inboxRows)).Debug("redis usage inbox processing started")
+	// processedRows 记录本轮实际取出的原始 inbox 行数，包含后续 decode_failed/process_failed 行。
+	processedRows := len(inboxRows)
 	validRows := make([]entities.RedisUsageInbox, 0, len(inboxRows))
 	events := make([]entities.UsageEvent, 0, len(inboxRows))
 	headerSnapshots := make([]quota.UsageHeaderSnapshot, 0)
@@ -213,7 +231,8 @@ func (s *SyncService) processRedisInboxRows(ctx context.Context, inboxRows []ent
 		if decodeErr != nil {
 			logrus.WithError(decodeErr).WithField("inbox_id", row.ID).Error("redis usage message decode failed")
 			if markErr := repository.MarkRedisUsageInboxDecodeFailed(s.db, row.ID, decodeErr); markErr != nil {
-				return &servicedto.RedisBatchSyncResult{Status: "failed"}, fmt.Errorf("mark redis usage inbox decode failed: %w", markErr)
+				// 标记坏消息失败时保留本轮已取行数，runner 仍按真正失败路径等待。
+				return newRedisBatchSyncResult("failed", processedRows), fmt.Errorf("mark redis usage inbox decode failed: %w", markErr)
 			}
 			decodeErrs = append(decodeErrs, decodeErr)
 			continue
@@ -232,9 +251,13 @@ func (s *SyncService) processRedisInboxRows(ctx context.Context, inboxRows []ent
 	}).Debug("redis usage inbox rows decoded")
 	if len(events) == 0 {
 		if decodeErr != nil {
-			return &servicedto.RedisBatchSyncResult{Status: "completed_with_warnings"}, decodeErr
+			// 全部消息解码失败时也算本轮已消耗这些 inbox 行，避免满批坏消息误触发 sleep。
+			return newRedisBatchSyncResult("completed_with_warnings", processedRows), decodeErr
 		}
-		return &servicedto.RedisBatchSyncResult{Empty: true, Status: "empty"}, nil
+		// 非空输入却没有事件且没有错误时保留已取行数供诊断。
+		result := newRedisBatchSyncResult("empty", processedRows)
+		// Empty 只表示本轮没有取到 inbox 行，因此这里不标记为空批。
+		return result, nil
 	}
 	var typeErr error
 	events, typeErr = normalizeRedisUsageEvents(ctx, s.db, events)
@@ -242,7 +265,8 @@ func (s *SyncService) processRedisInboxRows(ctx context.Context, inboxRows []ent
 		// type 查询失败代表当前无法可靠判断 provider 口径，不能当作“找不到 type”降级处理。
 		// 将已解码行标记为 process_failed，后续重试时再按真实 type 归一化入库。
 		markRedisInboxRowsProcessFailed(s.db, validRows, typeErr)
-		return &servicedto.RedisBatchSyncResult{Status: "failed"}, joinErrors(decodeErr, typeErr)
+		// 归一化失败时保留本轮已取行数，但 runner 仍按真正失败路径等待。
+		return newRedisBatchSyncResult("failed", processedRows), joinErrors(decodeErr, typeErr)
 	}
 
 	// usage_events 入库和 inbox processed 标记必须同事务提交，避免标记失败后同一 inbox 重试造成重复事件。
@@ -264,11 +288,13 @@ func (s *SyncService) processRedisInboxRows(ctx context.Context, inboxRows []ent
 	})
 	if result == nil {
 		markRedisInboxRowsProcessFailed(s.db, validRows, err)
-		return nil, err
+		// 事务未能进入持久化路径时也返回批次信号，避免 runner 和日志丢失本轮取数。
+		return newRedisBatchSyncResult("failed", processedRows), err
 	}
 	if err != nil {
 		markRedisInboxRowsProcessFailed(s.db, validRows, err)
-		return &servicedto.RedisBatchSyncResult{Status: "failed"}, err
+		// 事务失败时保留本轮已取行数，但不允许 runner 立即忙循环。
+		return newRedisBatchSyncResult("failed", processedRows), err
 	}
 	if result.InsertedEvents > 0 {
 		// usage_events 事务已经提交后才通知最近事件缓存，避免缓存看到未落库的数据。
@@ -278,7 +304,8 @@ func (s *SyncService) processRedisInboxRows(ctx context.Context, inboxRows []ent
 		}
 		// Redis process 是 usage_events 的高频写入入口，成功插入后串行刷新依赖事件表的增量统计。
 		if err := s.aggregateUsageEventStats(ctx, timeutil.NormalizeStorageTime(s.now())); err != nil {
-			return &servicedto.RedisBatchSyncResult{Status: "failed"}, err
+			// 聚合失败时保留本轮已取行数，但保持失败路径的保守等待。
+			return newRedisBatchSyncResult("failed", processedRows), err
 		}
 		// header quota 需要复用窗口 token/cost 兜底统计，因此必须在 usage overview 聚合追平后再通知 worker。
 		headerSnapshots = coalesceUsageHeaderSnapshotsByAuthIndex(headerSnapshots)
@@ -288,7 +315,7 @@ func (s *SyncService) processRedisInboxRows(ctx context.Context, inboxRows []ent
 		}
 	}
 	logrus.WithFields(logrus.Fields{
-		"processed_rows":  len(validRows),
+		"processed_rows":  processedRows,
 		"inserted_events": result.InsertedEvents,
 		"deduped_events":  result.DedupedEvents,
 		"status":          result.Status,
@@ -306,10 +333,29 @@ func (s *SyncService) processRedisInboxRows(ctx context.Context, inboxRows []ent
 		}
 	}
 	return &servicedto.RedisBatchSyncResult{
-		Status:         status,
+		// Status 保持原有 completed/completed_with_warnings 语义。
+		Status: status,
+		// InsertedEvents 保持原有 usage_events 新增数量语义。
 		InsertedEvents: result.InsertedEvents,
-		DedupedEvents:  result.DedupedEvents,
+		// DedupedEvents 保持原有 usage_events 去重数量语义。
+		DedupedEvents: result.DedupedEvents,
+		// ProcessedRows 使用本轮取出的 inbox 行数，而不是最终写入事件数。
+		ProcessedRows: processedRows,
+		// BatchFull 只表示本轮取数达到上限，供 runner 判断是否继续 drain。
+		BatchFull: processedRows >= redisInboxProcessLimit,
 	}, returnErr
+}
+
+func newRedisBatchSyncResult(status string, processedRows int) *servicedto.RedisBatchSyncResult {
+	// 负数输入没有业务意义，统一收敛为 0，避免调用方误报批次大小。
+	if processedRows < 0 {
+		// 只修正异常输入，不影响正常批次行数。
+		processedRows = 0
+	}
+	// BatchFull 只看取出的原始行数是否达到 service 批次上限。
+	batchFull := processedRows >= redisInboxProcessLimit
+	// 返回统一填充批次信号的 Redis 处理结果。
+	return &servicedto.RedisBatchSyncResult{Status: status, ProcessedRows: processedRows, BatchFull: batchFull}
 }
 
 func coalesceUsageHeaderSnapshotsByAuthIndex(snapshots []quota.UsageHeaderSnapshot) []quota.UsageHeaderSnapshot {

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -286,14 +286,11 @@ func (s *SyncService) processRedisInboxRows(ctx context.Context, inboxRows []ent
 		}
 		return nil
 	})
-	if result == nil {
+	// 事务错误或未产出持久化结果时统一走失败路径，避免两个等价分支后续漂移。
+	if err != nil || result == nil {
+		// 有具体错误时把可重试行标成 process_failed，异常空结果也复用同一保守返回。
 		markRedisInboxRowsProcessFailed(s.db, validRows, err)
-		// 事务未能进入持久化路径时也返回批次信号，避免 runner 和日志丢失本轮取数。
-		return newRedisBatchSyncResult("failed", processedRows), err
-	}
-	if err != nil {
-		markRedisInboxRowsProcessFailed(s.db, validRows, err)
-		// 事务失败时保留本轮已取行数，但不允许 runner 立即忙循环。
+		// 失败返回仍保留本轮已取行数，但不允许 runner 立即忙循环。
 		return newRedisBatchSyncResult("failed", processedRows), err
 	}
 	if result.InsertedEvents > 0 {

--- a/internal/service/sync_test.go
+++ b/internal/service/sync_test.go
@@ -323,12 +323,62 @@ func TestProcessRedisUsageInboxDoesNotNotifyRecentCacheOnRollback(t *testing.T) 
 		RecentUsageEvents: cache,
 	})
 
-	_, err := service.ProcessRedisUsageInbox(context.Background())
+	// 执行本地 inbox 处理，触发事务回滚路径。
+	result, err := service.ProcessRedisUsageInbox(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "processed mark failed") {
 		t.Fatalf("expected transaction failure, got %v", err)
 	}
+	// 事务失败也应返回本轮取出的 inbox 行数，避免 runner 日志丢失批次信号。
+	if result == nil || result.Status != "failed" || result.ProcessedRows != 1 || result.BatchFull {
+		t.Fatalf("expected failed result with one processed row, got %+v", result)
+	}
 	if cache.calls != 0 || len(cache.events) != 0 {
 		t.Fatalf("expected no cache notification on rollback, got calls=%d events=%+v", cache.calls, cache.events)
+	}
+}
+
+func TestProcessRedisUsageInboxReturnsBatchSignalWhenTransactionCannotStart(t *testing.T) {
+	// 准备独立测试数据库，避免关闭连接影响其它用例。
+	db := openSyncTestDatabase(t)
+	// 写入一条不需要 identity 查询的消息，使下一次数据库访问发生在事务开始阶段。
+	seedRedisInboxMessagesForTest(t, db, `{"timestamp":"2026-04-27T08:00:00Z","provider":"claude","model":"sonnet","request_id":"transaction-start-fails","tokens":{"input_tokens":1,"output_tokens":2}}`)
+	// callbackClosed 保护测试回调只关闭一次底层连接。
+	callbackClosed := false
+	// callbackName 使用测试专属名称，避免污染同一进程里的其它 GORM 回调。
+	callbackName := "test:close_db_after_redis_inbox_list"
+	// 注册查询后回调，在取出 redis_usage_inboxes 后关闭底层连接。
+	if err := db.Callback().Query().After("gorm:query").Register(callbackName, func(tx *gorm.DB) {
+		// 只在目标表查询后触发，避免关闭迁移或 seed 阶段使用的连接。
+		if callbackClosed || tx.Statement == nil || tx.Statement.Table != "redis_usage_inboxes" {
+			// 非目标查询不做任何处理。
+			return
+		}
+		// 标记已关闭，防止后续回调重复关闭连接。
+		callbackClosed = true
+		// 取出底层 sql.DB，用来模拟事务开始前连接不可用。
+		sqlDB, dbErr := tx.DB()
+		// 如果底层连接可取出，就关闭它制造事务启动失败。
+		if dbErr == nil {
+			// 关闭连接只作用于本测试临时数据库。
+			_ = sqlDB.Close()
+		}
+	}); err != nil {
+		t.Fatalf("register query callback returned error: %v", err)
+	}
+	// 测试退出时尽力移除 callback，保持 GORM 回调链干净。
+	t.Cleanup(func() { _ = db.Callback().Query().Remove(callbackName) })
+	// 构造 sync service，走真实 ProcessRedisUsageInbox 链路。
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{BaseURL: "https://cpa.example.com"})
+
+	// 执行处理，事务启动应因连接关闭而失败。
+	result, err := service.ProcessRedisUsageInbox(context.Background())
+	// 失败必须暴露给调用方，避免静默丢消息。
+	if err == nil {
+		t.Fatalf("expected transaction start failure, got nil")
+	}
+	// 即使事务未能开始，也应返回本轮取出的 inbox 行数。
+	if result == nil || result.Status != "failed" || result.ProcessedRows != 1 || result.BatchFull {
+		t.Fatalf("expected failed result with one processed row, got %+v", result)
 	}
 }
 
@@ -1003,7 +1053,8 @@ func TestProcessRedisUsageInboxDoesNotFallbackWhenUsageTypeLookupErrors(t *testi
 	if err == nil || !strings.Contains(err.Error(), "load active usage identity types for redis usage") {
 		t.Fatalf("expected usage type lookup error, got result=%+v err=%v", result, err)
 	}
-	if result == nil || result.Status != "failed" {
+	// type 查询失败也应保留本轮取出的 inbox 行数，供 runner 和日志判断批次状态。
+	if result == nil || result.Status != "failed" || result.ProcessedRows != 1 || result.BatchFull {
 		t.Fatalf("expected failed result, got %+v", result)
 	}
 	assertUsageEventCount(t, db, 0)
@@ -1200,7 +1251,8 @@ func TestProcessRedisUsageInboxSkipsEmptyBatchWithoutSnapshotOrMetadata(t *testi
 	if err != nil {
 		t.Fatalf("process Redis usage inbox returned error: %v", err)
 	}
-	if result == nil || !result.Empty || result.Status != "empty" {
+	// 空批结果应明确返回 0 行且非满批，避免 runner 误判为 backlog。
+	if result == nil || !result.Empty || result.Status != "empty" || result.ProcessedRows != 0 || result.BatchFull {
 		t.Fatalf("expected empty redis batch result, got %+v", result)
 	}
 	if metadata.authCalls != 0 || metadata.providerCalls() != 0 {
@@ -1222,7 +1274,8 @@ func TestProcessRedisUsageInboxPersistsNonEmptyBatchWithoutMetadata(t *testing.T
 	if err != nil {
 		t.Fatalf("process Redis usage inbox returned error: %v", err)
 	}
-	if result == nil || result.Empty || result.Status != "completed" || result.InsertedEvents != 1 || result.DedupedEvents != 0 {
+	// 单条成功消息应报告本轮取出 1 行且非满批，保持原有插入数量语义。
+	if result == nil || result.Empty || result.Status != "completed" || result.InsertedEvents != 1 || result.DedupedEvents != 0 || result.ProcessedRows != 1 || result.BatchFull {
 		t.Fatalf("unexpected redis batch result: %+v", result)
 	}
 	if metadata.authCalls != 0 || metadata.providerCalls() != 0 {
@@ -1257,7 +1310,8 @@ func TestProcessRedisUsageInboxPersistsValidRowsWhenBatchContainsMalformedMessag
 	if err == nil || !strings.Contains(err.Error(), "decode redis usage message") {
 		t.Fatalf("expected decode warning, got %v", err)
 	}
-	if result == nil || result.Status != "completed_with_warnings" || result.InsertedEvents != 1 {
+	// 混合好坏消息应把坏消息也计入本轮取出的 inbox 行数。
+	if result == nil || result.Status != "completed_with_warnings" || result.InsertedEvents != 1 || result.ProcessedRows != 2 || result.BatchFull {
 		t.Fatalf("expected warning result with valid event persisted, got %+v", result)
 	}
 
@@ -1293,7 +1347,8 @@ func TestProcessRedisUsageInboxMarksMalformedOnlyBatchWithoutSnapshot(t *testing
 	if err == nil || !strings.Contains(err.Error(), "decode redis usage message") {
 		t.Fatalf("expected decode warning, got %v", err)
 	}
-	if result == nil || result.Status != "completed_with_warnings" {
+	// 全坏消息也应报告本轮取出的 1 行，避免插入数为 0 时丢失批次信号。
+	if result == nil || result.Status != "completed_with_warnings" || result.ProcessedRows != 1 || result.BatchFull {
 		t.Fatalf("expected warning result, got %+v", result)
 	}
 
@@ -1303,6 +1358,33 @@ func TestProcessRedisUsageInboxMarksMalformedOnlyBatchWithoutSnapshot(t *testing
 	}
 	if inbox.Status != repository.RedisUsageInboxStatusDecodeFailed || inbox.RawMessage != `{bad-json}` {
 		t.Fatalf("expected decode_failed raw inbox row, got %+v", inbox)
+	}
+}
+
+func TestProcessRedisUsageInboxMarksFullMalformedBatch(t *testing.T) {
+	// 准备独立数据库，用真实 service 路径处理满批坏消息。
+	db := openSyncTestDatabase(t)
+	// messages 保存一整批无法解码的 Redis 原始消息。
+	messages := make([]string, 0, redisInboxProcessLimit)
+	// 构造刚好达到 Redis process 批次上限的坏消息集合。
+	for i := 0; i < redisInboxProcessLimit; i++ {
+		// 每条坏消息内容不同，便于插入 inbox 时保持独立行。
+		messages = append(messages, fmt.Sprintf("{bad-json-%d}", i))
+	}
+	// 将满批坏消息写入 durable inbox，模拟真实 backlog 输入。
+	seedRedisInboxMessagesForTest(t, db, messages...)
+	// 构造 sync service，后续走真实 ProcessRedisUsageInbox 链路。
+	service := NewSyncServiceWithOptions(db, SyncServiceOptions{BaseURL: "https://cpa.example.com"})
+
+	// 执行本地 inbox 处理，预期全部进入 decode_failed warning 路径。
+	result, err := processRedisUsageInboxForTest(t, service)
+	// 全坏消息应返回 decode warning，不能被静默吞掉。
+	if err == nil || !strings.Contains(err.Error(), "decode redis usage message") {
+		t.Fatalf("expected decode warning, got %v", err)
+	}
+	// 即使没有事件写入，满批坏消息也应报告 BatchFull，供 runner 继续 drain。
+	if result == nil || result.Status != "completed_with_warnings" || result.ProcessedRows != redisInboxProcessLimit || !result.BatchFull {
+		t.Fatalf("expected warning result with full malformed batch, got %+v", result)
 	}
 }
 


### PR DESCRIPTION
## Summary
- reduce the local Redis inbox process idle interval to 1s
- drain full Redis inbox batches immediately when processing succeeds
- add raw-row-based batch fullness signals across success and failure paths

## Validation
- `rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build go test ./internal/poller ./internal/service -count=1`
- `rtk git diff --check`
- `rtk gofmt -l internal/poller/redis_process_runner.go internal/poller/redis_process_runner_internal_test.go internal/service/dto/sync.go internal/service/sync.go internal/service/sync_test.go`
- `rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build go test ./... -count=1`