### PR TITLE
Filter failed requests from latency metrics

### DIFF
--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -466,9 +466,10 @@ type analysisIdentityLookup map[entities.UsageIdentityAuthType]map[string]analys
 
 func buildAnalysisLatencyDiagnosticsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (dto.AnalysisLatencyDiagnosticsRecord, error) {
 	empty := emptyAnalysisLatencyDiagnosticsRecord()
-	// 延迟诊断的 SQL 只按已有索引维度收窄窗口；TTFT/Latency 有效性在内存过滤，避免依赖未索引列。
+	// 延迟诊断只统计成功请求；TTFT/Latency 有效性仍在内存过滤，避免依赖未索引列。
 	query := db.Model(&entities.UsageEvent{}).
-		Select("latency_ms, ttft_ms")
+		Select("latency_ms, ttft_ms").
+		Where("failed = ?", false)
 	query = applyUsageAnalysisTabQuery(query, filter)
 
 	rows, err := query.Rows()
@@ -1719,13 +1720,15 @@ func buildUsageOverviewRealtime(db *gorm.DB, filter dto.UsageQueryFilter, costRe
 			// current usage 的请求数同样包含成功和失败，token 后续只由成功请求累计。
 			applyUsageOverviewRealtimeRequest(realtimeEvent, modelUsage, apiKeyUsage, authFileUsage, aiProviderUsage, identityLookup)
 		}
-		// TTFT 缺失或非正数时不补 0，避免 log 分布和 percentile 被无效样本拉低。
-		if event.TTFTMS != nil && *event.TTFTMS > 0 {
-			bucket.ttftSamples = append(bucket.ttftSamples, usageOverviewRealtimeResponseSample{timestamp: timestamp, ms: *event.TTFTMS})
-		}
-		// Latency 只有正数才作为样本。
-		if event.LatencyMS > 0 {
-			bucket.latencySamples = append(bucket.latencySamples, usageOverviewRealtimeResponseSample{timestamp: timestamp, ms: event.LatencyMS})
+		if !event.Failed {
+			// TTFT 缺失或非正数时不补 0，避免 log 分布和 percentile 被无效样本拉低。
+			if event.TTFTMS != nil && *event.TTFTMS > 0 {
+				bucket.ttftSamples = append(bucket.ttftSamples, usageOverviewRealtimeResponseSample{timestamp: timestamp, ms: *event.TTFTMS})
+			}
+			// Latency 只有成功请求的正数才作为耗时样本，避免失败快速返回污染响应统计。
+			if event.LatencyMS > 0 {
+				bucket.latencySamples = append(bucket.latencySamples, usageOverviewRealtimeResponseSample{timestamp: timestamp, ms: event.LatencyMS})
+			}
 		}
 		// 失败或无 token 的请求不参与 token velocity/cache/current token share。
 		if event.Failed || event.TotalTokens <= 0 {

--- a/internal/repository/usage_filter_test.go
+++ b/internal/repository/usage_filter_test.go
@@ -1326,7 +1326,7 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 		{APIGroupKey: "provider-a", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-1", Timestamp: now.Add(-16 * time.Minute), InputTokens: 900, TotalTokens: 900},
 		{APIGroupKey: "provider-a", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-1", Timestamp: now.Add(-4*time.Minute - 50*time.Second), InputTokens: 100, OutputTokens: 60, CachedTokens: 20, TotalTokens: 120, LatencyMS: 500, TTFTMS: &ttft100},
 		{APIGroupKey: "provider-a", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-1", Timestamp: now.Add(-4*time.Minute - 45*time.Second), InputTokens: 50, OutputTokens: 40, CachedTokens: 5, TotalTokens: 80, LatencyMS: 700, TTFTMS: &ttft200},
-		{APIGroupKey: "provider-a", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-1", Timestamp: now.Add(-4*time.Minute - 40*time.Second), InputTokens: 10, OutputTokens: 10, TotalTokens: 20, LatencyMS: 650, TTFTMS: &ttftZero},
+		{APIGroupKey: "provider-a", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-1", Timestamp: now.Add(-4*time.Minute - 40*time.Second), InputTokens: 10, OutputTokens: 10, TotalTokens: 20, TTFTMS: &ttftZero},
 		{APIGroupKey: "provider-a", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-1", Timestamp: now.Add(-4*time.Minute - 30*time.Second), Failed: true, InputTokens: 1000, TotalTokens: 1000, LatencyMS: 900, TTFTMS: &ttftFailed},
 		{APIGroupKey: "provider-a", Model: "claude-sonnet", AuthType: "apikey", Provider: "OpenAI Provider", AuthIndex: "provider-1", Timestamp: now.Add(-20 * time.Second), InputTokens: 100, OutputTokens: 25, TotalTokens: 50, LatencyMS: 300},
 		{APIGroupKey: "provider-b", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-2", Timestamp: now.Add(-10 * time.Second), InputTokens: 700, TotalTokens: 700, LatencyMS: 100},
@@ -1372,14 +1372,18 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 	if expiredUsageBucket.Tokens != 0 || expiredUsageBucket.TokensPerMinute != 0 {
 		t.Fatalf("expected token velocity to expire after the 3m sliding window, got %+v", expiredUsageBucket)
 	}
-	if realtime.ResponseLevel[21].LatencyP95MS == nil || *realtime.ResponseLevel[21].LatencyP95MS != 700 ||
+	if realtime.ResponseLevel[21].LatencyP50MS == nil || *realtime.ResponseLevel[21].LatencyP50MS != 500 ||
+		realtime.ResponseLevel[21].LatencyP95MS == nil || *realtime.ResponseLevel[21].LatencyP95MS != 700 ||
+		realtime.ResponseLevel[21].TTFTP50MS == nil || *realtime.ResponseLevel[21].TTFTP50MS != 100 ||
 		realtime.ResponseLevel[21].TTFTP95MS == nil || *realtime.ResponseLevel[21].TTFTP95MS != 200 {
 		t.Fatalf("expected response level to exclude failed latency samples from the sliding window, got %+v", realtime.ResponseLevel[21])
 	}
-	if realtime.ResponseLevel[26].LatencyP95MS != nil || realtime.ResponseLevel[26].TTFTP95MS != nil {
+	if realtime.ResponseLevel[26].LatencyP50MS != nil || realtime.ResponseLevel[26].LatencyP95MS != nil ||
+		realtime.ResponseLevel[26].TTFTP50MS != nil || realtime.ResponseLevel[26].TTFTP95MS != nil {
 		t.Fatalf("expected failed request latency samples to be excluded after successful samples expire, got %+v", realtime.ResponseLevel[26])
 	}
-	if realtime.ResponseLevel[27].LatencyP95MS != nil || realtime.ResponseLevel[27].TTFTP95MS != nil {
+	if realtime.ResponseLevel[27].LatencyP50MS != nil || realtime.ResponseLevel[27].LatencyP95MS != nil ||
+		realtime.ResponseLevel[27].TTFTP50MS != nil || realtime.ResponseLevel[27].TTFTP95MS != nil {
 		t.Fatalf("expected response level to expire after the sliding window, got %+v", realtime.ResponseLevel[27])
 	}
 	if len(realtime.ResponseDistribution.TTFT.AverageLine) != 30 || len(realtime.ResponseDistribution.Latency.AverageLine) != 30 {
@@ -1388,7 +1392,7 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 	if realtime.ResponseDistribution.TTFT.AverageLine[21].AvgMS == nil || math.Abs(*realtime.ResponseDistribution.TTFT.AverageLine[21].AvgMS-150) > 0.000000001 {
 		t.Fatalf("expected ttft average line to use sliding samples, got %+v", realtime.ResponseDistribution.TTFT.AverageLine[21])
 	}
-	if realtime.ResponseDistribution.Latency.AverageLine[21].AvgMS == nil || math.Abs(*realtime.ResponseDistribution.Latency.AverageLine[21].AvgMS-(1850.0/3.0)) > 0.000000001 {
+	if realtime.ResponseDistribution.Latency.AverageLine[21].AvgMS == nil || math.Abs(*realtime.ResponseDistribution.Latency.AverageLine[21].AvgMS-600) > 0.000000001 {
 		t.Fatalf("expected latency average line to exclude failed request latency, got %+v", realtime.ResponseDistribution.Latency.AverageLine[21])
 	}
 	if realtime.ResponseDistribution.TTFT.AverageLine[26].AvgMS != nil ||
@@ -1402,17 +1406,15 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 	assertRealtimeParticleCore(t, realtime.ResponseDistribution.TTFT.Particles[1], "2026-06-09T11:55:00Z", 200, 1)
 	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.TTFT.Particles[0], "2026-06-09T11:55:10Z")
 	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.TTFT.Particles[1], "2026-06-09T11:55:15Z")
-	if len(realtime.ResponseDistribution.Latency.Particles) != 4 {
+	if len(realtime.ResponseDistribution.Latency.Particles) != 3 {
 		t.Fatalf("expected response distribution latency particles to map one usage event to one point, got %+v", realtime.ResponseDistribution.Latency.Particles)
 	}
 	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[0], "2026-06-09T11:55:00Z", 500, 1)
 	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[1], "2026-06-09T11:55:00Z", 700, 1)
-	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[2], "2026-06-09T11:55:00Z", 650, 1)
-	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[3], "2026-06-09T11:59:30Z", 300, 1)
+	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[2], "2026-06-09T11:59:30Z", 300, 1)
 	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[0], "2026-06-09T11:55:10Z")
 	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[1], "2026-06-09T11:55:15Z")
-	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[2], "2026-06-09T11:55:20Z")
-	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[3], "2026-06-09T11:59:40Z")
+	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[2], "2026-06-09T11:59:40Z")
 	if realtime.RequestLevel[21].Requests != 4 || math.Abs(realtime.RequestLevel[21].RequestsPerMinute-(4.0/3.0)) > 0.000000001 {
 		t.Fatalf("expected request level to use the 3m sliding window, got %+v", realtime.RequestLevel[21])
 	}

--- a/internal/repository/usage_filter_test.go
+++ b/internal/repository/usage_filter_test.go
@@ -1318,6 +1318,7 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 	now := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
 	ttft100 := int64(100)
 	ttft200 := int64(200)
+	ttftFailed := int64(900)
 	ttftZero := int64(0)
 	cache := newEmptyUsageRecentEventCache(UsageRecentEventCacheOptions{Now: func() time.Time { return now }})
 	t.Cleanup(cache.Close)
@@ -1326,7 +1327,7 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 		{APIGroupKey: "provider-a", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-1", Timestamp: now.Add(-4*time.Minute - 50*time.Second), InputTokens: 100, OutputTokens: 60, CachedTokens: 20, TotalTokens: 120, LatencyMS: 500, TTFTMS: &ttft100},
 		{APIGroupKey: "provider-a", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-1", Timestamp: now.Add(-4*time.Minute - 45*time.Second), InputTokens: 50, OutputTokens: 40, CachedTokens: 5, TotalTokens: 80, LatencyMS: 700, TTFTMS: &ttft200},
 		{APIGroupKey: "provider-a", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-1", Timestamp: now.Add(-4*time.Minute - 40*time.Second), InputTokens: 10, OutputTokens: 10, TotalTokens: 20, LatencyMS: 650, TTFTMS: &ttftZero},
-		{APIGroupKey: "provider-a", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-1", Timestamp: now.Add(-4*time.Minute - 30*time.Second), Failed: true, InputTokens: 1000, TotalTokens: 1000, LatencyMS: 900},
+		{APIGroupKey: "provider-a", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-1", Timestamp: now.Add(-4*time.Minute - 30*time.Second), Failed: true, InputTokens: 1000, TotalTokens: 1000, LatencyMS: 900, TTFTMS: &ttftFailed},
 		{APIGroupKey: "provider-a", Model: "claude-sonnet", AuthType: "apikey", Provider: "OpenAI Provider", AuthIndex: "provider-1", Timestamp: now.Add(-20 * time.Second), InputTokens: 100, OutputTokens: 25, TotalTokens: 50, LatencyMS: 300},
 		{APIGroupKey: "provider-b", Model: "gpt-5", AuthType: "oauth", AuthIndex: "auth-file-2", Timestamp: now.Add(-10 * time.Second), InputTokens: 700, TotalTokens: 700, LatencyMS: 100},
 	})
@@ -1371,12 +1372,12 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 	if expiredUsageBucket.Tokens != 0 || expiredUsageBucket.TokensPerMinute != 0 {
 		t.Fatalf("expected token velocity to expire after the 3m sliding window, got %+v", expiredUsageBucket)
 	}
-	if realtime.ResponseLevel[21].LatencyP95MS == nil || *realtime.ResponseLevel[21].LatencyP95MS != 900 ||
+	if realtime.ResponseLevel[21].LatencyP95MS == nil || *realtime.ResponseLevel[21].LatencyP95MS != 700 ||
 		realtime.ResponseLevel[21].TTFTP95MS == nil || *realtime.ResponseLevel[21].TTFTP95MS != 200 {
-		t.Fatalf("expected response level to carry over the sliding window, got %+v", realtime.ResponseLevel[21])
+		t.Fatalf("expected response level to exclude failed latency samples from the sliding window, got %+v", realtime.ResponseLevel[21])
 	}
-	if realtime.ResponseLevel[26].LatencyP95MS == nil || *realtime.ResponseLevel[26].LatencyP95MS != 900 || realtime.ResponseLevel[26].TTFTP95MS != nil {
-		t.Fatalf("expected failed request latency to remain visible without token TTFT, got %+v", realtime.ResponseLevel[26])
+	if realtime.ResponseLevel[26].LatencyP95MS != nil || realtime.ResponseLevel[26].TTFTP95MS != nil {
+		t.Fatalf("expected failed request latency samples to be excluded after successful samples expire, got %+v", realtime.ResponseLevel[26])
 	}
 	if realtime.ResponseLevel[27].LatencyP95MS != nil || realtime.ResponseLevel[27].TTFTP95MS != nil {
 		t.Fatalf("expected response level to expire after the sliding window, got %+v", realtime.ResponseLevel[27])
@@ -1387,12 +1388,12 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 	if realtime.ResponseDistribution.TTFT.AverageLine[21].AvgMS == nil || math.Abs(*realtime.ResponseDistribution.TTFT.AverageLine[21].AvgMS-150) > 0.000000001 {
 		t.Fatalf("expected ttft average line to use sliding samples, got %+v", realtime.ResponseDistribution.TTFT.AverageLine[21])
 	}
-	if realtime.ResponseDistribution.Latency.AverageLine[21].AvgMS == nil || math.Abs(*realtime.ResponseDistribution.Latency.AverageLine[21].AvgMS-687.5) > 0.000000001 {
-		t.Fatalf("expected latency average line to include failed request latency, got %+v", realtime.ResponseDistribution.Latency.AverageLine[21])
+	if realtime.ResponseDistribution.Latency.AverageLine[21].AvgMS == nil || math.Abs(*realtime.ResponseDistribution.Latency.AverageLine[21].AvgMS-(1850.0/3.0)) > 0.000000001 {
+		t.Fatalf("expected latency average line to exclude failed request latency, got %+v", realtime.ResponseDistribution.Latency.AverageLine[21])
 	}
 	if realtime.ResponseDistribution.TTFT.AverageLine[26].AvgMS != nil ||
-		realtime.ResponseDistribution.Latency.AverageLine[26].AvgMS == nil || math.Abs(*realtime.ResponseDistribution.Latency.AverageLine[26].AvgMS-900) > 0.000000001 {
-		t.Fatalf("expected failed request latency distribution without ttft after sliding carry, got ttft=%+v latency=%+v", realtime.ResponseDistribution.TTFT.AverageLine[26], realtime.ResponseDistribution.Latency.AverageLine[26])
+		realtime.ResponseDistribution.Latency.AverageLine[26].AvgMS != nil {
+		t.Fatalf("expected failed request distribution samples to be excluded after successful samples expire, got ttft=%+v latency=%+v", realtime.ResponseDistribution.TTFT.AverageLine[26], realtime.ResponseDistribution.Latency.AverageLine[26])
 	}
 	if len(realtime.ResponseDistribution.TTFT.Particles) != 2 {
 		t.Fatalf("expected response distribution TTFT particles to map one usage event to one point, got %+v", realtime.ResponseDistribution.TTFT.Particles)
@@ -1401,19 +1402,17 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 	assertRealtimeParticleCore(t, realtime.ResponseDistribution.TTFT.Particles[1], "2026-06-09T11:55:00Z", 200, 1)
 	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.TTFT.Particles[0], "2026-06-09T11:55:10Z")
 	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.TTFT.Particles[1], "2026-06-09T11:55:15Z")
-	if len(realtime.ResponseDistribution.Latency.Particles) != 5 {
+	if len(realtime.ResponseDistribution.Latency.Particles) != 4 {
 		t.Fatalf("expected response distribution latency particles to map one usage event to one point, got %+v", realtime.ResponseDistribution.Latency.Particles)
 	}
 	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[0], "2026-06-09T11:55:00Z", 500, 1)
 	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[1], "2026-06-09T11:55:00Z", 700, 1)
 	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[2], "2026-06-09T11:55:00Z", 650, 1)
-	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[3], "2026-06-09T11:55:30Z", 900, 1)
-	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[4], "2026-06-09T11:59:30Z", 300, 1)
+	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[3], "2026-06-09T11:59:30Z", 300, 1)
 	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[0], "2026-06-09T11:55:10Z")
 	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[1], "2026-06-09T11:55:15Z")
 	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[2], "2026-06-09T11:55:20Z")
-	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[3], "2026-06-09T11:55:30Z")
-	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[4], "2026-06-09T11:59:40Z")
+	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[3], "2026-06-09T11:59:40Z")
 	if realtime.RequestLevel[21].Requests != 4 || math.Abs(realtime.RequestLevel[21].RequestsPerMinute-(4.0/3.0)) > 0.000000001 {
 		t.Fatalf("expected request level to use the 3m sliding window, got %+v", realtime.RequestLevel[21])
 	}

