### PR TITLE
Add request events export

### DIFF
--- a/internal/api/usage_analysis_test.go
+++ b/internal/api/usage_analysis_test.go
@@ -54,6 +54,10 @@ func (s *usageAnalysisStub) ListUsageEvents(context.Context, servicedto.UsageFil
 	return nil, nil
 }
 
+func (s *usageAnalysisStub) StreamUsageEvents(context.Context, servicedto.UsageFilter, func(servicedto.UsageEventRecord) error) error {
+	return nil
+}
+
 func (s *usageAnalysisStub) ListUsageEventFilterOptions(context.Context, servicedto.UsageFilter) (*servicedto.UsageEventFilterOptions, error) {
 	return nil, nil
 }

--- a/internal/api/usage_events.go
+++ b/internal/api/usage_events.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"encoding/csv"
+	"encoding/json"
 	"net/http"
 	"strconv"
 	"strings"
@@ -68,6 +70,37 @@ type usageEventTokenPayload struct {
 	TotalTokens         int64 `json:"total_tokens"`
 }
 
+type usageEventExportPayload struct {
+	ID                  string   `json:"id"`
+	Timestamp           string   `json:"timestamp"`
+	APIKey              string   `json:"api_key"`
+	CPAAPIKeyID         string   `json:"cpa_api_key_id"`
+	Source              string   `json:"source"`
+	SourceType          string   `json:"source_type"`
+	AuthIndex           string   `json:"auth_index"`
+	IsIdentityDeleted   bool     `json:"is_identity_deleted"`
+	Model               string   `json:"model"`
+	ReasoningEffort     string   `json:"reasoning_effort"`
+	ServiceTier         string   `json:"service_tier"`
+	ExecutorType        string   `json:"executor_type"`
+	Result              string   `json:"result"`
+	Endpoint            string   `json:"endpoint"`
+	TTFTMS              *int64   `json:"ttft_ms"`
+	LatencyMS           int64    `json:"latency_ms"`
+	SpeedTPS            *float64 `json:"speed_tps"`
+	InputTokens         int64    `json:"input_tokens"`
+	OutputTokens        int64    `json:"output_tokens"`
+	ReasoningTokens     int64    `json:"reasoning_tokens"`
+	CachedTokens        int64    `json:"cached_tokens"`
+	CacheReadTokens     int64    `json:"cache_read_tokens"`
+	CacheCreationTokens int64    `json:"cache_creation_tokens"`
+	CacheRate           *float64 `json:"cache_rate"`
+	TotalTokens         int64    `json:"total_tokens"`
+	CostUSD             float64  `json:"cost_usd"`
+}
+
+type usageEventStreamFunc func(func(servicedto.UsageEventRecord) error) error
+
 func registerUsageEventsRoute(
 	router gin.IRoutes,
 	usageProvider service.UsageProvider,
@@ -132,6 +165,57 @@ func registerUsageEventsRoute(
 			TotalPages: rows.TotalPages,
 		})
 	})
+
+	router.GET("/usage/events/export", func(c *gin.Context) {
+		format := strings.ToLower(strings.TrimSpace(c.Query("format")))
+		if format == "" {
+			format = "csv"
+		}
+		if format != "csv" && format != "json" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid export format"})
+			return
+		}
+
+		filter, err := parseUsageFilterQuery(c.Request, timeutil.NormalizeStorageTime(time.Now()))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		if err := applyUsageEventsSourceFilter(&filter); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		filter.Limit = 0
+		filter.Page = 0
+		filter.PageSize = 0
+		filter.Offset = 0
+
+		identities, err := loadUsageResolutionData(c, usageIdentityProvider)
+		if err != nil {
+			writeInternalError(c, "load usage resolution data failed", err)
+			return
+		}
+		resolver := newUsageIdentityResolver(identities)
+		apiKeyInfos, err := loadCPAAPIKeyInfos(c, cpaAPIKeyProvider)
+		if err != nil {
+			return
+		}
+		streamEvents := func(emit func(servicedto.UsageEventRecord) error) error {
+			if usageProvider == nil {
+				return nil
+			}
+			return usageProvider.StreamUsageEvents(c.Request.Context(), filter, emit)
+		}
+		if format == "json" {
+			if err := writeUsageEventsJSONExport(c, streamEvents, resolver, apiKeyInfos); err != nil {
+				writeUsageEventsExportError(c, err)
+			}
+			return
+		}
+		if err := writeUsageEventsCSVExport(c, streamEvents, resolver, apiKeyInfos); err != nil {
+			writeUsageEventsExportError(c, err)
+		}
+	})
 }
 
 // Source 下拉提交的是 usage identity；为了兼容前端命名，API 收 source，但进入仓储前只转换成 auth_index 查询。
@@ -195,6 +279,47 @@ func buildUsageEventsPayload(rows []servicedto.UsageEventRecord, resolver usageI
 	return payload
 }
 
