### PR TITLE
fix: fold reasoning tokens for OpenAI-compat sources with Gemini-style token semantics

### DIFF
--- a/internal/service/flatten.go
+++ b/internal/service/flatten.go
@@ -65,6 +65,14 @@ func normalizeClaudeTokens(tokens dto.TokenStats) dto.TokenStats {
 
 func normalizeOpenAIStyleTokens(tokens dto.TokenStats) dto.TokenStats {
 	tokens = clampTokenStats(tokens)
+	// Models routed via OpenAI-compatible gateway (e.g. Gemini) may report
+	// output_tokens without reasoning_tokens included. Detect via token
+	// arithmetic and fold to maintain the unified Codex-style storage format.
+	if tokens.ReasoningTokens > 0 &&
+		tokens.TotalTokens > 0 &&
+		tokens.InputTokens+tokens.OutputTokens+tokens.ReasoningTokens == tokens.TotalTokens {
+		tokens.OutputTokens += tokens.ReasoningTokens
+	}
 	return fillCodexStyleTotalTokens(tokens)
 }
 

--- a/internal/service/flatten.go
+++ b/internal/service/flatten.go
@@ -48,8 +48,10 @@ func normalizeUsageTokensByType(tokens dto.TokenStats, usageType string) dto.Tok
 		return normalizeKimiTokens(tokens)
 	case "xai":
 		return normalizeXAIStyleTokens(tokens)
-	case "openai", "openai-compatible", "openai_compatibility", "codex":
+	case "openai", "codex":
 		return normalizeOpenAIStyleTokens(tokens)
+	case "openai-compatible", "openai_compatibility":
+		return normalizeOpenAICompatibilityTokens(tokens)
 	default:
 		return normalizeDefaultTokens(tokens)
 	}
@@ -65,9 +67,16 @@ func normalizeClaudeTokens(tokens dto.TokenStats) dto.TokenStats {
 
 func normalizeOpenAIStyleTokens(tokens dto.TokenStats) dto.TokenStats {
 	tokens = clampTokenStats(tokens)
-	// Models routed via OpenAI-compatible gateway (e.g. Gemini) may report
-	// output_tokens without reasoning_tokens included. Detect via token
-	// arithmetic and fold to maintain the unified Codex-style storage format.
+	// Real OpenAI and Codex Responses usage already includes reasoning_tokens in output_tokens.
+	return fillCodexStyleTotalTokens(tokens)
+}
+
+func normalizeOpenAICompatibilityTokens(tokens dto.TokenStats) dto.TokenStats {
+	tokens = clampTokenStats(tokens)
+	// OpenAI-compatible protocol does not guarantee OpenAI token semantics. CPA may route
+	// Gemini-family models through OpenAICompatExecutor where output_tokens and
+	// reasoning_tokens are reported separately. Fold when arithmetic proves reasoning
+	// is not already included in output.
 	if tokens.ReasoningTokens > 0 &&
 		tokens.TotalTokens > 0 &&
 		tokens.InputTokens+tokens.OutputTokens+tokens.ReasoningTokens == tokens.TotalTokens {

--- a/internal/service/flatten_test.go
+++ b/internal/service/flatten_test.go
@@ -80,3 +80,57 @@ func TestNormalizeXAIStyleTokensKeepsResponsesOutput(t *testing.T) {
 		t.Fatalf("expected xAI Responses tokens to keep Codex-style output tokens, got %+v", tokens)
 	}
 }
+
+func TestNormalizeUsageEventTokensFoldsGeminiStyleReasoningForOpenAICompatible(t *testing.T) {
+	for _, usageType := range []string{"openai-compatible", "openai_compatibility"} {
+		t.Run(usageType, func(t *testing.T) {
+			event := NormalizeUsageEventTokens(entities.UsageEvent{
+				InputTokens:     11,
+				OutputTokens:    7,
+				ReasoningTokens: 3,
+				CachedTokens:    5,
+				TotalTokens:     21,
+			}, usageType)
+
+			if event.InputTokens != 11 || event.OutputTokens != 10 || event.ReasoningTokens != 3 || event.CachedTokens != 5 || event.TotalTokens != 21 {
+				t.Fatalf("expected %s to fold Gemini-style reasoning into output, got %+v", usageType, event)
+			}
+		})
+	}
+}
+
+func TestNormalizeUsageEventTokensKeepsCodexStyleOutputForOpenAICompatible(t *testing.T) {
+	for _, usageType := range []string{"openai-compatible", "openai_compatibility"} {
+		t.Run(usageType, func(t *testing.T) {
+			event := NormalizeUsageEventTokens(entities.UsageEvent{
+				InputTokens:     11,
+				OutputTokens:    10,
+				ReasoningTokens: 3,
+				CachedTokens:    5,
+				TotalTokens:     21,
+			}, usageType)
+
+			if event.InputTokens != 11 || event.OutputTokens != 10 || event.ReasoningTokens != 3 || event.CachedTokens != 5 || event.TotalTokens != 21 {
+				t.Fatalf("expected %s to keep Codex-style output when reasoning is already included, got %+v", usageType, event)
+			}
+		})
+	}
+}
+
+func TestNormalizeUsageEventTokensDoesNotFoldOpenAIStyleReasoningWhenTotalPresent(t *testing.T) {
+	for _, usageType := range []string{"codex", "openai"} {
+		t.Run(usageType, func(t *testing.T) {
+			event := NormalizeUsageEventTokens(entities.UsageEvent{
+				InputTokens:     11,
+				OutputTokens:    10,
+				ReasoningTokens: 3,
+				CachedTokens:    5,
+				TotalTokens:     21,
+			}, usageType)
+
+			if event.InputTokens != 11 || event.OutputTokens != 10 || event.ReasoningTokens != 3 || event.CachedTokens != 5 || event.TotalTokens != 21 {
+				t.Fatalf("expected %s strict normalization to keep output unchanged, got %+v", usageType, event)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #272

## Problem

Gemini models routed through `OpenAICompatExecutor` have `output_tokens` that does NOT include `reasoning_tokens` (Gemini native semantics). The `normalizeOpenAIStyleTokens` function does not fold them, causing `speed_tps` to always return `nil` (since `output - reasoning <= 0`).

## Solution

Add a conservative fold check to `normalizeOpenAIStyleTokens`: when `TotalTokens > 0` and the token arithmetic proves output does not contain reasoning (`input+output+reasoning == total` but `input+output != total`), fold reasoning into output.

This reuses the same mathematical detection already proven in `shouldFoldReasoningIntoOutput()` but with an additional `TotalTokens > 0` guard to avoid false positives when total is missing.

## Safety

This change also covers `normalizeDefaultTokens` and `normalizeKimiTokens` (which delegate to `normalizeOpenAIStyleTokens`). It is safe because:
- Standard OpenAI/Codex models: `input+output == total` → condition is false → no fold
- DeepSeek/Kimi (output already contains reasoning): same → no fold
- Gemini via OpenAI-compat: `input+output+reasoning == total` → fold correctly
- Models with no reasoning: `ReasoningTokens == 0` → short-circuits immediately

## Changes

- `internal/service/flatten.go`: Add conditional fold to `normalizeOpenAIStyleTokens`