### PR TITLE
Add upstream models as price setting options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ backups/
 .runtime-test/
 
 # frontend dependencies and build output
+node_modules/
 web/node_modules/
 web/dist/
 web/dist-ssr/

--- a/internal/api/pricing.go
+++ b/internal/api/pricing.go
@@ -55,6 +55,13 @@ func registerPricingRoutes(router gin.IRoutes, pricingProvider service.PricingPr
 			return
 		}
 
+		if models == nil {
+			models = []string{}
+		}
+		if upstreamModels == nil {
+			upstreamModels = []string{}
+		}
+
 		c.JSON(http.StatusOK, usedModelsResponse{Models: models, UpstreamModels: upstreamModels})
 	})
 

--- a/internal/api/pricing.go
+++ b/internal/api/pricing.go
@@ -10,7 +10,8 @@ import (
 )
 
 type usedModelsResponse struct {
-	Models []string `json:"models"`
+	Models         []string `json:"models"`
+	UpstreamModels []string `json:"upstream_models"`
 }
 
 type pricingEntryResponse struct {
@@ -38,7 +39,7 @@ type updatePricingRequest struct {
 func registerPricingRoutes(router gin.IRoutes, pricingProvider service.PricingProvider) {
 	router.GET("/models/used", func(c *gin.Context) {
 		if pricingProvider == nil {
-			c.JSON(http.StatusOK, usedModelsResponse{Models: []string{}})
+			c.JSON(http.StatusOK, usedModelsResponse{Models: []string{}, UpstreamModels: []string{}})
 			return
 		}
 
@@ -48,7 +49,13 @@ func registerPricingRoutes(router gin.IRoutes, pricingProvider service.PricingPr
 			return
 		}
 
-		c.JSON(http.StatusOK, usedModelsResponse{Models: models})
+		upstreamModels, err := pricingProvider.ListUpstreamModels(c.Request.Context())
+		if err != nil {
+			writeInternalError(c, "list upstream models failed", err)
+			return
+		}
+
+		c.JSON(http.StatusOK, usedModelsResponse{Models: models, UpstreamModels: upstreamModels})
 	})
 
 	router.GET("/pricing", func(c *gin.Context) {

--- a/internal/api/pricing_test.go
+++ b/internal/api/pricing_test.go
@@ -12,17 +12,22 @@ import (
 )
 
 type pricingStub struct {
-	usedModels []string
-	pricing    []entities.ModelPriceSetting
-	preview    servicedto.PricingSyncPreview
-	updated    *entities.ModelPriceSetting
-	lastUpdate *servicedto.UpdatePricingInput
-	deleted    string
-	err        error
+	usedModels     []string
+	upstreamModels []string
+	pricing        []entities.ModelPriceSetting
+	preview        servicedto.PricingSyncPreview
+	updated        *entities.ModelPriceSetting
+	lastUpdate     *servicedto.UpdatePricingInput
+	deleted        string
+	err            error
 }
 
 func (s pricingStub) ListUsedModels(context.Context) ([]string, error) {
 	return s.usedModels, s.err
+}
+
+func (s pricingStub) ListUpstreamModels(context.Context) ([]string, error) {
+	return s.upstreamModels, s.err
 }
 
 func (s pricingStub) ListPricing(context.Context) ([]entities.ModelPriceSetting, error) {

--- a/internal/api/pricing_test.go
+++ b/internal/api/pricing_test.go
@@ -101,6 +101,19 @@ func TestPricingRoutesReturnConfiguredData(t *testing.T) {
 	}
 }
 
+func TestPricingRoutesNormalizeNilUsedModelSlices(t *testing.T) {
+	router := NewRouter(nil, nil, nil, &pricingStub{}, AuthConfig{}, nil, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/models/used", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	body := resp.Body.String()
+	if resp.Code != http.StatusOK || !contains(body, `"models":[]`) || !contains(body, `"upstream_models":[]`) || contains(body, `null`) {
+		t.Fatalf("unexpected used models response: %d %s", resp.Code, body)
+	}
+}
+
 func TestPricingSyncPreviewRoute(t *testing.T) {
 	router := NewRouter(nil, nil, nil, &pricingStub{
 		preview: servicedto.PricingSyncPreview{

--- a/internal/service/pricing_service.go
+++ b/internal/service/pricing_service.go
@@ -17,6 +17,7 @@ import (
 
 type PricingProvider interface {
 	ListUsedModels(context.Context) ([]string, error)
+	ListUpstreamModels(context.Context) ([]string, error)
 	ListPricing(context.Context) ([]entities.ModelPriceSetting, error)
 	PreviewPricingSync(context.Context) (servicedto.PricingSyncPreview, error)
 	UpdatePricing(context.Context, servicedto.UpdatePricingInput) (*entities.ModelPriceSetting, error)
@@ -42,6 +43,12 @@ func NewPricingService(db *gorm.DB, modelsFetcher ...ModelsFetcher) PricingProvi
 
 func (s *pricingService) ListUsedModels(ctx context.Context) ([]string, error) {
 	return s.effectiveModels(ctx)
+}
+
+// ListUpstreamModels 返回历史 usage 事件里出现过的上游真实模型，供价格页把上游模型
+// 也列为可设价对象——给上游设一次价即可兜底覆盖同源全部未单独定价的别名。
+func (s *pricingService) ListUpstreamModels(ctx context.Context) ([]string, error) {
+	return repository.ListUsedModels(s.db.WithContext(ctx))
 }
 
 func (s *pricingService) ListPricing(context.Context) ([]entities.ModelPriceSetting, error) {

--- a/web/src/components/usage/PriceSettingsCard.test.tsx
+++ b/web/src/components/usage/PriceSettingsCard.test.tsx
@@ -161,4 +161,38 @@ describe('buildPricingModelOptions', () => {
     expect(options.find((option) => option.value === 'unpriced-alpha')?.suffix).toBeUndefined();
     expect(options.find((option) => option.value === 'unpriced-alpha')?.disabled).toBeUndefined();
   });
+
+  it('offers upstream models as options ahead of aliases', () => {
+    const options = buildPricingModelOptions(
+      ['axxx', 'bxxx', 'cxxx'],
+      {},
+      'Select model',
+      'Configured',
+      ['claude-opus-4-8', 'claude-sonnet'],
+    );
+
+    // 上游模型作为独立选项排在别名前面（占位项之后）。
+    const values = options.map((option) => option.value);
+    expect(values).toEqual([
+      '',
+      'claude-opus-4-8',
+      'claude-sonnet',
+      'axxx',
+      'bxxx',
+      'cxxx',
+    ]);
+  });
+
+  it('does not duplicate an upstream model that is also an alias candidate', () => {
+    const options = buildPricingModelOptions(
+      ['claude-opus-4-8', 'axxx'],
+      {},
+      'Select model',
+      'Configured',
+      ['claude-opus-4-8'],
+    );
+
+    const occurrences = options.filter((option) => option.value === 'claude-opus-4-8');
+    expect(occurrences).toHaveLength(1);
+  });
 });

--- a/web/src/components/usage/PriceSettingsCard.tsx
+++ b/web/src/components/usage/PriceSettingsCard.tsx
@@ -17,6 +17,7 @@ const formatDisplayName = (value: string): string => {
 
 export interface PriceSettingsCardProps {
   modelNames: string[];
+  upstreamModels?: string[];
   modelPrices: Record<string, ModelPrice>;
   onPricesChange: (prices: Record<string, ModelPrice>) => void | Promise<void>;
   onSyncPricesChange?: (prices: Record<string, ModelPrice>) => Promise<PricingSaveResult>;
@@ -157,28 +158,43 @@ export const buildPricingModelOptions = (
   modelPrices: Record<string, ModelPrice>,
   placeholder: string,
   configuredLabel = 'Configured',
+  upstreamModels: string[] = [],
 ): SelectOption[] => {
   const configuredModels = new Set(Object.keys(modelPrices));
-  const sortedModelNames = [...modelNames]
-    .sort((left, right) => formatDisplayName(left).localeCompare(formatDisplayName(right)));
+
+  const toOption = (name: string): SelectOption => {
+    const configured = configuredModels.has(name);
+    return {
+      value: name,
+      label: formatDisplayName(name),
+      disabled: configured || undefined,
+      suffix: configured ? <IconCheck size={12} /> : undefined,
+      suffixAriaLabel: configured ? configuredLabel : undefined,
+    };
+  };
+
+  const sortByDisplayName = (left: string, right: string) =>
+    formatDisplayName(left).localeCompare(formatDisplayName(right));
+
+  const sortedModelNames = [...modelNames].sort(sortByDisplayName);
+
+  // 上游模型排在最前：给上游设一次价即可兜底覆盖同源全部未单独定价的别名。
+  // 只列出不在别名候选（modelNames，来自 CPA /v1/models）里的上游，避免重复项。
+  const modelNameSet = new Set(modelNames.map((name) => name.trim()));
+  const upstreamOnly = [...new Set(upstreamModels.map((name) => name.trim()))]
+    .filter((model) => model && !modelNameSet.has(model))
+    .sort(sortByDisplayName);
 
   return [
     { value: '', label: placeholder },
-    ...sortedModelNames.map((name) => {
-      const configured = configuredModels.has(name);
-      return {
-        value: name,
-        label: formatDisplayName(name),
-        disabled: configured || undefined,
-        suffix: configured ? <IconCheck size={12} /> : undefined,
-        suffixAriaLabel: configured ? configuredLabel : undefined,
-      };
-    }),
+    ...upstreamOnly.map((name) => toOption(name)),
+    ...sortedModelNames.map((name) => toOption(name)),
   ];
 };
 
 export function PriceSettingsCard({
   modelNames,
+  upstreamModels = [],
   modelPrices,
   onPricesChange,
   onSyncPricesChange,
@@ -386,8 +402,9 @@ export function PriceSettingsCard({
       modelPrices,
       t('usage_stats.model_price_select_placeholder'),
       t('usage_stats.model_price_configured'),
+      upstreamModels,
     ),
-    [modelNames, modelPrices, t]
+    [modelNames, modelPrices, t, upstreamModels]
   );
   const styleOptions = useMemo(() => pricingStyleOptions(t), [t]);
   const selectedSyncCount = useMemo(

--- a/web/src/components/usage/hooks/usePricingData.ts
+++ b/web/src/components/usage/hooks/usePricingData.ts
@@ -11,6 +11,7 @@ export interface UsePricingDataOptions {
 
 export interface UsePricingDataReturn {
   modelNames: string[];
+  upstreamModels: string[];
   modelPrices: Record<string, ModelPrice>;
   loading: boolean;
   error: string;
@@ -81,6 +82,7 @@ export function usePricingData(options: UsePricingDataOptions = {}): UsePricingD
   const { t } = useTranslation();
   const { showNotification } = useNotificationStore();
   const [modelNames, setModelNames] = useState<string[]>([]);
+  const [upstreamModels, setUpstreamModels] = useState<string[]>([]);
   const [modelPrices, setModelPricesState] = useState<Record<string, ModelPrice>>({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -118,6 +120,7 @@ export function usePricingData(options: UsePricingDataOptions = {}): UsePricingD
       }
       applyPricingResponse(pricingResponse);
       setModelNames(usedModelsResponse.models);
+      setUpstreamModels(usedModelsResponse.upstream_models ?? []);
     } catch (error) {
       if (controller.signal.aborted) {
         return;
@@ -210,6 +213,7 @@ export function usePricingData(options: UsePricingDataOptions = {}): UsePricingD
 
   return {
     modelNames,
+    upstreamModels,
     modelPrices,
     loading,
     error,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -625,6 +625,7 @@ export interface PricingEntry {
 
 export interface UsedModelsResponse {
   models: string[]
+  upstream_models?: string[]
 }
 
 export interface PricingResponse {

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -866,6 +866,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   });
   const {
     modelNames,
+    upstreamModels,
     modelPrices,
     loading: pricingLoading,
     error: pricingError,
@@ -2134,6 +2135,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                 />
                 <PriceSettingsCard
                   modelNames={modelNames}
+                  upstreamModels={upstreamModels}
                   modelPrices={modelPrices}
                   onPricesChange={setModelPrices}
                   onSyncPricesChange={syncModelPrices}


### PR DESCRIPTION
## Summary

Surface upstream real models (from usage events) as selectable options in the price settings dropdown, placed ahead of aliases.

Motivation: when several aliases (e.g. `axxx`, `bxxx`, `cxxx`) all map to the same upstream model (`claude-opus-4-8`), the price settings page previously only let you price each alias one by one, with no way to see or pick the shared upstream model. Since the cost resolver already falls back from alias to upstream model, pricing an upstream model once now covers all its un-individually-priced aliases — no settlement logic changes needed.

## Changes
- **service**: add `ListUpstreamModels` reusing `repository.ListUsedModels` (DISTINCT upstream model from usage events)
- **api**: add `upstream_models` field to the `/models/used` response
- **web**: thread `upstreamModels` through the pricing hook and `buildPricingModelOptions`; upstream models are listed first and deduped against alias candidates
- **gitignore**: ignore root-level `node_modules/` (vitest cache)

## Testing
- `go test ./...` — all pass
- `npx vitest run` — 47 files / 467 tests pass