### PR TITLE
Hide duplicate Request Events model aliases

### DIFF
--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -623,8 +623,10 @@ export function RequestEventsDetailsCard({
       const source = String(event.source ?? '').trim() || '-';
       const sourceType = String(event.source_type ?? '').trim();
       const apiKey = String(event.api_key ?? '').trim() || '-';
-      const model = String(event.model ?? '').trim() || '-';
-      const modelAlias = String(event.model_alias ?? '').trim() || '-';
+      const modelValue = String(event.model ?? '').trim();
+      const model = modelValue || '-';
+      const modelAliasValue = String(event.model_alias ?? '').trim();
+      const modelAlias = modelAliasValue && modelAliasValue !== modelValue ? modelAliasValue : '-';
       const reasoningEffort = String(event.reasoning_effort ?? '').trim() || '-';
       const serviceTier = formatRequestSpeedMode(event.service_tier, t);
       const endpointFields = parseRequestEndpoint(event.endpoint);

--- a/web/src/components/usage/test/RequestEventsDetailsCardModelAlias.test.tsx
+++ b/web/src/components/usage/test/RequestEventsDetailsCardModelAlias.test.tsx
@@ -97,4 +97,16 @@ describe('RequestEventsDetailsCard model alias column', () => {
     expect(modelAliasHeaderIndex).toBeGreaterThanOrEqual(0);
     expect(cells[modelAliasHeaderIndex]).toBe('-');
   });
+
+  it('renders a dash when model alias matches the model name', () => {
+    const html = renderCard({
+      events: [{ ...events[0], model_alias: 'claude-sonnet' }],
+    });
+    const headers = extractTableHeaders(html);
+    const cells = extractFirstTableRowCells(html);
+    const modelAliasHeaderIndex = headers.indexOf('Model Alias');
+
+    expect(modelAliasHeaderIndex).toBeGreaterThanOrEqual(0);
+    expect(cells[modelAliasHeaderIndex]).toBe('-');
+  });
 });


### PR DESCRIPTION
## Summary

- Hide Request Events model aliases when the alias matches the model name.
- Add a regression test for duplicate model alias display.

## Validation

- `npm --prefix ./web run test`
- `npm --prefix ./web run lint`
- `npm --prefix ./web run typecheck`
- `npm --prefix ./web run build`