### PR TITLE
Improve dashboard layout scaling

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -3,7 +3,7 @@
   --keeper-ui-zoom: 0.9;
 
   zoom: var(--keeper-ui-zoom);
-  min-height: 111.111svh;
+  min-height: calc(100svh / var(--keeper-ui-zoom));
   display: flex;
   flex-direction: column;
   background: var(--bg-secondary);

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,5 +1,9 @@
 .app-frame {
-  min-height: 100svh;
+  --keeper-page-max-width: clamp(1245px, 86vw, 1600px);
+  --keeper-ui-zoom: 0.9;
+
+  zoom: var(--keeper-ui-zoom);
+  min-height: 111.111svh;
   display: flex;
   flex-direction: column;
   background: var(--bg-secondary);

--- a/web/src/i18n/index.test.ts
+++ b/web/src/i18n/index.test.ts
@@ -284,7 +284,7 @@ describe('i18n resources', () => {
 
   it('keeps the login product title aligned across languages', () => {
     expect(i18n.getResourceBundle('en', 'translation').auth.login_title).toBe('CPA Usage Statistics Dashboard');
-    expect(i18n.getResourceBundle('zh', 'translation').auth.login_title).toBe('CPA 用量统计仪表盘');
-    expect(i18n.getResourceBundle('zh-TW', 'translation').auth.login_title).toBe('CPA 用量統計儀表板');
+    expect(i18n.getResourceBundle('zh', 'translation').auth.login_title).toBe('CPA 用量统计\n仪表盘');
+    expect(i18n.getResourceBundle('zh-TW', 'translation').auth.login_title).toBe('CPA 用量統計\n儀表板');
   });
 });

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -547,7 +547,7 @@ const resources = {
         no_requests: '暂无请求'
       },
       auth: {
-        login_title: 'CPA 用量统计仪表盘',
+        login_title: 'CPA 用量统计\n仪表盘',
         login_subtitle: '持续保存 CPA 请求记录，聚合用量分析，并在受保护的控制台中查看请求健康、模型活动与 API 统计。',
         console_kicker: '访问控制',
         console_title: '选择访问方式',
@@ -1054,7 +1054,7 @@ const resources = {
         no_requests: '尚無請求'
       },
       auth: {
-        login_title: 'CPA 用量統計儀表板',
+        login_title: 'CPA 用量統計\n儀表板',
         login_subtitle: '持續保存 CPA 請求記錄，彙整用量分析，並在受保護的控制台中查看請求健康、模型活動與 API 統計。',
         console_kicker: '存取控制',
         console_title: '選擇存取方式',

--- a/web/src/pages/KeyOverviewPage.module.scss
+++ b/web/src/pages/KeyOverviewPage.module.scss
@@ -15,7 +15,7 @@
 }
 
 .pageFrame {
-  width: min(1245px, 100%);
+  width: min(var(--keeper-page-max-width, 1245px), 100%);
   margin: 0 auto;
   display: flex;
   flex-direction: column;

--- a/web/src/pages/LoginPage.module.scss
+++ b/web/src/pages/LoginPage.module.scss
@@ -119,7 +119,7 @@
 
 .loginCard {
   width: 100%;
-  height: 440px;
+  min-height: 440px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -132,7 +132,7 @@
   border: 1px solid color-mix(in srgb, var(--border-color) 84%, rgba($primary-color, 0.28));
 
   @include mobile {
-    height: auto;
+    min-height: 0;
     padding: 20px;
   }
 }
@@ -211,7 +211,7 @@
   border: 1px solid color-mix(in srgb, var(--primary-color) 48%, var(--border-color));
   background: color-mix(in srgb, var(--primary-color) 18%, var(--bg-primary));
   color: var(--text-primary);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.16), inset 0 0 0 1px color-mix(in srgb, #fff 18%, transparent);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.16), inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 18%, transparent);
 }
 
 .form {

--- a/web/src/pages/LoginPage.module.scss
+++ b/web/src/pages/LoginPage.module.scss
@@ -16,10 +16,10 @@
 }
 
 .frame {
-  width: min(1060px, 100%);
+  width: min(1180px, 100%);
   display: grid;
-  grid-template-columns: minmax(0, 1.1fr) minmax(340px, 440px);
-  gap: 30px;
+  grid-template-columns: minmax(0, 1.15fr) minmax(360px, 440px);
+  gap: 64px;
   align-items: center;
 
   @include mobile {
@@ -105,6 +105,7 @@
   font-size: clamp(38px, 5.6vw, 68px);
   line-height: 0.92;
   letter-spacing: -0.055em;
+  white-space: pre-line;
   color: var(--text-primary);
 }
 
@@ -117,6 +118,11 @@
 }
 
 .loginCard {
+  width: 100%;
+  height: 440px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
   padding: 28px;
   border-radius: 28px;
   background:
@@ -126,6 +132,7 @@
   border: 1px solid color-mix(in srgb, var(--border-color) 84%, rgba($primary-color, 0.28));
 
   @include mobile {
+    height: auto;
     padding: 20px;
   }
 }
@@ -180,7 +187,7 @@
 }
 
 .tab {
-  border: 0;
+  border: 1px solid transparent;
   border-radius: 999px;
   background: transparent;
   color: var(--text-secondary);
@@ -201,15 +208,21 @@
 }
 
 .tabActive {
-  background: var(--bg-primary);
+  border: 1px solid color-mix(in srgb, var(--primary-color) 48%, var(--border-color));
+  background: color-mix(in srgb, var(--primary-color) 18%, var(--bg-primary));
   color: var(--text-primary);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.16), inset 0 0 0 1px color-mix(in srgb, #fff 18%, transparent);
 }
 
 .form {
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   gap: 12px;
+
+  :global(.btn) {
+    margin-top: auto;
+  }
 
   :global(.input::placeholder) {
     font-size: 12px;

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -15,7 +15,7 @@
 }
 
 .pageFrame {
-  width: min(1245px, 100%);
+  width: min(var(--keeper-page-max-width, 1245px), 100%);
   margin: 0 auto;
   display: flex;
   flex-direction: column;

--- a/web/src/pages/test/LoginPage.styles.test.ts
+++ b/web/src/pages/test/LoginPage.styles.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 const loginPageStyles = readFileSync(new URL('../LoginPage.module.scss', import.meta.url), 'utf8').replace(/\r\n/g, '\n')
+const themeStyles = readFileSync(new URL('../../styles/themes.scss', import.meta.url), 'utf8').replace(/\r\n/g, '\n')
 
 describe('LoginPage layout styles', () => {
   it('gives the desktop login columns more room under the shared app zoom', () => {
@@ -20,20 +21,23 @@ describe('LoginPage layout styles', () => {
 
   it('keeps the login card width stable when localized copy changes', () => {
     expect(loginPageStyles).toMatch(/\.loginCard\s*\{[\s\S]*?width:\s*100%;/)
-    expect(loginPageStyles).toMatch(/\.loginCard\s*\{[\s\S]*?height:\s*440px;/)
+    expect(loginPageStyles).toMatch(/\.loginCard\s*\{[\s\S]*?min-height:\s*440px;/)
     expect(loginPageStyles).toMatch(/\.loginCard\s*\{[\s\S]*?box-sizing:\s*border-box;/)
     expect(loginPageStyles).toMatch(/\.loginCard\s*\{[\s\S]*?display:\s*flex;/)
     expect(loginPageStyles).toMatch(/\.loginCard\s*\{[\s\S]*?flex-direction:\s*column;/)
-    expect(loginPageStyles).toMatch(/\.loginCard\s*\{[\s\S]*?@include mobile\s*\{[\s\S]*?height:\s*auto;/)
+    expect(loginPageStyles).toMatch(/\.loginCard\s*\{[\s\S]*?@include mobile\s*\{[\s\S]*?min-height:\s*0;/)
   })
 
   it('makes the active login method visible in dark mode surfaces', () => {
     expect(loginPageStyles).toMatch(/\.tabActive\s*\{[\s\S]*?border:\s*1px solid color-mix\(in srgb, var\(--primary-color\) 48%, var\(--border-color\)\);/)
     expect(loginPageStyles).toMatch(/\.tabActive\s*\{[\s\S]*?background:\s*color-mix\(in srgb, var\(--primary-color\) 18%, var\(--bg-primary\)\);/)
-    expect(loginPageStyles).toMatch(/\.tabActive\s*\{[\s\S]*?box-shadow:\s*0 10px 24px rgba\(0, 0, 0, 0\.16\), inset 0 0 0 1px color-mix\(in srgb, #fff 18%, transparent\);/)
+    expect(loginPageStyles).toMatch(/\.tabActive\s*\{[\s\S]*?box-shadow:\s*0 10px 24px rgba\(0, 0, 0, 0\.16\), inset 0 0 0 1px color-mix\(in srgb, var\(--text-primary\) 18%, transparent\);/)
+    expect(themeStyles).toMatch(/:root\s*\{[\s\S]*?--text-primary:\s*#2d2a26;/)
+    expect(themeStyles).toMatch(/\[data-theme='white'\]\s*\{[\s\S]*?--text-primary:\s*#2d2a26;/)
+    expect(themeStyles).toMatch(/\[data-theme='dark'\]\s*\{[\s\S]*?--text-primary:\s*#f6f4f1;/)
   })
 
-  it('keeps the submit action anchored inside the fixed login card', () => {
+  it('keeps the submit action anchored inside the minimum-height login card', () => {
     expect(loginPageStyles).toMatch(/\.form\s*\{[\s\S]*?flex:\s*1 1 auto;/)
     expect(loginPageStyles).toMatch(/\.form\s*\{[\s\S]*?:global\(\.btn\)\s*\{[\s\S]*?margin-top:\s*auto;/)
   })

--- a/web/src/pages/test/LoginPage.styles.test.ts
+++ b/web/src/pages/test/LoginPage.styles.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const loginPageStyles = readFileSync(new URL('../LoginPage.module.scss', import.meta.url), 'utf8').replace(/\r\n/g, '\n')
+
+describe('LoginPage layout styles', () => {
+  it('gives the desktop login columns more room under the shared app zoom', () => {
+    expect(loginPageStyles).toMatch(/\.frame\s*\{[\s\S]*?width:\s*min\(1180px, 100%\);/)
+    expect(loginPageStyles).toMatch(/\.frame\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1\.15fr\) minmax\(360px, 440px\);/)
+    expect(loginPageStyles).toMatch(/\.frame\s*\{[\s\S]*?gap:\s*64px;/)
+  })
+
+  it('keeps the compact single-column layout on mobile', () => {
+    expect(loginPageStyles).toMatch(/@include mobile\s*\{[\s\S]*?grid-template-columns:\s*1fr;[\s\S]*?gap:\s*18px;/)
+  })
+
+  it('preserves intentional line breaks in localized login titles', () => {
+    expect(loginPageStyles).toMatch(/\.title\s*\{[\s\S]*?white-space:\s*pre-line;/)
+  })
+
+  it('keeps the login card width stable when localized copy changes', () => {
+    expect(loginPageStyles).toMatch(/\.loginCard\s*\{[\s\S]*?width:\s*100%;/)
+    expect(loginPageStyles).toMatch(/\.loginCard\s*\{[\s\S]*?height:\s*440px;/)
+    expect(loginPageStyles).toMatch(/\.loginCard\s*\{[\s\S]*?box-sizing:\s*border-box;/)
+    expect(loginPageStyles).toMatch(/\.loginCard\s*\{[\s\S]*?display:\s*flex;/)
+    expect(loginPageStyles).toMatch(/\.loginCard\s*\{[\s\S]*?flex-direction:\s*column;/)
+    expect(loginPageStyles).toMatch(/\.loginCard\s*\{[\s\S]*?@include mobile\s*\{[\s\S]*?height:\s*auto;/)
+  })
+
+  it('makes the active login method visible in dark mode surfaces', () => {
+    expect(loginPageStyles).toMatch(/\.tabActive\s*\{[\s\S]*?border:\s*1px solid color-mix\(in srgb, var\(--primary-color\) 48%, var\(--border-color\)\);/)
+    expect(loginPageStyles).toMatch(/\.tabActive\s*\{[\s\S]*?background:\s*color-mix\(in srgb, var\(--primary-color\) 18%, var\(--bg-primary\)\);/)
+    expect(loginPageStyles).toMatch(/\.tabActive\s*\{[\s\S]*?box-shadow:\s*0 10px 24px rgba\(0, 0, 0, 0\.16\), inset 0 0 0 1px color-mix\(in srgb, #fff 18%, transparent\);/)
+  })
+
+  it('keeps the submit action anchored inside the fixed login card', () => {
+    expect(loginPageStyles).toMatch(/\.form\s*\{[\s\S]*?flex:\s*1 1 auto;/)
+    expect(loginPageStyles).toMatch(/\.form\s*\{[\s\S]*?:global\(\.btn\)\s*\{[\s\S]*?margin-top:\s*auto;/)
+  })
+})

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -6,6 +6,7 @@ const readSource = (url: URL) => readFileSync(url, 'utf8').replace(/\r\n/g, '\n'
 const globalStyles = readSource(new URL('../../styles/global.scss', import.meta.url))
 const usagePageStyles = readSource(new URL('../UsagePage.module.scss', import.meta.url))
 const usagePageSource = readSource(new URL('../UsagePage.tsx', import.meta.url))
+const keyOverviewPageStyles = readSource(new URL('../KeyOverviewPage.module.scss', import.meta.url))
 const keyOverviewPageSource = readSource(new URL('../KeyOverviewPage.tsx', import.meta.url))
 const requestEventsSource = readSource(new URL('../../components/usage/RequestEventsDetailsCard.tsx', import.meta.url))
 const priceSettingsSource = readSource(new URL('../../components/usage/PriceSettingsCard.tsx', import.meta.url))
@@ -30,6 +31,11 @@ const requestEventColumnDefinitionBlock = (columnId: string) => {
 }
 
 describe('UsagePage toolbar styles', () => {
+  it('lets dashboard page frames consume the mode-specific width cap', () => {
+    expect(usagePageStyles).toMatch(/\.pageFrame\s*\{[\s\S]*?width:\s*min\(var\(--keeper-page-max-width, 1245px\), 100%\);/)
+    expect(keyOverviewPageStyles).toMatch(/\.pageFrame\s*\{[\s\S]*?width:\s*min\(var\(--keeper-page-max-width, 1245px\), 100%\);/)
+  })
+
   it('pins top notices to the viewport instead of the scrolled page body', () => {
     const noticeBlock = usagePageStyles.match(/\.updateCheckToast\s*\{[\s\S]*?\n\}/)?.[0] ?? ''
 

--- a/web/src/test/AppCPAMCEmbed.test.ts
+++ b/web/src/test/AppCPAMCEmbed.test.ts
@@ -20,7 +20,7 @@ describe('App CPAMC embed shell', () => {
   it('applies a shared app zoom preview across normal and CPAMC modes', () => {
     expect(appStyles).toMatch(/\.app-frame\s*\{[\s\S]*?--keeper-ui-zoom:\s*0\.9;/);
     expect(appStyles).toMatch(/\.app-frame\s*\{[\s\S]*?zoom:\s*var\(--keeper-ui-zoom\);/);
-    expect(appStyles).toMatch(/\.app-frame\s*\{[\s\S]*?min-height:\s*111\.111svh;/);
+    expect(appStyles).toMatch(/\.app-frame\s*\{[\s\S]*?min-height:\s*calc\(100svh\s*\/\s*var\(--keeper-ui-zoom\)\);/);
     expect(embedStyles).not.toContain('--keeper-ui-zoom');
     expect(embedStyles).not.toContain('zoom:');
   });

--- a/web/src/test/AppCPAMCEmbed.test.ts
+++ b/web/src/test/AppCPAMCEmbed.test.ts
@@ -2,11 +2,27 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const appSource = readFileSync(new URL('../App.tsx', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+const appStyles = readFileSync(new URL('../App.css', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+const embedStyles = readFileSync(new URL('../embed/cpamcEmbed.css', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 
 describe('App CPAMC embed shell', () => {
   it('loads the scoped CPAMC embed stylesheet and marks the app frame', () => {
     expect(appSource).toContain("import './embed/cpamcEmbed.css';");
     expect(appSource).toMatch(/<div className="app-frame" data-embed=\{isEmbeddedInCPAMC \? 'cpamc' : undefined\}>/);
+  });
+
+  it('shares the dynamic page width cap across normal and CPAMC modes', () => {
+    expect(appStyles).toMatch(/\.app-frame\s*\{[\s\S]*?--keeper-page-max-width:\s*clamp\(1245px, 86vw, 1600px\);/);
+    expect(appStyles).not.toContain('.app-frame:not([data-embed])');
+    expect(embedStyles).not.toContain('--keeper-page-max-width');
+  });
+
+  it('applies a shared app zoom preview across normal and CPAMC modes', () => {
+    expect(appStyles).toMatch(/\.app-frame\s*\{[\s\S]*?--keeper-ui-zoom:\s*0\.9;/);
+    expect(appStyles).toMatch(/\.app-frame\s*\{[\s\S]*?zoom:\s*var\(--keeper-ui-zoom\);/);
+    expect(appStyles).toMatch(/\.app-frame\s*\{[\s\S]*?min-height:\s*111\.111svh;/);
+    expect(embedStyles).not.toContain('--keeper-ui-zoom');
+    expect(embedStyles).not.toContain('zoom:');
   });
 
   it('preserves the CPAMC embed query when normalizing app paths', () => {


### PR DESCRIPTION
## Summary
- Expand the dashboard page width through a shared responsive page cap and apply a consistent app scale.
- Keep the CPAMC embed mode on the same shared scaling behavior without overriding embed-specific styles.
- Stabilize the login page layout across languages and improve the dark-theme login method selection state.

## Validation
- npm --prefix ./web run test -- src/pages/test/LoginPage.styles.test.ts src/i18n/index.test.ts src/test/AppCPAMCEmbed.test.ts src/pages/test/UsagePage.styles.test.ts
- npm --prefix ./web run lint
- npm --prefix ./web run typecheck
- npm --prefix ./web run build
- Local runtime checked with /cpa/healthz, /cpa/, and /cpa/?embed=cpamc

Fixes #278