### PR TITLE
Centralize version API handling

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -6,11 +6,13 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"os"
 	"path"
 	"strconv"
 	"strings"
 	"time"
 
+	"cpa-usage-keeper/internal/auth"
 	"cpa-usage-keeper/internal/poller"
 	"cpa-usage-keeper/internal/quota"
 	"cpa-usage-keeper/internal/service"
@@ -71,9 +73,9 @@ func NewRouter(
 	registerHealthRoutes(appGroup)
 
 	apiV1 := appGroup.Group("/api/v1")
-	apiV1.GET("/ping", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{"message": "ok"})
-	})
+	if debugAPIRoutesEnabled() {
+		registerPingRoutes(apiV1)
+	}
 
 	authGroup := apiV1.Group("/auth")
 	if authHandler == nil {
@@ -94,6 +96,10 @@ func NewRouter(
 		statusConfig = optionalProviders[0].Status
 	}
 	authHandler.setCPAAPIKeyProvider(cpaAPIKeyProvider)
+
+	versionProtected := apiV1.Group("")
+	versionProtected.Use(authHandler.roleMiddleware(auth.RoleAdmin, auth.RoleAPIKeyViewer))
+	registerVersionRoutes(versionProtected)
 
 	adminProtected := apiV1.Group("")
 	adminProtected.Use(authHandler.adminMiddleware())
@@ -168,7 +174,21 @@ func NewRouter(
 	return router
 }
 
+func debugAPIRoutesEnabled() bool {
+	return version.Version == "dev" || os.Getenv("GIN_MODE") == gin.DebugMode
+}
+
+func registerPingRoutes(router gin.IRoutes) {
+	router.GET("/ping", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "ok"})
+	})
+}
+
 func setHTMLCacheHeaders(c *gin.Context) {
+	setNoStoreHeaders(c)
+}
+
+func setNoStoreHeaders(c *gin.Context) {
 	c.Header("Cache-Control", "no-store")
 	c.Header("Pragma", "no-cache")
 	c.Header("Expires", "0")
@@ -241,14 +261,31 @@ type statusResponse struct {
 	Running                 bool       `json:"running"`
 	SyncRunning             bool       `json:"sync_running"`
 	Timezone                string     `json:"timezone"`
-	Version                 string     `json:"version"`
-	UpdateCheckEnabled      bool       `json:"updateCheckEnabled"`
 	QuotaAutoRefreshEnabled bool       `json:"quotaAutoRefreshEnabled"`
 	CPAPublicURL            string     `json:"cpa_public_url,omitempty"`
 	LastRunAt               *time.Time `json:"last_run_at,omitempty"`
 	LastError               string     `json:"last_error,omitempty"`
 	LastWarning             string     `json:"last_warning,omitempty"`
 	LastStatus              string     `json:"last_status,omitempty"`
+}
+
+type versionResponse struct {
+	Version            string `json:"version"`
+	UpdateCheckEnabled bool   `json:"updateCheckEnabled"`
+}
+
+func registerVersionRoutes(router gin.IRoutes) {
+	router.GET("/version", func(c *gin.Context) {
+		setNoStoreHeaders(c)
+		c.JSON(http.StatusOK, buildVersionResponse())
+	})
+}
+
+func buildVersionResponse() versionResponse {
+	return versionResponse{
+		Version:            version.Version,
+		UpdateCheckEnabled: updatecheck.IsStableVersion(version.Version),
+	}
 }
 
 func registerStatusRoutes(router gin.IRoutes, statusProvider StatusProvider, config StatusRouteConfig) {
@@ -274,8 +311,6 @@ func buildStatusResponse(status poller.Status, config StatusRouteConfig) statusR
 		Running:                 status.Running,
 		SyncRunning:             status.SyncRunning,
 		Timezone:                time.Local.String(),
-		Version:                 version.Version,
-		UpdateCheckEnabled:      updatecheck.IsStableVersion(version.Version),
 		QuotaAutoRefreshEnabled: config.QuotaAutoRefreshEnabled,
 		CPAPublicURL:            config.CPAPublicURL,
 		LastError:               status.LastError,

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,7 @@ import (
 	"testing/fstest"
 	"time"
 
+	"cpa-usage-keeper/internal/auth"
 	"cpa-usage-keeper/internal/poller"
 	"cpa-usage-keeper/internal/version"
 	"github.com/gin-gonic/gin"
@@ -47,6 +49,81 @@ func TestHealthzReturnsOK(t *testing.T) {
 
 	if resp.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", resp.Code)
+	}
+}
+
+func TestHealthzRemainsPublicWhenAuthEnabled(t *testing.T) {
+	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
+	router := NewRouter(nil, nil, nil, nil, config, NewAuthHandler(config, auth.NewSessionManager(time.Hour)), "")
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestPingOnlyAvailableForDevBuildsOrExplicitDebugMode(t *testing.T) {
+	previousVersion := version.Version
+	t.Cleanup(func() { version.Version = previousVersion })
+
+	for _, testCase := range []struct {
+		name       string
+		appVersion string
+		ginMode    string
+		wantStatus int
+	}{
+		{name: "release build hides ping by default", appVersion: "v1.2.3", wantStatus: http.StatusNotFound},
+		{name: "dev build exposes ping", appVersion: "dev", wantStatus: http.StatusOK},
+		{name: "explicit gin debug exposes ping", appVersion: "v1.2.3", ginMode: gin.DebugMode, wantStatus: http.StatusOK},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			version.Version = testCase.appVersion
+			t.Setenv("GIN_MODE", testCase.ginMode)
+
+			router := NewRouter(nil, nil, nil, nil, AuthConfig{}, nil, "")
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/ping", nil)
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			if resp.Code != testCase.wantStatus {
+				t.Fatalf("expected status %d, got %d body=%s", testCase.wantStatus, resp.Code, resp.Body.String())
+			}
+		})
+	}
+}
+
+func TestSubpathPingOnlyAvailableForDevBuildsOrExplicitDebugMode(t *testing.T) {
+	previousVersion := version.Version
+	t.Cleanup(func() { version.Version = previousVersion })
+
+	for _, testCase := range []struct {
+		name       string
+		appVersion string
+		ginMode    string
+		path       string
+		wantStatus int
+	}{
+		{name: "release build hides prefixed ping", appVersion: "v1.2.3", path: "/cpa/api/v1/ping", wantStatus: http.StatusNotFound},
+		{name: "dev build exposes prefixed ping", appVersion: "dev", path: "/cpa/api/v1/ping", wantStatus: http.StatusOK},
+		{name: "explicit gin debug exposes prefixed ping", appVersion: "v1.2.3", ginMode: gin.DebugMode, path: "/cpa/api/v1/ping", wantStatus: http.StatusOK},
+		{name: "dev build does not expose unprefixed ping", appVersion: "dev", path: "/api/v1/ping", wantStatus: http.StatusNotFound},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			version.Version = testCase.appVersion
+			t.Setenv("GIN_MODE", testCase.ginMode)
+
+			router := NewRouter(nil, nil, nil, nil, AuthConfig{BasePath: "/cpa"}, nil, "/cpa")
+			req := httptest.NewRequest(http.MethodGet, testCase.path, nil)
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			if resp.Code != testCase.wantStatus {
+				t.Fatalf("expected status %d, got %d body=%s", testCase.wantStatus, resp.Code, resp.Body.String())
+			}
+		})
 	}
 }
 
