### PR TITLE
fix: isolate OpenAI compatibility token normalization

### DIFF
--- a/internal/service/flatten.go
+++ b/internal/service/flatten.go
@@ -48,9 +48,10 @@ func normalizeUsageTokensByType(tokens dto.TokenStats, usageType string) dto.Tok
 		return normalizeKimiTokens(tokens)
 	case "xai":
 		return normalizeXAIStyleTokens(tokens)
-	case "openai", "codex":
-		return normalizeOpenAIStyleTokens(tokens)
-	case "openai-compatible", "openai_compatibility":
+	case "codex":
+		return normalizeCodexTokens(tokens)
+	// CPA OpenAI Compatibility metadata 当前会落成 type=openai，因此 openai 也走兼容口径。
+	case "openai", "openai-compatible", "openai_compatibility":
 		return normalizeOpenAICompatibilityTokens(tokens)
 	default:
 		return normalizeDefaultTokens(tokens)
@@ -65,9 +66,14 @@ func normalizeClaudeTokens(tokens dto.TokenStats) dto.TokenStats {
 	return fillCodexStyleTotalTokens(tokens)
 }
 
+func normalizeCodexTokens(tokens dto.TokenStats) dto.TokenStats {
+	// Codex Responses usage already includes reasoning_tokens in output_tokens.
+	return normalizeOpenAIStyleTokens(tokens)
+}
+
 func normalizeOpenAIStyleTokens(tokens dto.TokenStats) dto.TokenStats {
+	// 这里的 OpenAI-style 只描述 token 格式：output 已经包含 reasoning。
 	tokens = clampTokenStats(tokens)
-	// Real OpenAI and Codex Responses usage already includes reasoning_tokens in output_tokens.
 	return fillCodexStyleTotalTokens(tokens)
 }
 
@@ -104,11 +110,10 @@ func normalizeKimiTokens(tokens dto.TokenStats) dto.TokenStats {
 }
 
 func normalizeXAIStyleTokens(tokens dto.TokenStats) dto.TokenStats {
-	tokens = clampTokenStats(tokens)
 	// xAI 当前由 CPA XAIExecutor 调用 /v1/responses，usage 是 OpenAI Responses 风格：
 	// input_tokens 已包含 input_tokens_details.cached_tokens，output_tokens 已包含 reasoning_tokens。
 	// 后续如果 xAI 切到其他 usage 口径，只需要收敛修改这个分支。
-	return fillCodexStyleTotalTokens(tokens)
+	return normalizeOpenAIStyleTokens(tokens)
 }
 
 func normalizeDefaultTokens(tokens dto.TokenStats) dto.TokenStats {

--- a/internal/service/flatten_test.go
+++ b/internal/service/flatten_test.go
@@ -51,7 +51,7 @@ func TestNormalizeUsageEventTokensDoesNotDoubleCountCodexReasoningWhenTotalMissi
 	}
 }
 
