### PR TITLE
Add CPAMC embed mode

### DIFF
--- a/web/src/App.logic.test.ts
+++ b/web/src/App.logic.test.ts
@@ -27,7 +27,7 @@ describe('App role route normalization', () => {
   it('mounts the shared footer from the app shell', () => {
     expect(appSource).toContain("import './App.css';");
     expect(appSource).toContain("import { AppFooter } from './components/AppFooter';");
-    expect(appSource).toMatch(/<div className="app-frame">[\s\S]*<main className="app-main">\{page\}<\/main>[\s\S]*<AppFooter loadVersion=\{authState === 'authenticated'\} \/>[\s\S]*<\/div>/);
+    expect(appSource).toMatch(/<div className="app-frame"[^>]*>[\s\S]*<main className="app-main">\{page\}<\/main>[\s\S]*<AppFooter loadVersion=\{authState === 'authenticated'\} \/>[\s\S]*<\/div>/);
   });
 
   it('lets app pages fill the space above the shared footer', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,12 +2,14 @@ import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import './index.css';
 import './App.css';
+import './embed/cpamcEmbed.css';
 import { ApiError, appPath, getSession, login, loginWithCPAAPIKey } from './lib/api';
 import type { AuthRole, AuthSessionAPIKeySummary } from './lib/types';
 import { AppFooter } from './components/AppFooter';
 import { KeyOverviewPage } from './pages/KeyOverviewPage';
 import { LoginPage } from './pages/LoginPage';
 import { UsagePage } from './pages/UsagePage';
+import { cpamcEmbedSearch, isCPAMCEmbed, notifyCPAMCEmbedReady } from './embed/cpamcEmbed';
 import { useUsageStatsStore } from './stores/useUsageStatsStore';
 
 type AuthState = 'checking' | 'authenticated' | 'unauthenticated';
@@ -35,6 +37,7 @@ function App() {
   const [apiKeyLoginError, setAPIKeyLoginError] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const clearUsageStats = useUsageStatsStore((state) => state.clearUsageStats);
+  const isEmbeddedInCPAMC = isCPAMCEmbed();
 
   const clearSession = useCallback(() => {
     clearUsageStats();
@@ -66,10 +69,14 @@ function App() {
   }, [clearSession, loadSession]);
 
   useEffect(() => {
+    notifyCPAMCEmbedReady();
+  }, []);
+
+  useEffect(() => {
     if (authState !== 'authenticated' || !authRole) return;
     const currentPath = stripBasePath(window.location.pathname, window.__APP_BASE_PATH__);
     if (!shouldNormalizeRolePath(authRole, currentPath)) return;
-    window.history.replaceState(null, '', appPath(getRoleHomePath(authRole)));
+    window.history.replaceState(null, '', appPath(getRoleHomePath(authRole)) + cpamcEmbedSearch());
   }, [authRole, authState]);
 
   const handlePasswordLogin = useCallback(async (password: string) => {
@@ -83,7 +90,7 @@ function App() {
         clearSession();
         return;
       }
-      window.history.replaceState(null, '', appPath('/'));
+      window.history.replaceState(null, '', appPath('/') + cpamcEmbedSearch());
     } catch (error) {
       if (error instanceof ApiError && error.status === 401) {
         setAdminLoginError(t('auth.invalid_password'));
@@ -107,7 +114,7 @@ function App() {
         clearSession();
         return;
       }
-      window.history.replaceState(null, '', appPath('/key-overview'));
+      window.history.replaceState(null, '', appPath('/key-overview') + cpamcEmbedSearch());
     } catch (error) {
       if (error instanceof ApiError && error.status === 401) {
         setAPIKeyLoginError(t('auth.invalid_api_key'));
@@ -134,7 +141,7 @@ function App() {
   }
 
   return (
-    <div className="app-frame">
+    <div className="app-frame" data-embed={isEmbeddedInCPAMC ? 'cpamc' : undefined}>
       <main className="app-main">{page}</main>
       <AppFooter loadVersion={authState === 'authenticated'} />
     </div>

--- a/web/src/embed/cpamcEmbed.css
+++ b/web/src/embed/cpamcEmbed.css
@@ -11,10 +11,6 @@
   min-height: auto;
 }
 
-.app-frame[data-embed='cpamc'] [data-keeper-action='back-to-cpa'] {
-  display: none !important;
-}
-
 .app-frame[data-embed='cpamc'] .app-footer {
   padding: 12px 20px 14px;
   border-top: 1px solid color-mix(in srgb, var(--border) 68%, transparent);

--- a/web/src/embed/cpamcEmbed.css
+++ b/web/src/embed/cpamcEmbed.css
@@ -1,0 +1,28 @@
+.app-frame[data-embed='cpamc'] {
+  background: var(--bg);
+}
+
+.app-frame[data-embed='cpamc'] .app-main {
+  min-height: 0;
+}
+
+.app-frame[data-embed='cpamc'] [data-keeper-page='usage'],
+.app-frame[data-embed='cpamc'] [data-keeper-page='key-overview'] {
+  min-height: auto;
+}
+
+.app-frame[data-embed='cpamc'] [data-keeper-action='back-to-cpa'] {
+  display: none !important;
+}
+
+.app-frame[data-embed='cpamc'] .app-footer {
+  padding: 12px 20px 14px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 68%, transparent);
+  background: var(--bg);
+}
+
+@media (max-width: 640px) {
+  .app-frame[data-embed='cpamc'] .app-footer {
+    padding: 10px 16px 12px;
+  }
+}

--- a/web/src/embed/cpamcEmbed.ts
+++ b/web/src/embed/cpamcEmbed.ts
@@ -4,7 +4,7 @@ const CPAMC_READY_MESSAGE = 'cpa-usage-keeper:ready';
 const currentSearch = () => (typeof window === 'undefined' ? '' : window.location.search);
 
 export const isCPAMCEmbed = (search = currentSearch()): boolean => {
-  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  const params = new URLSearchParams(search);
   return params.get('embed') === CPAMC_EMBED_QUERY_VALUE;
 };
 

--- a/web/src/embed/cpamcEmbed.ts
+++ b/web/src/embed/cpamcEmbed.ts
@@ -1,0 +1,18 @@
+const CPAMC_EMBED_QUERY_VALUE = 'cpamc';
+const CPAMC_READY_MESSAGE = 'cpa-usage-keeper:ready';
+
+const currentSearch = () => (typeof window === 'undefined' ? '' : window.location.search);
+
+export const isCPAMCEmbed = (search = currentSearch()): boolean => {
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  return params.get('embed') === CPAMC_EMBED_QUERY_VALUE;
+};
+
+export const cpamcEmbedSearch = (search = currentSearch()): '' | '?embed=cpamc' => (
+  isCPAMCEmbed(search) ? '?embed=cpamc' : ''
+);
+
+export const notifyCPAMCEmbedReady = (search = currentSearch()): void => {
+  if (!isCPAMCEmbed(search) || typeof window === 'undefined' || window.parent === window) return;
+  window.parent.postMessage({ type: CPAMC_READY_MESSAGE }, '*');
+};

--- a/web/src/embed/test/cpamcEmbed.styles.test.ts
+++ b/web/src/embed/test/cpamcEmbed.styles.test.ts
@@ -6,6 +6,7 @@ const embedStylesSource = readFileSync(new URL('../cpamcEmbed.css', import.meta.
 describe('CPAMC embed styles', () => {
   it('keeps page overrides scoped under the CPAMC embed root', () => {
     expect(embedStylesSource).toContain(".app-frame[data-embed='cpamc']");
+    expect(embedStylesSource).not.toContain('back-to-cpa');
     expect(embedStylesSource).not.toMatch(/^\.app-footer\s*\{/m);
     expect(embedStylesSource).not.toMatch(/^\[data-keeper-page=/m);
 

--- a/web/src/embed/test/cpamcEmbed.styles.test.ts
+++ b/web/src/embed/test/cpamcEmbed.styles.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const embedStylesSource = readFileSync(new URL('../cpamcEmbed.css', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+
+describe('CPAMC embed styles', () => {
+  it('keeps page overrides scoped under the CPAMC embed root', () => {
+    expect(embedStylesSource).toContain(".app-frame[data-embed='cpamc']");
+    expect(embedStylesSource).not.toMatch(/^\.app-footer\s*\{/m);
+    expect(embedStylesSource).not.toMatch(/^\[data-keeper-page=/m);
+
+    const unscopedRule = embedStylesSource
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.endsWith('{'))
+      .filter((line) => !line.startsWith('@'))
+      .find((line) => !line.includes(".app-frame[data-embed='cpamc']"));
+
+    expect(unscopedRule).toBeUndefined();
+  });
+});

--- a/web/src/embed/test/cpamcEmbed.test.ts
+++ b/web/src/embed/test/cpamcEmbed.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cpamcEmbedSearch, isCPAMCEmbed, notifyCPAMCEmbedReady } from '../cpamcEmbed';
+
+describe('CPAMC embed query helpers', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('detects only the CPAMC embed mode', () => {
+    expect(isCPAMCEmbed('?embed=cpamc')).toBe(true);
+    expect(isCPAMCEmbed('embed=cpamc')).toBe(true);
+    expect(isCPAMCEmbed('?foo=1&embed=cpamc')).toBe(true);
+    expect(isCPAMCEmbed('?embed=iframe')).toBe(false);
+    expect(isCPAMCEmbed('?embed=CPAMC')).toBe(false);
+    expect(isCPAMCEmbed('')).toBe(false);
+  });
+
+  it('preserves only the CPAMC embed query for app navigation', () => {
+    expect(cpamcEmbedSearch('?embed=cpamc')).toBe('?embed=cpamc');
+    expect(cpamcEmbedSearch('?foo=1&embed=cpamc&bar=2')).toBe('?embed=cpamc');
+    expect(cpamcEmbedSearch('?embed=iframe')).toBe('');
+    expect(cpamcEmbedSearch('')).toBe('');
+  });
+
+  it('notifies the parent frame only in CPAMC embed mode', () => {
+    const messages: unknown[] = [];
+    vi.stubGlobal('window', {
+      parent: { postMessage: (message: unknown) => messages.push(message) },
+    });
+
+    notifyCPAMCEmbedReady('?embed=iframe');
+    notifyCPAMCEmbedReady('?embed=cpamc');
+
+    expect(messages).toEqual([{ type: 'cpa-usage-keeper:ready' }]);
+  });
+});

--- a/web/src/lib/test/apiCPAMCEmbed.test.ts
+++ b/web/src/lib/test/apiCPAMCEmbed.test.ts
@@ -1,0 +1,14 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { apiPath } from '../api';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('apiPath CPAMC embed behavior', () => {
+  it('keeps CPAMC embed query out of API paths', () => {
+    vi.stubGlobal('window', { __APP_BASE_PATH__: '/keeper/', location: { search: '?embed=cpamc' } });
+
+    expect(apiPath('/auth/session')).toBe('/keeper/api/v1/auth/session');
+  });
+});

--- a/web/src/pages/KeyOverviewPage.tsx
+++ b/web/src/pages/KeyOverviewPage.tsx
@@ -382,7 +382,7 @@ export function KeyOverviewPage({ apiKey, onAuthRequired }: KeyOverviewPageProps
     : '';
 
   return (
-    <div className={styles.pageShell}>
+    <div className={styles.pageShell} data-keeper-page="key-overview">
       <div className={styles.pageFrame}>
         <header className={styles.topBar}>
           <div className={styles.brandBlock}>

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -57,7 +57,7 @@ export function LoginPage({ loading = false, adminError = '', apiKeyError = '', 
   const canSubmit = mode === 'api_key' ? Boolean(apiKey.trim()) : Boolean(password.trim());
 
   return (
-    <div className={styles.pageShell}>
+    <div className={styles.pageShell} data-keeper-page="login">
       <div className={styles.frame}>
         <div className={styles.utilityDock}>
           <LanguageSwitcher />

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -1787,7 +1787,6 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                       target="_blank"
                       rel="noreferrer"
                       aria-label={t('usage_stats.back_to_cpa_aria')}
-                      data-keeper-action="back-to-cpa"
                     >
                       <span>{t('usage_stats.back_to_cpa')}</span>
                       <span className={styles.backToCpaIcon} aria-hidden="true">

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -42,6 +42,7 @@ import {
 } from '@/utils/usage';
 import type { Theme } from '@/types';
 import { BrandLink } from '@/components/BrandLink';
+import { isCPAMCEmbed } from '@/embed/cpamcEmbed';
 import styles from './UsagePage.module.scss';
 
 const TIME_RANGE_STORAGE_KEY = 'cli-proxy-usage-time-range-v1';
@@ -803,6 +804,7 @@ export const triggerBrowserFileDownload = (blob: Blob, filename: string) => {
 export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   const { t } = useTranslation();
   const isMobile = useMediaQuery('(max-width: 768px)');
+  const isEmbeddedInCPAMC = isCPAMCEmbed();
   const theme = useThemeStore((state) => state.theme);
   const resolvedTheme = useThemeStore((state) => state.resolvedTheme);
   const setTheme = useThemeStore((state) => state.setTheme);
@@ -1697,7 +1699,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   const dailyAveragePanelUsage = getDailyAveragePanelUsage(currentOverviewUsage, usage, reserveDailyAveragePanel, loading);
 
   return (
-    <div className={styles.pageShell}>
+    <div className={styles.pageShell} data-keeper-page="usage">
       <div className={styles.pageFrame}>
         <header className={styles.topBar}>
           <div className={styles.brandBlock}>
@@ -1770,14 +1772,14 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
               </div>
             )}
 
-            {(cpaManagementURL || lastSyncAt) && (
+            {((!isEmbeddedInCPAMC && cpaManagementURL) || lastSyncAt) && (
               <div className={styles.toolbarMetaRow}>
                 {lastSyncAt && (
                   <span className={styles.lastRefreshed}>
                     {t('usage_stats.last_updated')}: {lastSyncAt.toLocaleTimeString()}
                   </span>
                 )}
-                {cpaManagementURL && (
+                {(!isEmbeddedInCPAMC && cpaManagementURL) && (
                   <div className={styles.toolbarMetaRight}>
                     <a
                       className={styles.backToCpaLink}
@@ -1785,6 +1787,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                       target="_blank"
                       rel="noreferrer"
                       aria-label={t('usage_stats.back_to_cpa_aria')}
+                      data-keeper-action="back-to-cpa"
                     >
                       <span>{t('usage_stats.back_to_cpa')}</span>
                       <span className={styles.backToCpaIcon} aria-hidden="true">

--- a/web/src/pages/test/UsagePageCPAMCEmbed.test.ts
+++ b/web/src/pages/test/UsagePageCPAMCEmbed.test.ts
@@ -7,7 +7,6 @@ describe('UsagePage CPAMC embed behavior', () => {
   it('does not render the Back to CPA link in CPAMC embed mode', () => {
     expect(usagePageSource).toContain("import { isCPAMCEmbed } from '@/embed/cpamcEmbed';");
     expect(usagePageSource).toMatch(/const isEmbeddedInCPAMC = isCPAMCEmbed\(\);/);
-    expect(usagePageSource).toContain("data-keeper-action=\"back-to-cpa\"");
     expect(usagePageSource).toMatch(/\{\(!isEmbeddedInCPAMC && cpaManagementURL\) && \(/);
   });
 });

--- a/web/src/pages/test/UsagePageCPAMCEmbed.test.ts
+++ b/web/src/pages/test/UsagePageCPAMCEmbed.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const usagePageSource = readFileSync(new URL('../UsagePage.tsx', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+
+describe('UsagePage CPAMC embed behavior', () => {
+  it('does not render the Back to CPA link in CPAMC embed mode', () => {
+    expect(usagePageSource).toContain("import { isCPAMCEmbed } from '@/embed/cpamcEmbed';");
+    expect(usagePageSource).toMatch(/const isEmbeddedInCPAMC = isCPAMCEmbed\(\);/);
+    expect(usagePageSource).toContain("data-keeper-action=\"back-to-cpa\"");
+    expect(usagePageSource).toMatch(/\{\(!isEmbeddedInCPAMC && cpaManagementURL\) && \(/);
+  });
+});

--- a/web/src/test/AppCPAMCEmbed.test.ts
+++ b/web/src/test/AppCPAMCEmbed.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const appSource = readFileSync(new URL('../App.tsx', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+
+describe('App CPAMC embed shell', () => {
+  it('loads the scoped CPAMC embed stylesheet and marks the app frame', () => {
+    expect(appSource).toContain("import './embed/cpamcEmbed.css';");
+    expect(appSource).toMatch(/<div className="app-frame" data-embed=\{isEmbeddedInCPAMC \? 'cpamc' : undefined\}>/);
+  });
+
+  it('preserves the CPAMC embed query when normalizing app paths', () => {
+    const replaceStateTargets = Array.from(appSource.matchAll(/window\.history\.replaceState\(null, '', ([\s\S]*?)\);/g)).map((match) => match[1]);
+
+    expect(replaceStateTargets).toHaveLength(3);
+    replaceStateTargets.forEach((target) => {
+      expect(target).toContain('appPath(');
+      expect(target).toContain('+ cpamcEmbedSearch()');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add a CPAMC embed mode triggered by `?embed=cpamc`.
- Keep embed-specific styling scoped to the app shell while preserving the shared footer.
- Hide the Back to CPA link only inside CPAMC embed mode and keep normal pages unchanged.

Related to #167 

## Validation

- `npm --prefix ./web run test`
- `npm --prefix ./web run lint`
- `npm --prefix ./web run typecheck`
- `npm --prefix ./web run build`