@@ -135,7 +212,140 @@ func TestStatusReturnsEmptyStateWithoutProvider(t *testing.T) {
 	}
 }
 
-func TestStatusReturnsVersionAndUpdateCheckFlag(t *testing.T) {
+func TestVersionReturnsCurrentVersionAndUpdateCheckFlag(t *testing.T) {
+	previousVersion := version.Version
+	t.Cleanup(func() { version.Version = previousVersion })
+	version.Version = "v1.2.3"
+
+	router := NewRouter(nil, nil, nil, nil, AuthConfig{}, nil, "")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.Code)
+	}
+	if got := resp.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("expected version Cache-Control no-store, got %q", got)
+	}
+	if got := resp.Header().Get("Pragma"); got != "no-cache" {
+		t.Fatalf("expected version Pragma no-cache, got %q", got)
+	}
+	if got := resp.Header().Get("Expires"); got != "0" {
+		t.Fatalf("expected version Expires 0, got %q", got)
+	}
+	var body versionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response body: %v", err)
+	}
+	if body.Version != "v1.2.3" || !body.UpdateCheckEnabled {
+		t.Fatalf("unexpected response body: %+v", body)
+	}
+}
+
+func TestVersionRequiresAuthWhenAuthEnabled(t *testing.T) {
+	sessions := auth.NewSessionManager(time.Hour)
+	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
+	router := NewRouter(nil, nil, nil, nil, config, NewAuthHandler(config, sessions), "")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestVersionAllowsAdminAndAPIKeyViewerSessions(t *testing.T) {
+	previousVersion := version.Version
+	t.Cleanup(func() { version.Version = previousVersion })
+	version.Version = "v1.2.3"
+
+	for _, testCase := range []struct {
+		name        string
+		createToken func(*auth.SessionManager) (string, error)
+	}{
+		{
+			name: "admin",
+			createToken: func(sessions *auth.SessionManager) (string, error) {
+				token, _, err := sessions.Create()
+				return token, err
+			},
+		},
+		{
+			name: "api key viewer",
+			createToken: func(sessions *auth.SessionManager) (string, error) {
+				token, _, err := sessions.CreateAPIKeyViewer(42)
+				return token, err
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			sessions := auth.NewSessionManager(time.Hour)
+			config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
+			router := NewRouter(nil, nil, nil, nil, config, NewAuthHandler(config, sessions), "")
+			token, err := testCase.createToken(sessions)
+			if err != nil {
+				t.Fatalf("create session: %v", err)
+			}
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+			req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
+			resp := httptest.NewRecorder()
+
+			router.ServeHTTP(resp, req)
+
+			if resp.Code != http.StatusOK {
+				t.Fatalf("expected status 200, got %d body=%s", resp.Code, resp.Body.String())
+			}
+		})
+	}
+}
+
+func TestSubpathVersionRequiresAuthAndAllowsAdminAndAPIKeyViewerSessions(t *testing.T) {
+	previousVersion := version.Version
+	t.Cleanup(func() { version.Version = previousVersion })
+	version.Version = "v1.2.3"
+
+	sessions := auth.NewSessionManager(time.Hour)
+	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour, BasePath: "/cpa"}
+	router := NewRouter(nil, nil, nil, nil, config, NewAuthHandler(config, sessions), "/cpa")
+	adminToken, _, err := sessions.Create()
+	if err != nil {
+		t.Fatalf("create admin session: %v", err)
+	}
+	viewerToken, _, err := sessions.CreateAPIKeyViewer(42)
+	if err != nil {
+		t.Fatalf("create API key viewer session: %v", err)
+	}
+
+	for _, testCase := range []struct {
+		name       string
+		path       string
+		token      string
+		statusCode int
+	}{
+		{name: "unprefixed version route is not served", path: "/api/v1/version", statusCode: http.StatusNotFound},
+		{name: "prefixed version route requires auth", path: "/cpa/api/v1/version", statusCode: http.StatusUnauthorized},
+		{name: "prefixed version route allows admin", path: "/cpa/api/v1/version", token: adminToken, statusCode: http.StatusOK},
+		{name: "prefixed version route allows API key viewer", path: "/cpa/api/v1/version", token: viewerToken, statusCode: http.StatusOK},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, testCase.path, nil)
+			if testCase.token != "" {
+				req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: testCase.token})
+			}
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			if resp.Code != testCase.statusCode {
+				t.Fatalf("expected status %d, got %d body=%s", testCase.statusCode, resp.Code, resp.Body.String())
+			}
+		})
+	}
+}
+
+func TestStatusOmitsVersionFields(t *testing.T) {
 	previousVersion := version.Version
 	t.Cleanup(func() { version.Version = previousVersion })
 	version.Version = "v1.2.3"
@@ -148,9 +358,15 @@ func TestStatusReturnsVersionAndUpdateCheckFlag(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", resp.Code)
 	}
-	body := resp.Body.String()
-	if !contains(body, `"version":"v1.2.3"`) || !contains(body, `"updateCheckEnabled":true`) {
-		t.Fatalf("unexpected response body: %s", body)
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response body: %v", err)
+	}
+	if _, ok := body["version"]; ok {
+		t.Fatalf("expected status response to omit version, got %+v", body)
+	}
+	if _, ok := body["updateCheckEnabled"]; ok {
+		t.Fatalf("expected status response to omit updateCheckEnabled, got %+v", body)
 	}
 }
 
