### PR TITLE
Optimize request event model filter query

### DIFF
--- a/internal/repository/migration/20260506_usage_performance_indexes_test.go
+++ b/internal/repository/migration/20260506_usage_performance_indexes_test.go
@@ -114,7 +114,6 @@ func TestUsagePerformanceIndexesSupportRepresentativeQueryPlans(t *testing.T) {
 
 	assertQueryPlanUsesIndex(t, db, "idx_usage_events_model", `
 		EXPLAIN QUERY PLAN SELECT DISTINCT model FROM usage_events
-		WHERE model <> ''
 		ORDER BY model ASC`)
 
 	assertQueryPlanUsesIndex(t, db, "idx_usage_events_auth_index", `

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -130,12 +130,19 @@ func listUsageEventModelFilterOptions(db *gorm.DB, filter dto.UsageQueryFilter) 
 	// 第一步：model 候选值只来自 usage_events，并且只套用时间窗口。
 	query := applyUsageEventFilterOptionsQuery(queryUsageEvents(db), filter)
 
-	// 第二步：去重并排除空 model，保持下拉选项稳定排序。
+	// 第二步：只按 model 索引去重排序；空白值由内存兜底过滤，避免给索引扫描追加无意义条件。
 	var values []string
-	if err := query.Select("DISTINCT model").Where("model <> ''").Order("model ASC").Pluck("model", &values).Error; err != nil {
+	if err := query.Select("DISTINCT model").Order("model ASC").Pluck("model", &values).Error; err != nil {
 		return nil, fmt.Errorf("load usage event model filter options: %w", err)
 	}
-	return values, nil
+	models := values[:0]
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		models = append(models, value)
+	}
+	return models, nil
 }
 
 // queryUsageEvents 统一 usage_events 的 GORM model 入口，方便后续追加通用 scope。

--- a/internal/repository/usage_events_test.go
+++ b/internal/repository/usage_events_test.go
@@ -252,6 +252,7 @@ func TestListUsageEventFilterOptionsWithFilterReturnsStableModels(t *testing.T) 
 		{EventKey: "event-1", APIGroupKey: "provider-a", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 16, 9, 0, 0, 0, time.UTC), Source: "source-a", Failed: false, TotalTokens: 10},
 		{EventKey: "event-2", APIGroupKey: "provider-a", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC), Source: "source-b", Failed: true, TotalTokens: 20},
 		{EventKey: "event-3", APIGroupKey: "provider-b", Model: "gpt-5", Timestamp: time.Date(2026, 4, 16, 11, 0, 0, 0, time.UTC), Source: "source-a", Failed: false, TotalTokens: 30},
+		{EventKey: "event-blank-model", APIGroupKey: "provider-c", Model: "   ", Timestamp: time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC), Source: "source-c", Failed: false, TotalTokens: 40},
 	}
 	if _, _, err := InsertUsageEvents(db, events); err != nil {
 		t.Fatalf("InsertUsageEvents returned error: %v", err)

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -462,7 +462,7 @@ func (s *usageService) ListUsageEvents(_ context.Context, filter servicedto.Usag
 	return &servicedto.UsageEventsPage{Events: result, Models: page.Models, TotalCount: page.TotalCount, Page: page.Page, PageSize: page.PageSize, TotalPages: page.TotalPages}, nil
 }
 
-// Usage 页面里的 Request Event Log tab 的 model 筛选项只按当前时间窗口加载候选值。
+// Request Event Log 的 model 筛选项只应用调用方传入的时间窗口；独立筛选项接口当前传空 filter。
 func (s *usageService) ListUsageEventFilterOptions(_ context.Context, filter servicedto.UsageFilter) (*servicedto.UsageEventFilterOptions, error) {
 	options, err := repository.ListUsageEventFilterOptionsWithFilter(s.db, repodto.UsageQueryFilter{
 		StartTime: filter.StartTime,


### PR DESCRIPTION
## Summary
- remove the SQL-side `model <> ""` predicate from the Request Event Log model filter query
- keep blank model values out of the dropdown with lightweight in-memory filtering after `DISTINCT model`
- update the representative query-plan test to match the current query shape

## Validation
- `go test ./internal/repository ./internal/repository/migration ./internal/service ./internal/api -count=1`