-func TestNormalizeUsageEventTokensKeepsOpenAIStyleOutput(t *testing.T) {
+func TestNormalizeUsageEventTokensKeepsAlreadyIncludedOutputWhenTotalMissing(t *testing.T) {
 	for _, usageType := range []string{"codex", "openai", "custom"} {
 		t.Run(usageType, func(t *testing.T) {
 			event := NormalizeUsageEventTokens(entities.UsageEvent{
@@ -68,6 +68,20 @@ func TestNormalizeUsageEventTokensKeepsOpenAIStyleOutput(t *testing.T) {
 	}
 }
 
+func TestNormalizeUsageEventTokensDoesNotFoldCodexWhenCompatibilityWouldFold(t *testing.T) {
+	event := NormalizeUsageEventTokens(entities.UsageEvent{
+		InputTokens:     11,
+		OutputTokens:    7,
+		ReasoningTokens: 3,
+		CachedTokens:    5,
+		TotalTokens:     21,
+	}, "codex")
+
+	if event.InputTokens != 11 || event.OutputTokens != 7 || event.ReasoningTokens != 3 || event.CachedTokens != 5 || event.TotalTokens != 21 {
+		t.Fatalf("expected codex normalization to keep output unchanged, got %+v", event)
+	}
+}
+
 func TestNormalizeXAIStyleTokensKeepsResponsesOutput(t *testing.T) {
 	tokens := normalizeXAIStyleTokens(dto.TokenStats{
 		InputTokens:     11,
@@ -81,8 +95,8 @@ func TestNormalizeXAIStyleTokensKeepsResponsesOutput(t *testing.T) {
 	}
 }
 
-func TestNormalizeUsageEventTokensFoldsGeminiStyleReasoningForOpenAICompatible(t *testing.T) {
-	for _, usageType := range []string{"openai-compatible", "openai_compatibility"} {
+func TestNormalizeUsageEventTokensFoldsGeminiStyleReasoningForOpenAICompatibility(t *testing.T) {
+	for _, usageType := range []string{"openai", "openai-compatible", "openai_compatibility"} {
 		t.Run(usageType, func(t *testing.T) {
 			event := NormalizeUsageEventTokens(entities.UsageEvent{
 				InputTokens:     11,
@@ -99,8 +113,8 @@ func TestNormalizeUsageEventTokensFoldsGeminiStyleReasoningForOpenAICompatible(t
 	}
 }
 
-func TestNormalizeUsageEventTokensKeepsCodexStyleOutputForOpenAICompatible(t *testing.T) {
-	for _, usageType := range []string{"openai-compatible", "openai_compatibility"} {
+func TestNormalizeUsageEventTokensKeepsCodexStyleOutputForOpenAICompatibility(t *testing.T) {
+	for _, usageType := range []string{"openai", "openai-compatible", "openai_compatibility"} {
 		t.Run(usageType, func(t *testing.T) {
 			event := NormalizeUsageEventTokens(entities.UsageEvent{
 				InputTokens:     11,
@@ -117,8 +131,8 @@ func TestNormalizeUsageEventTokensKeepsCodexStyleOutputForOpenAICompatible(t *te
 	}
 }
 
-func TestNormalizeUsageEventTokensDoesNotFoldOpenAIStyleReasoningWhenTotalPresent(t *testing.T) {
-	for _, usageType := range []string{"codex", "openai"} {
+func TestNormalizeUsageEventTokensDoesNotFoldCodexReasoningWhenTotalPresent(t *testing.T) {
+	for _, usageType := range []string{"codex"} {
 		t.Run(usageType, func(t *testing.T) {
 			event := NormalizeUsageEventTokens(entities.UsageEvent{
 				InputTokens:     11,
@@ -129,7 +143,7 @@ func TestNormalizeUsageEventTokensDoesNotFoldOpenAIStyleReasoningWhenTotalPresen
 			}, usageType)
 
 			if event.InputTokens != 11 || event.OutputTokens != 10 || event.ReasoningTokens != 3 || event.CachedTokens != 5 || event.TotalTokens != 21 {
-				t.Fatalf("expected %s strict normalization to keep output unchanged, got %+v", usageType, event)
+				t.Fatalf("expected %s normalization to keep output unchanged, got %+v", usageType, event)
 			}
 		})
 	}

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -408,7 +408,7 @@ func normalizeRedisUsageEvents(ctx context.Context, db *gorm.DB, events []entiti
 				"auth_index": event.AuthIndex,
 				"event_key":  event.EventKey,
 			}).Warn("usage identity type not found for redis usage event")
-			usageType = "openai"
+			usageType = "default"
 		}
 		normalized[i] = NormalizeUsageEventTokens(event, usageType)
 	}
@@ -543,7 +543,7 @@ func resolveUsageEventType(event entities.UsageEvent, resolver usageEventTypeRes
 		key := usageEventIdentityKey{authType: entities.UsageIdentityAuthTypeAIProvider, identity: strings.TrimSpace(event.AuthIndex)}
 		return strings.TrimSpace(resolver.byIdentity[key])
 	default:
-		return "openai"
+		return "default"
 	}
 }
 

--- a/internal/service/sync_test.go
+++ b/internal/service/sync_test.go
@@ -1135,7 +1135,7 @@ func TestBuildUsageEventTypeResolverIgnoresBlankActiveType(t *testing.T) {
 	}
 	key := usageEventIdentityKey{authType: entities.UsageIdentityAuthTypeAIProvider, identity: "blank-active-auth-index"}
 	if got := resolver.byIdentity[key]; got != "" {
-		t.Fatalf("expected blank active type to remain unresolved for OpenAI-style fallback, got %q", got)
+		t.Fatalf("expected blank active type to remain unresolved for default token fallback, got %q", got)
 	}
 }
 
@@ -1173,7 +1173,7 @@ func TestProcessRedisUsageInboxFallsBackToDeletedUsageIdentityType(t *testing.T)
 	}
 }
 
-func TestProcessRedisUsageInboxUsesOpenAIStyleForKimiAndMissingType(t *testing.T) {
+func TestProcessRedisUsageInboxUsesStrictTokensForKimiAndMissingType(t *testing.T) {
 	db := openSyncTestDatabase(t)
 	logs := captureSyncDebugLogs(t)
 	if err := db.Create(&entities.UsageIdentity{
@@ -1194,7 +1194,7 @@ func TestProcessRedisUsageInboxUsesOpenAIStyleForKimiAndMissingType(t *testing.T
 		},
 		{
 			Source:     redisUsageInboxTestSource,
-			RawMessage: `{"timestamp":"2026-04-27T08:00:00Z","provider":"Unknown","auth_type":"apikey","auth_index":"missing-auth-index","model":"unknown-model","request_id":"missing-type-openai-style","tokens":{"input_tokens":100,"output_tokens":30,"cached_tokens":20,"cache_read_tokens":20,"cache_creation_tokens":10}}`,
+			RawMessage: `{"timestamp":"2026-04-27T08:00:00Z","provider":"Unknown","auth_type":"apikey","auth_index":"missing-auth-index","model":"unknown-model","request_id":"missing-type-default-style","tokens":{"input_tokens":100,"output_tokens":30,"cached_tokens":20,"cache_read_tokens":20,"cache_creation_tokens":10}}`,
 			PoppedAt:   time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC),
 		},
 	})
@@ -1206,10 +1206,10 @@ func TestProcessRedisUsageInboxUsesOpenAIStyleForKimiAndMissingType(t *testing.T
 	if _, err := service.ProcessRedisUsageInbox(context.Background()); err != nil {
 		t.Fatalf("ProcessRedisUsageInbox returned error: %v", err)
 	}
-	for _, eventKey := range []string{"kimi-openai-style", "missing-type-openai-style"} {
+	for _, eventKey := range []string{"kimi-openai-style", "missing-type-default-style"} {
 		event := loadUsageEventByKey(t, db, eventKey)
 		if event.InputTokens != 100 || event.CachedTokens != 20 || event.CacheReadTokens != 20 || event.CacheCreationTokens != 10 || event.OutputTokens != 30 || event.TotalTokens != 130 {
-			t.Fatalf("expected %s to use OpenAI-style token normalization, got %+v", eventKey, event)
+			t.Fatalf("expected %s to use strict token normalization, got %+v", eventKey, event)
 		}
 	}
 	if output := logs.String(); !strings.Contains(output, "usage identity type not found for redis usage event") || !strings.Contains(output, "missing-auth-index") {

--- a/internal/service/sync_test.go
+++ b/internal/service/sync_test.go
@@ -1194,7 +1194,7 @@ func TestProcessRedisUsageInboxUsesStrictTokensForKimiAndMissingType(t *testing.
 		},
 		{
 			Source:     redisUsageInboxTestSource,
-			RawMessage: `{"timestamp":"2026-04-27T08:00:00Z","provider":"Unknown","auth_type":"apikey","auth_index":"missing-auth-index","model":"unknown-model","request_id":"missing-type-default-style","tokens":{"input_tokens":100,"output_tokens":30,"cached_tokens":20,"cache_read_tokens":20,"cache_creation_tokens":10}}`,
+			RawMessage: `{"timestamp":"2026-04-27T08:00:00Z","provider":"Unknown","auth_type":"apikey","auth_index":"missing-auth-index","model":"unknown-model","request_id":"missing-type-default-style","tokens":{"input_tokens":100,"output_tokens":30,"reasoning_tokens":5,"cached_tokens":20,"cache_read_tokens":20,"cache_creation_tokens":10,"total_tokens":135}}`,
 			PoppedAt:   time.Date(2026, 4, 27, 8, 0, 0, 0, time.UTC),
 		},
 	})
@@ -1206,9 +1206,23 @@ func TestProcessRedisUsageInboxUsesStrictTokensForKimiAndMissingType(t *testing.
 	if _, err := service.ProcessRedisUsageInbox(context.Background()); err != nil {
 		t.Fatalf("ProcessRedisUsageInbox returned error: %v", err)
 	}
-	for _, eventKey := range []string{"kimi-openai-style", "missing-type-default-style"} {
+	cases := map[string]struct {
+		outputTokens    int64
+		reasoningTokens int64
+		totalTokens     int64
+	}{
+		"kimi-openai-style":          {outputTokens: 30, totalTokens: 130},
+		"missing-type-default-style": {outputTokens: 30, reasoningTokens: 5, totalTokens: 135},
+	}
+	for eventKey, expected := range cases {
 		event := loadUsageEventByKey(t, db, eventKey)
-		if event.InputTokens != 100 || event.CachedTokens != 20 || event.CacheReadTokens != 20 || event.CacheCreationTokens != 10 || event.OutputTokens != 30 || event.TotalTokens != 130 {
+		if event.InputTokens != 100 ||
+			event.CachedTokens != 20 ||
+			event.CacheReadTokens != 20 ||
+			event.CacheCreationTokens != 10 ||
+			event.OutputTokens != expected.outputTokens ||
+			event.ReasoningTokens != expected.reasoningTokens ||
+			event.TotalTokens != expected.totalTokens {
 			t.Fatalf("expected %s to use strict token normalization, got %+v", eventKey, event)
 		}
 	}

--- a/internal/service/test/flatten_test.go
+++ b/internal/service/test/flatten_test.go
@@ -1,16 +1,16 @@
-package service
+package test
 
 import (
 	"testing"
 
 	"cpa-usage-keeper/internal/entities"
-	"cpa-usage-keeper/internal/repository/dto"
+	"cpa-usage-keeper/internal/service"
 )
 
 func TestNormalizeUsageEventTokensUsesCodexStyleOutputForGeminiFamily(t *testing.T) {
 	for _, usageType := range []string{"gemini", "vertex", "gemini-cli", "gemini-cli-code-assist", "antigravity", "aistudio", "ai-studio"} {
 		t.Run(usageType, func(t *testing.T) {
-			event := NormalizeUsageEventTokens(entities.UsageEvent{
+			event := service.NormalizeUsageEventTokens(entities.UsageEvent{
 				InputTokens:     11,
 				OutputTokens:    7,
 				ReasoningTokens: 3,
@@ -26,7 +26,7 @@ func TestNormalizeUsageEventTokensUsesCodexStyleOutputForGeminiFamily(t *testing
 }
 
 func TestNormalizeUsageEventTokensBackfillsTotalWithCodexStyleOutput(t *testing.T) {
-	event := NormalizeUsageEventTokens(entities.UsageEvent{
+	event := service.NormalizeUsageEventTokens(entities.UsageEvent{
 		InputTokens:     11,
 		OutputTokens:    7,
 		ReasoningTokens: 3,
@@ -39,7 +39,7 @@ func TestNormalizeUsageEventTokensBackfillsTotalWithCodexStyleOutput(t *testing.
 }
 
 func TestNormalizeUsageEventTokensDoesNotDoubleCountCodexReasoningWhenTotalMissing(t *testing.T) {
-	event := NormalizeUsageEventTokens(entities.UsageEvent{
+	event := service.NormalizeUsageEventTokens(entities.UsageEvent{
 		InputTokens:     11,
 		OutputTokens:    10,
 		ReasoningTokens: 3,
@@ -52,9 +52,9 @@ func TestNormalizeUsageEventTokensDoesNotDoubleCountCodexReasoningWhenTotalMissi
 }
 
 func TestNormalizeUsageEventTokensKeepsAlreadyIncludedOutputWhenTotalMissing(t *testing.T) {
-	for _, usageType := range []string{"codex", "openai", "custom"} {
+	for _, usageType := range []string{"codex", "openai", "openai-compatible", "openai_compatibility", "custom"} {
 		t.Run(usageType, func(t *testing.T) {
-			event := NormalizeUsageEventTokens(entities.UsageEvent{
+			event := service.NormalizeUsageEventTokens(entities.UsageEvent{
 				InputTokens:     11,
 				OutputTokens:    10,
 				ReasoningTokens: 3,
@@ -69,7 +69,7 @@ func TestNormalizeUsageEventTokensKeepsAlreadyIncludedOutputWhenTotalMissing(t *
 }
 
 func TestNormalizeUsageEventTokensDoesNotFoldCodexWhenCompatibilityWouldFold(t *testing.T) {
-	event := NormalizeUsageEventTokens(entities.UsageEvent{
+	event := service.NormalizeUsageEventTokens(entities.UsageEvent{
 		InputTokens:     11,
 		OutputTokens:    7,
 		ReasoningTokens: 3,
@@ -82,23 +82,23 @@ func TestNormalizeUsageEventTokensDoesNotFoldCodexWhenCompatibilityWouldFold(t *
 	}
 }
 
-func TestNormalizeXAIStyleTokensKeepsResponsesOutput(t *testing.T) {
-	tokens := normalizeXAIStyleTokens(dto.TokenStats{
+func TestNormalizeUsageEventTokensKeepsResponsesOutputForXAI(t *testing.T) {
+	event := service.NormalizeUsageEventTokens(entities.UsageEvent{
 		InputTokens:     11,
 		OutputTokens:    10,
 		ReasoningTokens: 3,
 		CachedTokens:    5,
-	})
+	}, "xai")
 
-	if tokens.InputTokens != 11 || tokens.OutputTokens != 10 || tokens.ReasoningTokens != 3 || tokens.CachedTokens != 5 || tokens.TotalTokens != 21 {
-		t.Fatalf("expected xAI Responses tokens to keep Codex-style output tokens, got %+v", tokens)
+	if event.InputTokens != 11 || event.OutputTokens != 10 || event.ReasoningTokens != 3 || event.CachedTokens != 5 || event.TotalTokens != 21 {
+		t.Fatalf("expected xAI Responses tokens to keep Codex-style output tokens, got %+v", event)
 	}
 }
 
 func TestNormalizeUsageEventTokensFoldsGeminiStyleReasoningForOpenAICompatibility(t *testing.T) {
 	for _, usageType := range []string{"openai", "openai-compatible", "openai_compatibility"} {
 		t.Run(usageType, func(t *testing.T) {
-			event := NormalizeUsageEventTokens(entities.UsageEvent{
+			event := service.NormalizeUsageEventTokens(entities.UsageEvent{
 				InputTokens:     11,
 				OutputTokens:    7,
 				ReasoningTokens: 3,
@@ -113,10 +113,27 @@ func TestNormalizeUsageEventTokensFoldsGeminiStyleReasoningForOpenAICompatibilit
 	}
 }
 
+func TestNormalizeUsageEventTokensDoesNotFoldOpenAICompatibilityWithoutTotalProof(t *testing.T) {
+	for _, usageType := range []string{"openai", "openai-compatible", "openai_compatibility"} {
+		t.Run(usageType, func(t *testing.T) {
+			event := service.NormalizeUsageEventTokens(entities.UsageEvent{
+				InputTokens:     11,
+				OutputTokens:    7,
+				ReasoningTokens: 3,
+				CachedTokens:    5,
+			}, usageType)
+
+			if event.InputTokens != 11 || event.OutputTokens != 7 || event.ReasoningTokens != 3 || event.CachedTokens != 5 || event.TotalTokens != 18 {
+				t.Fatalf("expected %s to keep separated reasoning without total proof, got %+v", usageType, event)
+			}
+		})
+	}
+}
+
 func TestNormalizeUsageEventTokensKeepsCodexStyleOutputForOpenAICompatibility(t *testing.T) {
 	for _, usageType := range []string{"openai", "openai-compatible", "openai_compatibility"} {
 		t.Run(usageType, func(t *testing.T) {
-			event := NormalizeUsageEventTokens(entities.UsageEvent{
+			event := service.NormalizeUsageEventTokens(entities.UsageEvent{
 				InputTokens:     11,
 				OutputTokens:    10,
 				ReasoningTokens: 3,
@@ -134,7 +151,7 @@ func TestNormalizeUsageEventTokensKeepsCodexStyleOutputForOpenAICompatibility(t 
 func TestNormalizeUsageEventTokensDoesNotFoldCodexReasoningWhenTotalPresent(t *testing.T) {
 	for _, usageType := range []string{"codex"} {
 		t.Run(usageType, func(t *testing.T) {
-			event := NormalizeUsageEventTokens(entities.UsageEvent{
+			event := service.NormalizeUsageEventTokens(entities.UsageEvent{
 				InputTokens:     11,
 				OutputTokens:    10,
 				ReasoningTokens: 3,

--- a/internal/service/test/openai_token_normalization_test.go
+++ b/internal/service/test/openai_token_normalization_test.go
@@ -1,0 +1,131 @@
+package test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/config"
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+	repodto "cpa-usage-keeper/internal/repository/dto"
+	"cpa-usage-keeper/internal/service"
+	"gorm.io/gorm"
+)
+
+func TestProcessRedisUsageInboxNormalizesOpenAICompatibilityTokensForOpenAIIdentity(t *testing.T) {
+	db := openOpenAITokenNormalizationTestDatabase(t)
+	if err := db.Create(&entities.UsageIdentity{
+		Name:         "OpenAI Compatible",
+		AuthType:     entities.UsageIdentityAuthTypeAIProvider,
+		AuthTypeName: "apikey",
+		Identity:     "openai-compat-auth-index",
+		Type:         "openai",
+		Provider:     "OpenAI Compatible",
+	}).Error; err != nil {
+		t.Fatalf("seed usage identity: %v", err)
+	}
+	_, err := repository.InsertRedisUsageInboxMessages(db, []repodto.RedisInboxInsert{{
+		Source: "usage",
+		RawMessage: `{
+			"timestamp":"2026-07-06T08:00:00Z",
+			"provider":"OpenAI Compatible",
+			"auth_type":"api_key",
+			"auth_index":"openai-compat-auth-index",
+			"model":"gemini-2.5-pro",
+			"request_id":"openai-compatible-gemini-thinking",
+			"executor_type":"OpenAICompatExecutor",
+			"tokens":{
+				"input_tokens":11,
+				"output_tokens":7,
+				"reasoning_tokens":3,
+				"cached_tokens":5,
+				"total_tokens":21
+			}
+		}`,
+		PoppedAt: time.Date(2026, 7, 6, 8, 0, 0, 0, time.UTC),
+	}})
+	if err != nil {
+		t.Fatalf("seed inbox row: %v", err)
+	}
+	syncService := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{BaseURL: "https://cpa.example.com"})
+
+	result, err := syncService.ProcessRedisUsageInbox(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessRedisUsageInbox returned error: %v", err)
+	}
+	if result == nil || result.InsertedEvents != 1 {
+		t.Fatalf("expected one inserted event, got %+v", result)
+	}
+	event := loadOpenAITokenNormalizationEvent(t, db, "openai-compatible-gemini-thinking")
+	if event.InputTokens != 11 || event.OutputTokens != 10 || event.ReasoningTokens != 3 || event.CachedTokens != 5 || event.TotalTokens != 21 {
+		t.Fatalf("expected openai identity to normalize separated reasoning into output, got %+v", event)
+	}
+}
+
+func TestProcessRedisUsageInboxUsesDefaultTokensWhenUsageIdentityMissing(t *testing.T) {
+	db := openOpenAITokenNormalizationTestDatabase(t)
+	_, err := repository.InsertRedisUsageInboxMessages(db, []repodto.RedisInboxInsert{{
+		Source: "usage",
+		RawMessage: `{
+			"timestamp":"2026-07-06T08:00:00Z",
+			"provider":"Unknown Provider",
+			"auth_type":"api_key",
+			"auth_index":"missing-auth-index",
+			"model":"unknown-model",
+			"request_id":"missing-identity-thinking",
+			"tokens":{
+				"input_tokens":11,
+				"output_tokens":7,
+				"reasoning_tokens":3,
+				"cached_tokens":5,
+				"total_tokens":21
+			}
+		}`,
+		PoppedAt: time.Date(2026, 7, 6, 8, 0, 0, 0, time.UTC),
+	}})
+	if err != nil {
+		t.Fatalf("seed inbox row: %v", err)
+	}
+	syncService := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{BaseURL: "https://cpa.example.com"})
+
+	result, err := syncService.ProcessRedisUsageInbox(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessRedisUsageInbox returned error: %v", err)
+	}
+	if result == nil || result.InsertedEvents != 1 {
+		t.Fatalf("expected one inserted event, got %+v", result)
+	}
+	event := loadOpenAITokenNormalizationEvent(t, db, "missing-identity-thinking")
+	if event.InputTokens != 11 || event.OutputTokens != 7 || event.ReasoningTokens != 3 || event.CachedTokens != 5 || event.TotalTokens != 21 {
+		t.Fatalf("expected missing identity to use default strict token normalization, got %+v", event)
+	}
+}
+
+func openOpenAITokenNormalizationTestDatabase(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := repository.OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "openai-token-normalization.db")})
+	if err != nil {
+		t.Fatalf("OpenDatabase returned error: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sql database: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Fatalf("close database: %v", err)
+		}
+	})
+	return db
+}
+
+func loadOpenAITokenNormalizationEvent(t *testing.T, db *gorm.DB, eventKey string) entities.UsageEvent {
+	t.Helper()
+	var event entities.UsageEvent
+	if err := db.Where("event_key = ?", eventKey).First(&event).Error; err != nil {
+		t.Fatalf("load usage event %q: %v", eventKey, err)
+	}
+	return event
+}


### PR DESCRIPTION
## Summary

- Route CPA OpenAI Compatibility usage identities through a dedicated token normalizer, including the current `type=openai` metadata shape.
- Keep Codex on strict Responses-style token normalization and fall back unresolved Redis usage identity types to default strict handling.
- Move token normalization coverage under `internal/service/test` and add Redis-path regression tests for OpenAI-compatible Gemini-style reasoning tokens.

Fixes #272
Fixes #200
Follow-up to #273

## Scope

This normalizes newly ingested Redis usage events. Existing historical usage records are not backfilled here.

## Validation

- `rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build go test -count=1 ./internal/...`
- `rtk git diff --check origin/main..HEAD`