--- a/internal/repository/usage_test.go
+++ b/internal/repository/usage_test.go
@@ -136,6 +136,7 @@ func TestBuildAnalysisWithFilterBuildsLatencyDiagnosticsFromUsageEvents(t *testi
 	ttft300 := int64(300)
 	ttft450 := int64(450)
 	ttft900 := int64(900)
+	ttftFailed := int64(2500)
 	ttftZero := int64(0)
 	ttftOutside := int64(80)
 	ttftOtherKey := int64(700)
@@ -150,6 +151,7 @@ func TestBuildAnalysisWithFilterBuildsLatencyDiagnosticsFromUsageEvents(t *testi
 		{EventKey: "latency-2", APIGroupKey: "sk-target-key", Model: "claude-sonnet", Timestamp: start.Add(10 * time.Minute), LatencyMS: 1600, TTFTMS: &ttft300},
 		{EventKey: "latency-3", APIGroupKey: "sk-target-key", Model: "claude-sonnet", Timestamp: start.Add(20 * time.Minute), LatencyMS: 2300, TTFTMS: &ttft450},
 		{EventKey: "latency-4", APIGroupKey: "sk-target-key", Model: "claude-sonnet", Timestamp: start.Add(30 * time.Minute), LatencyMS: 5000, TTFTMS: &ttft900},
+		{EventKey: "failed-latency", APIGroupKey: "sk-target-key", Model: "claude-sonnet", Timestamp: start.Add(31 * time.Minute), Failed: true, LatencyMS: 20000, TTFTMS: &ttftFailed},
 		{EventKey: "zero-ttft", APIGroupKey: "sk-target-key", Model: "claude-sonnet", Timestamp: start.Add(32 * time.Minute), LatencyMS: 6000, TTFTMS: &ttftZero},
 		{EventKey: "missing-ttft", APIGroupKey: "sk-target-key", Model: "claude-sonnet", Timestamp: start.Add(35 * time.Minute), LatencyMS: 7000},
 		{EventKey: "outside-window", APIGroupKey: "sk-target-key", Model: "claude-sonnet", Timestamp: start.Add(-time.Minute), LatencyMS: 900, TTFTMS: &ttftOutside},

--- a/web/src/components/usage/OverviewRealtimePanel.logic.test.tsx
+++ b/web/src/components/usage/OverviewRealtimePanel.logic.test.tsx
@@ -459,8 +459,8 @@ describe('OverviewRealtimePanel', () => {
         { bucket: '2026-06-09T11:55:30Z', tokens_per_minute: 2000, tokens: 1000 },
       ],
       response_level: [
-        { bucket: '2026-06-09T11:55:00Z', ttft_p95_ms: 700, latency_p95_ms: 1500 },
-        { bucket: '2026-06-09T11:55:30Z', ttft_p95_ms: 900, latency_p95_ms: 2500 },
+        { bucket: '2026-06-09T11:55:00Z', ttft_p95_ms: 7000, latency_p95_ms: 15000 },
+        { bucket: '2026-06-09T11:55:30Z', ttft_p95_ms: 9000, latency_p95_ms: 25000 },
       ],
       response_distribution: {
         ttft: {
@@ -493,8 +493,20 @@ describe('OverviewRealtimePanel', () => {
 
     expect(html).toContain('2.00K/min');
     expect(html).toContain('1.50K/min');
+    expect(html).toContain('900ms');
+    expect(html).toContain('800ms');
     expect(html).toContain('2.5s');
     expect(html).toContain('2s');
+    expect(html).not.toContain('9s');
+    expect(html).not.toContain('25s');
+    expect(chartCapture.chartCalls[0].data.datasets[0].data).toEqual([
+      { x: Date.parse('2026-06-09T11:55:00Z'), y: 700 },
+      { x: Date.parse('2026-06-09T11:55:30Z'), y: 900 },
+    ]);
+    expect(chartCapture.chartCalls[1].data.datasets[0].data).toEqual([
+      { x: Date.parse('2026-06-09T11:55:00Z'), y: 1500 },
+      { x: Date.parse('2026-06-09T11:55:30Z'), y: 2500 },
+    ]);
   });
 
   it('keeps realtime response duration units fixed in non-English locales', async () => {


### PR DESCRIPTION
## Summary
- Exclude failed requests from Analysis latency diagnostics and Realtime TTFT/latency samples.
- Keep Realtime request and failure visibility based on the full recent-event cache.
- Strengthen backend and frontend regression tests for p50/p95 metrics and distribution-card source data.

## Validation
- `rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build go test -count=1 ./internal/repository`
- `rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build go test ./cmd/... ./internal/...`
- `rtk npm --prefix ./web run test -- OverviewRealtimePanel.logic.test.tsx`
- `rtk npm --prefix ./web run build`
- `rtk git diff --check`