### PR TITLE
Improve analysis donut interactions

### DIFF
--- a/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
@@ -277,6 +277,8 @@ describe('AnalysisPanel token chart data', () => {
   it('renders a clean circular usage distribution donut with token-share style rows', () => {
     const analysis: AnalysisResponse = {
       ...emptyAnalysis,
+      range_start: '2026-05-28T00:00:00Z',
+      range_end: '2026-05-28T02:00:00Z',
       api_key_composition: [{
         key: '1',
         label: 'Primary Key',
@@ -339,6 +341,10 @@ describe('AnalysisPanel token chart data', () => {
     expect(markup).toContain('compositionUsageBar');
     expect(markup).toContain('compositionUsageMetaPill');
     expect(markup).toContain('style="width:100%;--composition-bar-color:#1d4ed8"');
+    expect(markup).toContain('usage_stats.rpm');
+    expect(markup).toContain('0.03');
+    expect(markup).toContain('usage_stats.tpm');
+    expect(markup).toContain('8.33');
     expect(markup).not.toContain('<table');
     expect(markup).not.toContain('gpt-4o');
     expect(markup).not.toContain('usage_stats.analysis_model_composition_title');

--- a/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
@@ -461,7 +461,7 @@ describe('AnalysisPanel token chart data', () => {
     expect(chartCapture.doughnutPlugins).toBeUndefined();
   });
 
-  it('limits usage distribution hover to the painted doughnut arc', () => {
+  it('limits usage distribution hover to the doughnut ring while allowing arc edges', () => {
     renderToStaticMarkup(<AnalysisPanel analysis={{
       ...emptyAnalysis,
       api_key_composition: [{
@@ -503,7 +503,7 @@ describe('AnalysisPanel token chart data', () => {
       expect(mode?.({} as never, { x: 225, y: 225 }, {}, false)).toEqual([activeItem]);
       expect(mode?.({} as never, { x: 150, y: 150 }, {}, false)).toEqual([]);
       expect(mode?.({} as never, { x: 300, y: 150 }, {}, false)).toEqual([]);
-      expect(mode?.({} as never, { x: 255, y: 150 }, {}, false)).toEqual([]);
+      expect(mode?.({} as never, { x: 255, y: 150 }, {}, false)).toEqual([activeItem]);
     } finally {
       Interaction.modes.nearest = originalNearest;
     }

--- a/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
@@ -509,6 +509,64 @@ describe('AnalysisPanel token chart data', () => {
     }
   });
 
+  it('falls back to painted full-circle doughnut arcs when Chart.js radial nearest returns no candidates', () => {
+    renderToStaticMarkup(<AnalysisPanel analysis={{
+      ...emptyAnalysis,
+      api_key_composition: [{
+        key: '1',
+        label: 'Primary Key',
+        total_tokens: 1000,
+        requests: 4,
+        percent: 100,
+        input_tokens: 700,
+        output_tokens: 200,
+        cached_tokens: 50,
+        reasoning_tokens: 50,
+        cost_usd: 0.42,
+        cost_available: true,
+      }],
+    }} loading={false} isDark={false} isMobile={false} />);
+
+    const mode = (Interaction.modes as typeof Interaction.modes & {
+      analysisCompositionArc?: (chart: unknown, event: { x: number; y: number }, options: unknown, useFinalPosition?: boolean) => unknown[];
+    }).analysisCompositionArc;
+    expect(typeof mode).toBe('function');
+    const originalNearest = Interaction.modes.nearest;
+    const fullCircleArcElement = {
+      options: { spacing: 4, borderWidth: 0 },
+      getProps: () => ({
+        x: 150,
+        y: 150,
+        innerRadius: 70,
+        outerRadius: 140,
+        startAngle: -Math.PI / 2,
+        endAngle: (Math.PI * 3) / 2,
+        circumference: Math.PI * 2,
+      }),
+    };
+    const fakeChart = {
+      getSortedVisibleDatasetMetas: () => [{
+        type: 'doughnut',
+        index: 0,
+        data: [fullCircleArcElement],
+      }],
+    };
+
+    Interaction.modes.nearest = vi.fn(() => []) as typeof Interaction.modes.nearest;
+
+    try {
+      expect(mode?.(fakeChart as never, { x: 255, y: 150 }, {}, false)).toEqual([{
+        element: fullCircleArcElement,
+        datasetIndex: 0,
+        index: 0,
+      }]);
+      expect(mode?.(fakeChart as never, { x: 150, y: 150 }, {}, false)).toEqual([]);
+      expect(mode?.(fakeChart as never, { x: 300, y: 150 }, {}, false)).toEqual([]);
+    } finally {
+      Interaction.modes.nearest = originalNearest;
+    }
+  });
+
   it('positions the usage distribution tooltip away from the hovered arc', () => {
     renderToStaticMarkup(<AnalysisPanel analysis={{
       ...emptyAnalysis,

--- a/web/src/components/usage/analysis/AnalysisPanel.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.tsx
@@ -5,7 +5,7 @@ import { Interaction, Tooltip } from 'chart.js';
 import type { Chart, ChartData, ChartOptions, InteractionItem, InteractionModeFunction, Plugin, ScriptableContext, TooltipModel, TooltipPositionerFunction } from 'chart.js';
 import { Bar, Doughnut, Scatter } from 'react-chartjs-2';
 import type { AnalysisCompositionItem, AnalysisCostBreakdown, AnalysisHeatmapCell, AnalysisLatencyDiagnostics, AnalysisModelEfficiencyItem, AnalysisResponse, AnalysisTokenUsageBucket } from '@/lib/types';
-import { calculateDisplayInputTokens, calculateDisplayOutputTokens, formatCompactNumber, formatDurationMs, formatUsd } from '@/utils/usage';
+import { calculateDisplayInputTokens, calculateDisplayOutputTokens, formatCompactNumber, formatDurationMs, formatPerMinuteValue, formatUsd } from '@/utils/usage';
 import styles from './AnalysisPanel.module.scss';
 
 interface AnalysisPanelProps {
@@ -782,6 +782,13 @@ function calculateAverageTotalTokens(rows: ChartRow[]): number {
   return rows.reduce((sum, row) => sum + row.total, 0) / rows.length;
 }
 
+function calculateAnalysisWindowMinutes(analysis: AnalysisResponse | null): number | null {
+  const start = Date.parse(String(analysis?.range_start ?? ''));
+  const end = Date.parse(String(analysis?.range_end ?? ''));
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return null;
+  return (end - start) / 60_000;
+}
+
 function takeMajorComposition(items: AnalysisCompositionItem[], othersLabel: string, limit = 5): AnalysisCompositionItem[] {
   if (items.length <= limit) return items;
   const major = items.slice(0, limit);
@@ -1309,7 +1316,12 @@ function CompositionMetaPill({ label, value }: { label: string; value: string })
   );
 }
 
-function CompositionPanel({ tabs, loading, isDark }: { tabs: CompositionTab[]; loading: boolean; isDark: boolean }) {
+const formatCompositionRate = (value: number, windowMinutes: number | null): string => {
+  if (!windowMinutes || windowMinutes <= 0) return '--';
+  return formatPerMinuteValue(value / windowMinutes);
+};
+
+function CompositionPanel({ tabs, loading, isDark, windowMinutes }: { tabs: CompositionTab[]; loading: boolean; isDark: boolean; windowMinutes: number | null }) {
   const { t } = useTranslation();
   const [activeTabId, setActiveTabId] = useState<CompositionTab['id']>('api_key');
   const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? tabs[0];
@@ -1379,6 +1391,8 @@ function CompositionPanel({ tabs, loading, isDark }: { tabs: CompositionTab[]; l
                       <CompositionMetaPill label={t('usage_stats.total_tokens')} value={formatCompactNumber(toNumber(item.total_tokens))} />
                       <CompositionMetaPill label={t('usage_stats.requests_count')} value={formatCompactNumber(toNumber(item.requests))} />
                       <CompositionMetaPill label={t('usage_stats.total_cost')} value={formatUsd(toNumber(item.cost_usd))} />
+                      <CompositionMetaPill label={t('usage_stats.rpm')} value={formatCompositionRate(toNumber(item.requests), windowMinutes)} />
+                      <CompositionMetaPill label={t('usage_stats.tpm')} value={formatCompositionRate(toNumber(item.total_tokens), windowMinutes)} />
                     </div>
                   </div>
                 );
@@ -2020,6 +2034,7 @@ export function AnalysisPanel({ analysis, loading, isDark, isMobile }: AnalysisP
   const modelComposition = useMemo(() => takeMajorComposition(analysis?.model_composition ?? [], t('usage_stats.analysis_others')), [analysis, t]);
   const authFilesComposition = useMemo(() => takeMajorComposition(analysis?.auth_files_composition ?? [], t('usage_stats.analysis_others')), [analysis, t]);
   const aiProviderComposition = useMemo(() => takeMajorComposition(analysis?.ai_provider_composition ?? [], t('usage_stats.analysis_others')), [analysis, t]);
+  const analysisWindowMinutes = useMemo(() => calculateAnalysisWindowMinutes(analysis), [analysis]);
   const compositionTabs = useMemo<CompositionTab[]>(() => [
     { id: 'api_key', label: t('usage_stats.analysis_composition_api_key_tab'), items: apiComposition },
     { id: 'model', label: t('usage_stats.analysis_composition_model_tab'), items: modelComposition },
@@ -2035,7 +2050,7 @@ export function AnalysisPanel({ analysis, loading, isDark, isMobile }: AnalysisP
         <ModelEfficiencyCard rows={analysis?.model_efficiency ?? []} loading={loading} isDark={isDark} isMobile={isMobile} />
       </div>
       <LatencyDiagnosticsCard diagnostics={analysis?.latency_diagnostics} loading={loading} isDark={isDark} isMobile={isMobile} />
-      <CompositionPanel tabs={compositionTabs} loading={loading} isDark={isDark} />
+      <CompositionPanel tabs={compositionTabs} loading={loading} isDark={isDark} windowMinutes={analysisWindowMinutes} />
       <Heatmap cells={analysis?.heatmap?.cells ?? []} apiKeys={analysis?.heatmap?.api_keys ?? []} apiKeyLabels={analysis?.heatmap?.api_key_labels ?? {}} models={analysis?.heatmap?.models ?? []} loading={loading} isDark={isDark} />
     </div>
   );

--- a/web/src/components/usage/analysis/AnalysisPanel.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.tsx
@@ -293,19 +293,10 @@ type DoughnutArcProps = {
 };
 
 type DoughnutArcElement = {
-  options?: {
-    spacing?: unknown;
-    borderWidth?: unknown;
-  };
   getProps: (props: Array<keyof DoughnutArcProps>, useFinalPosition?: boolean) => Partial<DoughnutArcProps>;
 };
 
 const normalizeRadians = (angle: number): number => ((angle % FULL_CIRCLE) + FULL_CIRCLE) % FULL_CIRCLE;
-
-const getRadiansDistance = (first: number, second: number): number => {
-  const distance = Math.abs(normalizeRadians(first) - normalizeRadians(second));
-  return Math.min(distance, FULL_CIRCLE - distance);
-};
 
 const isAngleWithinArc = (angle: number, startAngle: number, endAngle: number, circumference: number): boolean => {
   if (Math.abs(circumference) >= FULL_CIRCLE - 0.0001) return true;
@@ -352,28 +343,13 @@ const isPointerInsidePaintedArc = (item: InteractionItem, event: unknown, useFin
   if (pointerX === undefined || pointerY === undefined) return false;
   const arc = getDoughnutArcProps(item.element, useFinalPosition);
   if (!arc) return false;
-  const { element, props } = arc;
+  const { props } = arc;
   const deltaX = pointerX - props.x;
   const deltaY = pointerY - props.y;
   const radius = Math.hypot(deltaX, deltaY);
   if (radius < props.innerRadius || radius > props.outerRadius) return false;
   const angle = Math.atan2(deltaY, deltaX);
-  if (!isAngleWithinArc(angle, props.startAngle, props.endAngle, props.circumference)) return false;
-  if (Math.abs(props.circumference) >= FULL_CIRCLE - 0.0001) return true;
-
-  const midRadius = (props.innerRadius + props.outerRadius) / 2;
-  if (midRadius <= 0) return true;
-  const spacing = toFiniteNumber(element.options?.spacing) ?? COMPOSITION_DONUT_SPACING;
-  const borderWidth = toFiniteNumber(element.options?.borderWidth) ?? 0;
-  const boundaryPadding = Math.min(
-    Math.abs(props.circumference) / 3,
-    ((spacing + borderWidth) / midRadius) * 1.2,
-  );
-  if (boundaryPadding <= 0) return true;
-
-  // Chart.js 的 nearest 负责小扇区候选；这里只剔除视觉切缝附近未绘制的像素。
-  return getRadiansDistance(angle, props.startAngle) > boundaryPadding
-    && getRadiansDistance(angle, props.endAngle) > boundaryPadding;
+  return isAngleWithinArc(angle, props.startAngle, props.endAngle, props.circumference);
 };
 
 const getFullCircleCompositionItems = (chart: Chart, event: unknown, useFinalPosition?: boolean): InteractionItem[] => {

--- a/web/src/components/usage/analysis/AnalysisPanel.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.tsx
@@ -376,9 +376,30 @@ const isPointerInsidePaintedArc = (item: InteractionItem, event: unknown, useFin
     && getRadiansDistance(angle, props.endAngle) > boundaryPadding;
 };
 
+const getFullCircleCompositionItems = (chart: Chart, event: unknown, useFinalPosition?: boolean): InteractionItem[] => {
+  const items: InteractionItem[] = [];
+  chart.getSortedVisibleDatasetMetas().forEach((meta) => {
+    if (meta.type !== 'doughnut') return;
+    meta.data.forEach((element, index) => {
+      const item = { element, datasetIndex: meta.index, index } as InteractionItem;
+      const arc = getDoughnutArcProps(element, useFinalPosition);
+      if (!arc || Math.abs(arc.props.circumference) < FULL_CIRCLE - 0.0001) return;
+      if (isPointerInsidePaintedArc(item, event, useFinalPosition)) {
+        items.push(item);
+      }
+    });
+  });
+  return items;
+};
+
 const analysisCompositionArcMode: InteractionModeFunction = (chart, event, options, useFinalPosition) => {
   const candidateItems = Interaction.modes.nearest(chart, event, { ...options, axis: 'r', intersect: false }, useFinalPosition);
-  return candidateItems.filter((item) => isPointerInsidePaintedArc(item, event, useFinalPosition));
+  if (candidateItems.length > 0) {
+    return candidateItems.filter((item) => isPointerInsidePaintedArc(item, event, useFinalPosition));
+  }
+
+  // Chart.js 径向 nearest 不把 start/end 归一后相等的 360° 扇区视作 full circle，这里只兜底单扇区候选丢失。
+  return getFullCircleCompositionItems(chart, event, useFinalPosition);
 };
 
 Interaction.modes.analysisCompositionArc = analysisCompositionArcMode;

--- a/web/src/components/usage/analysis/AnalysisPanel.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.tsx
@@ -783,8 +783,8 @@ function calculateAverageTotalTokens(rows: ChartRow[]): number {
 }
 
 function calculateAnalysisWindowMinutes(analysis: AnalysisResponse | null): number | null {
-  const start = Date.parse(String(analysis?.range_start ?? ''));
-  const end = Date.parse(String(analysis?.range_end ?? ''));
+  const start = Date.parse(analysis?.range_start ?? '');
+  const end = Date.parse(analysis?.range_end ?? '');
   if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return null;
   return (end - start) / 60_000;
 }


### PR DESCRIPTION
## Summary
- Restore hover/tooltip hit testing for single full-circle Analysis donuts.
- Make small donut segments easier to hover by allowing ring-edge gap hits while keeping the center hole excluded.
- Add RPM/TPM metrics to Analysis composition rows using the selected Analysis time range.

## Validation
- rtk npm --prefix ./web run test -- AnalysisPanel.logic.test.tsx
- rtk git diff --check
- rtk npm --prefix ./web run lint
- rtk npm --prefix ./web run typecheck
- rtk npm --prefix ./web run build