### PR TITLE
Align credential alias edit actions

### DIFF
--- a/web/src/components/usage/credentials/CredentialAliasEditor.tsx
+++ b/web/src/components/usage/credentials/CredentialAliasEditor.tsx
@@ -48,65 +48,73 @@ export function CredentialAliasEditor({ identityId, displayName, alias, saving, 
   if (editing) {
     return (
       <span className={styles.credentialAliasEditor}>
-        <input
-          className={styles.credentialAliasInput}
-          value={draftAlias}
-          placeholder={t('usage_stats.credentials_alias_placeholder')}
-          disabled={saving}
-          maxLength={50}
-          onChange={(event) => setDraftAlias(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter') {
-              event.preventDefault()
-              void saveAlias()
-            }
-            if (event.key === 'Escape') {
-              event.preventDefault()
-              cancelEditing()
-            }
-          }}
-          aria-label={t('usage_stats.credentials_alias_placeholder')}
-          autoFocus
-        />
-        <button
-          type="button"
-          className={styles.credentialAliasIconButton}
-          onClick={() => void saveAlias()}
-          disabled={!canSave}
-          title={saving ? t('usage_stats.credentials_alias_saving') : t('usage_stats.credentials_alias_save')}
-          aria-label={saving ? t('usage_stats.credentials_alias_saving') : t('usage_stats.credentials_alias_save')}
-          aria-busy={saving}
-        >
-          {saving ? <LoadingSpinner size={12} /> : <IconCheck size={13} />}
-        </button>
-        <button
-          type="button"
-          className={styles.credentialAliasIconButton}
-          onClick={cancelEditing}
-          disabled={saving}
-          title={t('usage_stats.credentials_alias_cancel')}
-          aria-label={t('usage_stats.credentials_alias_cancel')}
-        >
-          <IconX size={13} />
-        </button>
+        <span className={styles.credentialAliasEditLayout}>
+          <input
+            className={styles.credentialAliasInput}
+            value={draftAlias}
+            placeholder={t('usage_stats.credentials_alias_placeholder')}
+            disabled={saving}
+            maxLength={50}
+            onChange={(event) => setDraftAlias(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault()
+                void saveAlias()
+              }
+              if (event.key === 'Escape') {
+                event.preventDefault()
+                cancelEditing()
+              }
+            }}
+            aria-label={t('usage_stats.credentials_alias_placeholder')}
+            autoFocus
+          />
+          <span className={styles.credentialAliasEditActions}>
+            <button
+              type="button"
+              className={styles.credentialAliasIconButton}
+              onClick={() => void saveAlias()}
+              disabled={!canSave}
+              title={saving ? t('usage_stats.credentials_alias_saving') : t('usage_stats.credentials_alias_save')}
+              aria-label={saving ? t('usage_stats.credentials_alias_saving') : t('usage_stats.credentials_alias_save')}
+              aria-busy={saving}
+            >
+              {saving ? <LoadingSpinner size={12} /> : <IconCheck size={13} />}
+            </button>
+            <button
+              type="button"
+              className={styles.credentialAliasIconButton}
+              onClick={cancelEditing}
+              disabled={saving}
+              title={t('usage_stats.credentials_alias_cancel')}
+              aria-label={t('usage_stats.credentials_alias_cancel')}
+            >
+              <IconX size={13} />
+            </button>
+          </span>
+        </span>
       </span>
     )
   }
 
   return (
     <span className={styles.credentialAliasEditor}>
-      <span className={styles.credentialAliasDisplay}>{displayName}</span>
-      {canEdit && (
-        <button
-          type="button"
-          className={styles.credentialAliasEditButton}
-          onClick={startEditing}
-          title={t('usage_stats.credentials_alias_edit')}
-          aria-label={t('usage_stats.credentials_alias_edit')}
-        >
-          <IconPencil size={12} />
-        </button>
-      )}
+      <span className={styles.credentialAliasDisplayLayout}>
+        <span className={`${styles.credentialAliasDisplay} ${styles.credentialAliasNameSlot}`}>{displayName}</span>
+        <span className={styles.credentialAliasActionSlot}>
+          {canEdit && (
+            <button
+              type="button"
+              className={styles.credentialAliasEditButton}
+              onClick={startEditing}
+              title={t('usage_stats.credentials_alias_edit')}
+              aria-label={t('usage_stats.credentials_alias_edit')}
+            >
+              <IconPencil size={12} />
+            </button>
+          )}
+        </span>
+      </span>
     </span>
   )
 }

