### PR TITLE
Align realtime response distribution sample validation

### DIFF
--- a/internal/repository/test/usage_overview_realtime_response_distribution_test.go
+++ b/internal/repository/test/usage_overview_realtime_response_distribution_test.go
@@ -1,0 +1,62 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+	repodto "cpa-usage-keeper/internal/repository/dto"
+)
+
+func TestBuildUsageOverviewRealtimeWithFilterRequiresValidTTFTAndLatencyForBothDistributions(t *testing.T) {
+	db := openTestDatabase(t)
+	now := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	validTTFT := int64(100)
+	zeroTTFT := int64(0)
+	ttftWithoutLatency := int64(200)
+
+	if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{
+		{EventKey: "valid-response", Timestamp: now.Add(-4 * time.Minute), LatencyMS: 500, TTFTMS: &validTTFT},
+		{EventKey: "zero-ttft", Timestamp: now.Add(-3 * time.Minute), LatencyMS: 600, TTFTMS: &zeroTTFT},
+		{EventKey: "zero-latency", Timestamp: now.Add(-2 * time.Minute), LatencyMS: 0, TTFTMS: &ttftWithoutLatency},
+		{EventKey: "missing-ttft", Timestamp: now.Add(-time.Minute), LatencyMS: 700},
+	}); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+
+	realtime, err := repository.BuildUsageOverviewRealtimeWithFilter(db, repodto.UsageQueryFilter{
+		RealtimeWindow:  "15m",
+		RealtimeEndTime: &now,
+	})
+	if err != nil {
+		t.Fatalf("BuildUsageOverviewRealtimeWithFilter returned error: %v", err)
+	}
+
+	assertRealtimeResponseDistributionUsesOnlyValidPairs(t, realtime.ResponseDistribution.TTFT, 100)
+	assertRealtimeResponseDistributionUsesOnlyValidPairs(t, realtime.ResponseDistribution.Latency, 500)
+}
+
+func assertRealtimeResponseDistributionUsesOnlyValidPairs(t *testing.T, series repodto.RealtimeResponseDistributionSeriesRecord, wantMS int64) {
+	t.Helper()
+	if series.TotalParticles != 1 || len(series.Particles) != 1 {
+		t.Fatalf("expected one valid response sample, got total=%d particles=%+v", series.TotalParticles, series.Particles)
+	}
+	if series.Particles[0].MS != wantMS {
+		t.Fatalf("expected valid response sample %dms, got %+v", wantMS, series.Particles[0])
+	}
+
+	nonEmptyAveragePoints := 0
+	for _, point := range series.AverageLine {
+		if point.AvgMS == nil {
+			continue
+		}
+		nonEmptyAveragePoints++
+		if *point.AvgMS != float64(wantMS) {
+			t.Fatalf("expected average line to use only %dms samples, got %+v", wantMS, point)
+		}
+	}
+	if nonEmptyAveragePoints == 0 {
+		t.Fatal("expected average line to contain the valid response sample")
+	}
+}

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -1736,15 +1736,10 @@ func buildUsageOverviewRealtime(db *gorm.DB, filter dto.UsageQueryFilter, costRe
 			// current usage 的请求数同样包含成功和失败，token 后续只由成功请求累计。
 			applyUsageOverviewRealtimeRequest(realtimeEvent, modelUsage, apiKeyUsage, authFileUsage, aiProviderUsage, identityLookup)
 		}
-		if !event.Failed {
-			// TTFT 缺失或非正数时不补 0，避免 log 分布和 percentile 被无效样本拉低。
-			if event.TTFTMS != nil && *event.TTFTMS > 0 {
-				bucket.ttftSamples = append(bucket.ttftSamples, usageOverviewRealtimeResponseSample{timestamp: timestamp, ms: *event.TTFTMS})
-			}
-			// Latency 只有成功请求的正数才作为耗时样本，避免失败快速返回污染响应统计。
-			if event.LatencyMS > 0 {
-				bucket.latencySamples = append(bucket.latencySamples, usageOverviewRealtimeResponseSample{timestamp: timestamp, ms: event.LatencyMS})
-			}
+		if !event.Failed && event.TTFTMS != nil && *event.TTFTMS > 0 && event.LatencyMS > 0 {
+			// TTFT 和 Latency 共用同一有效请求样本，避免两张响应分布图的统计口径不一致。
+			bucket.ttftSamples = append(bucket.ttftSamples, usageOverviewRealtimeResponseSample{timestamp: timestamp, ms: *event.TTFTMS})
+			bucket.latencySamples = append(bucket.latencySamples, usageOverviewRealtimeResponseSample{timestamp: timestamp, ms: event.LatencyMS})
 		}
 		// 失败或无 token 的请求不参与 token velocity/cache/current token share。
 		if event.Failed || event.TotalTokens <= 0 {

--- a/internal/repository/usage_filter_test.go
+++ b/internal/repository/usage_filter_test.go
@@ -1406,15 +1406,13 @@ func TestBuildUsageOverviewRealtimeWithFilterBuildsRealtimeBlockFromRecentCache(
 	assertRealtimeParticleCore(t, realtime.ResponseDistribution.TTFT.Particles[1], "2026-06-09T11:55:00Z", 200, 1)
 	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.TTFT.Particles[0], "2026-06-09T11:55:10Z")
 	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.TTFT.Particles[1], "2026-06-09T11:55:15Z")
-	if len(realtime.ResponseDistribution.Latency.Particles) != 3 {
-		t.Fatalf("expected response distribution latency particles to map one usage event to one point, got %+v", realtime.ResponseDistribution.Latency.Particles)
+	if len(realtime.ResponseDistribution.Latency.Particles) != 2 {
+		t.Fatalf("expected response distribution latency particles to include only valid TTFT/latency pairs, got %+v", realtime.ResponseDistribution.Latency.Particles)
 	}
 	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[0], "2026-06-09T11:55:00Z", 500, 1)
 	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[1], "2026-06-09T11:55:00Z", 700, 1)
-	assertRealtimeParticleCore(t, realtime.ResponseDistribution.Latency.Particles[2], "2026-06-09T11:59:30Z", 300, 1)
 	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[0], "2026-06-09T11:55:10Z")
 	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[1], "2026-06-09T11:55:15Z")
-	assertRealtimeParticleTimestamp(t, realtime.ResponseDistribution.Latency.Particles[2], "2026-06-09T11:59:40Z")
 	if realtime.RequestLevel[21].Requests != 4 || math.Abs(realtime.RequestLevel[21].RequestsPerMinute-(4.0/3.0)) > 0.000000001 {
 		t.Fatalf("expected request level to use the 3m sliding window, got %+v", realtime.RequestLevel[21])
 	}


### PR DESCRIPTION
## Summary

- require successful requests to have both positive TTFT and latency before either realtime distribution records the sample
- keep TTFT and latency averages, percentiles, and particles on the same request set
- add regression coverage for zero and missing response timing values

## Testing

- `rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build make verify`