### PR TITLE
Fix model pricing resolution and pricing model options

### DIFF
--- a/internal/repository/pricing.go
+++ b/internal/repository/pricing.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"database/sql"
 	"fmt"
 	"math"
 	"sort"
@@ -29,11 +30,9 @@ func ListUsedModels(db *gorm.DB) ([]string, error) {
 		return nil, fmt.Errorf("database is nil")
 	}
 
-	var modelsList []string
+	var modelsList []sql.NullString
 	if err := db.Model(&entities.UsageEvent{}).
 		Distinct().
-		Where("trim(model) <> ''").
-		Order("model asc").
 		Pluck("model", &modelsList).Error; err != nil {
 		return nil, fmt.Errorf("list used models: %w", err)
 	}
@@ -41,7 +40,10 @@ func ListUsedModels(db *gorm.DB) ([]string, error) {
 	cleaned := make([]string, 0, len(modelsList))
 	seen := make(map[string]struct{}, len(modelsList))
 	for _, model := range modelsList {
-		trimmed := strings.TrimSpace(model)
+		if !model.Valid {
+			continue
+		}
+		trimmed := strings.TrimSpace(model.String)
 		if trimmed == "" {
 			continue
 		}

--- a/internal/repository/test/pricing_test.go
+++ b/internal/repository/test/pricing_test.go
@@ -1,0 +1,36 @@
+package test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+)
+
+func TestListUsedModelsNormalizesDirtyModelValuesInMemory(t *testing.T) {
+	db := openTestDatabase(t)
+	if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{
+		{EventKey: "model-alpha", Model: "alpha", Timestamp: time.Unix(1, 0)},
+		{EventKey: "model-beta-spaced", Model: " beta ", Timestamp: time.Unix(2, 0)},
+		{EventKey: "model-beta", Model: "beta", Timestamp: time.Unix(3, 0)},
+		{EventKey: "model-empty", Model: "", Timestamp: time.Unix(4, 0)},
+		{EventKey: "model-blank", Model: " ", Timestamp: time.Unix(5, 0)},
+	}); err != nil {
+		t.Fatalf("insert usage events: %v", err)
+	}
+	if err := db.Exec("INSERT INTO usage_events (event_key, model) VALUES (?, NULL)", "model-null").Error; err != nil {
+		t.Fatalf("insert null model usage event: %v", err)
+	}
+
+	models, err := repository.ListUsedModels(db)
+	if err != nil {
+		t.Fatalf("ListUsedModels returned error: %v", err)
+	}
+
+	expected := []string{"alpha", "beta"}
+	if strings.Join(models, ",") != strings.Join(expected, ",") {
+		t.Fatalf("expected normalized models %#v, got %#v", expected, models)
+	}
+}