--- a/web/src/components/usage/credentials/CredentialAliasEditor.tsx
+++ b/web/src/components/usage/credentials/CredentialAliasEditor.tsx
@@ -100,7 +100,7 @@ export function CredentialAliasEditor({ identityId, displayName, alias, saving, 
   return (
     <span className={styles.credentialAliasEditor}>
       <span className={styles.credentialAliasDisplayLayout}>
-        <span className={`${styles.credentialAliasDisplay} ${styles.credentialAliasNameSlot}`}>{displayName}</span>
+        <span className={styles.credentialAliasNameSlot}>{displayName}</span>
         <span className={styles.credentialAliasActionSlot}>
           {canEdit && (
             <button

--- a/web/src/components/usage/credentials/CredentialSections.module.scss
+++ b/web/src/components/usage/credentials/CredentialSections.module.scss
@@ -1673,6 +1673,8 @@
 }
 
 .credentialDisplayName {
+  display: block;
+  width: 100%;
   min-width: 0;
   max-width: 100%;
   overflow: visible;
@@ -1686,12 +1688,20 @@
 }
 
 .credentialAliasEditor {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+  display: block;
+  width: 100%;
   min-width: 0;
   max-width: 100%;
   vertical-align: middle;
+}
+
+.credentialAliasDisplayLayout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 28px;
+  column-gap: 8px;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
 }
 
 .credentialAliasDisplay {
@@ -1699,8 +1709,37 @@
   overflow-wrap: anywhere;
 }
 
+.credentialAliasNameSlot {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.credentialAliasActionSlot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  justify-self: start;
+  width: 24px;
+  min-height: 24px;
+}
+
+.credentialAliasEditLayout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  column-gap: 6px;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+}
+
+.credentialAliasEditActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .credentialAliasInput {
-  width: min(170px, 100%);
+  width: 100%;
   min-width: 0;
   height: 28px;
   border: 1px solid var(--border-color);

--- a/web/src/components/usage/credentials/CredentialSections.module.scss
+++ b/web/src/components/usage/credentials/CredentialSections.module.scss
@@ -1704,11 +1704,6 @@
   min-width: 0;
 }
 
-.credentialAliasDisplay {
-  min-width: 0;
-  overflow-wrap: anywhere;
-}
-
 .credentialAliasNameSlot {
   min-width: 0;
   overflow-wrap: anywhere;

--- a/web/src/components/usage/credentials/test/CredentialAliasEditor.test.tsx
+++ b/web/src/components/usage/credentials/test/CredentialAliasEditor.test.tsx
@@ -25,6 +25,23 @@ describe('CredentialAliasEditor', () => {
     expect(html).toContain('usage_stats.credentials_alias_edit')
   })
 
+  it('keeps the display name and edit action in separate layout slots', () => {
+    const html = renderToStaticMarkup(
+      <CredentialAliasEditor
+        identityId="1"
+        displayName="Very Long Credential Name"
+        alias="Very Long Credential Name"
+        saving={false}
+        onSaveAlias={async () => undefined}
+      />,
+    )
+
+    expect(html).toContain('credentialAliasDisplayLayout')
+    expect(html).toContain('credentialAliasNameSlot')
+    expect(html).toContain('credentialAliasActionSlot')
+    expect(html.indexOf('credentialAliasNameSlot')).toBeLessThan(html.indexOf('credentialAliasActionSlot'))
+  })
+
   it('disables other rows while an alias save is in flight', () => {
     expect(isCredentialAliasEditorDisabled('1', false, '')).toBe(false)
     expect(isCredentialAliasEditorDisabled('1', false, '1')).toBe(false)

--- a/web/src/components/usage/credentials/test/CredentialAliasEditor.test.tsx
+++ b/web/src/components/usage/credentials/test/CredentialAliasEditor.test.tsx
@@ -40,6 +40,7 @@ describe('CredentialAliasEditor', () => {
     expect(html).toContain('credentialAliasNameSlot')
     expect(html).toContain('credentialAliasActionSlot')
     expect(html.indexOf('credentialAliasNameSlot')).toBeLessThan(html.indexOf('credentialAliasActionSlot'))
+    expect(html).not.toMatch(/credentialAliasDisplay_[a-z0-9]+/)
   })
 
   it('disables other rows while an alias save is in flight', () => {

--- a/web/src/components/usage/credentials/test/CredentialSections.styles.test.ts
+++ b/web/src/components/usage/credentials/test/CredentialSections.styles.test.ts
@@ -212,6 +212,18 @@ describe('Credential section styles', () => {
     expect(aiProviderSectionSource).toContain('row.priorityLabel')
   })
 
+  it('keeps credential alias edit buttons in a fixed name-cell action slot', () => {
+    expect(credentialStyles).toMatch(/\.credentialDisplayName\s*\{[\s\S]*?width:\s*100%;/)
+    expect(credentialStyles).toMatch(/\.credentialAliasEditor\s*\{[\s\S]*?width:\s*100%;/)
+    expect(credentialStyles).toMatch(/\.credentialAliasDisplayLayout\s*\{[\s\S]*?display:\s*grid;/)
+    expect(credentialStyles).toMatch(/\.credentialAliasDisplayLayout\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) 28px;/)
+    expect(credentialStyles).toMatch(/\.credentialAliasDisplayLayout\s*\{[\s\S]*?column-gap:\s*8px;/)
+    expect(credentialStyles).toMatch(/\.credentialAliasNameSlot\s*\{[\s\S]*?min-width:\s*0;/)
+    expect(credentialStyles).toMatch(/\.credentialAliasNameSlot\s*\{[\s\S]*?overflow-wrap:\s*anywhere;/)
+    expect(credentialStyles).toMatch(/\.credentialAliasActionSlot\s*\{[\s\S]*?width:\s*24px;/)
+    expect(credentialStyles).toMatch(/\.credentialAliasActionSlot\s*\{[\s\S]*?justify-self:\s*start;/)
+  })
+
   it('keeps Auth Files inspection separate from the quota refresh pill', () => {
     expect(authFileSectionSource).toContain('credentialSectionActionButtons')
     expect(authFileSectionSource).toMatch(/credentialInspectionSwitcher[\s\S]*?credentialInspectionButton[\s\S]*?credentialRefreshSwitcher/)

--- a/web/src/components/usage/credentials/test/CredentialSections.styles.test.ts
+++ b/web/src/components/usage/credentials/test/CredentialSections.styles.test.ts
@@ -222,6 +222,7 @@ describe('Credential section styles', () => {
     expect(credentialStyles).toMatch(/\.credentialAliasNameSlot\s*\{[\s\S]*?overflow-wrap:\s*anywhere;/)
     expect(credentialStyles).toMatch(/\.credentialAliasActionSlot\s*\{[\s\S]*?width:\s*24px;/)
     expect(credentialStyles).toMatch(/\.credentialAliasActionSlot\s*\{[\s\S]*?justify-self:\s*start;/)
+    expect(credentialStyles).not.toMatch(/\.credentialAliasDisplay\s*\{/)
   })
 
   it('keeps Auth Files inspection separate from the quota refresh pill', () => {


### PR DESCRIPTION
## Summary
- Keep credential alias edit buttons in a fixed action slot inside the name cell.
- Let long Auth Files and AI Provider names wrap independently without shifting the edit button.
- Add regression checks for the alias editor structure and CSS slot sizing.

## Validation
- `rtk npm --prefix ./web run test`
- `rtk npm --prefix ./web run lint`
- `rtk npm --prefix ./web run typecheck`
- `rtk npm --prefix ./web run build`
- `rtk git diff --check`