### PR TITLE
Restore usage toolbar animation and card shadows

### DIFF
--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -458,6 +458,55 @@
   }
 }
 
+.toolbarActionsRightAnimated {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+}
+
+.usageFilterTransition {
+  width: max-content;
+  max-width: 0;
+  min-width: 0;
+  justify-self: end;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(8px);
+  transition:
+    max-width 340ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 260ms ease,
+    transform 340ms cubic-bezier(0.22, 1, 0.36, 1),
+    margin-bottom 340ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.usageFilterTransitionOpen {
+  max-width: 960px;
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(0);
+}
+
+.usageFilterTransitionInner {
+  width: max-content;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+// CPAMC 保留既有即时挂载布局；动画与 Grid 隔离只应用于普通 Keeper 页面。
+.usageFilterTransitionImmediate {
+  display: contents;
+  opacity: 1;
+  pointer-events: auto;
+  transform: none;
+  transition: none;
+}
+
+.usageFilterTransitionImmediate .usageFilterTransitionInner {
+  display: contents;
+}
+
 .lastRefreshed {
   font-size: 11px;
   color: var(--text-tertiary);
@@ -863,6 +912,21 @@
     width: 100%;
   }
 
+  .toolbarActionsRightAnimated {
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: 0;
+  }
+
+  .usageFilterTransition,
+  .usageFilterTransitionInner {
+    width: 100%;
+  }
+
+  .toolbarActionsRightAnimated .usageFilterTransitionOpen {
+    max-width: 100%;
+    margin-bottom: 10px;
+  }
+
   .usageFilterBar {
     display: grid;
     grid-template-columns: minmax(0, 1fr);
@@ -975,11 +1039,16 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .usageFilterTransition,
   .usageFilterBar,
   .timeRangeGroup,
   .customRangeInline,
   .dailyAveragePanel {
     transition: none;
+  }
+
+  .usageFilterTransition {
+    transform: none;
   }
 
   .dailyAveragePanelEntering,

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -922,8 +922,19 @@
     width: 100%;
   }
 
+  .toolbarActionsRightAnimated .usageFilterTransition {
+    max-height: 0;
+    transition:
+      max-width 340ms cubic-bezier(0.22, 1, 0.36, 1),
+      max-height 340ms cubic-bezier(0.22, 1, 0.36, 1),
+      opacity 260ms ease,
+      transform 340ms cubic-bezier(0.22, 1, 0.36, 1),
+      margin-bottom 340ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
   .toolbarActionsRightAnimated .usageFilterTransitionOpen {
     max-width: 100%;
+    max-height: 280px;
     margin-bottom: 10px;
   }
 

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -1921,6 +1921,10 @@
   --settings-list-scroll-height: 480px;
 }
 
+.settingsSections > :global(.card) {
+  box-shadow: var(--shadow-lg);
+}
+
 // Pricing Section (80%比例)
 .pricingFixedCard {
   height: auto;
@@ -2746,6 +2750,7 @@
 .requestEventsCard:global(.card) {
   padding: 0;
   overflow: hidden;
+  box-shadow: var(--shadow-lg);
 
   :global(.card-header) {
     align-items: stretch;

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -2009,9 +2009,16 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                 ))}
               </div>
 
-              <div className={styles.toolbarActionsRight}>
-                {showRangeControls && (
-                  <div className={styles.usageFilterBar}>
+              <div className={`${styles.toolbarActionsRight} ${!isEmbeddedInCPAMC ? styles.toolbarActionsRightAnimated : ''}`.trim()}>
+                {/* 普通模式保留筛选区节点以执行过渡；CPAMC 继续按需挂载，维持既有布局。 */}
+                {(!isEmbeddedInCPAMC || showRangeControls) && (
+                  <div
+                    className={`${styles.usageFilterTransition} ${isEmbeddedInCPAMC ? styles.usageFilterTransitionImmediate : ''} ${showRangeControls ? styles.usageFilterTransitionOpen : ''}`.trim()}
+                    aria-hidden={!showRangeControls}
+                    inert={!showRangeControls}
+                  >
+                    <div className={styles.usageFilterTransitionInner}>
+                      <div className={styles.usageFilterBar}>
                     <div className={styles.apiKeyFilterGroup}>
                     <label className={`${styles.usageFilterField} ${styles.apiKeyFilterField}`.trim()}>
                       <span className={styles.usageFilterLabel}>{t('usage_stats.api_key_filter')}</span>
@@ -2109,6 +2116,8 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                     {isCustomRange && customRangeError && (
                       <span className={styles.customRangeError}>{customRangeError}</span>
                     )}
+                      </div>
+                    </div>
                   </div>
                 )}
                 <div className={styles.usageRefreshSlot}>

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -172,6 +172,11 @@ describe('UsagePage toolbar styles', () => {
     expect(usagePageStyles).toMatch(/\.usageFilterTransitionImmediate\s+\.usageFilterTransitionInner\s*\{[\s\S]*?display:\s*contents;/)
   })
 
+  it('gives Request Events and Settings cards page-level elevation', () => {
+    expect(styleRuleBlock(usagePageStyles, '.requestEventsCard:global(.card)')).toContain('box-shadow: var(--shadow-lg);')
+    expect(styleRuleBlock(usagePageStyles, '.settingsSections > :global(.card)')).toContain('box-shadow: var(--shadow-lg);')
+  })
+
   it('does not reload Request Events filter options for table query changes', () => {
     const filterOptionsEffect = usagePageEffectBlock('void loadEventFilterOptions();')
     const eventsEffect = usagePageEffectBlock('void loadEvents();')

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -166,6 +166,18 @@ describe('UsagePage toolbar styles', () => {
     expect(usagePageStyles).toMatch(/@include mobile\s*\{[\s\S]*?\.usageFilterTransitionOpen\s*\{[\s\S]*?max-width:\s*100%;/)
   })
 
+  it('collapses the mobile filter height with the historical transition timing', () => {
+    const reducedMotionStart = usagePageStyles.indexOf('@media (prefers-reduced-motion: reduce)')
+    const mobileStart = usagePageStyles.lastIndexOf('@include mobile {', reducedMotionStart)
+    const mobileStyles = usagePageStyles.slice(mobileStart, reducedMotionStart)
+    const transitionBlock = mobileStyles.match(/\.toolbarActionsRightAnimated \.usageFilterTransition\s*\{([^}]*)\}/)?.[1] ?? ''
+    const openBlock = mobileStyles.match(/\.toolbarActionsRightAnimated \.usageFilterTransitionOpen\s*\{([^}]*)\}/)?.[1] ?? ''
+
+    expect(transitionBlock).toContain('max-height: 0;')
+    expect(transitionBlock).toContain('max-height 340ms cubic-bezier(0.22, 1, 0.36, 1)')
+    expect(openBlock).toContain('max-height: 280px;')
+  })
+
   it('keeps CPAMC range controls on the immediate toolbar layout path', () => {
     expect(usagePageSource).toContain('isEmbeddedInCPAMC ? styles.usageFilterTransitionImmediate')
     expect(usagePageStyles).toMatch(/\.usageFilterTransitionImmediate\s*\{[\s\S]*?display:\s*contents;/)

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -143,11 +143,33 @@ describe('UsagePage toolbar styles', () => {
     expect(i18nSource).not.toContain('overview_realtime_latency_p95')
   })
 
-  it('keeps refresh controls outside the query filter layout', () => {
-    expect(usagePageSource).toContain('{showRangeControls && (\n                  <div className={styles.usageFilterBar}>')
+  it('keeps normal-mode range controls mounted in a stable transition slot', () => {
+    expect(usagePageSource).toContain("${!isEmbeddedInCPAMC ? styles.toolbarActionsRightAnimated : ''}")
+    expect(usagePageSource).toContain('{(!isEmbeddedInCPAMC || showRangeControls) && (')
+    expect(usagePageSource).toContain('showRangeControls ? styles.usageFilterTransitionOpen : \'\'')
+    expect(usagePageSource).toContain('inert={!showRangeControls}')
+    expect(usagePageSource).toContain('<div className={styles.usageFilterBar}>')
+    expect(usagePageSource).not.toContain("key={showRangeControls ? 'open' : 'closed'}")
     expect(usagePageSource).toContain('className={styles.usageRefreshSlot}')
-    expect(usagePageSource).not.toContain('styles.usageFilterBarCollapsed')
+    expect(usagePageStyles).toMatch(/\.toolbarActionsRightAnimated\s*\{[\s\S]*?display:\s*grid;/)
+    expect(usagePageStyles).toMatch(/\.toolbarActionsRightAnimated\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) auto;/)
+    expect(usagePageStyles).toMatch(/\.usageFilterTransition\s*\{[\s\S]*?max-width:\s*0;/)
+    expect(usagePageStyles).toMatch(/\.usageFilterTransition\s*\{[\s\S]*?transform:\s*translateX\(8px\);/)
+    expect(usagePageStyles).toMatch(/\.usageFilterTransition\s*\{[\s\S]*?max-width 340ms cubic-bezier\(0\.22, 1, 0\.36, 1\)/)
+    expect(usagePageStyles).toMatch(/\.usageFilterTransition\s*\{[\s\S]*?opacity 260ms ease/)
+    expect(usagePageStyles).toMatch(/\.usageFilterTransitionOpen\s*\{[\s\S]*?max-width:\s*960px;/)
+    expect(usagePageStyles).toMatch(/\.usageFilterTransitionOpen\s*\{[\s\S]*?transform:\s*translateX\(0\);/)
+    expect(usagePageStyles).toMatch(/\.usageFilterTransitionInner\s*\{[\s\S]*?overflow:\s*hidden;/)
+    expect(usagePageStyles).toMatch(/\.usageFilterTransitionInner\s*\{[\s\S]*?width:\s*max-content;/)
     expect(usagePageStyles).toMatch(/\.usageRefreshSlot\s*\{[\s\S]*?flex:\s*0 0 auto;/)
+    expect(usagePageStyles).toMatch(/@include mobile\s*\{[\s\S]*?\.usageFilterTransition,\s*\.usageFilterTransitionInner\s*\{[\s\S]*?width:\s*100%;/)
+    expect(usagePageStyles).toMatch(/@include mobile\s*\{[\s\S]*?\.usageFilterTransitionOpen\s*\{[\s\S]*?max-width:\s*100%;/)
+  })
+
+  it('keeps CPAMC range controls on the immediate toolbar layout path', () => {
+    expect(usagePageSource).toContain('isEmbeddedInCPAMC ? styles.usageFilterTransitionImmediate')
+    expect(usagePageStyles).toMatch(/\.usageFilterTransitionImmediate\s*\{[\s\S]*?display:\s*contents;/)
+    expect(usagePageStyles).toMatch(/\.usageFilterTransitionImmediate\s+\.usageFilterTransitionInner\s*\{[\s\S]*?display:\s*contents;/)
   })
 
   it('does not reload Request Events filter options for table query changes', () => {


### PR DESCRIPTION
## Summary

- restore the API Key and Range toolbar transition with the historical horizontal timing
- keep refresh controls stable while preserving CPAMC and mobile behavior
- add page-level shadows to Request Events and Settings cards

## Validation

- rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build make verify