### PR TITLE
Upgrade Go toolchain to 1.26

### DIFF
--- a/.github/workflows/binary-dev-release.yml
+++ b/.github/workflows/binary-dev-release.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
           check-latest: true
           cache: true
 
@@ -145,7 +145,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
           check-latest: true
           cache: true
 
@@ -212,7 +212,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
           check-latest: true
           cache: true
 

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
           check-latest: true
           cache: true
 
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
           check-latest: true
           cache: true
 
@@ -163,7 +163,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
           check-latest: true
           cache: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN npm ci
 COPY web/ ./
 RUN npm run build
 
-FROM golang:1.22-alpine AS go-builder
+FROM golang:1.26-alpine AS go-builder
 WORKDIR /app
 RUN apk add --no-cache build-base
 COPY go.mod go.sum ./

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ web/                     React + TypeScript frontend
 
 ### Prerequisites
 
-- Go 1.22+
+- Go 1.26+
 - Node.js 22+
 - npm
 - A running [CLIProxyAPI (CPA)](https://github.com/router-for-me/CLIProxyAPI) instance

--- a/README.zh.md
+++ b/README.zh.md
@@ -383,7 +383,7 @@ web/                     React + TypeScript 前端
 
 ### 前置依赖
 
-- Go 1.22+
+- Go 1.26+
 - Node.js 22+
 - npm
 - 已运行的 [CLIProxyAPI（CPA）](https://github.com/router-for-me/CLIProxyAPI)

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module cpa-usage-keeper
 
-go 1.22
+go 1.26
 
 require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/joho/godotenv v1.5.1
+	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/sirupsen/logrus v1.9.3
 	gorm.io/driver/sqlite v1.5.7
 	gorm.io/gorm v1.25.12
@@ -27,7 +28,6 @@ require (
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect


### PR DESCRIPTION
## Summary
- Bump the module and Docker builder to Go 1.26.
- Update local development docs to require Go 1.26+.
- Make release and dev-release workflows read the Go version from go.mod instead of tracking stable.

## Why
- The latest macOS CI runner can land on macos-26-arm64, where Go 1.22 test binaries abort with missing LC_UUID load command before package tests run.
- Keeping CI, Docker, and release workflows aligned through go.mod avoids future drift across build surfaces.

## Validation
- rtk git diff --check
- env GOCACHE=/tmp/cpa-usage-keeper-go-build go test ./cmd/... ./internal/...
- npm --prefix ./web run test
- npm --prefix ./web run lint
- npm --prefix ./web run typecheck
- npm --prefix ./web run build
- docker build -t cpa-usage-keeper:go-1-26-ci .