### PR TITLE
Clarify CPA plugin embed support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ It relies on [CLIProxyAPI (CPA)](https://github.com/router-for-me/CLIProxyAPI) a
 - Request Events for per-request details, filtering, pagination, export, and customizable display
 - Analysis page for usage trends, cost analysis, model/API Key/AI Provider composition, and hourly heatmaps
 - Standalone API Key usage page for querying usage by CPA API Key
-- Embed the Keeper dashboard into CPAMC through the CPA plugin
 - Credentials page for Auth File and AI Provider usage, with quota lookup, refresh, inspection, and sorting
 - Provider quota window usage and quota display across supported providers
 - Maintain model prices for cost estimation and reporting
 - Automatically sync CPA Auth Files, API Keys, AI Providers, and other metadata changes
 - Optional password login protection, SQLite backups, Docker/Docker Compose, and systemd deployment
+- Embed the Keeper dashboard into CPAMC through the CPA plugin
 
 ## Sponsors and Special Thanks
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It relies on [CLIProxyAPI (CPA)](https://github.com/router-for-me/CLIProxyAPI) a
 - Request Events for per-request details, filtering, pagination, export, and customizable display
 - Analysis page for usage trends, cost analysis, model/API Key/AI Provider composition, and hourly heatmaps
 - Standalone API Key usage page for querying usage by CPA API Key
-- CPA plugin embedded mode support for using Keeper inside CPAMC
+- Embed the Keeper dashboard into CPAMC through the CPA plugin
 - Credentials page for Auth File and AI Provider usage, with quota lookup, refresh, inspection, and sorting
 - Provider quota window usage and quota display across supported providers
 - Maintain model prices for cost estimation and reporting

--- a/README.zh.md
+++ b/README.zh.md
@@ -23,12 +23,12 @@
 - Request Events 提供请求级明细查看、筛选、分页、导出和自定义显示
 - 分析页面提供用量趋势、成本分析、模型/API Key/AI Provider 构成和时段热力图
 - API Key 独立查询页，可按 CPA API Key 查看专属用量
-- 可通过 CPA 插件将 Keeper Dashboard 内嵌到 CPAMC 中使用
 - 凭证页面展示 Auth File 与 AI Provider 使用情况，支持限额查询、刷新、巡检和排序
 - 支持多 Provider quota 窗口用量与限额展示
 - 可维护模型价格，用于成本估算和统计展示
 - 自动同步 CPA Auth Files、API Keys、AI Providers 等 metadata 变化
 - 可选密码登录保护、SQLite 备份、Docker/Docker Compose 和 systemd 部署
+- 可通过 CPA 插件将 Keeper Dashboard 内嵌到 CPAMC 中使用
 
 ## 赞助与特别感谢
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -23,7 +23,7 @@
 - Request Events 提供请求级明细查看、筛选、分页、导出和自定义显示
 - 分析页面提供用量趋势、成本分析、模型/API Key/AI Provider 构成和时段热力图
 - API Key 独立查询页，可按 CPA API Key 查看专属用量
-- 支持 CPA 插件嵌入模式，可在 CPAMC 中使用 Keeper
+- 可通过 CPA 插件将 Keeper Dashboard 内嵌到 CPAMC 中使用
 - 凭证页面展示 Auth File 与 AI Provider 使用情况，支持限额查询、刷新、巡检和排序
 - 支持多 Provider quota 窗口用量与限额展示
 - 可维护模型价格，用于成本估算和统计展示


### PR DESCRIPTION
## Summary
- clarify the English README feature bullet for embedding the Keeper dashboard into CPAMC through the CPA plugin
- update the matching Chinese README feature bullet

## Validation
- rtk git diff --check