### PR TITLE
Improve model pricing settings ordering and layout

### DIFF
--- a/web/src/components/usage/PriceSettingsCard.tsx
+++ b/web/src/components/usage/PriceSettingsCard.tsx
@@ -20,9 +20,19 @@ const modelNameCollator = new Intl.Collator('en', {
   sensitivity: 'base',
 });
 
-const compareModelNamesDescending = (left: string, right: string): number => (
-  modelNameCollator.compare(formatDisplayName(right), formatDisplayName(left))
-);
+const compareModelNamesDescending = (left: string, right: string): number => {
+  const leftDisplayName = formatDisplayName(left);
+  const rightDisplayName = formatDisplayName(right);
+  const naturalOrder = modelNameCollator.compare(rightDisplayName, leftDisplayName);
+  if (naturalOrder !== 0) return naturalOrder;
+
+  // 自然排序等值时按精确字符串兜底，避免保存与刷新后的顺序随输入来源变化。
+  if (leftDisplayName !== rightDisplayName) {
+    return leftDisplayName > rightDisplayName ? -1 : 1;
+  }
+  if (left === right) return 0;
+  return left > right ? -1 : 1;
+};
 
 export interface PriceSettingsCardProps {
   modelNames: string[];

--- a/web/src/components/usage/PriceSettingsCard.tsx
+++ b/web/src/components/usage/PriceSettingsCard.tsx
@@ -15,6 +15,15 @@ const formatDisplayName = (value: string): string => {
   return normalized;
 };
 
+const modelNameCollator = new Intl.Collator('en', {
+  numeric: true,
+  sensitivity: 'base',
+});
+
+const compareModelNamesDescending = (left: string, right: string): number => (
+  modelNameCollator.compare(formatDisplayName(right), formatDisplayName(left))
+);
+
 export interface PriceSettingsCardProps {
   modelNames: string[];
   modelPrices: Record<string, ModelPrice>;
@@ -235,7 +244,10 @@ export const buildPricingModelOptions = (
 ): SelectOption[] => {
   const configuredModels = new Set(Object.keys(modelPrices));
   const sortedModelNames = [...modelNames]
-    .sort((left, right) => formatDisplayName(left).localeCompare(formatDisplayName(right)));
+    .sort((left, right) => {
+      const configuredOrder = Number(configuredModels.has(left)) - Number(configuredModels.has(right));
+      return configuredOrder || compareModelNamesDescending(left, right);
+    });
 
   return [
     { value: '', label: placeholder },
@@ -513,6 +525,11 @@ export function PriceSettingsCard({
     [modelNames, modelPrices, t]
   );
   const styleOptions = useMemo(() => pricingStyleOptions(t), [t]);
+  const sortedModelPrices = useMemo(
+    () => Object.entries(modelPrices)
+      .sort(([left], [right]) => compareModelNamesDescending(left, right)),
+    [modelPrices]
+  );
   const selectedSyncCount = useMemo(
     () => syncDrafts.filter((draft) => draft.selected).length,
     [syncDrafts]
@@ -552,7 +569,7 @@ export function PriceSettingsCard({
               )}
               <div className={styles.priceForm}>
                 <div className={styles.formRow}>
-                  <div className={styles.formField}>
+                  <div className={`${styles.formField} ${styles.priceFormModelField}`}>
                     <label>{t('usage_stats.model_name')}</label>
                     <Select
                       value={selectedModel}
@@ -634,7 +651,7 @@ export function PriceSettingsCard({
                       className={styles.usagePillControl}
                     />
                   </div>
-                  <Button variant="primary" className={styles.usagePillAction} onClick={() => void handleSavePrice()} disabled={!selectedModel || priceSaving} loading={priceSaving}>
+                  <Button variant="primary" className={`${styles.usagePillAction} ${styles.priceFormAction}`} onClick={() => void handleSavePrice()} disabled={!selectedModel || priceSaving} loading={priceSaving}>
                     {t('common.save')}
                   </Button>
                 </div>
@@ -642,9 +659,9 @@ export function PriceSettingsCard({
 
               <div className={styles.pricesList}>
                 <h4 className={styles.pricesTitle}>{t('usage_stats.saved_prices')}</h4>
-                {Object.keys(modelPrices).length > 0 ? (
+                {sortedModelPrices.length > 0 ? (
                   <div className={styles.pricesGrid}>
-                    {Object.entries(modelPrices).map(([model, price]) => (
+                    {sortedModelPrices.map(([model, price]) => (
                       <div key={model} className={styles.priceItem}>
                         <div className={styles.priceInfo}>
                           <span className={styles.priceModel}>{formatDisplayName(model)}</span>

--- a/web/src/components/usage/test/PriceSettingsCard.test.tsx
+++ b/web/src/components/usage/test/PriceSettingsCard.test.tsx
@@ -143,6 +143,35 @@ describe('PriceSettingsCard', () => {
     expect(renderedOrder).toEqual([...renderedOrder].sort((left, right) => left - right));
   });
 
+  it('uses an exact-name tie-break for naturally equivalent saved model names', () => {
+    const prices = Object.fromEntries([
+      'gpt-02',
+      'GPT-2',
+      'gpt-2',
+    ].map((model, index) => [model, {
+      style: 'openai' as const,
+      prompt: index + 1,
+      completion: index + 2,
+      cacheRead: 0,
+      cacheWrite: 0,
+      multiplier: 1,
+    }]));
+    const html = renderToStaticMarkup(
+      <PriceSettingsCard
+        modelNames={[]}
+        modelPrices={prices}
+        onPriceSave={() => undefined}
+        onPriceDelete={() => undefined}
+        loading={false}
+      />,
+    );
+    const renderedOrder = ['gpt-2', 'gpt-02', 'GPT-2']
+      .map((model) => html.indexOf(`>${model}</span>`));
+
+    expect(renderedOrder.every((index) => index >= 0)).toBe(true);
+    expect(renderedOrder).toEqual([...renderedOrder].sort((left, right) => left - right));
+  });
+
 	it('shows cache read and write controls for OpenAI create, edit and sync drafts', () => {
 		const html = renderToStaticMarkup(
 			<PriceSettingsCard
@@ -489,5 +518,20 @@ describe('buildPricingModelOptions', () => {
     expect(options.find((option) => option.value === 'gpt-5.9')?.suffix).toBeTruthy();
     expect(options.find((option) => option.value === 'gpt-5.10')?.suffix).toBeUndefined();
     expect(options.find((option) => option.value === 'gpt-5.10')?.disabled).toBeUndefined();
+  });
+
+  it('uses an exact-name tie-break when natural model names compare equally', () => {
+    const options = buildPricingModelOptions(
+      ['gpt-02', 'GPT-2', 'gpt-2'],
+      {},
+      'Select model',
+    );
+
+    expect(options.map((option) => option.value)).toEqual([
+      '',
+      'gpt-2',
+      'gpt-02',
+      'GPT-2',
+    ]);
   });
 });

--- a/web/src/components/usage/test/PriceSettingsCard.test.tsx
+++ b/web/src/components/usage/test/PriceSettingsCard.test.tsx
@@ -107,6 +107,42 @@ describe('PriceSettingsCard', () => {
 		expect(html).toContain('$3.1250/1M');
 	});
 
+  it('renders saved model prices in natural descending model-name order', () => {
+    const prices = Object.fromEntries([
+      'gpt-5.5',
+      'gpt-5.6-sol',
+      'gpt-5.10',
+      'gpt-5.6-terra',
+      'gpt-5.9',
+    ].map((model, index) => [model, {
+      style: 'openai' as const,
+      prompt: index + 1,
+      completion: index + 2,
+      cacheRead: 0,
+      cacheWrite: 0,
+      multiplier: 1,
+    }]));
+    const html = renderToStaticMarkup(
+      <PriceSettingsCard
+        modelNames={[]}
+        modelPrices={prices}
+        onPriceSave={() => undefined}
+        onPriceDelete={() => undefined}
+        loading={false}
+      />,
+    );
+    const renderedOrder = [
+      'gpt-5.10',
+      'gpt-5.9',
+      'gpt-5.6-terra',
+      'gpt-5.6-sol',
+      'gpt-5.5',
+    ].map((model) => html.indexOf(`>${model}</span>`));
+
+    expect(renderedOrder.every((index) => index >= 0)).toBe(true);
+    expect(renderedOrder).toEqual([...renderedOrder].sort((left, right) => left - right));
+  });
+
 	it('shows cache read and write controls for OpenAI create, edit and sync drafts', () => {
 		const html = renderToStaticMarkup(
 			<PriceSettingsCard
@@ -427,12 +463,12 @@ describe('PriceSettingsCard', () => {
 });
 
 describe('buildPricingModelOptions', () => {
-  it('keeps configured models visible but disabled', () => {
+  it('groups unconfigured models first and naturally sorts both groups descending', () => {
     const options = buildPricingModelOptions(
-      ['priced-zeta', 'unpriced-beta', 'priced-alpha', 'unpriced-alpha'],
+      ['gpt-5.5', 'gpt-5.6-sol', 'gpt-5.10', 'gpt-5.6-terra', 'gpt-5.9'],
       {
-        'priced-zeta': { style: 'openai', prompt: 3, completion: 15, cacheRead: 0.3, cacheWrite: 0, multiplier: 1 },
-        'priced-alpha': { style: 'openai', prompt: 2, completion: 8, cacheRead: 0.2, cacheWrite: 0, multiplier: 1 },
+        'gpt-5.9': { style: 'openai', prompt: 3, completion: 15, cacheRead: 0.3, cacheWrite: 0, multiplier: 1 },
+        'gpt-5.5': { style: 'openai', prompt: 2, completion: 8, cacheRead: 0.2, cacheWrite: 0, multiplier: 1 },
       },
       'Select model',
       'Configured',
@@ -440,17 +476,18 @@ describe('buildPricingModelOptions', () => {
 
     expect(options.map((option) => option.value)).toEqual([
       '',
-      'priced-alpha',
-      'priced-zeta',
-      'unpriced-alpha',
-      'unpriced-beta',
+      'gpt-5.10',
+      'gpt-5.6-terra',
+      'gpt-5.6-sol',
+      'gpt-5.9',
+      'gpt-5.5',
     ]);
-    expect(options.find((option) => option.value === 'priced-alpha')).toMatchObject({
+    expect(options.find((option) => option.value === 'gpt-5.9')).toMatchObject({
       disabled: true,
       suffixAriaLabel: 'Configured',
     });
-    expect(options.find((option) => option.value === 'priced-alpha')?.suffix).toBeTruthy();
-    expect(options.find((option) => option.value === 'unpriced-alpha')?.suffix).toBeUndefined();
-    expect(options.find((option) => option.value === 'unpriced-alpha')?.disabled).toBeUndefined();
+    expect(options.find((option) => option.value === 'gpt-5.9')?.suffix).toBeTruthy();
+    expect(options.find((option) => option.value === 'gpt-5.10')?.suffix).toBeUndefined();
+    expect(options.find((option) => option.value === 'gpt-5.10')?.disabled).toBeUndefined();
   });
 });

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -1893,21 +1893,18 @@
   border-radius: 22px;
   border: 1px solid var(--border-color);
   flex: 0 0 auto;
+  container-name: model-pricing-form;
+  container-type: inline-size;
 }
 
 .formRow {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(180px, 1.4fr) minmax(130px, 0.85fr) repeat(5, minmax(120px, 1fr)) auto;
   gap: 10px;
   align-items: flex-end;
-  flex-wrap: wrap;
 
   :global(.btn) {
     min-height: 40px;
-  }
-
-  @include mobile {
-    flex-direction: column;
-    align-items: stretch;
   }
 }
 
@@ -1945,6 +1942,34 @@
   > button,
   :global(.btn) {
     min-height: 40px;
+  }
+}
+
+.priceFormAction {
+  align-self: end;
+  justify-self: stretch;
+}
+
+@container model-pricing-form (max-width: 1120px) {
+  .formRow {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@container model-pricing-form (max-width: 720px) {
+  .formRow {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .priceFormModelField,
+  .priceFormAction {
+    grid-column: 1 / -1;
+  }
+}
+
+@container model-pricing-form (max-width: 480px) {
+  .formRow {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -347,6 +347,18 @@ describe('UsagePage toolbar styles', () => {
     expect(pricingGridBlock).not.toMatch(/@include mobile\s*\{[\s\S]*?overflow:\s*visible;/)
   })
 
+  it('reflows the model pricing form from four to two to one column based on its container width', () => {
+    expect(priceSettingsSource).toContain('className={`${styles.formField} ${styles.priceFormModelField}`}')
+    expect(priceSettingsSource).toContain('className={`${styles.usagePillAction} ${styles.priceFormAction}`}')
+    expect(usagePageStyles).toMatch(/\.priceForm\s*\{[\s\S]*?container-name:\s*model-pricing-form;/)
+    expect(usagePageStyles).toMatch(/\.priceForm\s*\{[\s\S]*?container-type:\s*inline-size;/)
+    expect(usagePageStyles).toMatch(/\.formRow\s*\{[\s\S]*?display:\s*grid;/)
+    expect(usagePageStyles).toMatch(/\.formRow\s*\{[\s\S]*?grid-template-columns:\s*minmax\(180px, 1\.4fr\) minmax\(130px, 0\.85fr\) repeat\(5, minmax\(120px, 1fr\)\) auto;/)
+    expect(usagePageStyles).toMatch(/@container model-pricing-form \(max-width:\s*1120px\)\s*\{[\s\S]*?grid-template-columns:\s*repeat\(4, minmax\(0, 1fr\)\);/)
+    expect(usagePageStyles).toMatch(/@container model-pricing-form \(max-width:\s*720px\)\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2, minmax\(0, 1fr\)\);[\s\S]*?\.priceFormModelField,[\s\S]*?\.priceFormAction\s*\{[\s\S]*?grid-column:\s*1 \/ -1;/)
+    expect(usagePageStyles).toMatch(/@container model-pricing-form \(max-width:\s*480px\)\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\);/)
+  })
+
   it('keeps the Analysis chart presentation aligned with the redesigned Analysis dashboard', () => {
     expect(analysisPanelSource).toContain("t('usage_stats.analysis_token_usage_title')")
     expect(analysisPanelSource).toContain("t('usage_stats.analysis_token_usage_subtitle')")


### PR DESCRIPTION
## Summary

- group unconfigured pricing models before configured models and sort both groups in deterministic natural descending order
- sort saved model prices with the same ordering while preserving configured-option disabled and check states
- reflow the model pricing entry form based on its container width at wide, four-column, two-column, and single-column breakpoints
- leave Models.dev synchronization and pricing persistence behavior unchanged

## Validation

- `rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build make verify`
- local built-frontend preview of Model Pricing Settings