--- a/internal/repository/test/usage_cost_resolver_test.go
+++ b/internal/repository/test/usage_cost_resolver_test.go
@@ -15,7 +15,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func TestUsageCostResolverPrefersModelAliasAndFallsBackToModel(t *testing.T) {
+func TestUsageCostResolverPrefersModelPricingOverAliasWhenBothPriced(t *testing.T) {
 	db := openUsageCostResolverDatabase(t, "usage-cost-resolver.db")
 	upsertUsageCostResolverPrice(t, db, "base-model", 10)
 	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
@@ -25,19 +25,15 @@ func TestUsageCostResolverPrefersModelAliasAndFallsBackToModel(t *testing.T) {
 		t.Fatalf("NewUsageCostResolver returned error: %v", err)
 	}
 
-	aliasResult := resolver.Calculate(repository.UsageCostSubject{
+	result := resolver.Calculate(repository.UsageCostSubject{
 		Model:      "base-model",
 		ModelAlias: "alias-model",
 		Tokens:     helper.UsageTokenCostInput{InputTokens: 1_000_000},
 	})
-	assertUsageCostResolverResult(t, aliasResult, 2, true)
-
-	fallbackResult := resolver.Calculate(repository.UsageCostSubject{
-		Model:      "base-model",
-		ModelAlias: "missing-alias",
-		Tokens:     helper.UsageTokenCostInput{InputTokens: 1_000_000},
-	})
-	assertUsageCostResolverResult(t, fallbackResult, 10, true)
+	assertUsageCostResolverResult(t, result, 10, true)
+	if result.MatchedModel != "base-model" || result.MatchedBy != "model" {
+		t.Fatalf("expected resolver to match real model pricing, got %+v", result)
+	}
 }
 
 func TestUsageCostResolverCostAvailabilityForMissingPrices(t *testing.T) {
@@ -60,6 +56,26 @@ func TestUsageCostResolverCostAvailabilityForMissingPrices(t *testing.T) {
 
 	empty := resolver.Calculate(repository.UsageCostSubject{Model: "missing-model"})
 	assertUsageCostResolverResult(t, empty, 0, true)
+}
+
+func TestUsageCostResolverFallsBackToAliasWhenModelPriceIsMissing(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-cost-resolver-alias-only.db")
+	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
+
+	resolver, err := repository.NewUsageCostResolver(context.Background(), db)
+	if err != nil {
+		t.Fatalf("NewUsageCostResolver returned error: %v", err)
+	}
+	result := resolver.Calculate(repository.UsageCostSubject{
+		Model:      "missing-model",
+		ModelAlias: "alias-model",
+		Tokens:     helper.UsageTokenCostInput{InputTokens: 1_000_000},
+	})
+
+	assertUsageCostResolverResult(t, result, 2, true)
+	if result.MatchedModel != "alias-model" || result.MatchedBy != "model_alias" {
+		t.Fatalf("expected resolver to fall back to alias pricing, got %+v", result)
+	}
 }
 
 func TestUsageCostResolverTreatsZeroMultiplierAsMatchedAvailableCost(t *testing.T) {
@@ -96,8 +112,8 @@ func TestUsageCostResolverDoesNotApplyMultiplierWhenPriceMissing(t *testing.T) {
 	assertUsageCostResolverResult(t, result, 0, false)
 }
 
-func TestListUsageEventsWithFilterUsesModelAliasPricing(t *testing.T) {
-	db := openUsageCostResolverDatabase(t, "usage-events-alias-cost.db")
+func TestListUsageEventsWithFilterUsesModelPricingWhenAliasDiffers(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-events-model-cost.db")
 	upsertUsageCostResolverPrice(t, db, "base-model", 10)
 	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
 	alias := "alias-model"
@@ -122,14 +138,48 @@ func TestListUsageEventsWithFilterUsesModelAliasPricing(t *testing.T) {
 	if len(page.Events) != 1 {
 		t.Fatalf("expected one usage event, got %d", len(page.Events))
 	}
-	assertUsageCostClose(t, page.Events[0].CostUSD, 2)
+	assertUsageCostClose(t, page.Events[0].CostUSD, 10)
 	if !page.Events[0].CostAvailable {
-		t.Fatalf("expected alias-priced event cost to be available, got %+v", page.Events[0])
+		t.Fatalf("expected model-priced event cost to be available, got %+v", page.Events[0])
 	}
 }
 
-func TestBuildUsageOverviewWithFilterUsesHourlyModelAliasPricing(t *testing.T) {
-	db := openUsageCostResolverDatabase(t, "usage-overview-hourly-alias-cost.db")
+func TestListUsageEventsWithFilterFallsBackToAliasPricingWhenModelPriceMissing(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-events-alias-fallback-cost.db")
+	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
+	alias := "alias-model"
+	eventTime := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{{
+		EventKey:    "event-alias-fallback-cost",
+		Model:       "missing-model",
+		ModelAlias:  &alias,
+		Timestamp:   eventTime,
+		InputTokens: 1_000_000,
+		TotalTokens: 1_000_000,
+	}}); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+
+	start := eventTime.Add(-time.Minute)
+	end := eventTime.Add(time.Minute)
+	page, err := repository.ListUsageEventsWithFilter(db, repodto.UsageQueryFilter{StartTime: &start, EndTime: &end})
+	if err != nil {
+		t.Fatalf("ListUsageEventsWithFilter returned error: %v", err)
+	}
+	if len(page.Events) != 1 {
+		t.Fatalf("expected one usage event, got %d", len(page.Events))
+	}
+	if page.Events[0].Model != "missing-model" {
+		t.Fatalf("expected usage event to keep real model display value, got %+v", page.Events[0])
+	}
+	assertUsageCostClose(t, page.Events[0].CostUSD, 2)
+	if !page.Events[0].CostAvailable {
+		t.Fatalf("expected alias-fallback event cost to be available, got %+v", page.Events[0])
+	}
+}
+
+func TestBuildUsageOverviewWithFilterUsesHourlyModelPricingWhenAliasDiffers(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-overview-hourly-model-cost.db")
 	upsertUsageCostResolverPrice(t, db, "base-model", 10)
 	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
 	bucket := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
@@ -152,14 +202,43 @@ func TestBuildUsageOverviewWithFilterUsesHourlyModelAliasPricing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildUsageOverviewWithFilter returned error: %v", err)
 	}
-	assertUsageCostClose(t, overview.Summary.TotalCost, 2)
+	assertUsageCostClose(t, overview.Summary.TotalCost, 10)
 	if !overview.Summary.CostAvailable {
-		t.Fatalf("expected overview alias cost to be available, got %+v", overview.Summary)
+		t.Fatalf("expected overview model cost to be available, got %+v", overview.Summary)
 	}
 }
 
-func TestBuildUsageOverviewWithFilterUsesDailyModelAliasPricing(t *testing.T) {
-	db := openUsageCostResolverDatabase(t, "usage-overview-daily-alias-cost.db")
+func TestBuildUsageOverviewWithFilterFallsBackToHourlyAliasPricingWhenModelPriceMissing(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-overview-hourly-alias-fallback-cost.db")
+	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
+	bucket := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	if err := db.Create(&entities.UsageOverviewHourlyStat{
+		BucketStart: bucket,
+		APIGroupKey: "api-key",
+		Model:       "missing-model",
+		ModelAlias:  "alias-model",
+		InputTokens: 1_000_000,
+		TotalTokens: 1_000_000,
+		CreatedAt:   bucket,
+		UpdatedAt:   bucket,
+	}).Error; err != nil {
+		t.Fatalf("seed hourly stat: %v", err)
+	}
+
+	start := bucket
+	end := bucket.Add(time.Hour)
+	overview, err := repository.BuildUsageOverviewWithFilter(db, repodto.UsageQueryFilter{StartTime: &start, EndTime: &end})
+	if err != nil {
+		t.Fatalf("BuildUsageOverviewWithFilter returned error: %v", err)
+	}
+	assertUsageCostClose(t, overview.Summary.TotalCost, 2)
+	if !overview.Summary.CostAvailable {
+		t.Fatalf("expected overview hourly alias-fallback cost to be available, got %+v", overview.Summary)
+	}
+}
+
+func TestBuildUsageOverviewWithFilterUsesDailyModelPricingWhenAliasDiffers(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-overview-daily-model-cost.db")
 	upsertUsageCostResolverPrice(t, db, "base-model", 10)
 	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
 	bucket := time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)
@@ -182,14 +261,43 @@ func TestBuildUsageOverviewWithFilterUsesDailyModelAliasPricing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildUsageOverviewWithFilter returned error: %v", err)
 	}
-	assertUsageCostClose(t, overview.Summary.TotalCost, 2)
+	assertUsageCostClose(t, overview.Summary.TotalCost, 10)
 	if !overview.Summary.CostAvailable {
-		t.Fatalf("expected overview daily alias cost to be available, got %+v", overview.Summary)
+		t.Fatalf("expected overview daily model cost to be available, got %+v", overview.Summary)
 	}
 }
 
-func TestBuildAnalysisWithFilterUsesModelAliasPricing(t *testing.T) {
-	db := openUsageCostResolverDatabase(t, "usage-analysis-alias-cost.db")
+func TestBuildUsageOverviewWithFilterFallsBackToDailyAliasPricingWhenModelPriceMissing(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-overview-daily-alias-fallback-cost.db")
+	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
+	bucket := time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)
+	if err := db.Create(&entities.UsageOverviewDailyStat{
+		BucketStart: bucket,
+		APIGroupKey: "api-key",
+		Model:       "missing-model",
+		ModelAlias:  "alias-model",
+		InputTokens: 1_000_000,
+		TotalTokens: 1_000_000,
+		CreatedAt:   bucket,
+		UpdatedAt:   bucket,
+	}).Error; err != nil {
+		t.Fatalf("seed daily stat: %v", err)
+	}
+
+	start := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 6, 9, 0, 0, 0, 0, time.UTC)
+	overview, err := repository.BuildUsageOverviewWithFilter(db, repodto.UsageQueryFilter{Range: "custom", StartTime: &start, EndTime: &end})
+	if err != nil {
+		t.Fatalf("BuildUsageOverviewWithFilter returned error: %v", err)
+	}
+	assertUsageCostClose(t, overview.Summary.TotalCost, 2)
+	if !overview.Summary.CostAvailable {
+		t.Fatalf("expected overview daily alias-fallback cost to be available, got %+v", overview.Summary)
+	}
+}
+
+func TestBuildAnalysisWithFilterUsesModelPricingWhenAliasDiffers(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-analysis-model-cost.db")
 	upsertUsageCostResolverPrice(t, db, "base-model", 10)
 	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
 	bucket := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
@@ -216,18 +324,58 @@ func TestBuildAnalysisWithFilterUsesModelAliasPricing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildAnalysisWithFilter returned error: %v", err)
 	}
-	assertUsageCostClose(t, analysis.CostBreakdown.TotalCostUSD, 2)
+	assertUsageCostClose(t, analysis.CostBreakdown.TotalCostUSD, 10)
 	if !analysis.CostBreakdown.CostAvailable {
-		t.Fatalf("expected analysis alias cost to be available, got %+v", analysis.CostBreakdown)
+		t.Fatalf("expected analysis model cost to be available, got %+v", analysis.CostBreakdown)
 	}
 	if len(analysis.ModelEfficiency) != 1 {
 		t.Fatalf("expected one model efficiency row, got %+v", analysis.ModelEfficiency)
 	}
+	assertUsageCostClose(t, analysis.ModelEfficiency[0].CostUSD, 10)
+}
+
+func TestBuildAnalysisWithFilterFallsBackToAliasPricingWhenModelPriceMissing(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-analysis-alias-fallback-cost.db")
+	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
+	bucket := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	if err := db.Create(&entities.CPAAPIKey{APIKey: "api-key", DisplayKey: "sk-*********alias"}).Error; err != nil {
+		t.Fatalf("seed CPA API key: %v", err)
+	}
+	if err := db.Create(&entities.UsageOverviewHourlyStat{
+		BucketStart:  bucket,
+		APIGroupKey:  "api-key",
+		Model:        "missing-model",
+		ModelAlias:   "alias-model",
+		RequestCount: 1,
+		InputTokens:  1_000_000,
+		TotalTokens:  1_000_000,
+		CreatedAt:    bucket,
+		UpdatedAt:    bucket,
+	}).Error; err != nil {
+		t.Fatalf("seed hourly stat: %v", err)
+	}
+
+	start := bucket
+	end := bucket.Add(time.Hour)
+	analysis, err := repository.BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{StartTime: &start, EndTime: &end})
+	if err != nil {
+		t.Fatalf("BuildAnalysisWithFilter returned error: %v", err)
+	}
+	assertUsageCostClose(t, analysis.CostBreakdown.TotalCostUSD, 2)
+	if !analysis.CostBreakdown.CostAvailable {
+		t.Fatalf("expected analysis alias-fallback cost to be available, got %+v", analysis.CostBreakdown)
+	}
+	if len(analysis.ModelEfficiency) != 1 {
+		t.Fatalf("expected one model efficiency row, got %+v", analysis.ModelEfficiency)
+	}
+	if analysis.ModelEfficiency[0].Model != "missing-model" {
+		t.Fatalf("expected analysis to keep real model display value, got %+v", analysis.ModelEfficiency[0])
+	}
 	assertUsageCostClose(t, analysis.ModelEfficiency[0].CostUSD, 2)
 }
 
-func TestBuildAnalysisWithFilterUsesDailyModelAliasPricing(t *testing.T) {
-	db := openUsageCostResolverDatabase(t, "usage-analysis-daily-alias-cost.db")
+func TestBuildAnalysisWithFilterUsesDailyModelPricingWhenAliasDiffers(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-analysis-daily-model-cost.db")
 	upsertUsageCostResolverPrice(t, db, "base-model", 10)
 	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
 	bucket := time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)
@@ -254,18 +402,58 @@ func TestBuildAnalysisWithFilterUsesDailyModelAliasPricing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildAnalysisWithFilter returned error: %v", err)
 	}
-	assertUsageCostClose(t, analysis.CostBreakdown.TotalCostUSD, 2)
+	assertUsageCostClose(t, analysis.CostBreakdown.TotalCostUSD, 10)
 	if !analysis.CostBreakdown.CostAvailable {
-		t.Fatalf("expected analysis daily alias cost to be available, got %+v", analysis.CostBreakdown)
+		t.Fatalf("expected analysis daily model cost to be available, got %+v", analysis.CostBreakdown)
 	}
 	if len(analysis.ModelEfficiency) != 1 {
 		t.Fatalf("expected one model efficiency row, got %+v", analysis.ModelEfficiency)
 	}
+	assertUsageCostClose(t, analysis.ModelEfficiency[0].CostUSD, 10)
+}
+
+func TestBuildAnalysisWithFilterFallsBackToDailyAliasPricingWhenModelPriceMissing(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-analysis-daily-alias-fallback-cost.db")
+	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
+	bucket := time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)
+	if err := db.Create(&entities.CPAAPIKey{APIKey: "api-key", DisplayKey: "sk-*********alias"}).Error; err != nil {
+		t.Fatalf("seed CPA API key: %v", err)
+	}
+	if err := db.Create(&entities.UsageOverviewDailyStat{
+		BucketStart:  bucket,
+		APIGroupKey:  "api-key",
+		Model:        "missing-model",
+		ModelAlias:   "alias-model",
+		RequestCount: 1,
+		InputTokens:  1_000_000,
+		TotalTokens:  1_000_000,
+		CreatedAt:    bucket,
+		UpdatedAt:    bucket,
+	}).Error; err != nil {
+		t.Fatalf("seed daily stat: %v", err)
+	}
+
+	start := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 6, 9, 0, 0, 0, 0, time.UTC)
+	analysis, err := repository.BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{Range: "custom", StartTime: &start, EndTime: &end})
+	if err != nil {
+		t.Fatalf("BuildAnalysisWithFilter returned error: %v", err)
+	}
+	assertUsageCostClose(t, analysis.CostBreakdown.TotalCostUSD, 2)
+	if !analysis.CostBreakdown.CostAvailable {
+		t.Fatalf("expected analysis daily alias-fallback cost to be available, got %+v", analysis.CostBreakdown)
+	}
+	if len(analysis.ModelEfficiency) != 1 {
+		t.Fatalf("expected one model efficiency row, got %+v", analysis.ModelEfficiency)
+	}
+	if analysis.ModelEfficiency[0].Model != "missing-model" {
+		t.Fatalf("expected analysis daily row to keep real model display value, got %+v", analysis.ModelEfficiency[0])
+	}
 	assertUsageCostClose(t, analysis.ModelEfficiency[0].CostUSD, 2)
 }
 