+func buildUsageEventExportPayload(row servicedto.UsageEventRecord, resolver usageIdentityResolver, apiKeyInfos map[string]analysisAPIKeyInfo) usageEventExportPayload {
+	identity, matched := resolver.resolveByAuthIndex(row.AuthIndex)
+	source, isIdentityDeleted := usageEventPublicSource(row, identity, matched)
+	id := ""
+	if row.ID != 0 {
+		id = strconv.FormatInt(row.ID, 10)
+	}
+	result := "success"
+	if row.Failed {
+		result = "failed"
+	}
+	return usageEventExportPayload{
+		ID:                  id,
+		Timestamp:           timeutil.FormatStorageTime(row.Timestamp),
+		APIKey:              usageEventAPIKeyLabel(row.APIGroupKey, apiKeyInfos),
+		CPAAPIKeyID:         usageEventCPAAPIKeyID(row.APIGroupKey, apiKeyInfos),
+		Source:              source,
+		SourceType:          identity.Type,
+		AuthIndex:           strings.TrimSpace(row.AuthIndex),
+		IsIdentityDeleted:   isIdentityDeleted,
+		Model:               row.Model,
+		ReasoningEffort:     strings.TrimSpace(row.ReasoningEffort),
+		ServiceTier:         strings.TrimSpace(row.ServiceTier),
+		ExecutorType:        strings.TrimSpace(row.ExecutorType),
+		Result:              result,
+		Endpoint:            strings.TrimSpace(row.Endpoint),
+		TTFTMS:              row.TTFTMS,
+		LatencyMS:           row.LatencyMS,
+		SpeedTPS:            usageEventSpeedTPS(row),
+		InputTokens:         row.InputTokens,
+		OutputTokens:        row.OutputTokens,
+		ReasoningTokens:     row.ReasoningTokens,
+		CachedTokens:        row.CachedTokens,
+		CacheReadTokens:     row.CacheReadTokens,
+		CacheCreationTokens: row.CacheCreationTokens,
+		CacheRate:           usageEventCacheRate(row),
+		TotalTokens:         row.TotalTokens,
+		CostUSD:             row.CostUSD,
+	}
+}
+
 func usageEventSpeedTPS(row servicedto.UsageEventRecord) *float64 {
 	visibleOutputTokens := row.OutputTokens - row.ReasoningTokens
 	if visibleOutputTokens < 0 {
@@ -208,12 +333,215 @@ func usageEventSpeedTPS(row servicedto.UsageEventRecord) *float64 {
 	return &speed
 }
 
+func usageEventCacheRate(row servicedto.UsageEventRecord) *float64 {
+	if row.InputTokens <= 0 {
+		return nil
+	}
+	rate := float64(row.CachedTokens) / float64(row.InputTokens) * 100
+	return &rate
+}
+
+var usageEventsExportCSVHeader = []string{
+	"id",
+	"timestamp",
+	"api_key",
+	"cpa_api_key_id",
+	"source",
+	"source_type",
+	"auth_index",
+	"is_identity_deleted",
+	"model",
+	"reasoning_effort",
+	"service_tier",
+	"executor_type",
+	"result",
+	"endpoint",
+	"ttft_ms",
+	"latency_ms",
+	"speed_tps",
+	"input_tokens",
+	"output_tokens",
+	"reasoning_tokens",
+	"cached_tokens",
+	"cache_read_tokens",
+	"cache_creation_tokens",
+	"cache_rate",
+	"total_tokens",
+	"cost_usd",
+}
+
+func writeUsageEventsJSONExport(c *gin.Context, stream usageEventStreamFunc, resolver usageIdentityResolver, apiKeyInfos map[string]analysisAPIKeyInfo) error {
+	encoder := json.NewEncoder(c.Writer)
+	encoder.SetEscapeHTML(false)
+	started := false
+	begin := func() error {
+		if started {
+			return nil
+		}
+		c.Header("Content-Disposition", `attachment; filename="`+usageEventsExportFilename("json")+`"`)
+		c.Header("Content-Type", "application/json; charset=utf-8")
+		c.Status(http.StatusOK)
+		if _, err := c.Writer.Write([]byte(`{"events":[`)); err != nil {
+			return err
+		}
+		started = true
+		return nil
+	}
+	var count int64
+	if err := stream(func(row servicedto.UsageEventRecord) error {
+		if err := begin(); err != nil {
+			return err
+		}
+		if count > 0 {
+			if _, err := c.Writer.Write([]byte(",")); err != nil {
+				return err
+			}
+		}
+		if err := encoder.Encode(buildUsageEventExportPayload(row, resolver, apiKeyInfos)); err != nil {
+			return err
+		}
+		count++
+		return nil
+	}); err != nil {
+		return err
+	}
+	if err := begin(); err != nil {
+		return err
+	}
+	if _, err := c.Writer.Write([]byte(`],"total_count":` + strconv.FormatInt(count, 10) + `}`)); err != nil {
+		return err
+	}
+	c.Writer.Flush()
+	return nil
+}
+
+func writeUsageEventsCSVExport(c *gin.Context, stream usageEventStreamFunc, resolver usageIdentityResolver, apiKeyInfos map[string]analysisAPIKeyInfo) error {
+	var writer *csv.Writer
+	started := false
+	begin := func() error {
+		if started {
+			return nil
+		}
+		c.Header("Content-Disposition", `attachment; filename="`+usageEventsExportFilename("csv")+`"`)
+		c.Header("Content-Type", "text/csv; charset=utf-8")
+		c.Status(http.StatusOK)
+		writer = csv.NewWriter(c.Writer)
+		if err := writer.Write(usageEventsExportCSVHeader); err != nil {
+			return err
+		}
+		started = true
+		return nil
+	}
+	var count int64
+	if err := stream(func(row servicedto.UsageEventRecord) error {
+		if err := begin(); err != nil {
+			return err
+		}
+		if err := writer.Write(usageEventExportCSVRecord(buildUsageEventExportPayload(row, resolver, apiKeyInfos))); err != nil {
+			return err
+		}
+		count++
+		if count%100 == 0 {
+			writer.Flush()
+			if err := writer.Error(); err != nil {
+				return err
+			}
+			c.Writer.Flush()
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	if err := begin(); err != nil {
+		return err
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return err
+	}
+	c.Writer.Flush()
+	return nil
+}
+
+func writeUsageEventsExportError(c *gin.Context, err error) {
+	if err == nil {
+		return
+	}
+	if c.Writer.Written() {
+		_ = c.Error(err)
+		return
+	}
+	c.Writer.Header().Del("Content-Disposition")
+	writeInternalError(c, "export usage events failed", err)
+}
+
+func usageEventsExportFilename(format string) string {
+	timestamp := timeutil.NormalizeStorageTime(time.Now()).Format("20060102-150405")
+	return "usage-events-" + timestamp + "." + format
+}
+
+func usageEventExportCSVRecord(event usageEventExportPayload) []string {
+	return []string{
+		event.ID,
+		event.Timestamp,
+		event.APIKey,
+		event.CPAAPIKeyID,
+		event.Source,
+		event.SourceType,
+		event.AuthIndex,
+		strconv.FormatBool(event.IsIdentityDeleted),
+		event.Model,
+		event.ReasoningEffort,
+		event.ServiceTier,
+		event.ExecutorType,
+		event.Result,
+		event.Endpoint,
+		formatOptionalInt64(event.TTFTMS),
+		strconv.FormatInt(event.LatencyMS, 10),
+		formatOptionalFloat64(event.SpeedTPS),
+		strconv.FormatInt(event.InputTokens, 10),
+		strconv.FormatInt(event.OutputTokens, 10),
+		strconv.FormatInt(event.ReasoningTokens, 10),
+		strconv.FormatInt(event.CachedTokens, 10),
+		strconv.FormatInt(event.CacheReadTokens, 10),
+		strconv.FormatInt(event.CacheCreationTokens, 10),
+		formatOptionalFloat64(event.CacheRate),
+		strconv.FormatInt(event.TotalTokens, 10),
+		strconv.FormatFloat(event.CostUSD, 'f', -1, 64),
+	}
+}
+
+func formatOptionalInt64(value *int64) string {
+	if value == nil {
+		return ""
+	}
+	return strconv.FormatInt(*value, 10)
+}
+
+func formatOptionalFloat64(value *float64) string {
+	if value == nil {
+		return ""
+	}
+	return strconv.FormatFloat(*value, 'f', -1, 64)
+}
+
 func usageEventAPIKeyLabel(apiGroupKey string, apiKeyInfos map[string]analysisAPIKeyInfo) string {
 	apiKey := strings.TrimSpace(apiGroupKey)
 	if apiKey == "" {
 		return ""
 	}
 	return analysisAPIKeyLabel(apiKey, apiKeyInfos)
+}
+
+func usageEventCPAAPIKeyID(apiGroupKey string, apiKeyInfos map[string]analysisAPIKeyInfo) string {
+	apiKey := strings.TrimSpace(apiGroupKey)
+	if apiKey == "" {
+		return ""
+	}
+	if info, ok := apiKeyInfos[apiKey]; ok {
+		return info.ID
+	}
+	return ""
 }
 
 func usageEventPublicSource(row servicedto.UsageEventRecord, identity resolvedUsageIdentity, matched bool) (string, bool) {

--- a/internal/api/usage_events_test.go
+++ b/internal/api/usage_events_test.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"context"
+	"errors"
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 	"time"
 
@@ -15,11 +17,13 @@ import (
 type usageEventsStub struct {
 	events             []servicedto.UsageEventRecord
 	eventsPage         *servicedto.UsageEventsPage
+	exportEvents       []servicedto.UsageEventRecord
 	eventFilterOptions *servicedto.UsageEventFilterOptions
 	err                error
 	lastFilter         servicedto.UsageFilter
 	filterCalls        int
 	filterOptionCalls  int
+	exportCalls        int
 }
 
 func (s *usageEventsStub) GetUsageOverview(context.Context, servicedto.UsageFilter) (*servicedto.UsageOverviewSnapshot, error) {
@@ -37,6 +41,21 @@ func (s *usageEventsStub) ListUsageEvents(_ context.Context, filter servicedto.U
 		return s.eventsPage, s.err
 	}
 	return &servicedto.UsageEventsPage{Events: s.events, TotalCount: int64(len(s.events)), Page: 1, PageSize: servicedto.DefaultUsageEventsLimit, TotalPages: 1}, s.err
+}
+
+func (s *usageEventsStub) StreamUsageEvents(_ context.Context, filter servicedto.UsageFilter, emit func(servicedto.UsageEventRecord) error) error {
+	s.lastFilter = filter
+	s.exportCalls++
+	events := s.events
+	if s.exportEvents != nil {
+		events = s.exportEvents
+	}
+	for _, event := range events {
+		if err := emit(event); err != nil {
+			return err
+		}
+	}
+	return s.err
 }
 
 func (s *usageEventsStub) ListUsageEventFilterOptions(_ context.Context, filter servicedto.UsageFilter) (*servicedto.UsageEventFilterOptions, error) {
@@ -153,6 +172,170 @@ func TestUsageEventsReturnsFilteredRows(t *testing.T) {
 	}
 	if provider.lastFilter.StartTime == nil || provider.lastFilter.EndTime == nil {
 		t.Fatalf("expected resolved time bounds in filter, got %+v", provider.lastFilter)
+	}
+}
+
+func TestUsageEventsExportCSVReturnsFilteredRowsWithoutPagination(t *testing.T) {
+	provider := &usageEventsStub{exportEvents: []servicedto.UsageEventRecord{{
+		ID:                  52,
+		Timestamp:           time.Date(2026, 4, 22, 11, 0, 0, 0, time.UTC),
+		APIGroupKey:         "sk-export123456",
+		Model:               "claude-sonnet",
+		ReasoningEffort:     "medium",
+		ServiceTier:         "priority",
+		ExecutorType:        "responses",
+		Endpoint:            "POST /v1/responses",
+		AuthType:            "apikey",
+		Provider:            "Provider Fallback",
+		AuthIndex:           "authidx-export-main",
+		Failed:              true,
+		LatencyMS:           2045,
+		TTFTMS:              usageEventInt64Ptr(45),
+		InputTokens:         10,
+		OutputTokens:        61,
+		ReasoningTokens:     2,
+		CachedTokens:        1,
+		CacheReadTokens:     3,
+		CacheCreationTokens: 4,
+		TotalTokens:         18,
+		CostUSD:             0.1234,
+		CostAvailable:       true,
+		PricingStyle:        "claude",
+	}}}
+	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "", OptionalProviders{
+		CPAAPIKeys: &authCPAAPIKeyStub{row: entities.CPAAPIKey{
+			ID:         7,
+			APIKey:     "sk-export123456",
+			DisplayKey: "sk-*********123456",
+			KeyAlias:   "Export Key",
+		}},
+		UsageIdentity: usageIdentitiesStub{items: []entities.UsageIdentity{{
+			ID:           12,
+			Name:         "Export Provider",
+			AuthType:     entities.UsageIdentityAuthTypeAIProvider,
+			AuthTypeName: "apikey",
+			Identity:     "authidx-export-main",
+			Type:         "openai",
+			Provider:     "Provider",
+		}}},
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/events/export?range=24h&page=3&page_size=100&model=claude-sonnet&source=authidx-export-main&result=failed&format=csv", nil)
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	body := resp.Body.String()
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", resp.Code, body)
+	}
+	if provider.exportCalls != 1 || provider.filterCalls != 0 {
+		t.Fatalf("expected export only, export=%d list=%d", provider.exportCalls, provider.filterCalls)
+	}
+	if provider.lastFilter.Page != 0 || provider.lastFilter.PageSize != 0 || provider.lastFilter.Limit != 0 || provider.lastFilter.Offset != 0 {
+		t.Fatalf("expected export to drop pagination, got %+v", provider.lastFilter)
+	}
+	if provider.lastFilter.Model != "claude-sonnet" || provider.lastFilter.AuthIndex != "authidx-export-main" || provider.lastFilter.Source != "" || provider.lastFilter.Result != "failed" {
+		t.Fatalf("expected export filters to match list filters, got %+v", provider.lastFilter)
+	}
+	if !contains(resp.Header().Get("Content-Type"), "text/csv") || !contains(resp.Header().Get("Content-Disposition"), "attachment;") {
+		t.Fatalf("expected csv attachment headers, got content-type=%q disposition=%q", resp.Header().Get("Content-Type"), resp.Header().Get("Content-Disposition"))
+	}
+	if !regexp.MustCompile(`filename="usage-events-\d{8}-\d{6}\.csv"`).MatchString(resp.Header().Get("Content-Disposition")) {
+		t.Fatalf("expected timestamped csv filename, got %q", resp.Header().Get("Content-Disposition"))
+	}
+	if !contains(body, "cpa_api_key_id") || !contains(body, "auth_index") || !contains(body, "executor_type") || !contains(body, "is_identity_deleted") {
+		t.Fatalf("expected cpa_api_key_id, auth_index, executor_type, and is_identity_deleted columns, got %s", body)
+	}
+	if contains(body, "is_deleted") {
+		t.Fatalf("expected export to use is_identity_deleted instead of is_deleted, got %s", body)
+	}
+	if contains(body, "cost_available") || contains(body, "pricing_style") {
+		t.Fatalf("expected csv export to omit cost availability metadata, got %s", body)
+	}
+	if !contains(body, "Export Key") || !contains(body, ",7,") || !contains(body, "authidx-export-main") || !contains(body, "responses") || !contains(body, "failed") {
+		t.Fatalf("expected exported row values, got %s", body)
+	}
+}
+
+func TestUsageEventsExportJSONIncludesAllExportFields(t *testing.T) {
+	provider := &usageEventsStub{events: []servicedto.UsageEventRecord{{
+		ID:            53,
+		Timestamp:     time.Date(2026, 4, 22, 11, 0, 0, 0, time.UTC),
+		APIGroupKey:   "sk-json-export",
+		Model:         "gpt-5",
+		ServiceTier:   "default",
+		ExecutorType:  "chat_completions",
+		Endpoint:      "GET /v1/responses",
+		AuthType:      "oauth",
+		Source:        "claude-code",
+		AuthIndex:     "auth-file-export",
+		Failed:        false,
+		LatencyMS:     300,
+		InputTokens:   9,
+		OutputTokens:  5,
+		TotalTokens:   14,
+		CostAvailable: true,
+		PricingStyle:  "openai",
+	}}}
+	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "", OptionalProviders{
+		CPAAPIKeys: &authCPAAPIKeyStub{row: entities.CPAAPIKey{
+			ID:       9,
+			APIKey:   "sk-json-export",
+			KeyAlias: "Team <Ops> & Co",
+		}},
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/events/export?range=24h&format=json", nil)
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	body := resp.Body.String()
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", resp.Code, body)
+	}
+	if !contains(resp.Header().Get("Content-Type"), "application/json") || !contains(resp.Header().Get("Content-Disposition"), "attachment;") {
+		t.Fatalf("expected json attachment headers, got content-type=%q disposition=%q", resp.Header().Get("Content-Type"), resp.Header().Get("Content-Disposition"))
+	}
+	if !regexp.MustCompile(`filename="usage-events-\d{8}-\d{6}\.json"`).MatchString(resp.Header().Get("Content-Disposition")) {
+		t.Fatalf("expected timestamped json filename, got %q", resp.Header().Get("Content-Disposition"))
+	}
+	if !contains(body, `"total_count":1`) || contains(body, `"page"`) || contains(body, `"page_size"`) {
+		t.Fatalf("expected export metadata without pagination, got %s", body)
+	}
+	if !contains(body, `"auth_index":"auth-file-export"`) || !contains(body, `"executor_type":"chat_completions"`) || !contains(body, `"endpoint":"GET /v1/responses"`) || !contains(body, `"is_identity_deleted":true`) {
+		t.Fatalf("expected raw export fields in json body, got %s", body)
+	}
+	if !contains(body, `"api_key":"Team <Ops> & Co"`) || contains(body, `\u003c`) || contains(body, `\u0026`) || contains(body, `\u003e`) {
+		t.Fatalf("expected json export to preserve plain text values without HTML escaping, got %s", body)
+	}
+	if !contains(body, `"cpa_api_key_id":"9"`) || !contains(body, `"source_type":""`) || !contains(body, `"reasoning_effort":""`) || !contains(body, `"ttft_ms":null`) || !contains(body, `"speed_tps":null`) {
+		t.Fatalf("expected json export to keep a stable field set, got %s", body)
+	}
+	if contains(body, `"is_deleted"`) {
+		t.Fatalf("expected json export to use is_identity_deleted instead of is_deleted, got %s", body)
+	}
+	if contains(body, `"cost_available"`) || contains(body, `"pricing_style"`) {
+		t.Fatalf("expected json export to omit cost availability metadata, got %s", body)
+	}
+}
+
+func TestUsageEventsExportStreamSetupErrorReturnsServerError(t *testing.T) {
+	for _, format := range []string{"csv", "json"} {
+		t.Run(format, func(t *testing.T) {
+			provider := &usageEventsStub{err: errors.New("stream setup failed")}
+			router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "")
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/events/export?range=24h&format="+format, nil)
+			resp := httptest.NewRecorder()
+
+			router.ServeHTTP(resp, req)
+
+			if resp.Code != http.StatusInternalServerError {
+				t.Fatalf("expected status 500 before export body is written, got %d: %s", resp.Code, resp.Body.String())
+			}
+			if contains(resp.Body.String(), "usage-events-") || contains(resp.Body.String(), `"events":[`) || contains(resp.Body.String(), "id,timestamp") {
+				t.Fatalf("expected error response instead of partial export body, got %s", resp.Body.String())
+			}
+		})
 	}
 }
 

--- a/internal/api/usage_overview_test.go
+++ b/internal/api/usage_overview_test.go
@@ -42,6 +42,10 @@ func (s *usageFilterStub) ListUsageEvents(context.Context, servicedto.UsageFilte
 	return nil, s.err
 }
 
+func (s *usageFilterStub) StreamUsageEvents(context.Context, servicedto.UsageFilter, func(servicedto.UsageEventRecord) error) error {
+	return s.err
+}
+
 func (s *usageFilterStub) ListUsageEventFilterOptions(context.Context, servicedto.UsageFilter) (*servicedto.UsageEventFilterOptions, error) {
 	return nil, s.err
 }

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -91,27 +91,37 @@ func ListUsageEventsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (*dto.U
 	query := applyUsageEventListQuery(db.Model(&entities.UsageEvent{}), filter)
 	query = query.Select(usageEventProjectionColumns).Order("timestamp DESC, id DESC").Limit(pageSize).Offset(offset)
 
-	var events []usageEventProjection
-	if err := query.Find(&events).Error; err != nil {
-		return nil, fmt.Errorf("load usage events: %w", err)
-	}
-	pricingByModel, err := loadPriceSettingsByModel(db)
+	rows, err := loadUsageEventRecordsForQuery(db, query)
 	if err != nil {
-		return nil, fmt.Errorf("load usage event pricing settings: %w", err)
-	}
-
-	rows := make([]dto.UsageEventRecord, 0, len(events))
-	for _, event := range events {
-		record := usageEventProjectionToRecord(event)
-		// Request Events cost 只在响应阶段按当前价格配置计算，不回写 usage_events。
-		record.CostUSD, record.CostAvailable, record.PricingStyle = usageEventRecordCost(record, pricingByModel)
-		rows = append(rows, record)
+		return nil, err
 	}
 	totalPages := 0
 	if totalCount > 0 {
 		totalPages = int((totalCount + int64(pageSize) - 1) / int64(pageSize))
 	}
 	return &dto.UsageEventsPageRecord{Events: rows, Models: modelOptions, TotalCount: totalCount, Page: page, PageSize: pageSize, TotalPages: totalPages}, nil
+}
+
+// ExportUsageEventsWithFilter 使用 Request Event Log 相同筛选，但不应用分页。
+func ExportUsageEventsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) ([]dto.UsageEventRecord, error) {
+	rows := []dto.UsageEventRecord{}
+	if err := StreamUsageEventsWithFilter(db, filter, func(row dto.UsageEventRecord) error {
+		rows = append(rows, row)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// StreamUsageEventsWithFilter 使用 Request Event Log 相同筛选逐行导出，不应用分页。
+func StreamUsageEventsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, emit func(dto.UsageEventRecord) error) error {
+	if db == nil {
+		return fmt.Errorf("database is nil")
+	}
+	query := applyUsageEventListQuery(db.Model(&entities.UsageEvent{}), filter)
+	query = query.Select(usageEventProjectionColumns).Order("timestamp DESC, id DESC")
+	return streamUsageEventRecordsForQuery(db, query, emit)
 }
 
 // Request Event Log Filter Options：只按时间窗口收集 model 候选值。
@@ -148,6 +158,58 @@ func listUsageEventModelFilterOptions(db *gorm.DB, filter dto.UsageQueryFilter) 
 // queryUsageEvents 统一 usage_events 的 GORM model 入口，方便后续追加通用 scope。
 func queryUsageEvents(db *gorm.DB) *gorm.DB {
 	return db.Model(&entities.UsageEvent{})
+}
+
+func loadUsageEventRecordsForQuery(db *gorm.DB, query *gorm.DB) ([]dto.UsageEventRecord, error) {
+	var events []usageEventProjection
+	if err := query.Find(&events).Error; err != nil {
+		return nil, fmt.Errorf("load usage events: %w", err)
+	}
+	pricingByModel, err := loadPriceSettingsByModel(db)
+	if err != nil {
+		return nil, fmt.Errorf("load usage event pricing settings: %w", err)
+	}
+
+	rows := make([]dto.UsageEventRecord, 0, len(events))
+	for _, event := range events {
+		record := usageEventProjectionToRecord(event)
+		// Request Events cost 只在响应阶段按当前价格配置计算，不回写 usage_events。
+		record.CostUSD, record.CostAvailable, record.PricingStyle = usageEventRecordCost(record, pricingByModel)
+		rows = append(rows, record)
+	}
+	return rows, nil
+}
+
+func streamUsageEventRecordsForQuery(db *gorm.DB, query *gorm.DB, emit func(dto.UsageEventRecord) error) error {
+	if emit == nil {
+		return fmt.Errorf("usage event stream callback is nil")
+	}
+	pricingByModel, err := loadPriceSettingsByModel(db)
+	if err != nil {
+		return fmt.Errorf("load usage event pricing settings: %w", err)
+	}
+	rows, err := query.Rows()
+	if err != nil {
+		return fmt.Errorf("load usage events: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var event usageEventProjection
+		if err := db.ScanRows(rows, &event); err != nil {
+			return fmt.Errorf("scan usage event: %w", err)
+		}
+		record := usageEventProjectionToRecord(event)
+		// Request Events cost 只在响应阶段按当前价格配置计算，不回写 usage_events。
+		record.CostUSD, record.CostAvailable, record.PricingStyle = usageEventRecordCost(record, pricingByModel)
+		if err := emit(record); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate usage events: %w", err)
+	}
+	return nil
 }
 
 // usageEventProjectionToRecord 把数据库投影转换成 Request Event Log 的外部 DTO。

--- a/internal/repository/usage_events_test.go
+++ b/internal/repository/usage_events_test.go
@@ -141,6 +141,39 @@ func TestListUsageEventsWithFilterAppliesModelAuthIndexAndResultFilters(t *testi
 	}
 }
 
+func TestExportUsageEventsWithFilterAppliesFiltersWithoutPagination(t *testing.T) {
+	db, err := OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "usage-events-export.db")})
+	if err != nil {
+		t.Fatalf("OpenDatabase returned error: %v", err)
+	}
+	closeTestDatabase(t, db)
+	events := []entities.UsageEvent{
+		{EventKey: "event-1", APIGroupKey: "provider-a", Model: "claude-sonnet", ExecutorType: "responses", Timestamp: time.Date(2026, 4, 16, 9, 0, 0, 0, time.UTC), Source: "source-a", AuthIndex: "auth-a", Failed: false, TotalTokens: 10},
+		{EventKey: "event-2", APIGroupKey: "provider-a", Model: "claude-sonnet", ExecutorType: "responses", Timestamp: time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC), Source: "source-a", AuthIndex: "auth-a", Failed: false, TotalTokens: 20},
+		{EventKey: "event-3", APIGroupKey: "provider-a", Model: "claude-sonnet", ExecutorType: "chat_completions", Timestamp: time.Date(2026, 4, 16, 11, 0, 0, 0, time.UTC), Source: "source-a", AuthIndex: "auth-b", Failed: false, TotalTokens: 30},
+		{EventKey: "event-4", APIGroupKey: "provider-a", Model: "claude-sonnet", ExecutorType: "responses", Timestamp: time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC), Source: "source-a", AuthIndex: "auth-a", Failed: true, TotalTokens: 40},
+	}
+	if _, _, err := InsertUsageEvents(db, events); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+
+	rows, err := ExportUsageEventsWithFilter(db, dto.UsageQueryFilter{Model: "claude-sonnet", AuthIndex: "auth-a", Result: "success", Page: 1, PageSize: 1, Limit: 1})
+	if err != nil {
+		t.Fatalf("ExportUsageEventsWithFilter returned error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected export to ignore pagination and return two filtered rows, got %+v", rows)
+	}
+	if rows[0].TotalTokens != 20 || rows[1].TotalTokens != 10 {
+		t.Fatalf("expected newest filtered rows first, got %+v", rows)
+	}
+	for _, row := range rows {
+		if row.AuthIndex != "auth-a" || row.ExecutorType != "responses" || row.Failed {
+			t.Fatalf("unexpected exported row: %+v", row)
+		}
+	}
+}
+
 func TestListUsageEventsWithFilterAddsBackendCost(t *testing.T) {
 	db, err := OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "usage-events-cost.db")})
 	if err != nil {

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -462,6 +462,50 @@ func (s *usageService) ListUsageEvents(_ context.Context, filter servicedto.Usag
 	return &servicedto.UsageEventsPage{Events: result, Models: page.Models, TotalCount: page.TotalCount, Page: page.Page, PageSize: page.PageSize, TotalPages: page.TotalPages}, nil
 }
 
+// StreamUsageEvents 使用 Request Event Log 相同筛选条件逐行导出，不应用分页。
+func (s *usageService) StreamUsageEvents(ctx context.Context, filter servicedto.UsageFilter, emit func(servicedto.UsageEventRecord) error) error {
+	apiGroupKey, err := s.resolveAPIGroupKey(filter.APIKeyID)
+	if err != nil {
+		return err
+	}
+	return repository.StreamUsageEventsWithFilter(s.db.WithContext(ctx), repodto.UsageQueryFilter{
+		StartTime:   filter.StartTime,
+		EndTime:     filter.EndTime,
+		Model:       filter.Model,
+		AuthIndex:   filter.AuthIndex,
+		APIGroupKey: apiGroupKey,
+		Result:      filter.Result,
+	}, func(row repodto.UsageEventRecord) error {
+		return emit(servicedto.UsageEventRecord{
+			ID:                  row.ID,
+			Timestamp:           row.Timestamp,
+			APIGroupKey:         row.APIGroupKey,
+			Model:               row.Model,
+			ReasoningEffort:     row.ReasoningEffort,
+			ServiceTier:         row.ServiceTier,
+			ExecutorType:        row.ExecutorType,
+			Endpoint:            row.Endpoint,
+			AuthType:            row.AuthType,
+			Provider:            row.Provider,
+			Source:              row.Source,
+			AuthIndex:           row.AuthIndex,
+			Failed:              row.Failed,
+			LatencyMS:           row.LatencyMS,
+			TTFTMS:              row.TTFTMS,
+			InputTokens:         row.InputTokens,
+			OutputTokens:        row.OutputTokens,
+			ReasoningTokens:     row.ReasoningTokens,
+			CachedTokens:        row.CachedTokens,
+			CacheReadTokens:     row.CacheReadTokens,
+			CacheCreationTokens: row.CacheCreationTokens,
+			TotalTokens:         row.TotalTokens,
+			CostUSD:             row.CostUSD,
+			CostAvailable:       row.CostAvailable,
+			PricingStyle:        row.PricingStyle,
+		})
+	})
+}
+
 // Request Event Log 的 model 筛选项只应用调用方传入的时间窗口；独立筛选项接口当前传空 filter。
 func (s *usageService) ListUsageEventFilterOptions(_ context.Context, filter servicedto.UsageFilter) (*servicedto.UsageEventFilterOptions, error) {
 	options, err := repository.ListUsageEventFilterOptionsWithFilter(s.db, repodto.UsageQueryFilter{

--- a/internal/service/usage_service.go
+++ b/internal/service/usage_service.go
@@ -10,6 +10,7 @@ type UsageProvider interface {
 	GetUsageOverview(context.Context, servicedto.UsageFilter) (*servicedto.UsageOverviewSnapshot, error)
 	GetUsageOverviewRealtime(context.Context, servicedto.UsageFilter) (*servicedto.UsageOverviewRealtime, error)
 	ListUsageEvents(context.Context, servicedto.UsageFilter) (*servicedto.UsageEventsPage, error)
+	StreamUsageEvents(context.Context, servicedto.UsageFilter, func(servicedto.UsageEventRecord) error) error
 	ListUsageEventFilterOptions(context.Context, servicedto.UsageFilter) (*servicedto.UsageEventFilterOptions, error)
 	GetAnalysis(context.Context, servicedto.UsageFilter) (*servicedto.AnalysisSnapshot, error)
 }

--- a/web/src/components/usage/RequestEventsDetailsCard.test.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.test.tsx
@@ -293,10 +293,15 @@ describe('RequestEventsDetailsCard pagination', () => {
     expect(html).not.toContain('_requestEventsLimitHint_');
   });
 
-  it('hides export buttons while keeping clear filters available', () => {
+  it('renders one export menu trigger instead of separate CSV and JSON buttons', () => {
     const html = renderCard({ modelFilter: 'claude-sonnet' });
 
     expect(html).toContain('Clear Filters');
+    expect(countOccurrences(html, '>Export<')).toBe(1);
+    expect(html.indexOf('Clear Filters')).toBeLessThan(html.indexOf('>Export<'));
+    expect(html).toContain('aria-haspopup="menu"');
+    expect(html).toContain('_requestEventsExportButton_');
+    expect(html).toContain('_requestEventsExportButtonInner_');
     expect(html).not.toContain('Export CSV');
     expect(html).not.toContain('Export JSON');
   });

--- a/web/src/components/usage/RequestEventsDetailsCard.test.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.test.tsx
@@ -5,6 +5,7 @@ import {
   RequestEventsDetailsCard,
   isRequestEventColumnSelectionControlled,
   resolveRequestEventColumnMenuFocusIndex,
+  shouldCloseMenuOnFocusLeave,
   toggleRequestEventColumnId,
   type RequestEventColumnId,
 } from './RequestEventsDetailsCard';
@@ -373,6 +374,16 @@ describe('RequestEventsDetailsCard pagination', () => {
     expect(isRequestEventColumnSelectionControlled(['timestamp'], () => undefined)).toBe(true);
     expect(isRequestEventColumnSelectionControlled(undefined, () => undefined)).toBe(false);
     expect(isRequestEventColumnSelectionControlled(['timestamp'], undefined)).toBe(false);
+  });
+
+  it('closes export menu only when focus leaves the menu container', () => {
+    const insideTarget = {};
+    const outsideTarget = {};
+    const container = { contains: (target: EventTarget) => target === insideTarget };
+
+    expect(shouldCloseMenuOnFocusLeave(container, insideTarget as EventTarget)).toBe(false);
+    expect(shouldCloseMenuOnFocusLeave(container, outsideTarget as EventTarget)).toBe(true);
+    expect(shouldCloseMenuOnFocusLeave(container, null)).toBe(true);
   });
 
   it('cycles column menu focus for arrow and tab navigation', () => {

--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -14,7 +14,7 @@ import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { Select } from '@/components/ui/Select';
-import { IconCheck, IconChevronDown } from '@/components/ui/icons';
+import { IconCheck, IconChevronDown, IconDownload } from '@/components/ui/icons';
 import type { UsageEvent, UsageSourceFilterOption } from '@/lib/types';
 import {
   calculateCacheRate,
@@ -28,6 +28,8 @@ import styles from '@/pages/UsagePage.module.scss';
 const ALL_FILTER = '__all__';
 
 type SelectOption = { value: string; label: string };
+
+export type RequestEventExportFormat = 'csv' | 'json';
 
 export const REQUEST_EVENT_COLUMN_IDS = [
   'timestamp',
@@ -153,6 +155,7 @@ export interface RequestEventsDetailsCardProps {
   modelFilter: string;
   sourceFilter: string;
   resultFilter: string;
+  exportingFormat?: RequestEventExportFormat | null;
   initialVisibleColumnIds?: readonly RequestEventColumnId[];
   visibleColumnIds?: readonly RequestEventColumnId[];
   onPageChange: (page: number) => void;
@@ -160,6 +163,7 @@ export interface RequestEventsDetailsCardProps {
   onModelFilterChange: (model: string) => void;
   onSourceFilterChange: (source: string) => void;
   onResultFilterChange: (result: string) => void;
+  onExport?: (format: RequestEventExportFormat) => void;
   onVisibleColumnIdsChange?: (columnIds: RequestEventColumnId[]) => void;
 }
 
@@ -488,6 +492,76 @@ function RequestEventsTitle({ title, subtitle, totalLabel }: { title: string; su
   );
 }
 
+function RequestEventsExportMenu({
+  label,
+  csvLabel,
+  jsonLabel,
+  exportingFormat,
+  onExport,
+}: {
+  label: string;
+  csvLabel: string;
+  jsonLabel: string;
+  exportingFormat: RequestEventExportFormat | null;
+  onExport?: (format: RequestEventExportFormat) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const disabled = !onExport || exportingFormat !== null;
+
+  const handleSelect = (format: RequestEventExportFormat) => {
+    setOpen(false);
+    onExport?.(format);
+  };
+
+  const handleTriggerClick = () => {
+    if (disabled) return;
+    setOpen((currentOpen) => !currentOpen);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div
+      className={styles.requestEventsExportMenu}
+      onMouseEnter={() => !disabled && setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onKeyDown={handleKeyDown}
+    >
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        className={styles.requestEventsExportButton}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        disabled={disabled}
+        loading={exportingFormat !== null}
+        onClick={handleTriggerClick}
+      >
+        <span className={styles.requestEventsExportButtonInner}>
+          <IconDownload size={12} aria-hidden="true" />
+          <span>{label}</span>
+          <IconChevronDown size={12} aria-hidden="true" />
+        </span>
+      </Button>
+      {open && !disabled && (
+        <div className={styles.requestEventsExportDropdown} role="menu" aria-label={label}>
+          <button type="button" role="menuitem" onClick={() => handleSelect('csv')}>
+            {csvLabel}
+          </button>
+          <button type="button" role="menuitem" onClick={() => handleSelect('json')}>
+            {jsonLabel}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function RequestEventsDetailsCard({
   events,
   loading,
@@ -501,6 +575,7 @@ export function RequestEventsDetailsCard({
   modelFilter,
   sourceFilter,
   resultFilter,
+  exportingFormat = null,
   initialVisibleColumnIds,
   visibleColumnIds,
   onPageChange,
@@ -508,6 +583,7 @@ export function RequestEventsDetailsCard({
   onModelFilterChange,
   onSourceFilterChange,
   onResultFilterChange,
+  onExport,
   onVisibleColumnIdsChange,
 }: RequestEventsDetailsCardProps) {
   const { t } = useTranslation();
@@ -856,6 +932,13 @@ export function RequestEventsDetailsCard({
           >
             {t('usage_stats.clear_filters')}
           </Button>
+          <RequestEventsExportMenu
+            label={t('usage_stats.export')}
+            csvLabel={t('usage_stats.export_csv')}
+            jsonLabel={t('usage_stats.export_json')}
+            exportingFormat={exportingFormat}
+            onExport={onExport}
+          />
         </div>
       }
     >

--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -94,6 +94,11 @@ export const isRequestEventColumnSelectionControlled = (
   onVisibleColumnIdsChange: ((columnIds: RequestEventColumnId[]) => void) | undefined,
 ) => visibleColumnIds !== undefined && onVisibleColumnIdsChange !== undefined;
 
+export const shouldCloseMenuOnFocusLeave = (
+  container: { contains: (target: EventTarget) => boolean },
+  nextFocus: EventTarget | null
+): boolean => nextFocus === null || !container.contains(nextFocus);
+
 const appendSelectedOption = (
   options: SelectOption[],
   selectedValue: string,
@@ -524,12 +529,21 @@ function RequestEventsExportMenu({
     }
   };
 
+  const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
+    if (shouldCloseMenuOnFocusLeave({
+      contains: (target) => target instanceof Node && event.currentTarget.contains(target),
+    }, event.relatedTarget)) {
+      setOpen(false);
+    }
+  };
+
   return (
     <div
       className={styles.requestEventsExportMenu}
       onMouseEnter={() => !disabled && setOpen(true)}
       onMouseLeave={() => setOpen(false)}
       onKeyDown={handleKeyDown}
+      onBlur={handleBlur}
     >
       <Button
         type="button"

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { appPath, deleteAuthFiles, fetchAnalysis, fetchAuthSessions, fetchCpaApiKeyOptions, fetchCpaApiKeys, fetchCpaApiKeySettings, fetchKeyOverview, fetchKeyOverviewRealtime, fetchUsageOverview, fetchUsageOverviewRealtime, fetchUsageQuotaCache, fetchUsageQuotaInspectionStatus, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchUsageIdentities, fetchUsageIdentitiesPage, fetchUsageQuotaRefreshTask, fetchVersion, loginWithCPAAPIKey, logout, markStatusActive, refreshUsageQuotas, resetUsageQuota, revokeAuthSession, setAuthFilesDisabled, startUsageQuotaInspection, updateCpaApiKeyAlias } from './api';
+import { appPath, deleteAuthFiles, exportUsageEvents, fetchAnalysis, fetchAuthSessions, fetchCpaApiKeyOptions, fetchCpaApiKeys, fetchCpaApiKeySettings, fetchKeyOverview, fetchKeyOverviewRealtime, fetchUsageOverview, fetchUsageOverviewRealtime, fetchUsageQuotaCache, fetchUsageQuotaInspectionStatus, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchUsageIdentities, fetchUsageIdentitiesPage, fetchUsageQuotaRefreshTask, fetchVersion, loginWithCPAAPIKey, logout, markStatusActive, refreshUsageQuotas, resetUsageQuota, revokeAuthSession, setAuthFilesDisabled, startUsageQuotaInspection, updateCpaApiKeyAlias } from './api';
 
 describe('fetchUsageEvents', () => {
   afterEach(() => {
@@ -264,6 +264,45 @@ describe('fetchUsageEvents', () => {
     expect(parsed.searchParams.get('result')).toBe('failed');
     expect(parsed.searchParams.get('auth_index')).toBeNull();
     expect(init).toMatchObject({ credentials: 'include', signal });
+  });
+
+  it('exports usage events with filters but without pagination params', async () => {
+    vi.stubGlobal('window', { __APP_BASE_PATH__: undefined });
+    const blob = new Blob(['id,timestamp\n']);
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      headers: new Headers({ 'Content-Disposition': 'attachment; filename="usage-events-20260627-013245.csv"' }),
+      blob: async () => blob,
+    } as Response);
+
+    const file = await exportUsageEvents('custom', '2026-04-20T00:00:00Z', '2026-04-21T00:00:00Z', 'csv', {
+      page: 3,
+      pageSize: 100,
+      model: 'claude-sonnet',
+      source: 'authidx-source-a',
+      result: 'failed',
+      apiKeyId: '42',
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsed = new URL(String(url), 'http://localhost');
+
+    expect(file.blob).toBe(blob);
+    expect(file.filename).toBe('usage-events-20260627-013245.csv');
+    expect(parsed.pathname).toBe('/api/v1/usage/events/export');
+    expect(parsed.searchParams.get('range')).toBe('custom');
+    expect(parsed.searchParams.get('start')).toBe('2026-04-20T00:00:00Z');
+    expect(parsed.searchParams.get('end')).toBe('2026-04-21T00:00:00Z');
+    expect(parsed.searchParams.get('format')).toBe('csv');
+    expect(parsed.searchParams.get('model')).toBe('claude-sonnet');
+    expect(parsed.searchParams.get('source')).toBe('authidx-source-a');
+    expect(parsed.searchParams.get('result')).toBe('failed');
+    expect(parsed.searchParams.get('api_key_id')).toBe('42');
+    expect(parsed.searchParams.get('page')).toBeNull();
+    expect(parsed.searchParams.get('page_size')).toBeNull();
+    expect(parsed.searchParams.get('auth_index')).toBeNull();
+    expect(parsed.searchParams.get('visibleColumnIds')).toBeNull();
+    expect(init).toMatchObject({ credentials: 'include' });
   });
 
   it('passes API key id to overview and events requests', async () => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -260,23 +260,14 @@ export interface FetchUsageEventsOptions {
   apiKeyId?: string
 }
 
-export async function fetchUsageEventModelFilterOptions(signal?: AbortSignal): Promise<UsageEventModelFilterOptionsResponse> {
-  const response = await apiFetch(apiPath('/usage/events/filters/models'), { signal, cache: 'no-store' })
-  if (!response.ok) {
-    await parseApiError(response, `Failed to load usage event model filters: ${response.status}`)
-  }
-  return response.json()
+export type UsageEventsExportFormat = 'csv' | 'json'
+
+export interface UsageEventsExportFile {
+  blob: Blob
+  filename: string
 }
 
-export async function fetchUsageEventSourceFilterOptions(signal?: AbortSignal): Promise<UsageEventSourceFilterOptionsResponse> {
-  const response = await apiFetch(apiPath('/usage/events/filters/sources'), { signal, cache: 'no-store' })
-  if (!response.ok) {
-    await parseApiError(response, `Failed to load usage event source filters: ${response.status}`)
-  }
-  return response.json()
-}
-
-export async function fetchUsageEvents(range: string, start?: string, end?: string, signal?: AbortSignal, options?: FetchUsageEventsOptions): Promise<UsageEventsResponse> {
+function buildUsageEventsParams(range: string, start?: string, end?: string, options?: FetchUsageEventsOptions, includePagination = true): URLSearchParams {
   const params = new URLSearchParams()
   params.set('range', range)
   if (start) {
@@ -285,10 +276,10 @@ export async function fetchUsageEvents(range: string, start?: string, end?: stri
   if (end) {
     params.set('end', end)
   }
-  if (typeof options?.page === 'number' && Number.isFinite(options.page) && options.page > 0) {
+  if (includePagination && typeof options?.page === 'number' && Number.isFinite(options.page) && options.page > 0) {
     params.set('page', String(Math.floor(options.page)))
   }
-  if (typeof options?.pageSize === 'number' && Number.isFinite(options.pageSize) && options.pageSize > 0) {
+  if (includePagination && typeof options?.pageSize === 'number' && Number.isFinite(options.pageSize) && options.pageSize > 0) {
     params.set('page_size', String(Math.floor(options.pageSize)))
   }
   const model = options?.model?.trim()
@@ -308,12 +299,52 @@ export async function fetchUsageEvents(range: string, start?: string, end?: stri
   if (selectedAPIKeyId) {
     params.set('api_key_id', selectedAPIKeyId)
   }
+  return params
+}
+
+function parseAttachmentFilename(contentDisposition: string | null, fallback: string): string {
+  const match = contentDisposition?.match(/filename="([^"]+)"/i)
+  return match?.[1]?.trim() || fallback
+}
+
+export async function fetchUsageEventModelFilterOptions(signal?: AbortSignal): Promise<UsageEventModelFilterOptionsResponse> {
+  const response = await apiFetch(apiPath('/usage/events/filters/models'), { signal, cache: 'no-store' })
+  if (!response.ok) {
+    await parseApiError(response, `Failed to load usage event model filters: ${response.status}`)
+  }
+  return response.json()
+}
+
+export async function fetchUsageEventSourceFilterOptions(signal?: AbortSignal): Promise<UsageEventSourceFilterOptionsResponse> {
+  const response = await apiFetch(apiPath('/usage/events/filters/sources'), { signal, cache: 'no-store' })
+  if (!response.ok) {
+    await parseApiError(response, `Failed to load usage event source filters: ${response.status}`)
+  }
+  return response.json()
+}
+
+export async function fetchUsageEvents(range: string, start?: string, end?: string, signal?: AbortSignal, options?: FetchUsageEventsOptions): Promise<UsageEventsResponse> {
+  const params = buildUsageEventsParams(range, start, end, options)
   const query = params.toString()
   const response = await apiFetch(`${apiPath('/usage/events')}${query ? `?${query}` : ''}`, { signal })
   if (!response.ok) {
     await parseApiError(response, `Failed to load usage events: ${response.status}`)
   }
   return response.json()
+}
+
+export async function exportUsageEvents(range: string, start: string | undefined, end: string | undefined, format: UsageEventsExportFormat, options?: FetchUsageEventsOptions): Promise<UsageEventsExportFile> {
+  const params = buildUsageEventsParams(range, start, end, options, false)
+  params.set('format', format)
+  const query = params.toString()
+  const response = await apiFetch(`${apiPath('/usage/events/export')}${query ? `?${query}` : ''}`)
+  if (!response.ok) {
+    await parseApiError(response, `Failed to export usage events: ${response.status}`)
+  }
+  return {
+    blob: await response.blob(),
+    filename: parseAttachmentFilename(response.headers.get('Content-Disposition'), `usage-events.${format}`),
+  }
 }
 
 export type UsageIdentityPageSort = 'priority' | 'total_requests' | 'total_tokens' | 'last_used_at'

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -2646,8 +2646,111 @@
 .requestEventsActions {
   display: inline-flex;
   align-items: center;
+  justify-content: flex-end;
   gap: $spacing-xs;
   flex-wrap: wrap;
+}
+
+.requestEventsExportMenu {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  min-height: 42px;
+  padding: 4px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--bg-secondary) 78%, transparent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    right: 0;
+    left: 0;
+    height: 6px;
+  }
+}
+
+.requestEventsExportButton:global(.btn) {
+  border: 0;
+  border-radius: 999px;
+  padding: 8px 12px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);
+  font-size: 12px;
+  font-weight: 600;
+  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+
+  &:hover:not(:disabled) {
+    color: var(--text-primary);
+  }
+
+  &:disabled {
+    cursor: wait;
+    opacity: 0.75;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+  }
+
+  > span:not(:global(.loading-spinner)) {
+    display: inline-flex;
+    align-items: center;
+  }
+}
+
+.requestEventsExportButtonInner {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  line-height: 1;
+
+  svg {
+    display: block;
+    flex: 0 0 auto;
+  }
+}
+
+.requestEventsExportDropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 2020;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 128px;
+  padding: 6px;
+  border: 1px solid var(--border-color);
+  border-radius: $radius-lg;
+  background: var(--bg-primary);
+  box-shadow: var(--shadow-lg);
+
+  button {
+    display: flex;
+    align-items: center;
+    min-height: 32px;
+    border: 1px solid transparent;
+    border-radius: $radius-md;
+    padding: 7px 10px;
+    background: transparent;
+    color: var(--text-primary);
+    font: inherit;
+    font-size: 12px;
+    font-weight: 700;
+    text-align: left;
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible {
+      background: var(--bg-secondary);
+      outline: none;
+    }
+  }
 }
 
 .requestEventsToolbar {

--- a/web/src/pages/UsagePage.styles.test.ts
+++ b/web/src/pages/UsagePage.styles.test.ts
@@ -550,4 +550,34 @@ describe('UsagePage toolbar styles', () => {
     expect(priceSettingsSource).toContain('styles.usagePillAction')
     expect(priceSettingsSource).toContain('styles.usagePillActionDanger')
   })
+
+  it('keeps the Request Event export menu styled and hoverable like the credential inspection control', () => {
+    const exportMenuBlock = usagePageStyles.slice(
+      usagePageStyles.indexOf('.requestEventsExportMenu {'),
+      usagePageStyles.indexOf('.requestEventsExportButton:global(.btn) {')
+    )
+    const exportButtonBlock = usagePageStyles.slice(
+      usagePageStyles.indexOf('.requestEventsExportButton:global(.btn) {'),
+      usagePageStyles.indexOf('.requestEventsExportButtonInner {')
+    )
+    const exportDropdownBlock = usagePageStyles.slice(
+      usagePageStyles.indexOf('.requestEventsExportDropdown {'),
+      usagePageStyles.indexOf('.requestEventsToolbar {')
+    )
+
+    expect(requestEventsSource).toContain('styles.requestEventsExportButton')
+    expect(requestEventsSource).toContain('styles.requestEventsExportButtonInner')
+    expect(requestEventsSource).toContain('<IconDownload size={12} aria-hidden="true" />')
+    expect(exportMenuBlock).toMatch(/min-height:\s*42px;/)
+    expect(exportMenuBlock).toMatch(/padding:\s*4px;/)
+    expect(exportMenuBlock).toMatch(/align-items:\s*center;/)
+    expect(exportMenuBlock).not.toMatch(/padding-bottom:\s*6px;/)
+    expect(exportMenuBlock).not.toMatch(/margin-bottom:\s*-6px;/)
+    expect(exportMenuBlock).toContain('&::after')
+    expect(exportMenuBlock).toMatch(/border-radius:\s*999px;/)
+    expect(exportButtonBlock).toMatch(/border:\s*0;/)
+    expect(exportButtonBlock).toMatch(/background:\s*var\(--bg-primary\);/)
+    expect(exportButtonBlock).toMatch(/box-shadow:\s*0 8px 20px rgba\(0,\s*0,\s*0,\s*0\.1\);/)
+    expect(exportDropdownBlock).toMatch(/top:\s*calc\(100% \+ 6px\);/)
+  })
 })

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback, useEffect, useRef, type KeyboardEvent, type SyntheticEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ApiError, fetchAnalysis, fetchAuthSessions, fetchCpaApiKeyOptions, fetchCpaApiKeySettings, fetchStatus, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchVersion, logout, markStatusActive, revokeAuthSession, updateCpaApiKeyAlias } from '@/lib/api';
+import { ApiError, exportUsageEvents, fetchAnalysis, fetchAuthSessions, fetchCpaApiKeyOptions, fetchCpaApiKeySettings, fetchStatus, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchVersion, logout, markStatusActive, revokeAuthSession, updateCpaApiKeyAlias, type UsageEventsExportFormat } from '@/lib/api';
 import type { AnalysisResponse, AuthManagedSessionItem, CpaApiKeyOption, CpaApiKeySettingsItem, OverviewRealtimeWindow, StatusResponse, UsageEvent, UsageSourceFilterOption, VersionResponse } from '@/lib/types';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { LanguageSwitcher } from '@/components/ui/LanguageSwitcher';
@@ -789,6 +789,17 @@ const loadRealtimeWindow = (): OverviewRealtimeWindow => {
   }
 };
 
+export const triggerBrowserFileDownload = (blob: Blob, filename: string) => {
+  const url = window.URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.URL.revokeObjectURL(url);
+};
+
 export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   const { t } = useTranslation();
   const isMobile = useMediaQuery('(max-width: 768px)');
@@ -885,6 +896,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   const [eventsSourceFilter, setEventsSourceFilter] = useState(initialRequestEventsPreferences.filters.source);
   const [eventsResultFilter, setEventsResultFilter] = useState(initialRequestEventsPreferences.filters.result);
   const [eventsVisibleColumnIds, setEventsVisibleColumnIds] = useState<RequestEventColumnId[]>(initialRequestEventsPreferences.visibleColumnIds);
+  const [eventsExportingFormat, setEventsExportingFormat] = useState<UsageEventsExportFormat | null>(null);
   const [eventsFilterOptionsLoaded, setEventsFilterOptionsLoaded] = useState(false);
   const eventsRequestControllerRef = useRef<AbortController | null>(null);
   const eventsFilterOptionsRequestControllerRef = useRef<AbortController | null>(null);
@@ -1435,6 +1447,32 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     setEventsResultFilter(result);
     resetEventsPage();
   }, [resetEventsPage]);
+
+  const handleEventsExport = useCallback(async (format: UsageEventsExportFormat) => {
+    const queryWindow = getEventQueryWindow();
+    if (!queryWindow.valid) {
+      return;
+    }
+    setEventsExportingFormat(format);
+    try {
+      const file = await exportUsageEvents(timeRange, queryWindow.start, queryWindow.end, format, {
+        model: eventsModelFilter === ALL_REQUEST_EVENTS_FILTER ? undefined : eventsModelFilter,
+        source: eventsSourceFilter === ALL_REQUEST_EVENTS_FILTER ? undefined : eventsSourceFilter,
+        result: eventsResultFilter === ALL_REQUEST_EVENTS_FILTER ? undefined : eventsResultFilter,
+        apiKeyId: selectedApiKeyId,
+      });
+      triggerBrowserFileDownload(file.blob, file.filename);
+      showTopNotice('success', t('usage_stats.export_success'));
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 401) {
+        onAuthRequired?.();
+        return;
+      }
+      showTopNotice('error', t('notification.download_failed'));
+    } finally {
+      setEventsExportingFormat(null);
+    }
+  }, [eventsModelFilter, eventsResultFilter, eventsSourceFilter, getEventQueryWindow, onAuthRequired, selectedApiKeyId, showTopNotice, t, timeRange]);
 
   const refreshActiveTab = useCallback(async () => {
     if (activeTab === 'events') {
@@ -1991,12 +2029,14 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                   modelFilter={eventsModelFilter}
                   sourceFilter={eventsSourceFilter}
                   resultFilter={eventsResultFilter}
+                  exportingFormat={eventsExportingFormat}
                   visibleColumnIds={eventsVisibleColumnIds}
                   onPageChange={setEventsPage}
                   onPageSizeChange={handleEventsPageSizeChange}
                   onModelFilterChange={handleEventsModelFilterChange}
                   onSourceFilterChange={handleEventsSourceFilterChange}
                   onResultFilterChange={handleEventsResultFilterChange}
+                  onExport={handleEventsExport}
                   onVisibleColumnIdsChange={setEventsVisibleColumnIds}
                 />
               </>


### PR DESCRIPTION
## Summary
- Add streaming CSV and JSON export for Request Events with current filters and no pagination.
- Include export fields for auth index, executor type, identity deletion state, and CPA API key id with timestamped filenames.
- Add the single Export dropdown UI and focused backend/frontend coverage for export behavior.

Closes #54
Closes #174

## Validation
- `rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build go test ./cmd/... ./internal/...`
- `rtk npm --prefix web run test`
- `rtk npm --prefix web run lint`
- `rtk npm --prefix web run typecheck`
- `rtk npm --prefix web run build`
- `rtk git diff --check`