@@ -225,22 +441,25 @@ func TestStatusActiveRecordsBackendActivity(t *testing.T) {
 	}
 }
 
-func TestStatusHidesUpdateCheckForDevVersion(t *testing.T) {
+func TestVersionHidesUpdateCheckForDevVersion(t *testing.T) {
 	previousVersion := version.Version
 	t.Cleanup(func() { version.Version = previousVersion })
 	version.Version = "dev"
 
 	router := NewRouter(nil, nil, nil, nil, AuthConfig{}, nil, "")
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
 
 	if resp.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", resp.Code)
 	}
-	body := resp.Body.String()
-	if !contains(body, `"version":"dev"`) || !contains(body, `"updateCheckEnabled":false`) {
-		t.Fatalf("unexpected response body: %s", body)
+	var body versionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response body: %v", err)
+	}
+	if body.Version != "dev" || body.UpdateCheckEnabled {
+		t.Fatalf("unexpected response body: %+v", body)
 	}
 }
 
@@ -269,8 +488,10 @@ func TestSubpathRoutesOnlyServePrefixedEndpoints(t *testing.T) {
 	}{
 		{path: "/cpa/healthz", statusCode: http.StatusOK},
 		{path: "/cpa/api/v1/status", statusCode: http.StatusOK},
+		{path: "/cpa/api/v1/version", statusCode: http.StatusOK},
 		{path: "/healthz", statusCode: http.StatusNotFound},
 		{path: "/api/v1/status", statusCode: http.StatusNotFound},
+		{path: "/api/v1/version", statusCode: http.StatusNotFound},
 	} {
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, testCase.path, nil)

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -109,4 +109,14 @@
   .app-footer-line {
     gap: 7px;
   }
+
+  .app-footer-version-separator {
+    display: none;
+  }
+
+  .app-footer-version {
+    display: block;
+    flex-basis: 100%;
+    text-align: center;
+  }
 }