-func TestBuildUsageOverviewRealtimeWithFilterUsesRawModelAliasPricing(t *testing.T) {
-	db := openUsageCostResolverDatabase(t, "usage-realtime-alias-cost.db")
+func TestBuildUsageOverviewRealtimeWithFilterUsesRawModelPricingWhenAliasDiffers(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-realtime-model-cost.db")
 	upsertUsageCostResolverPrice(t, db, "base-model", 10)
 	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
 	alias := "alias-model"
@@ -295,11 +483,47 @@ func TestBuildUsageOverviewRealtimeWithFilterUsesRawModelAliasPricing(t *testing
 	if realtime.CurrentUsage.Models[0].CostUSD == nil {
 		t.Fatalf("expected realtime model cost to be available, got %+v", realtime.CurrentUsage.Models[0])
 	}
+	assertUsageCostClose(t, *realtime.CurrentUsage.Models[0].CostUSD, 10)
+}
+
+func TestBuildUsageOverviewRealtimeWithFilterFallsBackToRawAliasPricingWhenModelPriceMissing(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-realtime-alias-fallback-cost.db")
+	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
+	alias := "alias-model"
+	now := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{{
+		EventKey:    "realtime-alias-fallback-cost",
+		APIGroupKey: "api-key",
+		Model:       "missing-model",
+		ModelAlias:  &alias,
+		Timestamp:   now.Add(-time.Minute),
+		InputTokens: 1_000_000,
+		TotalTokens: 1_000_000,
+	}}); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+
+	realtime, err := repository.BuildUsageOverviewRealtimeWithFilter(db, repodto.UsageQueryFilter{
+		RealtimeWindow:  "15m",
+		RealtimeEndTime: &now,
+	})
+	if err != nil {
+		t.Fatalf("BuildUsageOverviewRealtimeWithFilter returned error: %v", err)
+	}
+	if len(realtime.CurrentUsage.Models) != 1 {
+		t.Fatalf("expected one realtime model row, got %+v", realtime.CurrentUsage.Models)
+	}
+	if realtime.CurrentUsage.Models[0].Key != "missing-model" {
+		t.Fatalf("expected realtime model row to keep real model display value, got %+v", realtime.CurrentUsage.Models[0])
+	}
+	if realtime.CurrentUsage.Models[0].CostUSD == nil {
+		t.Fatalf("expected realtime alias-fallback cost to be available, got %+v", realtime.CurrentUsage.Models[0])
+	}
 	assertUsageCostClose(t, *realtime.CurrentUsage.Models[0].CostUSD, 2)
 }
 
-func TestBuildUsageOverviewRealtimeWithRecentCacheUsesModelAliasPricing(t *testing.T) {
-	db := openUsageCostResolverDatabase(t, "usage-realtime-cache-alias-cost.db")
+func TestBuildUsageOverviewRealtimeWithRecentCacheUsesModelPricingWhenAliasDiffers(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-realtime-cache-model-cost.db")
 	upsertUsageCostResolverPrice(t, db, "base-model", 10)
 	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
 	alias := "alias-model"
@@ -336,11 +560,54 @@ func TestBuildUsageOverviewRealtimeWithRecentCacheUsesModelAliasPricing(t *testi
 	if realtime.CurrentUsage.Models[0].CostUSD == nil {
 		t.Fatalf("expected realtime cache model cost to be available, got %+v", realtime.CurrentUsage.Models[0])
 	}
+	assertUsageCostClose(t, *realtime.CurrentUsage.Models[0].CostUSD, 10)
+}
+
+func TestBuildUsageOverviewRealtimeWithRecentCacheFallsBackToAliasPricingWhenModelPriceMissing(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-realtime-cache-alias-fallback-cost.db")
+	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
+	alias := "alias-model"
+	now := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{{
+		EventKey:    "realtime-cache-alias-fallback-cost",
+		APIGroupKey: "api-key",
+		Model:       "missing-model",
+		ModelAlias:  &alias,
+		Timestamp:   now.Add(-time.Minute),
+		InputTokens: 1_000_000,
+		TotalTokens: 1_000_000,
+	}}); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+	recentCache, err := repository.NewUsageRecentEventCache(db, repository.UsageRecentEventCacheOptions{Now: func() time.Time {
+		return now
+	}})
+	if err != nil {
+		t.Fatalf("NewUsageRecentEventCache returned error: %v", err)
+	}
+	t.Cleanup(recentCache.Close)
+
+	realtime, err := repository.BuildUsageOverviewRealtimeWithFilterAndRecentCache(db, repodto.UsageQueryFilter{
+		RealtimeWindow:  "15m",
+		RealtimeEndTime: &now,
+	}, recentCache)
+	if err != nil {
+		t.Fatalf("BuildUsageOverviewRealtimeWithFilterAndRecentCache returned error: %v", err)
+	}
+	if len(realtime.CurrentUsage.Models) != 1 {
+		t.Fatalf("expected one realtime model row, got %+v", realtime.CurrentUsage.Models)
+	}
+	if realtime.CurrentUsage.Models[0].Key != "missing-model" {
+		t.Fatalf("expected realtime cache model row to keep real model display value, got %+v", realtime.CurrentUsage.Models[0])
+	}
+	if realtime.CurrentUsage.Models[0].CostUSD == nil {
+		t.Fatalf("expected realtime cache alias-fallback cost to be available, got %+v", realtime.CurrentUsage.Models[0])
+	}
 	assertUsageCostClose(t, *realtime.CurrentUsage.Models[0].CostUSD, 2)
 }
 
-func TestSumUsageWindowStatsByAuthIndexUsesRawAndHourlyModelAliasPricing(t *testing.T) {
-	db := openUsageCostResolverDatabase(t, "usage-window-alias-cost.db")
+func TestSumUsageWindowStatsByAuthIndexUsesRawAndHourlyModelPricingWhenAliasDiffers(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-window-model-cost.db")
 	upsertUsageCostResolverPrice(t, db, "base-model", 10)
 	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
 	alias := "alias-model"
@@ -361,7 +628,7 @@ func TestSumUsageWindowStatsByAuthIndexUsesRawAndHourlyModelAliasPricing(t *test
 	if err != nil {
 		t.Fatalf("SumUsageWindowStatsByAuthIndex raw returned error: %v", err)
 	}
-	assertUsageCostClose(t, rawStats.Cost, 2)
+	assertUsageCostClose(t, rawStats.Cost, 10)
 
 	hourlyStart := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
 	hourlyEnd := hourlyStart.Add(7 * 24 * time.Hour)
@@ -382,11 +649,56 @@ func TestSumUsageWindowStatsByAuthIndexUsesRawAndHourlyModelAliasPricing(t *test
 	if err != nil {
 		t.Fatalf("SumUsageWindowStatsByAuthIndex hourly returned error: %v", err)
 	}
+	assertUsageCostClose(t, hourlyStats.Cost, 10)
+}
+
+func TestSumUsageWindowStatsByAuthIndexFallsBackToAliasPricingWhenModelPriceMissing(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-window-alias-fallback-cost.db")
+	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
+	alias := "alias-model"
+
+	rawStart := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	rawEnd := rawStart.Add(time.Hour)
+	if err := db.Create(&entities.UsageEvent{
+		AuthIndex:   "auth-raw",
+		Model:       "missing-model",
+		ModelAlias:  &alias,
+		Timestamp:   rawStart.Add(10 * time.Minute),
+		InputTokens: 1_000_000,
+		TotalTokens: 1_000_000,
+	}).Error; err != nil {
+		t.Fatalf("seed raw usage event: %v", err)
+	}
+	rawStats, err := repository.SumUsageWindowStatsByAuthIndex(context.Background(), db, "auth-raw", rawStart, &rawEnd)
+	if err != nil {
+		t.Fatalf("SumUsageWindowStatsByAuthIndex raw returned error: %v", err)
+	}
+	assertUsageCostClose(t, rawStats.Cost, 2)
+
+	hourlyStart := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	hourlyEnd := hourlyStart.Add(7 * 24 * time.Hour)
+	hourlyBucket := hourlyStart.Add(48 * time.Hour)
+	if err := db.Create(&entities.UsageOverviewHourlyStat{
+		BucketStart: hourlyBucket,
+		AuthIndex:   "auth-hourly",
+		Model:       "missing-model",
+		ModelAlias:  "alias-model",
+		InputTokens: 1_000_000,
+		TotalTokens: 1_000_000,
+		CreatedAt:   hourlyBucket,
+		UpdatedAt:   hourlyBucket,
+	}).Error; err != nil {
+		t.Fatalf("seed hourly stat: %v", err)
+	}
+	hourlyStats, err := repository.SumUsageWindowStatsByAuthIndex(context.Background(), db, "auth-hourly", hourlyStart, &hourlyEnd)
+	if err != nil {
+		t.Fatalf("SumUsageWindowStatsByAuthIndex hourly returned error: %v", err)
+	}
 	assertUsageCostClose(t, hourlyStats.Cost, 2)
 }
 
-func TestSumUsageWindowStatsByAuthIndexMergesRawAndHourlyByModelAliasAndModel(t *testing.T) {
-	db := openUsageCostResolverDatabase(t, "usage-window-merged-alias-cost.db")
+func TestSumUsageWindowStatsByAuthIndexMergesRawAndHourlyByModelAliasAndModelButPricesByModel(t *testing.T) {
+	db := openUsageCostResolverDatabase(t, "usage-window-merged-model-cost.db")
 	upsertUsageCostResolverPrice(t, db, "base-model", 10)
 	upsertUsageCostResolverPrice(t, db, "alias-model", 2)
 	authIndex := "auth-merged"
@@ -416,7 +728,7 @@ func TestSumUsageWindowStatsByAuthIndexMergesRawAndHourlyByModelAliasAndModel(t 
 	if stats.Tokens != 5_000_000 {
 		t.Fatalf("expected raw and hourly tokens to merge by model_alias/model, got %+v", stats)
 	}
-	assertUsageCostClose(t, stats.Cost, 26)
+	assertUsageCostClose(t, stats.Cost, 50)
 }
 
 func openUsageCostResolverDatabase(t *testing.T, name string) *gorm.DB {

--- a/internal/repository/usage_cost_resolver.go
+++ b/internal/repository/usage_cost_resolver.go
@@ -53,7 +53,7 @@ func NewUsageCostResolver(ctx context.Context, db *gorm.DB) (*UsageCostResolver,
 }
 
 func (r *UsageCostResolver) Calculate(subject UsageCostSubject) UsageCostResult {
-	pricing, matchedModel, matchedBy, ok := r.matchPricing(subject.ModelAlias, subject.Model)
+	pricing, matchedModel, matchedBy, ok := r.matchPricing(subject.Model, subject.ModelAlias)
 	if !ok {
 		return UsageCostResult{Available: !helper.UsageTokenInputRequiresPricing(subject.Tokens)}
 	}
@@ -86,18 +86,18 @@ func (r *UsageCostResolver) CalculateEvent(event entities.UsageEvent) UsageCostR
 	})
 }
 
-func (r *UsageCostResolver) matchPricing(modelAlias string, model string) (entities.ModelPriceSetting, string, string, bool) {
+func (r *UsageCostResolver) matchPricing(model string, modelAlias string) (entities.ModelPriceSetting, string, string, bool) {
 	if r == nil {
 		return entities.ModelPriceSetting{}, "", "", false
-	}
-	if alias := strings.TrimSpace(modelAlias); alias != "" {
-		if pricing, ok := r.pricesByModel[alias]; ok {
-			return pricing, alias, "model_alias", true
-		}
 	}
 	if modelName := strings.TrimSpace(model); modelName != "" {
 		if pricing, ok := r.pricesByModel[modelName]; ok {
 			return pricing, modelName, "model", true
+		}
+	}
+	if alias := strings.TrimSpace(modelAlias); alias != "" {
+		if pricing, ok := r.pricesByModel[alias]; ok {
+			return pricing, alias, "model_alias", true
 		}
 	}
 	return entities.ModelPriceSetting{}, "", "", false

--- a/internal/repository/usage_recent_event_cache.go
+++ b/internal/repository/usage_recent_event_cache.go
@@ -38,7 +38,7 @@ type RecentUsageEvent struct {
 	APIGroupKey string
 	// Model 用于 realtime 当前模型占比和 cost 价格表匹配。
 	Model string
-	// ModelAlias 用于当前价格配置按 alias 优先匹配。
+	// ModelAlias 保留 CPA 上报的请求来源别名，真实 Model 缺价时可用于价格回退。
 	ModelAlias string
 	// AuthIndex 用于关联 usage_identities，找不到身份时才使用 fallback。
 	AuthIndex string

--- a/internal/repository/usage_window_stats.go
+++ b/internal/repository/usage_window_stats.go
@@ -215,7 +215,7 @@ func sumRawUsageWindowTokenStats(db *gorm.DB, authIndex string, start time.Time,
 		Select("model, COALESCE(model_alias, '') AS model_alias, COALESCE(SUM(total_tokens), 0) AS total_tokens, COALESCE(SUM(input_tokens), 0) AS input_tokens, COALESCE(SUM(output_tokens), 0) AS output_tokens, COALESCE(SUM(cached_tokens), 0) AS cached_tokens, COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens, COALESCE(SUM(cache_creation_tokens), 0) AS cache_creation_tokens").
 		// auth_index 已经是唯一身份维度，这里不再额外按 auth_type 过滤。
 		Where("auth_index = ? AND timestamp >= ?", authIndex, timeutil.FormatStorageTime(start)).
-		// 按 model_alias/model 分组，后续按 alias 优先价格表计算 cost。
+		// 按 model_alias/model 分组保留现有聚合边界，后续 cost 先按真实 model、再按 alias 回退。
 		Group("model_alias, model")
 	// 如果调用方传入结束时间，就用半开区间避免边界重复累计。
 	if end != nil {
@@ -240,7 +240,7 @@ func sumHourlyUsageWindowTokenStats(db *gorm.DB, authIndex string, start time.Ti
 		Select("model, model_alias, COALESCE(SUM(total_tokens), 0) AS total_tokens, COALESCE(SUM(input_tokens), 0) AS input_tokens, COALESCE(SUM(output_tokens), 0) AS output_tokens, COALESCE(SUM(cached_tokens), 0) AS cached_tokens, COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens, COALESCE(SUM(cache_creation_tokens), 0) AS cache_creation_tokens").
 		// auth_index + bucket_start 范围可以使用现有 hourly auth_bucket 索引。
 		Where("auth_index = ? AND bucket_start >= ? AND bucket_start < ?", authIndex, timeutil.FormatStorageTime(start), timeutil.FormatStorageTime(end)).
-		// 按 model_alias/model 分组，后续按 alias 优先价格表计算 cost。
+		// 按 model_alias/model 分组保留现有聚合边界，后续 cost 先按真实 model、再按 alias 回退。
 		Group("model_alias, model")
 	// rows 只承接聚合后的少量 model 行。
 	var rows []usageWindowTokenStats
@@ -301,7 +301,7 @@ func usageWindowStatsFromTokenStats(rows []usageWindowTokenStats, costResolver *
 	for _, row := range rows {
 		// total_tokens 直接累计到前端展示的窗口 token。
 		stats.Tokens += row.TotalTokens
-		// 使用统一 resolver 按 alias 优先规则计算该维度的 cost。
+		// 使用统一 resolver 先按真实 model、再按 alias 回退计算该维度的 cost。
 		result := costResolver.Calculate(UsageCostSubject{
 			Model:      row.Model,
 			ModelAlias: row.ModelAlias,

--- a/internal/service/pricing_service.go
+++ b/internal/service/pricing_service.go
@@ -87,36 +87,54 @@ func (s *pricingService) DeletePricing(_ context.Context, model string) error {
 }
 
 func (s *pricingService) effectiveModels(ctx context.Context) ([]string, error) {
+	localModels, err := repository.ListUsedModels(s.db)
+	if err != nil {
+		return nil, err
+	}
 	if s.modelsFetcher == nil {
-		return repository.ListUsedModels(s.db)
+		return localModels, nil
 	}
 
 	result, err := s.modelsFetcher.FetchModels(ctx)
 	if err != nil {
 		logrus.WithError(err).Error("pricing model listing falling back to local usage aggregation")
-		return repository.ListUsedModels(s.db)
+		return localModels, nil
 	}
 
 	logrus.Debug("pricing model listing using CPA models endpoint")
-	return normalizeCPAModels(result), nil
+	return mergeModelNames(localModels, normalizeCPAModels(result)), nil
 }
 
 func normalizeCPAModels(result *response.ModelsResult) []string {
 	if result == nil {
 		return []string{}
 	}
-	seen := make(map[string]struct{}, len(result.Payload.Data))
 	models := make([]string, 0, len(result.Payload.Data))
 	for _, model := range result.Payload.Data {
-		id := strings.TrimSpace(model.ID)
-		if id == "" {
-			continue
+		models = append(models, model.ID)
+	}
+	return mergeModelNames(models)
+}
+
+func mergeModelNames(modelLists ...[]string) []string {
+	total := 0
+	for _, list := range modelLists {
+		total += len(list)
+	}
+	seen := make(map[string]struct{}, total)
+	models := make([]string, 0, total)
+	for _, list := range modelLists {
+		for _, model := range list {
+			id := strings.TrimSpace(model)
+			if id == "" {
+				continue
+			}
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			models = append(models, id)
 		}
-		if _, ok := seen[id]; ok {
-			continue
-		}
-		seen[id] = struct{}{}
-		models = append(models, id)
 	}
 	sort.Strings(models)
 	return models

--- a/internal/service/pricing_service.go
+++ b/internal/service/pricing_service.go
@@ -102,10 +102,10 @@ func (s *pricingService) effectiveModels(ctx context.Context) ([]string, error) 
 	}
 
 	logrus.Debug("pricing model listing using CPA models endpoint")
-	return mergeModelNames(localModels, normalizeCPAModels(result)), nil
+	return mergeModelNames(localModels, extractCPAModelIDs(result)), nil
 }
 
-func normalizeCPAModels(result *response.ModelsResult) []string {
+func extractCPAModelIDs(result *response.ModelsResult) []string {
 	if result == nil {
 		return []string{}
 	}
@@ -113,7 +113,7 @@ func normalizeCPAModels(result *response.ModelsResult) []string {
 	for _, model := range result.Payload.Data {
 		models = append(models, model.ID)
 	}
-	return mergeModelNames(models)
+	return models
 }
 
 func mergeModelNames(modelLists ...[]string) []string {

--- a/internal/service/test/pricing_service_test.go
+++ b/internal/service/test/pricing_service_test.go
@@ -162,14 +162,22 @@ func TestPricingServiceRejectsUnknownPricingStyle(t *testing.T) {
 	}
 }
 
-func TestPricingServiceListsModelsFromCPAWhenAvailable(t *testing.T) {
+func TestPricingServiceMergesCPAAndLocalModelsWhenCPAAvailable(t *testing.T) {
 	db := openPricingServiceTestDatabase(t)
-	if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{{
-		EventKey:    "evt-local",
-		Model:       "local-model",
-		Timestamp:   time.Unix(1, 0),
-		APIGroupKey: "provider-a",
-	}}); err != nil {
+	if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{
+		{
+			EventKey:    "evt-local",
+			Model:       "local-model",
+			Timestamp:   time.Unix(1, 0),
+			APIGroupKey: "provider-a",
+		},
+		{
+			EventKey:    "evt-overlap",
+			Model:       "alpha-model",
+			Timestamp:   time.Unix(2, 0),
+			APIGroupKey: "provider-a",
+		},
+	}); err != nil {
 		t.Fatalf("insert usage event: %v", err)
 	}
 	logs := captureDebugLogs(t)
@@ -185,9 +193,9 @@ func TestPricingServiceListsModelsFromCPAWhenAvailable(t *testing.T) {
 		t.Fatalf("list models: %v", err)
 	}
 
-	expected := []string{"alpha-model", "zeta-model"}
+	expected := []string{"alpha-model", "local-model", "zeta-model"}
 	if strings.Join(modelsList, ",") != strings.Join(expected, ",") {
-		t.Fatalf("expected CPA models %#v, got %#v", expected, modelsList)
+		t.Fatalf("expected merged CPA and local models %#v, got %#v", expected, modelsList)
 	}
 	if !strings.Contains(logs.String(), "using CPA models endpoint") {
 		t.Fatalf("expected CPA source debug log, got %q", logs.String())
@@ -226,7 +234,7 @@ func TestPricingServiceFallsBackToLocalModelsWhenCPAFetchFails(t *testing.T) {
 	}
 }
 
-func TestPricingServiceReturnsEmptyCPAListWithoutFallback(t *testing.T) {
+func TestPricingServiceKeepsLocalModelsWhenCPAListIsEmpty(t *testing.T) {
 	db := openPricingServiceTestDatabase(t)
 	if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{{
 		EventKey:    "evt-local",
@@ -237,13 +245,13 @@ func TestPricingServiceReturnsEmptyCPAListWithoutFallback(t *testing.T) {
 		t.Fatalf("insert usage event: %v", err)
 	}
 
-	service := service.NewPricingService(db, stubModelsFetcher{result: &response.ModelsResult{Payload: models.ModelsResponse{Data: []models.ModelInfo{{ID: " "}}}}})
+	service := service.NewPricingService(db, stubModelsFetcher{result: &response.ModelsResult{Payload: models.ModelsResponse{Data: []models.ModelInfo{}}}})
 	modelsList, err := service.ListUsedModels(context.Background())
 	if err != nil {
 		t.Fatalf("list models: %v", err)
 	}
-	if len(modelsList) != 0 {
-		t.Fatalf("expected empty CPA model list, got %#v", modelsList)
+	if len(modelsList) != 1 || modelsList[0] != "local-model" {
+		t.Fatalf("expected local model when CPA list is empty, got %#v", modelsList)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Prefer the real usage model for price matching, using model_alias only as a fallback when no real-model price exists.
- Merge CPA models with local usage models for price settings, and keep local models when CPA is unavailable or empty.
- Normalize local model list values in memory, including NULL and blank historical rows.

Related to #32 
Related to #35 
Related to #37 

## Validation
- rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build go test ./...
- rtk git diff --check