### PR TITLE
Distinguish OpenAI-compatible provider keys

### DIFF
--- a/internal/helper/test/usage_identity_display_name_test.go
+++ b/internal/helper/test/usage_identity_display_name_test.go
@@ -101,6 +101,21 @@ func TestDisplayNameAppendsMaskedLookupKeyForOpenAICompatibility(t *testing.T) {
 	}
 }
 
+func TestDisplayNameSkipsUnknownLookupKeyForOpenAICompatibility(t *testing.T) {
+	identity := entities.UsageIdentity{
+		Name:      "Fireworks",
+		AuthType:  entities.UsageIdentityAuthTypeAIProvider,
+		Type:      "openai",
+		Provider:  "Fireworks",
+		Identity:  "fireworks-auth-index",
+		LookupKey: " unknown ",
+	}
+
+	if got := helper.UsageIdentityDisplayName(identity); got != "Fireworks" {
+		t.Fatalf("expected openai compatibility displayName to skip unknown lookup key, got %q", got)
+	}
+}
+
 func TestDisplayNameFallsBackWhenOpenAICompatibilityNameIsMissing(t *testing.T) {
 	identity := entities.UsageIdentity{
 		Prefix:   "openrouter",

--- a/internal/helper/test/usage_identity_display_name_test.go
+++ b/internal/helper/test/usage_identity_display_name_test.go
@@ -84,6 +84,23 @@ func TestDisplayNameKeepsOpenAICompatibilityName(t *testing.T) {
 	}
 }
 
+func TestDisplayNameAppendsMaskedLookupKeyForOpenAICompatibility(t *testing.T) {
+	identity := entities.UsageIdentity{
+		Name:      "Fireworks",
+		Prefix:    "fireworks",
+		BaseURL:   "https://api.fireworks.ai/inference/v1",
+		AuthType:  entities.UsageIdentityAuthTypeAIProvider,
+		Type:      "openai",
+		Provider:  "Fireworks",
+		Identity:  "fireworks-auth-index",
+		LookupKey: "fw-abcdefghijklmnopqrstuvwxyz123456",
+	}
+
+	if got := helper.UsageIdentityDisplayName(identity); got != "Fireworks @ fw-*********123456" {
+		t.Fatalf("expected openai compatibility displayName to append masked lookup key, got %q", got)
+	}
+}
+
 func TestDisplayNameFallsBackWhenOpenAICompatibilityNameIsMissing(t *testing.T) {
 	identity := entities.UsageIdentity{
 		Prefix:   "openrouter",

--- a/internal/helper/usage_identity_display_name.go
+++ b/internal/helper/usage_identity_display_name.go
@@ -39,10 +39,15 @@ func UsageIdentityDisplayName(item entities.UsageIdentity) string {
 }
 
 func maskedUsageIdentityLookupKey(value string) string {
-	if strings.TrimSpace(value) == "" {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
 		return ""
 	}
-	return RedactSensitiveValue(value)
+	masked := RedactSensitiveValue(trimmed)
+	if masked == "unknown" {
+		return ""
+	}
+	return masked
 }
 
 func displayQualifiers(values ...string) []string {

--- a/internal/helper/usage_identity_display_name.go
+++ b/internal/helper/usage_identity_display_name.go
@@ -23,6 +23,9 @@ func UsageIdentityDisplayName(item entities.UsageIdentity) string {
 
 	isOpenAICompatible := strings.TrimSpace(item.Type) == "openai"
 	if isOpenAICompatible && name != "" && name != "openai" && provider == name {
+		if lookupKey := maskedUsageIdentityLookupKey(item.LookupKey); lookupKey != "" {
+			return strings.Join(displayQualifiers(name, lookupKey), " @ ")
+		}
 		return name
 	}
 
@@ -33,6 +36,13 @@ func UsageIdentityDisplayName(item entities.UsageIdentity) string {
 		return strings.Join(qualifiers, " @ ")
 	}
 	return name
+}
+
+func maskedUsageIdentityLookupKey(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return ""
+	}
+	return RedactSensitiveValue(value)
 }
 
 func displayQualifiers(values ...string) []string {

--- a/web/src/components/usage/credentials/CredentialSections.module.scss
+++ b/web/src/components/usage/credentials/CredentialSections.module.scss
@@ -1633,10 +1633,10 @@
 }
 
 .authFileCredentialRow {
-  grid-template-columns: 200px minmax(0, 448px) minmax(250px, 1fr);
+  grid-template-columns: 236px minmax(0, 448px) minmax(250px, 1fr);
 
   .credentialIdentityBlock {
-    max-width: 200px;
+    max-width: 236px;
   }
 
   @include tablet {
@@ -1649,10 +1649,10 @@
 }
 
 .aiProviderCredentialRow {
-  grid-template-columns: 200px minmax(0, 448px) minmax(250px, 1fr);
+  grid-template-columns: 236px minmax(0, 448px) minmax(250px, 1fr);
 
   .credentialIdentityBlock {
-    max-width: 200px;
+    max-width: 236px;
   }
 
   @include tablet {

--- a/web/src/components/usage/credentials/test/CredentialSections.styles.test.ts
+++ b/web/src/components/usage/credentials/test/CredentialSections.styles.test.ts
@@ -17,12 +17,12 @@ const cssBlock = (selector: string) => {
 
 describe('Credential section styles', () => {
   it('keeps Auth Files and AI Provider row sizing separate', () => {
-    expect(credentialStyles).toMatch(/\.authFileCredentialRow\s*\{[\s\S]*?grid-template-columns:\s*200px minmax\(0, 448px\) minmax\(250px, 1fr\);/)
-    expect(credentialStyles).toMatch(/\.authFileCredentialRow\s*\{[\s\S]*?\.credentialIdentityBlock\s*\{[\s\S]*?max-width:\s*200px;/)
+    expect(credentialStyles).toMatch(/\.authFileCredentialRow\s*\{[\s\S]*?grid-template-columns:\s*236px minmax\(0, 448px\) minmax\(250px, 1fr\);/)
+    expect(credentialStyles).toMatch(/\.authFileCredentialRow\s*\{[\s\S]*?\.credentialIdentityBlock\s*\{[\s\S]*?max-width:\s*236px;/)
     expect(credentialStyles).toMatch(/\.authFileCredentialRow\s*\{[\s\S]*?@include tablet\s*\{[\s\S]*?grid-template-columns:\s*1fr;/)
     expect(credentialStyles).toMatch(/\.authFileCredentialRow\s*\{[\s\S]*?@include mobile\s*\{[\s\S]*?grid-template-columns:\s*1fr;/)
-    expect(credentialStyles).toMatch(/\.aiProviderCredentialRow\s*\{[\s\S]*?grid-template-columns:\s*200px minmax\(0, 448px\) minmax\(250px, 1fr\);/)
-    expect(credentialStyles).toMatch(/\.aiProviderCredentialRow\s*\{[\s\S]*?\.credentialIdentityBlock\s*\{[\s\S]*?max-width:\s*200px;/)
+    expect(credentialStyles).toMatch(/\.aiProviderCredentialRow\s*\{[\s\S]*?grid-template-columns:\s*236px minmax\(0, 448px\) minmax\(250px, 1fr\);/)
+    expect(credentialStyles).toMatch(/\.aiProviderCredentialRow\s*\{[\s\S]*?\.credentialIdentityBlock\s*\{[\s\S]*?max-width:\s*236px;/)
     expect(credentialStyles).toMatch(/\.aiProviderCredentialRow\s*\{[\s\S]*?@include tablet\s*\{[\s\S]*?grid-template-columns:\s*1fr;/)
     expect(credentialStyles).toMatch(/\.aiProviderCredentialRow\s*\{[\s\S]*?@include mobile\s*\{[\s\S]*?grid-template-columns:\s*1fr;/)
     expect(credentialShellSource).toContain('rowClassName?: string')


### PR DESCRIPTION
## Summary
- Display OpenAI-compatible identities with the provider name plus a masked key when no alias is set.
- Keep the credential name text area at its intended width after the alias edit button.

Fixes #281

## Tests
- `go test ./internal/helper ./internal/helper/test ./internal/api ./internal/repository ./internal/service`
- `npm --prefix ./web run test -- CredentialSections.styles.test.ts`
- `npm --prefix ./web run build`