--- a/web/src/App.logic.test.ts
+++ b/web/src/App.logic.test.ts
@@ -27,7 +27,7 @@ describe('App role route normalization', () => {
   it('mounts the shared footer from the app shell', () => {
     expect(appSource).toContain("import './App.css';");
     expect(appSource).toContain("import { AppFooter } from './components/AppFooter';");
-    expect(appSource).toMatch(/<div className="app-frame">[\s\S]*<main className="app-main">\{page\}<\/main>[\s\S]*<AppFooter \/>[\s\S]*<\/div>/);
+    expect(appSource).toMatch(/<div className="app-frame">[\s\S]*<main className="app-main">\{page\}<\/main>[\s\S]*<AppFooter loadVersion=\{authState === 'authenticated'\} \/>[\s\S]*<\/div>/);
   });
 
   it('lets app pages fill the space above the shared footer', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -136,7 +136,7 @@ function App() {
   return (
     <div className="app-frame">
       <main className="app-main">{page}</main>
-      <AppFooter />
+      <AppFooter loadVersion={authState === 'authenticated'} />
     </div>
   );
 }

--- a/web/src/components/AppFooter.test.tsx
+++ b/web/src/components/AppFooter.test.tsx
@@ -1,8 +1,11 @@
+import { readFileSync } from 'node:fs';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { CLIPROXYAPI_REPOSITORY_URL, GITHUB_PROFILE_URL, GITHUB_REPOSITORY_URL } from '@/utils/constants';
-import { AppFooter, footerVersionLabel } from './AppFooter';
+import { AppFooter, footerVersionLabel, loadFooterVersion } from './AppFooter';
+
+const appStyles = readFileSync(new URL('../App.css', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 
 describe('AppFooter', () => {
   it('renders project links, powered by line, and version label', () => {
@@ -23,9 +26,8 @@ describe('AppFooter', () => {
     expect(html).toContain(`CPA Usage Keeper</a><span>·</span><a href="${GITHUB_REPOSITORY_URL}/blob/main/LICENSE"`);
     expect(html).toContain(`License</a><span>·</span><a href="${CLIPROXYAPI_REPOSITORY_URL}"`);
     expect(html).toContain(`href="${GITHUB_PROFILE_URL}"`);
-    expect(html).toContain('Willxup</span></a><span>·</span><span class="app-footer-version">Version: v1.2.3</span>');
+    expect(html).toContain('Willxup</span></a><span class="app-footer-version-separator" aria-hidden="true">·</span><span class="app-footer-version">Version: v1.2.3</span>');
     expect(html).not.toContain('|');
-    expect(html).not.toContain('app-footer-separator');
   });
 
   it('does not render a version label before the version is available', () => {
@@ -34,10 +36,44 @@ describe('AppFooter', () => {
     expect(html).not.toContain('Version:');
   });
 
+  it('respects disabled version loading while still allowing a fixed version', () => {
+    const unloadedHtml = renderToStaticMarkup(<AppFooter loadVersion={false} />);
+    const fixedHtml = renderToStaticMarkup(<AppFooter version="v1.2.3" loadVersion={false} />);
+
+    expect(unloadedHtml).not.toContain('Version:');
+    expect(fixedHtml).toContain('Version: v1.2.3');
+  });
+
   it('formats only non-empty version values', () => {
     expect(footerVersionLabel('v1.2.3')).toBe('Version: v1.2.3');
     expect(footerVersionLabel('dev')).toBe('Version: dev');
     expect(footerVersionLabel('')).toBeUndefined();
     expect(footerVersionLabel(undefined)).toBeUndefined();
+  });
+
+  it('loads footer version through the provided version loader', async () => {
+    const signal = new AbortController().signal;
+    const loadVersion = vi.fn(async () => ({ version: 'v1.2.3', updateCheckEnabled: true }));
+
+    await expect(loadFooterVersion(loadVersion, signal)).resolves.toBe('v1.2.3');
+
+    expect(loadVersion).toHaveBeenCalledWith(signal);
+  });
+
+  it('falls back to an empty footer version when version loading fails', async () => {
+    const signal = new AbortController().signal;
+    const loadVersion = vi.fn(async () => {
+      throw new Error('network failed');
+    });
+
+    await expect(loadFooterVersion(loadVersion, signal)).resolves.toBe('');
+  });
+
+  it('keeps the version label visible on its own mobile footer line', () => {
+    const mobileFooterStyles = appStyles.slice(appStyles.indexOf('@media (max-width: 640px)'));
+    expect(mobileFooterStyles).toContain('.app-footer-version-separator');
+    expect(mobileFooterStyles).not.toContain(':has(');
+    expect(mobileFooterStyles).toMatch(/\.app-footer-version-separator\s*\{[\s\S]*?display:\s*none;/);
+    expect(mobileFooterStyles).toMatch(/\.app-footer-version\s*\{[\s\S]*?display:\s*block;[\s\S]*?flex-basis:\s*100%;/);
   });
 });

--- a/web/src/components/AppFooter.tsx
+++ b/web/src/components/AppFooter.tsx
@@ -1,23 +1,37 @@
 import { useEffect, useState } from 'react';
-import { fetchStatus } from '@/lib/api';
+import { fetchVersion } from '@/lib/api';
+import type { VersionResponse } from '@/lib/types';
 import { IconGithub } from '@/components/ui/icons';
 import { CLIPROXYAPI_REPOSITORY_URL, GITHUB_PROFILE_URL, GITHUB_REPOSITORY_URL } from '@/utils/constants';
+
+type FooterVersionLoader = (signal: AbortSignal) => Promise<Pick<VersionResponse, 'version'>>;
 
 export function footerVersionLabel(version?: string): string | undefined {
   const trimmed = version?.trim();
   return trimmed ? `Version: ${trimmed}` : undefined;
 }
 
-export function AppFooter({ version: fixedVersion }: { version?: string }) {
+export async function loadFooterVersion(loadVersion: FooterVersionLoader, signal: AbortSignal): Promise<string> {
+  try {
+    const versionInfo = await loadVersion(signal);
+    return versionInfo.version ?? '';
+  } catch {
+    return '';
+  }
+}
+
+export function AppFooter({ version: fixedVersion, loadVersion = true }: { version?: string; loadVersion?: boolean }) {
   const [version, setVersion] = useState('');
 
   useEffect(() => {
     if (fixedVersion !== undefined) return;
+    if (!loadVersion) return;
 
     let cancelled = false;
-    void fetchStatus()
-      .then((status) => {
-        if (!cancelled) setVersion(status.version ?? '');
+    const requestController = new AbortController();
+    void loadFooterVersion(fetchVersion, requestController.signal)
+      .then((nextVersion) => {
+        if (!cancelled) setVersion(nextVersion);
       })
       .catch(() => {
         if (!cancelled) setVersion('');
@@ -25,10 +39,11 @@ export function AppFooter({ version: fixedVersion }: { version?: string }) {
 
     return () => {
       cancelled = true;
+      requestController.abort();
     };
-  }, [fixedVersion]);
+  }, [fixedVersion, loadVersion]);
 
-  const versionLabel = footerVersionLabel(fixedVersion ?? version);
+  const versionLabel = footerVersionLabel(fixedVersion ?? (loadVersion ? version : ''));
 
   return (
     <footer className="app-footer">
@@ -48,7 +63,7 @@ export function AppFooter({ version: fixedVersion }: { version?: string }) {
         </a>
         {versionLabel ? (
           <>
-            <span>·</span>
+            <span className="app-footer-version-separator" aria-hidden="true">·</span>
             <span className="app-footer-version">{versionLabel}</span>
           </>
         ) : null}

--- a/web/src/components/AppFooter.tsx
+++ b/web/src/components/AppFooter.tsx
@@ -27,18 +27,15 @@ export function AppFooter({ version: fixedVersion, loadVersion = true }: { versi
     if (fixedVersion !== undefined) return;
     if (!loadVersion) return;
 
-    let cancelled = false;
     const requestController = new AbortController();
     void loadFooterVersion(fetchVersion, requestController.signal)
       .then((nextVersion) => {
-        if (!cancelled) setVersion(nextVersion);
-      })
-      .catch(() => {
-        if (!cancelled) setVersion('');
+        if (!requestController.signal.aborted) {
+          setVersion(nextVersion);
+        }
       });
 
     return () => {
-      cancelled = true;
       requestController.abort();
     };
   }, [fixedVersion, loadVersion]);

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { appPath, deleteAuthFiles, fetchAnalysis, fetchAuthSessions, fetchCpaApiKeyOptions, fetchCpaApiKeys, fetchCpaApiKeySettings, fetchKeyOverview, fetchKeyOverviewRealtime, fetchUsageOverview, fetchUsageOverviewRealtime, fetchUsageQuotaCache, fetchUsageQuotaInspectionStatus, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchUsageIdentities, fetchUsageIdentitiesPage, fetchUsageQuotaRefreshTask, loginWithCPAAPIKey, logout, markStatusActive, refreshUsageQuotas, resetUsageQuota, revokeAuthSession, setAuthFilesDisabled, startUsageQuotaInspection, updateCpaApiKeyAlias } from './api';
+import { appPath, deleteAuthFiles, fetchAnalysis, fetchAuthSessions, fetchCpaApiKeyOptions, fetchCpaApiKeys, fetchCpaApiKeySettings, fetchKeyOverview, fetchKeyOverviewRealtime, fetchUsageOverview, fetchUsageOverviewRealtime, fetchUsageQuotaCache, fetchUsageQuotaInspectionStatus, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchUsageIdentities, fetchUsageIdentitiesPage, fetchUsageQuotaRefreshTask, fetchVersion, loginWithCPAAPIKey, logout, markStatusActive, refreshUsageQuotas, resetUsageQuota, revokeAuthSession, setAuthFilesDisabled, startUsageQuotaInspection, updateCpaApiKeyAlias } from './api';
 
 describe('fetchUsageEvents', () => {
   afterEach(() => {
@@ -169,6 +169,23 @@ describe('fetchUsageEvents', () => {
     const [url, init] = fetchMock.mock.calls[0];
     expect(new URL(String(url), 'http://localhost').pathname).toBe('/api/v1/status/active');
     expect(init).toMatchObject({ credentials: 'include', signal });
+  });
+
+  it('loads app version from the dedicated version endpoint', async () => {
+    vi.stubGlobal('window', { __APP_BASE_PATH__: undefined });
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: 'v1.2.3', updateCheckEnabled: true }),
+    } as Response);
+    const signal = new AbortController().signal;
+
+    const response = await fetchVersion(signal);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(response.version).toBe('v1.2.3');
+    expect(response.updateCheckEnabled).toBe(true);
+    expect(new URL(String(url), 'http://localhost').pathname).toBe('/api/v1/version');
+    expect(init).toMatchObject({ credentials: 'include', signal, cache: 'no-store' });
   });
 
   it('loads model filter options without query params', async () => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { type AnalysisResponse, type AuthFilesManagementResponse, type AuthManagedSessionsResponse, type AuthSessionResponse, type CpaApiKeyDisplayItem, type CpaApiKeyOptionsResponse, type CpaApiKeySettingsResponse, type CpaApiKeysResponse, type KeyOverviewTimeRange, type OverviewRealtimeBlock, type OverviewRealtimeWindow, type PricingEntry, type PricingResponse, type PricingSyncPreviewResponse, type StatusResponse, type UpdateCheckResponse, type UsageEventModelFilterOptionsResponse, type UsageEventSourceFilterOptionsResponse, type UsedModelsResponse, type UsageIdentitiesPageResponse, type UsageIdentitiesResponse, type UsageEventsResponse, type UsageIdentityAuthType, type UsageOverviewResponse, type UsageQuotaCacheResponse, type UsageQuotaInspectionStatusResponse, type UsageQuotaRefreshResponse, type UsageQuotaRefreshTaskResponse, type UsageQuotaResetResponse } from './types'
+import { type AnalysisResponse, type AuthFilesManagementResponse, type AuthManagedSessionsResponse, type AuthSessionResponse, type CpaApiKeyDisplayItem, type CpaApiKeyOptionsResponse, type CpaApiKeySettingsResponse, type CpaApiKeysResponse, type KeyOverviewTimeRange, type OverviewRealtimeBlock, type OverviewRealtimeWindow, type PricingEntry, type PricingResponse, type PricingSyncPreviewResponse, type StatusResponse, type UpdateCheckResponse, type UsageEventModelFilterOptionsResponse, type UsageEventSourceFilterOptionsResponse, type UsedModelsResponse, type UsageIdentitiesPageResponse, type UsageIdentitiesResponse, type UsageEventsResponse, type UsageIdentityAuthType, type UsageOverviewResponse, type UsageQuotaCacheResponse, type UsageQuotaInspectionStatusResponse, type UsageQuotaRefreshResponse, type UsageQuotaRefreshTaskResponse, type UsageQuotaResetResponse, type VersionResponse } from './types'
 
 export class ApiError extends Error {
   status: number
@@ -541,6 +541,14 @@ export async function fetchStatus(signal?: AbortSignal): Promise<StatusResponse>
   const response = await apiFetch(apiPath('/status'), { signal })
   if (!response.ok) {
     await parseApiError(response, `Failed to load status: ${response.status}`)
+  }
+  return response.json()
+}
+
+export async function fetchVersion(signal?: AbortSignal): Promise<VersionResponse> {
+  const response = await apiFetch(apiPath('/version'), { signal, cache: 'no-store' })
+  if (!response.ok) {
+    await parseApiError(response, `Failed to load version: ${response.status}`)
   }
   return response.json()
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -33,14 +33,17 @@ export interface StatusResponse {
   running: boolean
   sync_running: boolean
   timezone: string
-  version?: string
-  updateCheckEnabled?: boolean
   quotaAutoRefreshEnabled?: boolean
   cpa_public_url?: string
   last_run_at?: string
   last_error?: string
   last_warning?: string
   last_status?: string
+}
+
+export interface VersionResponse {
+  version: string
+  updateCheckEnabled: boolean
 }
 
 export interface UpdateCheckResponse {

--- a/web/src/pages/UsagePage.logic.test.ts
+++ b/web/src/pages/UsagePage.logic.test.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from 'node:fs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { buildCustomDateRangeQuery, clampCustomDateRangeToBounds, CUSTOM_DATE_RANGE_BOUNDS_REFRESH_INTERVAL_MS, getBackToCPALinkURL, getCredentialSectionVisibility, getCustomDateRangeBounds, getOverviewDisplayLoading, getTimeRangeOptions, getUsageTabOptions, isCustomDateWithinBounds, isUsagePageVisible, loadRequestEventsPreferences, normalizeRequestEventsPreferences, normalizeUsageTabValue, openDateInputPicker, refreshPageData, REQUEST_EVENTS_PREFERENCES_STORAGE_KEY, sanitizeRequestEventFilters, saveRequestEventsPreferences, scheduleCustomDateRangeBoundsRefresh, scheduleOverviewAutoRefresh, scheduleStatusActiveHeartbeat, shouldAutoRefreshUsageTab, shouldShowApiKeyFilter, shouldShowRangeControls, shouldShowUpdateCheckButton, STATUS_ACTIVE_HEARTBEAT_INTERVAL_MS, getUpdateCheckToastDuration } from './UsagePage';
+import { buildCustomDateRangeQuery, clampCustomDateRangeToBounds, CUSTOM_DATE_RANGE_BOUNDS_REFRESH_INTERVAL_MS, getBackToCPALinkURL, getCredentialSectionVisibility, getCustomDateRangeBounds, getOverviewDisplayLoading, getTimeRangeOptions, getUsageTabOptions, isCustomDateWithinBounds, isUsagePageVisible, loadRequestEventsPreferences, loadUsagePageVersionInfo, normalizeRequestEventsPreferences, normalizeUsageTabValue, openDateInputPicker, refreshPageData, REQUEST_EVENTS_PREFERENCES_STORAGE_KEY, sanitizeRequestEventFilters, saveRequestEventsPreferences, scheduleCustomDateRangeBoundsRefresh, scheduleOverviewAutoRefresh, scheduleStatusActiveHeartbeat, shouldAutoRefreshUsageTab, shouldShowApiKeyFilter, shouldShowRangeControls, shouldShowUpdateCheckButton, STATUS_ACTIVE_HEARTBEAT_INTERVAL_MS, getUpdateCheckToastDuration } from './UsagePage';
 import { REQUEST_EVENT_COLUMN_IDS } from '@/components/usage/RequestEventsDetailsCard';
-import type { StatusResponse, UsageFilterWindow } from '@/lib/types';
+import { ApiError } from '@/lib/api';
+import type { StatusResponse, UsageFilterWindow, VersionResponse } from '@/lib/types';
 
 const usagePageSource = readFileSync(new URL('./UsagePage.tsx', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 
@@ -91,16 +92,68 @@ describe('UsagePage Back to CPA link', () => {
 });
 
 describe('UsagePage update check controls', () => {
-  it('hides the update button before status loads', () => {
+  it('loads version info through the dedicated version loader', async () => {
+    const signal = new AbortController().signal;
+    const versionInfo = { version: 'v1.2.3', updateCheckEnabled: true };
+    const loadVersion = vi.fn(async () => versionInfo);
+    const setVersionInfo = vi.fn();
+
+    await loadUsagePageVersionInfo({ loadVersion, signal, setVersionInfo });
+
+    expect(loadVersion).toHaveBeenCalledWith(signal);
+    expect(setVersionInfo).toHaveBeenCalledWith(versionInfo);
+  });
+
+  it('clears version info when version loading fails', async () => {
+    const signal = new AbortController().signal;
+    const loadVersion = vi.fn(async () => {
+      throw new Error('network failed');
+    });
+    const setVersionInfo = vi.fn();
+
+    await loadUsagePageVersionInfo({ loadVersion, signal, setVersionInfo });
+
+    expect(setVersionInfo).toHaveBeenCalledWith(null);
+  });
+
+  it('requests reauthentication when version loading returns 401', async () => {
+    const signal = new AbortController().signal;
+    const loadVersion = vi.fn(async () => {
+      throw new ApiError('expired', 401);
+    });
+    const setVersionInfo = vi.fn();
+    const onAuthRequired = vi.fn();
+
+    await loadUsagePageVersionInfo({ loadVersion, signal, setVersionInfo, onAuthRequired });
+
+    expect(onAuthRequired).toHaveBeenCalledTimes(1);
+    expect(setVersionInfo).not.toHaveBeenCalled();
+  });
+
+  it('ignores version results after the request is aborted', async () => {
+    const requestController = new AbortController();
+    const versionInfo = { version: 'v1.2.3', updateCheckEnabled: true };
+    const loadVersion = vi.fn(async () => {
+      requestController.abort();
+      return versionInfo;
+    });
+    const setVersionInfo = vi.fn();
+
+    await loadUsagePageVersionInfo({ loadVersion, signal: requestController.signal, setVersionInfo });
+
+    expect(setVersionInfo).not.toHaveBeenCalled();
+  });
+
+  it('hides the update button before version loads', () => {
     expect(shouldShowUpdateCheckButton(null)).toBe(false);
   });
 
   it('hides the update button for dev builds', () => {
-    expect(shouldShowUpdateCheckButton({ updateCheckEnabled: false })).toBe(false);
+    expect(shouldShowUpdateCheckButton({ version: 'dev', updateCheckEnabled: false } satisfies VersionResponse)).toBe(false);
   });
 
   it('shows the update button for release builds', () => {
-    expect(shouldShowUpdateCheckButton({ updateCheckEnabled: true })).toBe(true);
+    expect(shouldShowUpdateCheckButton({ version: 'v1.2.3', updateCheckEnabled: true })).toBe(true);
   });
 
   it('keeps failure toasts visible longer than success toasts', () => {

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback, useEffect, useRef, type KeyboardEvent, type SyntheticEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ApiError, fetchAnalysis, fetchAuthSessions, fetchCpaApiKeyOptions, fetchCpaApiKeySettings, fetchStatus, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventSourceFilterOptions, fetchUsageEvents, logout, markStatusActive, revokeAuthSession, updateCpaApiKeyAlias } from '@/lib/api';
-import type { AnalysisResponse, AuthManagedSessionItem, CpaApiKeyOption, CpaApiKeySettingsItem, OverviewRealtimeWindow, StatusResponse, UsageEvent, UsageSourceFilterOption } from '@/lib/types';
+import { ApiError, fetchAnalysis, fetchAuthSessions, fetchCpaApiKeyOptions, fetchCpaApiKeySettings, fetchStatus, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchVersion, logout, markStatusActive, revokeAuthSession, updateCpaApiKeyAlias } from '@/lib/api';
+import type { AnalysisResponse, AuthManagedSessionItem, CpaApiKeyOption, CpaApiKeySettingsItem, OverviewRealtimeWindow, StatusResponse, UsageEvent, UsageSourceFilterOption, VersionResponse } from '@/lib/types';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { LanguageSwitcher } from '@/components/ui/LanguageSwitcher';
 import { Select } from '@/components/ui/Select';
@@ -102,7 +102,7 @@ export const shouldShowRangeControls = (tab: UsageTab) => tab !== 'settings' && 
 
 export const shouldShowApiKeyFilter = (tab: UsageTab) => shouldShowRangeControls(tab);
 
-export const shouldShowUpdateCheckButton = (status: Pick<StatusResponse, 'updateCheckEnabled'> | null) => status?.updateCheckEnabled === true;
+export const shouldShowUpdateCheckButton = (versionInfo: Pick<VersionResponse, 'updateCheckEnabled'> | null) => versionInfo?.updateCheckEnabled === true;
 
 export const isUsagePageVisible = (documentRef?: Pick<Document, 'visibilityState'>) => {
   const targetDocument = documentRef ?? (typeof document === 'undefined' ? undefined : document);
@@ -342,6 +342,35 @@ type StatusActiveHeartbeatOptions = {
   documentRef?: StatusActiveHeartbeatDocument;
   timerTarget?: StatusActiveHeartbeatTimerTarget;
   intervalMs?: number;
+};
+
+type VersionInfoLoader = (signal: AbortSignal) => Promise<VersionResponse>;
+
+type UsagePageVersionInfoOptions = {
+  loadVersion: VersionInfoLoader;
+  signal: AbortSignal;
+  setVersionInfo: (versionInfo: VersionResponse | null) => void;
+  onAuthRequired?: () => void;
+};
+
+export const loadUsagePageVersionInfo = async ({
+  loadVersion,
+  signal,
+  setVersionInfo,
+  onAuthRequired,
+}: UsagePageVersionInfoOptions) => {
+  try {
+    const nextVersionInfo = await loadVersion(signal);
+    if (signal.aborted) return;
+    setVersionInfo(nextVersionInfo);
+  } catch (error) {
+    if (signal.aborted) return;
+    if (error instanceof ApiError && error.status === 401) {
+      onAuthRequired?.();
+      return;
+    }
+    setVersionInfo(null);
+  }
 };
 
 export const refreshPageData = async ({ refreshActiveTab }: RefreshPageDataOptions) => {
@@ -774,6 +803,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   const [selectedApiKeyId, setSelectedApiKeyId] = useState('');
   const [apiKeyOptions, setApiKeyOptions] = useState<CpaApiKeyOption[]>([]);
   const [status, setStatus] = useState<StatusResponse | null>(null);
+  const [versionInfo, setVersionInfo] = useState<VersionResponse | null>(null);
   const [customDateRangeAnchorMs, setCustomDateRangeAnchorMs] = useState(() => Date.now());
   const apiKeyOptionsRequestControllerRef = useRef<AbortController | null>(null);
   const credentialSectionVisibility = getCredentialSectionVisibility(activeTab);
@@ -1238,6 +1268,19 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   }, [onAuthRequired]);
 
   useEffect(() => {
+    const requestController = new AbortController();
+    void loadUsagePageVersionInfo({
+      loadVersion: fetchVersion,
+      signal: requestController.signal,
+      setVersionInfo,
+      onAuthRequired,
+    });
+    return () => {
+      requestController.abort();
+    };
+  }, [onAuthRequired]);
+
+  useEffect(() => {
     void loadApiKeyOptions();
     return () => {
       apiKeyOptionsRequestControllerRef.current?.abort();
@@ -1252,10 +1295,10 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   }, [apiKeyOptions, selectedApiKeyId]);
 
   useEffect(() => {
-    if (!shouldShowUpdateCheckButton(status)) {
+    if (!shouldShowUpdateCheckButton(versionInfo)) {
       setHasNewVersion(false);
     }
-  }, [status]);
+  }, [versionInfo]);
 
   useEffect(() => () => {
     if (topNoticeTimerRef.current !== null) {
@@ -1641,7 +1684,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                 );
               })}
             </div>
-            {shouldShowUpdateCheckButton(status) && (
+            {shouldShowUpdateCheckButton(versionInfo) && (
               <div className={styles.updateCheckSwitcher} role="group" aria-label={t('usage_stats.check_updates')}>
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- add a dedicated `/api/v1/version` endpoint for version and update-check metadata
- remove version metadata from `/api/v1/status` and migrate frontend callers
- keep `/api/v1/ping` limited to dev/debug builds while preserving `/healthz` as the stable health endpoint
- fix mobile footer version visibility

Fixes #109

## Validation
- `rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build go test ./cmd/... ./internal/...`
- `rtk npm --prefix ./web run test`
- `rtk npm --prefix ./web run typecheck`
- `rtk npm --prefix ./web run lint`
- `rtk npm --prefix ./web run build`
- `git diff --check`