### PR TITLE
Flatten Analysis heatmap styling

### DIFF
--- a/web/src/components/usage/analysis/AnalysisPanel.module.scss
+++ b/web/src/components/usage/analysis/AnalysisPanel.module.scss
@@ -28,8 +28,8 @@
 }
 
 .heatmapCardDark .analysisChartSurface {
-  background: #100e16;
-  border-color: rgba(255, 255, 255, 0.08);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 .heatmapCardLight .analysisChartSurface {
@@ -724,10 +724,13 @@
 
 .heatmapCardDark {
   .heatmapCorner,
-  .heatmapHeaderCell,
+  .heatmapHeaderCell {
+    border-color: var(--border-color);
+    background: color-mix(in srgb, var(--bg-tertiary) 72%, var(--bg-primary));
+  }
+
   .heatmapCell {
-    border-color: rgba(255, 255, 255, 0.08);
-    background: #17131d;
+    border-color: var(--border-color);
   }
 }
 

--- a/web/src/components/usage/analysis/AnalysisPanel.module.scss
+++ b/web/src/components/usage/analysis/AnalysisPanel.module.scss
@@ -836,7 +836,7 @@
 }
 
 .heatmapCell:focus-visible {
-  box-shadow: 0 0 0 2px color-mix(in srgb, #d86a4a 70%, transparent), inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--heatmap-focus-color, #d86a4a) 70%, transparent), inset 0 0 0 1px rgba(255, 255, 255, 0.12);
 }
 
 .heatmapCellTokenValue {

--- a/web/src/components/usage/analysis/AnalysisPanel.module.scss
+++ b/web/src/components/usage/analysis/AnalysisPanel.module.scss
@@ -820,7 +820,6 @@
 
 .heatmapCell {
   position: relative;
-  overflow: hidden;
   height: 30px;
   min-height: 30px;
   display: flex;
@@ -828,33 +827,13 @@
   justify-content: center;
   padding: 0 4px;
   border-radius: 5px;
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.20),
-    inset 0 -10px 18px rgba(127, 29, 29, 0.18),
-    0 1px 3px rgba(67, 20, 7, 0.10);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.10);
   font-variant-numeric: tabular-nums;
   outline: none;
 }
 
-.heatmapCell::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(circle at 50% 115%, rgba(255, 247, 237, 0.78), rgba(239, 68, 68, 0.30) 34%, rgba(127, 29, 29, 0) 72%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.24), rgba(255, 255, 255, 0) 38%);
-  opacity: var(--heatmap-flame-alpha, 0.35);
-  pointer-events: none;
-}
-
-.heatmapCardDark .heatmapCell::before {
-  background:
-    radial-gradient(circle at 50% 115%, rgba(255, 247, 237, 0.28), rgba(239, 68, 68, 0.50) 36%, rgba(127, 29, 29, 0) 74%),
-    linear-gradient(180deg, rgba(255, 247, 237, 0.10), rgba(255, 247, 237, 0) 42%);
-}
-
 .heatmapCell:focus-visible {
-  box-shadow: 0 0 0 2px color-mix(in srgb, #d86a4a 70%, transparent), inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  box-shadow: 0 0 0 2px color-mix(in srgb, #d86a4a 70%, transparent), inset 0 0 0 1px rgba(255, 255, 255, 0.12);
 }
 
 .heatmapCellTokenValue {

--- a/web/src/components/usage/analysis/AnalysisPanel.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.tsx
@@ -1978,7 +1978,6 @@ function Heatmap({ cells, apiKeys, apiKeyLabels, models, loading, isDark }: { ce
                             style={{
                               background: getHeatmapCellColor(intensity, isDark),
                               color: getHeatmapCellTextColor(intensity, isDark),
-                              '--heatmap-flame-alpha': intensity.toFixed(3),
                             } as CSSProperties}
                             tabIndex={0}
                             aria-label={tooltipLines.join(', ')}

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -400,7 +400,10 @@ describe('UsagePage toolbar styles', () => {
     expect(analysisPanelStyles).toMatch(/\.compositionTabActive\s*\{[\s\S]*?background:\s*color-mix\(in srgb, var\(--bg-primary\) 84%, var\(--bg-secondary\)\);/)
     expect(analysisPanelStyles).not.toMatch(/\.compositionTabActive\s*\{[\s\S]*?#2563eb/)
     expect(analysisPanelStyles).toMatch(/\.heatmapCardLight \.analysisChartSurface\s*\{[\s\S]*?background:\s*color-mix/)
-    expect(analysisPanelStyles).toMatch(/\.heatmapCardDark \.analysisChartSurface\s*\{[\s\S]*?background:\s*#100e16;/)
+    expect(analysisPanelStyles).toMatch(/\.heatmapCardDark \.analysisChartSurface\s*\{[\s\S]*?background:\s*var\(--bg-secondary\);/)
+    expect(analysisPanelStyles).toMatch(/\.heatmapCardDark\s*\{[\s\S]*?\.heatmapCorner,\s*\.heatmapHeaderCell\s*\{[\s\S]*?background:\s*color-mix\(in srgb, var\(--bg-tertiary\) 72%, var\(--bg-primary\)\);/)
+    expect(analysisPanelStyles).not.toContain('#100e16')
+    expect(analysisPanelStyles).not.toContain('#17131d')
     expect(analysisPanelStyles).not.toContain('.heatmapCell::before')
     const heatmapCellBlock = [...analysisPanelStyles.matchAll(/\.heatmapCell\s*\{([\s\S]*?)\n\}/g)]
       .map((match) => match[1])

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -410,6 +410,9 @@ describe('UsagePage toolbar styles', () => {
       .find((block) => block.includes('font-variant-numeric: tabular-nums;')) ?? ''
     expect(heatmapCellBlock).toContain('box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.10);')
     expect(heatmapCellBlock).not.toContain('inset 0 -10px 18px')
+    const heatmapCellFocusBlock = [...analysisPanelStyles.matchAll(/\.heatmapCell:focus-visible\s*\{([\s\S]*?)\n\}/g)]
+      .map((match) => match[1])[0] ?? ''
+    expect(heatmapCellFocusBlock).toContain('box-shadow: 0 0 0 2px color-mix(in srgb, var(--heatmap-focus-color, #d86a4a) 70%, transparent), inset 0 0 0 1px rgba(255, 255, 255, 0.12);')
     expect(analysisPanelStyles).not.toContain('--heatmap-flame-alpha')
     expect(analysisPanelStyles).not.toContain('radial-gradient(circle at 50% 115%')
     expect(analysisPanelStyles).toMatch(/\.heatmapCorner,\s*\.heatmapHeaderCell\s*\{[\s\S]*?min-height:\s*48px;/)

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -401,7 +401,14 @@ describe('UsagePage toolbar styles', () => {
     expect(analysisPanelStyles).not.toMatch(/\.compositionTabActive\s*\{[\s\S]*?#2563eb/)
     expect(analysisPanelStyles).toMatch(/\.heatmapCardLight \.analysisChartSurface\s*\{[\s\S]*?background:\s*color-mix/)
     expect(analysisPanelStyles).toMatch(/\.heatmapCardDark \.analysisChartSurface\s*\{[\s\S]*?background:\s*#100e16;/)
-    expect(analysisPanelStyles).toMatch(/\.heatmapCell::before\s*\{[\s\S]*?radial-gradient\(circle at 50% 115%/)
+    expect(analysisPanelStyles).not.toContain('.heatmapCell::before')
+    const heatmapCellBlock = [...analysisPanelStyles.matchAll(/\.heatmapCell\s*\{([\s\S]*?)\n\}/g)]
+      .map((match) => match[1])
+      .find((block) => block.includes('font-variant-numeric: tabular-nums;')) ?? ''
+    expect(heatmapCellBlock).toContain('box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.10);')
+    expect(heatmapCellBlock).not.toContain('inset 0 -10px 18px')
+    expect(analysisPanelStyles).not.toContain('--heatmap-flame-alpha')
+    expect(analysisPanelStyles).not.toContain('radial-gradient(circle at 50% 115%')
     expect(analysisPanelStyles).toMatch(/\.heatmapCorner,\s*\.heatmapHeaderCell\s*\{[\s\S]*?min-height:\s*48px;/)
     const heatmapRowLabelBlock = [...analysisPanelStyles.matchAll(/\.heatmapRowLabel\s*\{([\s\S]*?)\n\}/g)]
       .map((match) => match[1])


### PR DESCRIPTION
## Summary
- Flatten the Analysis heatmap cells so they match the rest of the dashboard charts
- Align the dark-theme heatmap surface and header colors with the shared chart palette

## Tests
- npm --prefix ./web run test -- UsagePage.styles.test.ts
- npm --prefix ./web run lint
- npm --prefix ./web run typecheck
- npm --prefix ./web run build
- git diff --check