### PR TITLE
Support xAI weekly and monthly quotas

### DIFF
--- a/internal/cpa/dto/authfiles/auth_files.go
+++ b/internal/cpa/dto/authfiles/auth_files.go
@@ -1,6 +1,13 @@
 package authfiles
 
-import "time"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+)
 
 // AuthFilesResponse 是 CPA /management/auth-files 响应 DTO。
 type AuthFilesResponse struct {
@@ -9,24 +16,79 @@ type AuthFilesResponse struct {
 
 // AuthFile 是 CPA /management/auth-files 中单个 auth file 的原始响应 DTO。
 type AuthFile struct {
-	AuthIndex   string           `json:"auth_index"`
-	Name        string           `json:"name"`
-	Path        string           `json:"path"`
-	Email       string           `json:"email"`
-	Type        string           `json:"type"`
-	Provider    string           `json:"provider"`
-	Label       string           `json:"label"`
-	Status      string           `json:"status"`
-	Source      string           `json:"source"`
-	Prefix      string           `json:"prefix"`
-	Priority    *int             `json:"priority"`
-	Disabled    *bool            `json:"disabled"`
-	Note        *string          `json:"note"`
-	Unavailable bool             `json:"unavailable"`
-	RuntimeOnly bool             `json:"runtime_only"`
-	Account     string           `json:"account,omitempty"`
-	ProjectID   string           `json:"project_id,omitempty"`
-	IDToken     *AuthFileIDToken `json:"id_token"`
+	AuthIndex   string                  `json:"auth_index"`
+	Name        string                  `json:"name"`
+	Path        string                  `json:"path"`
+	Email       string                  `json:"email"`
+	Type        string                  `json:"type"`
+	Provider    string                  `json:"provider"`
+	Label       string                  `json:"label"`
+	Status      string                  `json:"status"`
+	Source      string                  `json:"source"`
+	Prefix      string                  `json:"prefix"`
+	Priority    *int                    `json:"priority"`
+	Disabled    *bool                   `json:"disabled"`
+	Note        *string                 `json:"note"`
+	Unavailable bool                    `json:"unavailable"`
+	RuntimeOnly bool                    `json:"runtime_only"`
+	Account     string                  `json:"account,omitempty"`
+	ProjectID   string                  `json:"project_id,omitempty"`
+	Sub         *AuthFileXAIUserIDValue `json:"sub,omitempty"`
+	Subject     *AuthFileXAIUserIDValue `json:"subject,omitempty"`
+	UserID      *AuthFileXAIUserIDValue `json:"user_id,omitempty"`
+	UserIDCamel *AuthFileXAIUserIDValue `json:"userId,omitempty"`
+	Metadata    *AuthFileClaims         `json:"metadata,omitempty"`
+	Attributes  *AuthFileClaims         `json:"attributes,omitempty"`
+	OAuth       *AuthFileOAuth          `json:"oauth,omitempty"`
+	User        *AuthFileUser           `json:"user,omitempty"`
+	IDToken     *AuthFileIDToken        `json:"id_token"`
+}
+
+// AuthFileClaims 是 CPA auth file 中可能携带身份 subject 的通用 claims DTO。
+type AuthFileClaims struct {
+	Sub         *AuthFileXAIUserIDValue `json:"sub,omitempty"`
+	Subject     *AuthFileXAIUserIDValue `json:"subject,omitempty"`
+	UserID      *AuthFileXAIUserIDValue `json:"user_id,omitempty"`
+	UserIDCamel *AuthFileXAIUserIDValue `json:"userId,omitempty"`
+	OAuth       *AuthFileOAuth          `json:"oauth,omitempty"`
+	User        *AuthFileUser           `json:"user,omitempty"`
+}
+
+// AuthFileOAuth 是 CPA auth file 中 oauth 身份字段的最小 DTO。
+type AuthFileOAuth struct {
+	Sub     *AuthFileXAIUserIDValue `json:"sub,omitempty"`
+	Subject *AuthFileXAIUserIDValue `json:"subject,omitempty"`
+}
+
+// AuthFileUser 是 CPA auth file 中 user 身份字段的最小 DTO。
+type AuthFileUser struct {
+	Sub *AuthFileXAIUserIDValue `json:"sub,omitempty"`
+	ID  *AuthFileXAIUserIDValue `json:"id,omitempty"`
+}
+
+// AuthFileXAIUserIDValue 兼容 CPAMC 对 xAI user id 字符串和有限数字候选的读取语义。
+type AuthFileXAIUserIDValue string
+
+// UnmarshalJSON 将有限数字规范成字符串；对象、数组和布尔值保持为空，交给同步层跳过。
+func (value *AuthFileXAIUserIDValue) UnmarshalJSON(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var raw any
+	if err := decoder.Decode(&raw); err != nil {
+		return fmt.Errorf("decode xAI user id candidate: %w", err)
+	}
+	switch candidate := raw.(type) {
+	case string:
+		*value = AuthFileXAIUserIDValue(candidate)
+	case json.Number:
+		number, err := strconv.ParseFloat(candidate.String(), 64)
+		if err == nil && !math.IsInf(number, 0) && !math.IsNaN(number) {
+			*value = AuthFileXAIUserIDValue(strconv.FormatFloat(number, 'g', -1, 64))
+		}
+	default:
+		*value = ""
+	}
+	return nil
 }
 
 // AuthFileIDToken 是 Codex auth file 的 id_token 订阅元数据 DTO。

--- a/internal/cpa/dto/authfiles/auth_files.go
+++ b/internal/cpa/dto/authfiles/auth_files.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -42,6 +43,8 @@ type AuthFile struct {
 	OAuth       *AuthFileOAuth          `json:"oauth,omitempty"`
 	User        *AuthFileUser           `json:"user,omitempty"`
 	IDToken     *AuthFileIDToken        `json:"id_token"`
+	xaiOAuthSet bool
+	xaiUserSet  bool
 }
 
 // AuthFileClaims 是 CPA auth file 中可能携带身份 subject 的通用 claims DTO。
@@ -52,6 +55,8 @@ type AuthFileClaims struct {
 	UserIDCamel *AuthFileXAIUserIDValue `json:"userId,omitempty"`
 	OAuth       *AuthFileOAuth          `json:"oauth,omitempty"`
 	User        *AuthFileUser           `json:"user,omitempty"`
+	xaiOAuthSet bool
+	xaiUserSet  bool
 }
 
 // AuthFileOAuth 是 CPA auth file 中 oauth 身份字段的最小 DTO。
@@ -69,26 +74,215 @@ type AuthFileUser struct {
 // AuthFileXAIUserIDValue 兼容 CPAMC 对 xAI user id 字符串和有限数字候选的读取语义。
 type AuthFileXAIUserIDValue string
 
+// UnmarshalJSON 先沿用既有 AuthFile 字段解码，再对 xAI 候选按精确 JSON key 做容错解析。
+func (file *AuthFile) UnmarshalJSON(data []byte) error {
+	type authFileAlias AuthFile
+	var decoded authFileAlias
+	shadow := struct {
+		*authFileAlias
+		Sub         json.RawMessage `json:"sub"`
+		Subject     json.RawMessage `json:"subject"`
+		UserID      json.RawMessage `json:"user_id"`
+		UserIDCamel json.RawMessage `json:"userId"`
+		Metadata    json.RawMessage `json:"metadata"`
+		Attributes  json.RawMessage `json:"attributes"`
+		OAuth       json.RawMessage `json:"oauth"`
+		User        json.RawMessage `json:"user"`
+	}{authFileAlias: &decoded}
+	if err := json.Unmarshal(data, &shadow); err != nil {
+		return fmt.Errorf("decode auth file: %w", err)
+	}
+
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(data, &object); err != nil {
+		return fmt.Errorf("decode auth file claims: %w", err)
+	}
+	decoded.Sub = authFileXAIUserIDValue(object["sub"])
+	decoded.Subject = authFileXAIUserIDValue(object["subject"])
+	decoded.UserID = authFileXAIUserIDValue(object["user_id"])
+	decoded.UserIDCamel = authFileXAIUserIDValue(object["userId"])
+	decoded.Metadata = authFileClaims(object["metadata"])
+	decoded.Attributes = authFileClaims(object["attributes"])
+	decoded.OAuth, decoded.xaiOAuthSet = authFileOAuth(object["oauth"])
+	decoded.User, decoded.xaiUserSet = authFileUser(object["user"])
+	*file = AuthFile(decoded)
+	return nil
+}
+
+// ResolvedXAIOAuth 按 file.oauth ?? metadata.oauth ?? attributes.oauth 选择候选对象。
+func (file AuthFile) ResolvedXAIOAuth() *AuthFileOAuth {
+	if file.OAuth != nil || file.xaiOAuthSet {
+		return file.OAuth
+	}
+	if file.Metadata != nil && (file.Metadata.OAuth != nil || file.Metadata.xaiOAuthSet) {
+		return file.Metadata.OAuth
+	}
+	if file.Attributes != nil && (file.Attributes.OAuth != nil || file.Attributes.xaiOAuthSet) {
+		return file.Attributes.OAuth
+	}
+	return nil
+}
+
+// ResolvedXAIUser 按 file.user ?? metadata.user ?? attributes.user 选择候选对象。
+func (file AuthFile) ResolvedXAIUser() *AuthFileUser {
+	if file.User != nil || file.xaiUserSet {
+		return file.User
+	}
+	if file.Metadata != nil && (file.Metadata.User != nil || file.Metadata.xaiUserSet) {
+		return file.Metadata.User
+	}
+	if file.Attributes != nil && (file.Attributes.User != nil || file.Attributes.xaiUserSet) {
+		return file.Attributes.User
+	}
+	return nil
+}
+
 // UnmarshalJSON 将有限数字规范成字符串；对象、数组和布尔值保持为空，交给同步层跳过。
 func (value *AuthFileXAIUserIDValue) UnmarshalJSON(data []byte) error {
+	parsed := authFileXAIUserIDValue(data)
+	if parsed == nil {
+		*value = ""
+		return nil
+	}
+	*value = *parsed
+	return nil
+}
+
+func authFileClaims(data json.RawMessage) *AuthFileClaims {
+	object := authFileObject(data)
+	if object == nil {
+		return nil
+	}
+	claims := &AuthFileClaims{
+		Sub:         authFileXAIUserIDValue(object["sub"]),
+		Subject:     authFileXAIUserIDValue(object["subject"]),
+		UserID:      authFileXAIUserIDValue(object["user_id"]),
+		UserIDCamel: authFileXAIUserIDValue(object["userId"]),
+	}
+	claims.OAuth, claims.xaiOAuthSet = authFileOAuth(object["oauth"])
+	claims.User, claims.xaiUserSet = authFileUser(object["user"])
+	return claims
+}
+
+func authFileOAuth(data json.RawMessage) (*AuthFileOAuth, bool) {
+	if len(data) == 0 || bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return nil, false
+	}
+	object := authFileObject(data)
+	if object == nil {
+		return nil, true
+	}
+	return &AuthFileOAuth{
+		Sub:     authFileXAIUserIDValue(object["sub"]),
+		Subject: authFileXAIUserIDValue(object["subject"]),
+	}, true
+}
+
+func authFileUser(data json.RawMessage) (*AuthFileUser, bool) {
+	if len(data) == 0 || bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return nil, false
+	}
+	object := authFileObject(data)
+	if object == nil {
+		return nil, true
+	}
+	return &AuthFileUser{
+		Sub: authFileXAIUserIDValue(object["sub"]),
+		ID:  authFileXAIUserIDValue(object["id"]),
+	}, true
+}
+
+func authFileObject(data json.RawMessage) map[string]json.RawMessage {
+	if len(data) == 0 {
+		return nil
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(data, &object); err != nil || object == nil {
+		return nil
+	}
+	return object
+}
+
+func authFileXAIUserIDValue(data json.RawMessage) *AuthFileXAIUserIDValue {
+	if len(data) == 0 {
+		return nil
+	}
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.UseNumber()
 	var raw any
 	if err := decoder.Decode(&raw); err != nil {
-		return fmt.Errorf("decode xAI user id candidate: %w", err)
+		return nil
 	}
 	switch candidate := raw.(type) {
 	case string:
-		*value = AuthFileXAIUserIDValue(candidate)
+		value := AuthFileXAIUserIDValue(candidate)
+		return &value
 	case json.Number:
 		number, err := strconv.ParseFloat(candidate.String(), 64)
 		if err == nil && !math.IsInf(number, 0) && !math.IsNaN(number) {
-			*value = AuthFileXAIUserIDValue(strconv.FormatFloat(number, 'g', -1, 64))
+			value := AuthFileXAIUserIDValue(formatJavaScriptNumber(number))
+			return &value
 		}
-	default:
-		*value = ""
 	}
 	return nil
+}
+
+func formatJavaScriptNumber(value float64) string {
+	if value == 0 {
+		return "0"
+	}
+	formatted := strconv.FormatFloat(value, 'g', -1, 64)
+	abs := math.Abs(value)
+	if abs >= 1e-6 && abs < 1e21 {
+		return expandScientificNumber(formatted)
+	}
+	return normalizeScientificExponent(formatted)
+}
+
+func expandScientificNumber(value string) string {
+	mantissa, exponentText, ok := strings.Cut(value, "e")
+	if !ok {
+		return value
+	}
+	exponent, err := strconv.Atoi(exponentText)
+	if err != nil {
+		return value
+	}
+	sign := ""
+	if strings.HasPrefix(mantissa, "-") {
+		sign = "-"
+		mantissa = strings.TrimPrefix(mantissa, "-")
+	}
+	decimalIndex := strings.IndexByte(mantissa, '.')
+	if decimalIndex < 0 {
+		decimalIndex = len(mantissa)
+	} else {
+		mantissa = strings.Replace(mantissa, ".", "", 1)
+	}
+	decimalIndex += exponent
+	switch {
+	case decimalIndex <= 0:
+		return sign + "0." + strings.Repeat("0", -decimalIndex) + mantissa
+	case decimalIndex >= len(mantissa):
+		return sign + mantissa + strings.Repeat("0", decimalIndex-len(mantissa))
+	default:
+		return sign + mantissa[:decimalIndex] + "." + mantissa[decimalIndex:]
+	}
+}
+
+func normalizeScientificExponent(value string) string {
+	mantissa, exponentText, ok := strings.Cut(value, "e")
+	if !ok {
+		return value
+	}
+	exponent, err := strconv.Atoi(exponentText)
+	if err != nil {
+		return value
+	}
+	if exponent >= 0 {
+		return mantissa + "e+" + strconv.Itoa(exponent)
+	}
+	return mantissa + "e" + strconv.Itoa(exponent)
 }
 
 // AuthFileIDToken 是 Codex auth file 的 id_token 订阅元数据 DTO。

--- a/internal/cpa/dto/authfiles/test/xai_user_id_test.go
+++ b/internal/cpa/dto/authfiles/test/xai_user_id_test.go
@@ -1,0 +1,72 @@
+package test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"cpa-usage-keeper/internal/cpa/dto/authfiles"
+)
+
+func TestAuthFilePreservesXAIUserIDCandidates(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		path  []string
+		want  string
+	}{
+		{name: "top level sub", input: `{"sub":"top-sub"}`, path: []string{"sub"}, want: "top-sub"},
+		{name: "top level subject", input: `{"subject":"top-subject"}`, path: []string{"subject"}, want: "top-subject"},
+		{name: "top level user_id", input: `{"user_id":"top-user-id"}`, path: []string{"user_id"}, want: "top-user-id"},
+		{name: "top level userId", input: `{"userId":"top-user-id-camel"}`, path: []string{"userId"}, want: "top-user-id-camel"},
+		{name: "metadata sub", input: `{"metadata":{"sub":"metadata-sub"}}`, path: []string{"metadata", "sub"}, want: "metadata-sub"},
+		{name: "metadata subject", input: `{"metadata":{"subject":"metadata-subject"}}`, path: []string{"metadata", "subject"}, want: "metadata-subject"},
+		{name: "metadata user_id", input: `{"metadata":{"user_id":"metadata-user-id"}}`, path: []string{"metadata", "user_id"}, want: "metadata-user-id"},
+		{name: "metadata userId", input: `{"metadata":{"userId":"metadata-user-id-camel"}}`, path: []string{"metadata", "userId"}, want: "metadata-user-id-camel"},
+		{name: "attributes sub", input: `{"attributes":{"sub":"attributes-sub"}}`, path: []string{"attributes", "sub"}, want: "attributes-sub"},
+		{name: "attributes subject", input: `{"attributes":{"subject":"attributes-subject"}}`, path: []string{"attributes", "subject"}, want: "attributes-subject"},
+		{name: "attributes user_id", input: `{"attributes":{"user_id":"attributes-user-id"}}`, path: []string{"attributes", "user_id"}, want: "attributes-user-id"},
+		{name: "attributes userId", input: `{"attributes":{"userId":"attributes-user-id"}}`, path: []string{"attributes", "userId"}, want: "attributes-user-id"},
+		{name: "oauth sub", input: `{"oauth":{"sub":"oauth-sub"}}`, path: []string{"oauth", "sub"}, want: "oauth-sub"},
+		{name: "oauth subject", input: `{"oauth":{"subject":"oauth-subject"}}`, path: []string{"oauth", "subject"}, want: "oauth-subject"},
+		{name: "metadata oauth", input: `{"metadata":{"oauth":{"sub":"metadata-oauth-sub"}}}`, path: []string{"metadata", "oauth", "sub"}, want: "metadata-oauth-sub"},
+		{name: "attributes oauth", input: `{"attributes":{"oauth":{"subject":"attributes-oauth-subject"}}}`, path: []string{"attributes", "oauth", "subject"}, want: "attributes-oauth-subject"},
+		{name: "user sub", input: `{"user":{"sub":"user-sub"}}`, path: []string{"user", "sub"}, want: "user-sub"},
+		{name: "user id", input: `{"user":{"id":"user-id"}}`, path: []string{"user", "id"}, want: "user-id"},
+		{name: "metadata user", input: `{"metadata":{"user":{"sub":"metadata-user-sub"}}}`, path: []string{"metadata", "user", "sub"}, want: "metadata-user-sub"},
+		{name: "attributes user", input: `{"attributes":{"user":{"id":"attributes-user-id"}}}`, path: []string{"attributes", "user", "id"}, want: "attributes-user-id"},
+		{name: "numeric candidate", input: `{"sub":12345}`, path: []string{"sub"}, want: "12345"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var file authfiles.AuthFile
+			if err := json.Unmarshal([]byte(tt.input), &file); err != nil {
+				t.Fatalf("unmarshal AuthFile: %v", err)
+			}
+			encoded, err := json.Marshal(file)
+			if err != nil {
+				t.Fatalf("marshal AuthFile: %v", err)
+			}
+			var roundTrip map[string]any
+			if err := json.Unmarshal(encoded, &roundTrip); err != nil {
+				t.Fatalf("unmarshal round-trip AuthFile: %v", err)
+			}
+			if got := nestedString(roundTrip, tt.path...); got != tt.want {
+				t.Fatalf("expected %v to survive AuthFile decoding, got %q from %s", tt.path, got, encoded)
+			}
+		})
+	}
+}
+
+func nestedString(value map[string]any, path ...string) string {
+	var current any = value
+	for _, key := range path {
+		object, ok := current.(map[string]any)
+		if !ok {
+			return ""
+		}
+		current = object[key]
+	}
+	result, _ := current.(string)
+	return result
+}

--- a/internal/cpa/dto/authfiles/test/xai_user_id_test.go
+++ b/internal/cpa/dto/authfiles/test/xai_user_id_test.go
@@ -58,6 +58,68 @@ func TestAuthFilePreservesXAIUserIDCandidates(t *testing.T) {
 	}
 }
 
+func TestAuthFileIgnoresNonObjectXAIContainers(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "metadata string", input: `{"auth_index":"auth-1","metadata":"opaque"}`},
+		{name: "attributes array", input: `{"auth_index":"auth-1","attributes":[]}`},
+		{name: "oauth boolean", input: `{"auth_index":"auth-1","oauth":false}`},
+		{name: "user number", input: `{"auth_index":"auth-1","user":123}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var file authfiles.AuthFile
+			if err := json.Unmarshal([]byte(tt.input), &file); err != nil {
+				t.Fatalf("non-object xAI container must not fail AuthFile decoding: %v", err)
+			}
+			if file.AuthIndex != "auth-1" {
+				t.Fatalf("expected ordinary AuthFile fields to keep decoding, got %+v", file)
+			}
+		})
+	}
+}
+
+func TestAuthFileXAIClaimsUseExactJSONKeys(t *testing.T) {
+	var file authfiles.AuthFile
+	if err := json.Unmarshal([]byte(`{"SUB":"wrong-account","subject":"correct-account"}`), &file); err != nil {
+		t.Fatalf("unmarshal AuthFile: %v", err)
+	}
+	if file.Sub != nil {
+		t.Fatalf("expected uppercase SUB to be ignored, got %q", string(*file.Sub))
+	}
+	if file.Subject == nil || string(*file.Subject) != "correct-account" {
+		t.Fatalf("expected exact subject candidate, got %+v", file.Subject)
+	}
+}
+
+func TestAuthFileFormatsNumericXAIUserIDLikeJavaScript(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "fixed upper boundary", input: `{"sub":1e20}`, want: "100000000000000000000"},
+		{name: "scientific upper boundary", input: `{"sub":1e21}`, want: "1e+21"},
+		{name: "scientific lower boundary", input: `{"sub":1e-7}`, want: "1e-7"},
+		{name: "negative zero", input: `{"sub":-0}`, want: "0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var file authfiles.AuthFile
+			if err := json.Unmarshal([]byte(tt.input), &file); err != nil {
+				t.Fatalf("unmarshal AuthFile: %v", err)
+			}
+			if file.Sub == nil || string(*file.Sub) != tt.want {
+				t.Fatalf("expected JavaScript number string %q, got %+v", tt.want, file.Sub)
+			}
+		})
+	}
+}
+
 func nestedString(value map[string]any, path ...string) string {
 	var current any = value
 	for _, key := range path {

--- a/internal/entities/usage_identity.go
+++ b/internal/entities/usage_identity.go
@@ -30,6 +30,7 @@ type UsageIdentity struct {
 	Note         *string
 	AccountID    *string
 	ProjectID    *string
+	XAIUserID    *string
 
 	ActiveStart *time.Time `gorm:"serializer:storageTime"`
 	ActiveUntil *time.Time `gorm:"serializer:storageTime"`

--- a/internal/quota/config.go
+++ b/internal/quota/config.go
@@ -23,6 +23,9 @@ const (
 
 	// CodexRateLimitResetCreditsURL 返回当前账号每次可用 reset credit 及其过期时间。
 	CodexRateLimitResetCreditsURL = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits"
+
+	// xaiGrokClientVersion 与 CPA 当前 Grok CLI chat-proxy 请求保持一致。
+	xaiGrokClientVersion = "0.2.93"
 )
 
 // RefreshCacheableHTTPStatusCodes 定义会写入页面恢复缓存并被自动刷新跳过的 provider HTTP 状态码。
@@ -45,7 +48,8 @@ type ProviderConfigs struct {
 	ClaudeUsage         APICallConfig
 	ClaudeProfile       APICallConfig
 	Kimi                APICallConfig
-	XAI                 APICallConfig
+	XAIWeekly           APICallConfig
+	XAIMonthly          APICallConfig
 }
 
 func DefaultProviderConfigs() ProviderConfigs {
@@ -129,18 +133,32 @@ func DefaultProviderConfigs() ProviderConfigs {
 				"Authorization": "Bearer $TOKEN$",
 			},
 		},
-		XAI: APICallConfig{
-			Method: "GET",
-			URL:    "https://cli-chat-proxy.grok.com/v1/billing",
-			Headers: map[string]string{
-				"Authorization": "Bearer $TOKEN$",
-			},
+		XAIWeekly: APICallConfig{
+			Method:  "GET",
+			URL:     "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+			Headers: xaiRequestHeaders(),
+		},
+		XAIMonthly: APICallConfig{
+			Method:  "GET",
+			URL:     "https://cli-chat-proxy.grok.com/v1/billing",
+			Headers: xaiRequestHeaders(),
 		},
 	}
 }
 
+func xaiRequestHeaders() map[string]string {
+	userAgent := "grok-pager/" + xaiGrokClientVersion + " grok-shell/" + xaiGrokClientVersion + " (macos; aarch64)"
+	return map[string]string{
+		"Authorization":         "Bearer $TOKEN$",
+		"x-xai-token-auth":      "xai-grok-cli",
+		"x-grok-client-version": xaiGrokClientVersion,
+		"Accept":                "*/*",
+		"User-Agent":            userAgent,
+	}
+}
+
 func (c ProviderConfigs) APICallTemplates() []APICallConfig {
-	templates := make([]APICallConfig, 0, len(c.Antigravity)+7)
+	templates := make([]APICallConfig, 0, len(c.Antigravity)+8)
 	templates = append(templates, c.Antigravity...)
 	templates = append(templates,
 		c.Codex,
@@ -149,7 +167,8 @@ func (c ProviderConfigs) APICallTemplates() []APICallConfig {
 		c.ClaudeUsage,
 		c.ClaudeProfile,
 		c.Kimi,
-		c.XAI,
+		c.XAIWeekly,
+		c.XAIMonthly,
 	)
 	return templates
 }

--- a/internal/quota/inspection.go
+++ b/internal/quota/inspection.go
@@ -406,9 +406,15 @@ func kimiInspectionLimitReached(rows []QuotaRow) bool {
 }
 
 func xaiInspectionLimitReached(rows []QuotaRow) bool {
-	// xAI 支持显式 limit_reached，也支持 used/limit 费用类窗口。
+	// 新 xAI 行的显式 false 代表仍有其它额度（例如 PAYG）；旧缓存没有标志时才回退 used/limit。
 	for _, row := range rows {
-		if quotaRowLimitReached(row) || quotaRowUsedAtLimit(row) {
+		if row.LimitReached != nil {
+			if *row.LimitReached {
+				return true
+			}
+			continue
+		}
+		if quotaRowUsedAtLimit(row) {
 			return true
 		}
 	}

--- a/internal/quota/normalize.go
+++ b/internal/quota/normalize.go
@@ -3,6 +3,7 @@ package quota
 import (
 	"fmt"
 	"math"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -352,32 +353,178 @@ func normalizeKimiQuotaRows(result KimiResult) []QuotaRow {
 }
 
 func normalizeXAIQuotaRows(result XAIResult) []QuotaRow {
-	// xAI billing 的 val 是 USD cents；后端缓存保留 cents，前端按 metric=usd_cents 格式化成美元。
-	if result.Billing == nil || result.Billing.Config == nil {
+	// xAI 两个 billing endpoint 同级返回，输出顺序固定为 Weekly、Monthly、PAYG、产品额度。
+	weeklyConfig := xaiBillingConfig(result.Weekly)
+	monthlyConfig := xaiBillingConfig(result.Monthly)
+	rows := make([]QuotaRow, 0, 3)
+	if row, ok := xaiWeeklyQuotaRow(weeklyConfig); ok {
+		rows = append(rows, row)
+	}
+	rows = append(rows, xaiMonthlyQuotaRows(monthlyConfig)...)
+	rows = append(rows, xaiProductQuotaRows(weeklyConfig)...)
+	return rows
+}
+
+func xaiBillingConfig(payload *XAIBillingPayload) *XAIBillingConfig {
+	if payload == nil {
 		return nil
 	}
-	config := result.Billing.Config
-	limit := config.MonthlyLimit.Val
-	used := config.Used.Val
-	remaining := math.Max(0, limit-used)
-	row := QuotaRow{
-		Key:       "billing.monthly",
-		Label:     "Monthly Spend",
-		Scope:     "billing",
-		Metric:    "usd_cents",
-		Used:      floatPtr(used),
-		Limit:     floatPtr(limit),
-		Remaining: floatPtr(remaining),
-		Window:    &QuotaWindow{Seconds: intPtr(quotaWindowThirtyDaySeconds)},
-		ResetAt:   config.BillingPeriodEnd,
+	return payload.Config
+}
+
+func xaiWeeklyQuotaRow(config *XAIBillingConfig) (QuotaRow, bool) {
+	if config == nil || config.CreditUsagePercent == nil {
+		return QuotaRow{}, false
 	}
-	if limit > 0 {
-		row.UsedPercent = floatPtr(used / limit * 100)
-		limitReached := used >= limit
-		row.LimitReached = boolPtr(limitReached)
-		row.Allowed = boolPtr(!limitReached)
+	usedPercent := *config.CreditUsagePercent
+	limitReached := usedPercent >= 100
+	return QuotaRow{
+		Key:          "billing.weekly",
+		Label:        "Weekly",
+		Scope:        "billing",
+		Metric:       "weekly",
+		UsedPercent:  floatPtr(usedPercent),
+		Allowed:      boolPtr(!limitReached),
+		LimitReached: boolPtr(limitReached),
+		Window:       &QuotaWindow{Seconds: intPtr(quotaWindowSevenDaySeconds)},
+		ResetAt:      xaiWeeklyResetAt(config),
+	}, true
+}
+
+func xaiMonthlyQuotaRows(config *XAIBillingConfig) []QuotaRow {
+	if config == nil {
+		return nil
 	}
-	return []QuotaRow{row}
+	monthlyLimit, hasMonthlyLimit := xaiMoneyValue(config.MonthlyLimit)
+	totalUsed, hasTotalUsed := xaiMoneyValue(config.Used)
+	onDemandCap, hasOnDemandCap := xaiMoneyValue(config.OnDemandCap)
+	onDemandUsed, hasOnDemandUsed := xaiMoneyValue(config.OnDemandUsed)
+	if !hasOnDemandUsed && hasTotalUsed && hasMonthlyLimit {
+		onDemandUsed = math.Max(0, totalUsed-monthlyLimit)
+		hasOnDemandUsed = true
+	}
+
+	rows := make([]QuotaRow, 0, 2)
+	if hasMonthlyLimit || hasTotalUsed {
+		row := QuotaRow{
+			Key:     "billing.monthly",
+			Label:   "Monthly Spend",
+			Scope:   "billing",
+			Metric:  "usd_cents",
+			Window:  &QuotaWindow{Seconds: intPtr(quotaWindowThirtyDaySeconds)},
+			ResetAt: config.BillingPeriodEnd,
+		}
+		if hasMonthlyLimit {
+			row.Limit = floatPtr(monthlyLimit)
+		}
+		if hasTotalUsed {
+			includedUsed := totalUsed
+			if hasMonthlyLimit {
+				includedUsed = math.Min(totalUsed, math.Max(0, monthlyLimit))
+			}
+			row.Used = floatPtr(includedUsed)
+			if hasMonthlyLimit {
+				row.Remaining = floatPtr(math.Max(0, monthlyLimit-includedUsed))
+				if monthlyLimit > 0 {
+					row.UsedPercent = floatPtr(includedUsed / monthlyLimit * 100)
+					onDemandAvailable := hasOnDemandCap && onDemandCap > 0 && hasOnDemandUsed && onDemandUsed < onDemandCap
+					limitReached := includedUsed >= monthlyLimit && !onDemandAvailable
+					row.LimitReached = boolPtr(limitReached)
+					row.Allowed = boolPtr(!limitReached)
+				}
+			}
+		}
+		rows = append(rows, row)
+	}
+
+	if hasOnDemandCap && onDemandCap > 0 {
+		row := QuotaRow{
+			Key:     "billing.on_demand",
+			Label:   "Pay-as-you-go",
+			Scope:   "billing",
+			Metric:  "usd_cents",
+			Limit:   floatPtr(onDemandCap),
+			Window:  &QuotaWindow{Seconds: intPtr(quotaWindowThirtyDaySeconds)},
+			ResetAt: config.BillingPeriodEnd,
+		}
+		if hasOnDemandUsed {
+			row.Used = floatPtr(onDemandUsed)
+			row.Remaining = floatPtr(math.Max(0, onDemandCap-onDemandUsed))
+			row.UsedPercent = floatPtr(onDemandUsed / onDemandCap * 100)
+			limitReached := onDemandUsed >= onDemandCap
+			row.LimitReached = boolPtr(limitReached)
+			row.Allowed = boolPtr(!limitReached)
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func xaiProductQuotaRows(config *XAIBillingConfig) []QuotaRow {
+	if config == nil || len(config.ProductUsage) == 0 {
+		return nil
+	}
+	type productQuota struct {
+		name           string
+		normalizedName string
+		usedPercent    float64
+	}
+	products := make(map[string]productQuota, len(config.ProductUsage))
+	for _, item := range config.ProductUsage {
+		name := strings.Join(strings.Fields(item.Product), " ")
+		normalizedName := strings.ToLower(name)
+		if normalizedName == "" || item.UsagePercent == nil {
+			continue
+		}
+		if current, ok := products[normalizedName]; ok {
+			if *item.UsagePercent > current.usedPercent {
+				current.usedPercent = *item.UsagePercent
+				products[normalizedName] = current
+			}
+			continue
+		}
+		products[normalizedName] = productQuota{name: name, normalizedName: normalizedName, usedPercent: *item.UsagePercent}
+	}
+	ordered := make([]productQuota, 0, len(products))
+	for _, product := range products {
+		ordered = append(ordered, product)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		return ordered[i].normalizedName < ordered[j].normalizedName
+	})
+	rows := make([]QuotaRow, 0, len(ordered))
+	for _, product := range ordered {
+		limitReached := product.usedPercent >= 100
+		rows = append(rows, QuotaRow{
+			Key:          "billing.weekly.product." + url.QueryEscape(product.normalizedName),
+			Label:        product.name + " Usage",
+			Scope:        "product",
+			Metric:       product.name,
+			UsedPercent:  floatPtr(product.usedPercent),
+			Allowed:      boolPtr(!limitReached),
+			LimitReached: boolPtr(limitReached),
+			Window:       &QuotaWindow{Seconds: intPtr(quotaWindowSevenDaySeconds)},
+			ResetAt:      xaiWeeklyResetAt(config),
+		})
+	}
+	return rows
+}
+
+func xaiWeeklyResetAt(config *XAIBillingConfig) string {
+	if config == nil {
+		return ""
+	}
+	if config.CurrentPeriod != nil && strings.TrimSpace(config.CurrentPeriod.End) != "" {
+		return config.CurrentPeriod.End
+	}
+	return config.BillingPeriodEnd
+}
+
+func xaiMoneyValue(value XAIMoneyValue) (float64, bool) {
+	if value.Val == nil {
+		return 0, false
+	}
+	return *value.Val, true
 }
 
 func kimiDetailQuotaRow(key string, scope string, fallbackLabel string, detail *KimiUsageDetail) QuotaRow {

--- a/internal/quota/payloads.go
+++ b/internal/quota/payloads.go
@@ -303,11 +303,24 @@ func parseXAIBillingConfig(object map[string]json.RawMessage) *XAIBillingConfig 
 		return nil
 	}
 	config := &XAIBillingConfig{
-		MonthlyLimit:       parseXAIMoneyValue(objectField(object, "monthlyLimit", "monthly_limit")),
-		Used:               parseXAIMoneyValue(objectField(object, "used")),
-		OnDemandCap:        parseXAIMoneyValue(objectField(object, "onDemandCap", "on_demand_cap")),
+		CurrentPeriod:      parseXAIBillingPeriod(objectField(object, "currentPeriod", "current_period")),
+		CreditUsagePercent: floatPtrField(object, "creditUsagePercent", "credit_usage_percent"),
+		MonthlyLimit:       parseXAIMoneyField(object, "monthlyLimit", "monthly_limit"),
+		Used:               parseXAIMoneyField(object, "used"),
+		OnDemandCap:        parseXAIMoneyField(object, "onDemandCap", "on_demand_cap"),
+		OnDemandUsed:       parseXAIMoneyField(object, "onDemandUsed", "on_demand_used"),
 		BillingPeriodStart: stringField(object, "billingPeriodStart", "billing_period_start"),
 		BillingPeriodEnd:   stringField(object, "billingPeriodEnd", "billing_period_end"),
+	}
+	for _, raw := range arrayField(object, "productUsage", "product_usage") {
+		productObject := rawObject(raw)
+		if productObject == nil {
+			continue
+		}
+		config.ProductUsage = append(config.ProductUsage, XAIBillingProductUsage{
+			Product:      stringField(productObject, "product"),
+			UsagePercent: floatPtrField(productObject, "usagePercent", "usage_percent"),
+		})
 	}
 	for _, raw := range arrayField(object, "history") {
 		historyObject := rawObject(raw)
@@ -316,9 +329,9 @@ func parseXAIBillingConfig(object map[string]json.RawMessage) *XAIBillingConfig 
 		}
 		config.History = append(config.History, XAIBillingHistoryItem{
 			BillingCycle: parseXAIBillingCycle(objectField(historyObject, "billingCycle", "billing_cycle")),
-			IncludedUsed: parseXAIMoneyValue(objectField(historyObject, "includedUsed", "included_used")),
-			OnDemandUsed: parseXAIMoneyValue(objectField(historyObject, "onDemandUsed", "on_demand_used")),
-			TotalUsed:    parseXAIMoneyValue(objectField(historyObject, "totalUsed", "total_used")),
+			IncludedUsed: parseXAIMoneyField(historyObject, "includedUsed", "included_used"),
+			OnDemandUsed: parseXAIMoneyField(historyObject, "onDemandUsed", "on_demand_used"),
+			TotalUsed:    parseXAIMoneyField(historyObject, "totalUsed", "total_used"),
 		})
 	}
 	return config
@@ -334,11 +347,29 @@ func parseXAIBillingCycle(object map[string]json.RawMessage) XAIBillingCycle {
 	}
 }
 
-func parseXAIMoneyValue(object map[string]json.RawMessage) XAIMoneyValue {
+func parseXAIBillingPeriod(object map[string]json.RawMessage) *XAIBillingPeriod {
 	if object == nil {
-		return XAIMoneyValue{}
+		return nil
 	}
-	return XAIMoneyValue{Val: floatField(object, "val")}
+	return &XAIBillingPeriod{
+		Type:  stringField(object, "type"),
+		Start: stringField(object, "start"),
+		End:   stringField(object, "end"),
+	}
+}
+
+func parseXAIMoneyField(object map[string]json.RawMessage, keys ...string) XAIMoneyValue {
+	for _, key := range keys {
+		raw, ok := object[key]
+		if !ok || rawJSONNull(raw) {
+			continue
+		}
+		if valueObject := rawObject(raw); valueObject != nil {
+			return XAIMoneyValue{Val: floatPtrField(valueObject, "val")}
+		}
+		return XAIMoneyValue{Val: floatPtrField(map[string]json.RawMessage{"value": raw}, "value")}
+	}
+	return XAIMoneyValue{}
 }
 
 func parseKimiUsageDetail(object map[string]json.RawMessage) *KimiUsageDetail {

--- a/internal/quota/payloads.go
+++ b/internal/quota/payloads.go
@@ -3,6 +3,7 @@ package quota
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -304,7 +305,7 @@ func parseXAIBillingConfig(object map[string]json.RawMessage) *XAIBillingConfig 
 	}
 	config := &XAIBillingConfig{
 		CurrentPeriod:      parseXAIBillingPeriod(objectField(object, "currentPeriod", "current_period")),
-		CreditUsagePercent: floatPtrField(object, "creditUsagePercent", "credit_usage_percent"),
+		CreditUsagePercent: xaiFloatPtrField(object, "creditUsagePercent", "credit_usage_percent"),
 		MonthlyLimit:       parseXAIMoneyField(object, "monthlyLimit", "monthly_limit"),
 		Used:               parseXAIMoneyField(object, "used"),
 		OnDemandCap:        parseXAIMoneyField(object, "onDemandCap", "on_demand_cap"),
@@ -319,7 +320,7 @@ func parseXAIBillingConfig(object map[string]json.RawMessage) *XAIBillingConfig 
 		}
 		config.ProductUsage = append(config.ProductUsage, XAIBillingProductUsage{
 			Product:      stringField(productObject, "product"),
-			UsagePercent: floatPtrField(productObject, "usagePercent", "usage_percent"),
+			UsagePercent: xaiFloatPtrField(productObject, "usagePercent", "usage_percent"),
 		})
 	}
 	for _, raw := range arrayField(object, "history") {
@@ -365,11 +366,19 @@ func parseXAIMoneyField(object map[string]json.RawMessage, keys ...string) XAIMo
 			continue
 		}
 		if valueObject := rawObject(raw); valueObject != nil {
-			return XAIMoneyValue{Val: floatPtrField(valueObject, "val")}
+			return XAIMoneyValue{Val: xaiFloatPtrField(valueObject, "val")}
 		}
-		return XAIMoneyValue{Val: floatPtrField(map[string]json.RawMessage{"value": raw}, "value")}
+		return XAIMoneyValue{Val: xaiFloatPtrField(map[string]json.RawMessage{"value": raw}, "value")}
 	}
 	return XAIMoneyValue{}
+}
+
+func xaiFloatPtrField(object map[string]json.RawMessage, keys ...string) *float64 {
+	value := floatPtrField(object, keys...)
+	if value == nil || math.IsNaN(*value) || math.IsInf(*value, 0) {
+		return nil
+	}
+	return value
 }
 
 func parseKimiUsageDetail(object map[string]json.RawMessage) *KimiUsageDetail {

--- a/internal/quota/registry.go
+++ b/internal/quota/registry.go
@@ -13,7 +13,7 @@ func NewDefaultProviderRegistry(caller ManagementAPICaller, configs ProviderConf
 		"gemini-cli":  NewGeminiCLIProvider(caller, configs.GeminiCLI, configs.GeminiCLICodeAssist),
 		"claude":      NewClaudeProvider(caller, configs.ClaudeUsage, configs.ClaudeProfile),
 		"kimi":        NewKimiProvider(caller, configs.Kimi),
-		"xai":         NewXAIProvider(caller, configs.XAI),
+		"xai":         NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly),
 	})
 }
 

--- a/internal/quota/test/auto_refresh_test.go
+++ b/internal/quota/test/auto_refresh_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -231,8 +232,13 @@ func TestStartAutoRefreshWakesWhenSettingsChange(t *testing.T) {
 	service := newQuotaServiceWithRegistry(t, db, NewProviderRegistry(map[string]ProviderHandler{"claude": handler}))
 	service.SetRefreshContext(ctx)
 	setRefreshCooldown(service, func(time.Duration) {})
+	var nowMu sync.RWMutex
 	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.Local)
-	setAutoRefreshNow(service, func() time.Time { return now })
+	setAutoRefreshNow(service, func() time.Time {
+		nowMu.RLock()
+		defer nowMu.RUnlock()
+		return now
+	})
 	if _, err := service.UpdateAutoRefreshSettings(context.Background(), AutoRefreshSettings{
 		Enabled:  true,
 		Schedule: &AutoRefreshSchedule{Unit: AutoRefreshScheduleUnitHour, Value: 24},
@@ -262,7 +268,9 @@ func TestStartAutoRefreshWakesWhenSettingsChange(t *testing.T) {
 		t.Fatal("expected long day schedule not to run before settings change")
 	case <-time.After(50 * time.Millisecond):
 	}
+	nowMu.Lock()
 	now = time.Date(2026, 5, 26, 23, 59, 59, int(999*time.Millisecond), time.Local)
+	nowMu.Unlock()
 	if _, err := service.UpdateAutoRefreshSettings(context.Background(), AutoRefreshSettings{
 		Enabled:  true,
 		Schedule: &AutoRefreshSchedule{Unit: AutoRefreshScheduleUnitDay, Value: 1},

--- a/internal/quota/test/config_test.go
+++ b/internal/quota/test/config_test.go
@@ -6,11 +6,11 @@ import (
 	"cpa-usage-keeper/internal/quota"
 )
 
-func TestDefaultProviderConfigsContainsSevenAPICallTemplates(t *testing.T) {
+func TestDefaultProviderConfigsContainsAPICallTemplates(t *testing.T) {
 	configs := quota.DefaultProviderConfigs()
 	templates := configs.APICallTemplates()
-	if len(templates) != 10 {
-		t.Fatalf("expected 10 api-call templates, got %d", len(templates))
+	if len(templates) != 11 {
+		t.Fatalf("expected 11 api-call templates, got %d", len(templates))
 	}
 	if len(configs.Antigravity) != 3 {
 		t.Fatalf("expected 3 antigravity api-call templates, got %d", len(configs.Antigravity))
@@ -40,8 +40,11 @@ func TestDefaultProviderConfigsContainsSevenAPICallTemplates(t *testing.T) {
 	if configs.Kimi.Method != "GET" || configs.Kimi.URL != "https://api.kimi.com/coding/v1/usages" {
 		t.Fatalf("unexpected kimi config: %+v", configs.Kimi)
 	}
-	if configs.XAI.Method != "GET" || configs.XAI.URL != "https://cli-chat-proxy.grok.com/v1/billing" {
-		t.Fatalf("unexpected xai config: %+v", configs.XAI)
+	if configs.XAIWeekly.Method != "GET" || configs.XAIWeekly.URL != "https://cli-chat-proxy.grok.com/v1/billing?format=credits" {
+		t.Fatalf("unexpected xai weekly config: %+v", configs.XAIWeekly)
+	}
+	if configs.XAIMonthly.Method != "GET" || configs.XAIMonthly.URL != "https://cli-chat-proxy.grok.com/v1/billing" {
+		t.Fatalf("unexpected xai monthly config: %+v", configs.XAIMonthly)
 	}
 
 	if configs.Antigravity[0].Headers["Authorization"] != "Bearer $TOKEN$" || configs.Antigravity[0].Headers["Content-Type"] != "application/json" || configs.Antigravity[0].Headers["User-Agent"] != "antigravity/1.11.5 windows/amd64" {
@@ -65,7 +68,16 @@ func TestDefaultProviderConfigsContainsSevenAPICallTemplates(t *testing.T) {
 	if configs.Kimi.Headers["Authorization"] != "Bearer $TOKEN$" {
 		t.Fatalf("unexpected kimi headers: %+v", configs.Kimi.Headers)
 	}
-	if configs.XAI.Headers["Authorization"] != "Bearer $TOKEN$" {
-		t.Fatalf("unexpected xai headers: %+v", configs.XAI.Headers)
+	for _, config := range []quota.APICallConfig{configs.XAIWeekly, configs.XAIMonthly} {
+		if config.Headers["Authorization"] != "Bearer $TOKEN$" ||
+			config.Headers["x-xai-token-auth"] != "xai-grok-cli" ||
+			config.Headers["x-grok-client-version"] != "0.2.93" ||
+			config.Headers["Accept"] != "*/*" ||
+			config.Headers["User-Agent"] != "grok-pager/0.2.93 grok-shell/0.2.93 (macos; aarch64)" {
+			t.Fatalf("unexpected xai headers: %+v", config.Headers)
+		}
+		if _, ok := config.Headers["x-userid"]; ok {
+			t.Fatalf("x-userid must not be fabricated without a reliable subject: %+v", config.Headers)
+		}
 	}
 }

--- a/internal/quota/test/normalizer_test.go
+++ b/internal/quota/test/normalizer_test.go
@@ -283,32 +283,121 @@ func TestNormalizeKimiQuotaRows(t *testing.T) {
 }
 
 func TestNormalizeXAIQuotaRows(t *testing.T) {
-	rows := quota.NormalizeQuotaRows(quota.ProviderOutput{Provider: "xai", Result: quota.XAIResult{Billing: &quota.XAIBillingPayload{
-		Config: &quota.XAIBillingConfig{
-			MonthlyLimit:       quota.XAIMoneyValue{Val: 20000},
-			Used:               quota.XAIMoneyValue{Val: 167},
-			OnDemandCap:        quota.XAIMoneyValue{Val: 0},
-			BillingPeriodStart: "2026-06-01T00:00:00+00:00",
-			BillingPeriodEnd:   "2026-07-01T00:00:00+00:00",
-			History: []quota.XAIBillingHistoryItem{{
-				BillingCycle: quota.XAIBillingCycle{Year: 2026, Month: 5},
-				TotalUsed:    quota.XAIMoneyValue{Val: 0},
-			}},
-		},
-	}}})
+	rows := quota.NormalizeQuotaRows(quota.ProviderOutput{Provider: "xai", Result: quota.XAIResult{
+		Weekly: &quota.XAIBillingPayload{Config: &quota.XAIBillingConfig{
+			CurrentPeriod:      &quota.XAIBillingPeriod{Type: "weekly", Start: "2026-07-06T00:00:00Z", End: "2026-07-13T00:00:00Z"},
+			CreditUsagePercent: floatPtr(62.5),
+		}},
+		Monthly: &quota.XAIBillingPayload{Config: &quota.XAIBillingConfig{
+			MonthlyLimit:       quota.XAIMoneyValue{Val: floatPtr(1000)},
+			Used:               quota.XAIMoneyValue{Val: floatPtr(1250)},
+			OnDemandCap:        quota.XAIMoneyValue{Val: floatPtr(500)},
+			OnDemandUsed:       quota.XAIMoneyValue{Val: floatPtr(200)},
+			BillingPeriodStart: "2026-07-01T00:00:00Z",
+			BillingPeriodEnd:   "2026-08-01T00:00:00Z",
+		}},
+	}})
 
-	if len(rows) != 1 {
-		t.Fatalf("expected 1 quota row, got %#v", rows)
+	if len(rows) != 3 {
+		t.Fatalf("expected weekly, monthly, and pay-as-you-go rows, got %#v", rows)
+	}
+	if rows[0].Key != "billing.weekly" || rows[1].Key != "billing.monthly" || rows[2].Key != "billing.on_demand" {
+		t.Fatalf("unexpected xai quota order: %#v", rows)
+	}
+	weekly := rows[0]
+	assertQuotaText(t, weekly, "Weekly", "billing", "weekly")
+	assertFloatField(t, weekly.UsedPercent, 62.5, "xai weekly usedPercent")
+	assertIntField(t, weekly.Window.Seconds, 604800, "xai weekly window seconds")
+	if weekly.ResetAt != "2026-07-13T00:00:00Z" || weekly.LimitReached == nil || *weekly.LimitReached {
+		t.Fatalf("unexpected xai weekly row: %#v", weekly)
 	}
 	monthly := findQuotaRow(t, rows, "billing.monthly")
 	assertQuotaText(t, monthly, "Monthly Spend", "billing", "usd_cents")
-	assertFloatField(t, monthly.Used, 167, "xai monthly used")
-	assertFloatField(t, monthly.Limit, 20000, "xai monthly limit")
-	assertFloatField(t, monthly.Remaining, 19833, "xai monthly remaining")
-	assertFloatField(t, monthly.UsedPercent, 0.835, "xai monthly usedPercent")
+	assertFloatField(t, monthly.Used, 1000, "xai monthly used")
+	assertFloatField(t, monthly.Limit, 1000, "xai monthly limit")
+	assertFloatField(t, monthly.Remaining, 0, "xai monthly remaining")
+	assertFloatField(t, monthly.UsedPercent, 100, "xai monthly usedPercent")
 	assertIntField(t, monthly.Window.Seconds, 2592000, "xai monthly window seconds")
-	if monthly.ResetAt != "2026-07-01T00:00:00+00:00" {
+	if monthly.ResetAt != "2026-08-01T00:00:00Z" || monthly.LimitReached == nil || *monthly.LimitReached || monthly.Allowed == nil || !*monthly.Allowed {
 		t.Fatalf("unexpected xai monthly resetAt: %#v", monthly)
+	}
+	onDemand := findQuotaRow(t, rows, "billing.on_demand")
+	assertQuotaText(t, onDemand, "Pay-as-you-go", "billing", "usd_cents")
+	assertFloatField(t, onDemand.Used, 200, "xai pay-as-you-go used")
+	assertFloatField(t, onDemand.Limit, 500, "xai pay-as-you-go limit")
+	assertFloatField(t, onDemand.Remaining, 300, "xai pay-as-you-go remaining")
+	assertFloatField(t, onDemand.UsedPercent, 40, "xai pay-as-you-go usedPercent")
+	if onDemand.LimitReached == nil || *onDemand.LimitReached {
+		t.Fatalf("unexpected xai pay-as-you-go state: %#v", onDemand)
+	}
+}
+
+func TestNormalizeXAIProductRowsUsesStableKeysDeduplicationAndSorting(t *testing.T) {
+	rows := quota.NormalizeQuotaRows(quota.ProviderOutput{Provider: "xai", Result: quota.XAIResult{
+		Weekly: &quota.XAIBillingPayload{Config: &quota.XAIBillingConfig{
+			CurrentPeriod:      &quota.XAIBillingPeriod{Type: "weekly", End: "2026-07-13T00:00:00Z"},
+			CreditUsagePercent: floatPtr(20),
+			ProductUsage: []quota.XAIBillingProductUsage{
+				{Product: "  Grok Code  ", UsagePercent: floatPtr(80)},
+				{Product: "grok 4", UsagePercent: floatPtr(100)},
+				{Product: "GROK CODE", UsagePercent: floatPtr(90)},
+				{Product: "", UsagePercent: floatPtr(50)},
+				{Product: "No Data"},
+			},
+		}},
+	}})
+
+	if len(rows) != 3 {
+		t.Fatalf("expected weekly plus two product rows, got %#v", rows)
+	}
+	if rows[0].Key != "billing.weekly" || rows[1].Key != "billing.weekly.product.grok+4" || rows[2].Key != "billing.weekly.product.grok+code" {
+		t.Fatalf("unexpected product row order or keys: %#v", rows)
+	}
+	assertQuotaText(t, rows[1], "grok 4 Usage", "product", "grok 4")
+	assertFloatField(t, rows[1].UsedPercent, 100, "grok 4 usedPercent")
+	if rows[1].LimitReached == nil || !*rows[1].LimitReached {
+		t.Fatalf("expected grok 4 product quota to be reached: %#v", rows[1])
+	}
+	assertQuotaText(t, rows[2], "Grok Code Usage", "product", "Grok Code")
+	assertFloatField(t, rows[2].UsedPercent, 90, "deduplicated grok code usedPercent")
+	assertIntField(t, rows[2].Window.Seconds, 604800, "product weekly window seconds")
+	if rows[2].ResetAt != "2026-07-13T00:00:00Z" {
+		t.Fatalf("unexpected product resetAt: %#v", rows[2])
+	}
+}
+
+func TestNormalizeXAIDerivesPayAsYouGoUsageFromTotalSpend(t *testing.T) {
+	rows := quota.NormalizeQuotaRows(quota.ProviderOutput{Provider: "xai", Result: quota.XAIResult{
+		Monthly: &quota.XAIBillingPayload{Config: &quota.XAIBillingConfig{
+			MonthlyLimit: quota.XAIMoneyValue{Val: floatPtr(1000)},
+			Used:         quota.XAIMoneyValue{Val: floatPtr(1300)},
+			OnDemandCap:  quota.XAIMoneyValue{Val: floatPtr(500)},
+		}},
+	}})
+
+	monthly := findQuotaRow(t, rows, "billing.monthly")
+	if monthly.LimitReached == nil || *monthly.LimitReached {
+		t.Fatalf("monthly included spend must remain allowed while PAYG is available: %#v", monthly)
+	}
+	onDemand := findQuotaRow(t, rows, "billing.on_demand")
+	assertFloatField(t, onDemand.Used, 300, "derived pay-as-you-go used")
+	assertFloatField(t, onDemand.Remaining, 200, "derived pay-as-you-go remaining")
+	assertFloatField(t, onDemand.UsedPercent, 60, "derived pay-as-you-go usedPercent")
+}
+
+func TestNormalizeXAIQuotaRowsMarksPayAsYouGoExhaustion(t *testing.T) {
+	rows := quota.NormalizeQuotaRows(quota.ProviderOutput{Provider: "xai", Result: quota.XAIResult{
+		Monthly: &quota.XAIBillingPayload{Config: &quota.XAIBillingConfig{
+			MonthlyLimit: quota.XAIMoneyValue{Val: floatPtr(1000)},
+			Used:         quota.XAIMoneyValue{Val: floatPtr(1500)},
+			OnDemandCap:  quota.XAIMoneyValue{Val: floatPtr(500)},
+		}},
+	}})
+
+	monthly := findQuotaRow(t, rows, "billing.monthly")
+	onDemand := findQuotaRow(t, rows, "billing.on_demand")
+	if monthly.LimitReached == nil || !*monthly.LimitReached || onDemand.LimitReached == nil || !*onDemand.LimitReached {
+		t.Fatalf("expected exhausted included and PAYG rows to be limit reached: %#v", rows)
 	}
 }
 

--- a/internal/quota/test/service_refresh_test.go
+++ b/internal/quota/test/service_refresh_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"cpa-usage-keeper/internal/cpa/dto/apicall"
 	"cpa-usage-keeper/internal/entities"
 	. "cpa-usage-keeper/internal/quota"
 
@@ -1074,6 +1075,28 @@ func TestInspectionStatusClassifiesLimitReachedByKnownAuthFileType(t *testing.T)
 			wantLimitReached: 1,
 		},
 		{
+			name:     "xai monthly included spend exhausted with payg available",
+			identity: entities.UsageIdentity{Identity: "xai-payg-auth", Name: "xAI PAYG", Provider: "xai", Type: "xai", AuthType: entities.UsageIdentityAuthTypeAuthFile},
+			quota: []QuotaRow{
+				{
+					Key:          "billing.monthly",
+					Label:        "Monthly Spend",
+					Used:         floatPtr(100),
+					Limit:        floatPtr(100),
+					LimitReached: boolPtr(false),
+				},
+				{
+					Key:          "billing.on_demand",
+					Label:        "Pay-as-you-go",
+					Used:         floatPtr(20),
+					Limit:        floatPtr(100),
+					LimitReached: boolPtr(false),
+				},
+			},
+			wantStatus: "normal",
+			wantNormal: 1,
+		},
+		{
 			name:     "generic type with known provider does not use provider fallback",
 			identity: entities.UsageIdentity{Identity: "generic-codex-auth", Name: "Generic Codex", Provider: "codex", Type: "generic", AuthType: entities.UsageIdentityAuthTypeAuthFile},
 			quota: []QuotaRow{{
@@ -1161,9 +1184,9 @@ func TestInspectionStatusClassifiesLimitReachedThroughRefreshPipeline(t *testing
 		{
 			name:     "xai used at billing limit from normalized billing row",
 			identity: entities.UsageIdentity{Identity: "xai-auth", Provider: "xai", Type: "xai", AuthType: entities.UsageIdentityAuthTypeAuthFile},
-			output: ProviderOutput{Provider: "xai", Result: XAIResult{Billing: &XAIBillingPayload{Config: &XAIBillingConfig{
-				MonthlyLimit:       XAIMoneyValue{Val: 100},
-				Used:               XAIMoneyValue{Val: 100},
+			output: ProviderOutput{Provider: "xai", Result: XAIResult{Monthly: &XAIBillingPayload{Config: &XAIBillingConfig{
+				MonthlyLimit:       XAIMoneyValue{Val: floatPtr(100)},
+				Used:               XAIMoneyValue{Val: floatPtr(100)},
 				BillingPeriodEnd:   "2026-07-01T00:00:00+00:00",
 				BillingPeriodStart: "2026-06-01T00:00:00+00:00",
 			}}}},
@@ -1380,6 +1403,69 @@ func TestRefreshTaskCachesConfiguredHTTPError(t *testing.T) {
 	}
 	if cache.Items[0].RefreshedAt == nil || cache.Items[0].RefreshedAt.IsZero() {
 		t.Fatalf("expected cached failed item to expose refreshed_at, got %+v", cache.Items[0])
+	}
+}
+
+func TestXAIRefreshCachesCompletedPartialQuota(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "xai-auth", Provider: "xai", Type: "xai", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	monthlyJSON := `{"config":{"monthlyLimit":{"val":1000},"used":{"val":250},"onDemandCap":{"val":0},"billingPeriodEnd":"2026-08-01T00:00:00Z"}}`
+	caller := newXAIManagementCaller(
+		&apicall.Response{StatusCode: 500, BodyText: "weekly unavailable"},
+		&apicall.Response{StatusCode: 200, BodyText: monthlyJSON, Body: json.RawMessage(monthlyJSON)},
+	)
+	configs := DefaultProviderConfigs()
+	service := newQuotaServiceWithRegistry(t, db, NewProviderRegistry(map[string]ProviderHandler{
+		"xai": NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly),
+	}))
+	setRefreshCooldown(service, func(time.Duration) {})
+
+	response, err := service.Refresh(context.Background(), RefreshRequest{AuthIndexes: []string{"xai-auth"}, Source: RefreshSourceManual})
+	if err != nil {
+		t.Fatalf("Refresh returned error: %v", err)
+	}
+	task := waitForRefreshTask(t, service, response.Tasks[0].AuthIndex, RefreshTaskStatusCompleted)
+	if task.Quota == nil || len(task.Quota.Quota) != 1 || task.Quota.Quota[0].Key != "billing.monthly" {
+		t.Fatalf("expected completed monthly-only xai quota, got %+v", task)
+	}
+
+	cache, err := service.GetCachedQuota(context.Background(), CacheRequest{AuthIndexes: []string{"xai-auth"}})
+	if err != nil {
+		t.Fatalf("GetCachedQuota returned error: %v", err)
+	}
+	if len(cache.Items) != 1 || cache.Items[0].Status != RefreshTaskStatusCompleted || cache.Items[0].Quota == nil || len(cache.Items[0].Quota.Quota) != 1 || cache.Items[0].Quota.Quota[0].Key != "billing.monthly" {
+		t.Fatalf("expected partial xai result in the existing completed cache, got %+v", cache.Items)
+	}
+}
+
+func TestXAIRefreshCachesFailureOnlyWhenBothBillingSourcesFail(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "xai-auth", Provider: "xai", Type: "xai", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	caller := newXAIManagementCaller(
+		&apicall.Response{StatusCode: 500, BodyText: "weekly unavailable"},
+		&apicall.Response{StatusCode: 401, BodyText: "token expired"},
+	)
+	configs := DefaultProviderConfigs()
+	service := newQuotaServiceWithRegistry(t, db, NewProviderRegistry(map[string]ProviderHandler{
+		"xai": NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly),
+	}))
+	setRefreshCooldown(service, func(time.Duration) {})
+
+	response, err := service.Refresh(context.Background(), RefreshRequest{AuthIndexes: []string{"xai-auth"}, Source: RefreshSourceManual})
+	if err != nil {
+		t.Fatalf("Refresh returned error: %v", err)
+	}
+	task := waitForRefreshTask(t, service, response.Tasks[0].AuthIndex, RefreshTaskStatusFailed)
+	if task.HTTPStatusCode == nil || *task.HTTPStatusCode != 401 || task.ExpiresAt == nil || task.RefreshedAt == nil || task.ExpiresAt.Sub(*task.RefreshedAt) != RefreshErrorCacheTTL {
+		t.Fatalf("expected xai failure to reuse cacheable HTTP error semantics, got %+v", task)
+	}
+
+	cache, err := service.GetCachedQuota(context.Background(), CacheRequest{AuthIndexes: []string{"xai-auth"}})
+	if err != nil {
+		t.Fatalf("GetCachedQuota returned error: %v", err)
+	}
+	if len(cache.Items) != 1 || cache.Items[0].Status != RefreshTaskStatusFailed || cache.Items[0].HTTPStatusCode == nil || *cache.Items[0].HTTPStatusCode != 401 {
+		t.Fatalf("expected both-failed xai result in the existing failed cache, got %+v", cache.Items)
 	}
 }
 

--- a/internal/quota/test/xai_test.go
+++ b/internal/quota/test/xai_test.go
@@ -3,22 +3,31 @@ package test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strconv"
+	"sync"
 	"testing"
+	"time"
 
 	"cpa-usage-keeper/internal/cpa/dto/apicall"
 	"cpa-usage-keeper/internal/entities"
 	"cpa-usage-keeper/internal/quota"
 )
 
+const (
+	xaiWeeklyBillingURL  = "https://cli-chat-proxy.grok.com/v1/billing?format=credits"
+	xaiMonthlyBillingURL = "https://cli-chat-proxy.grok.com/v1/billing"
+)
+
 func TestXAIProviderCallsBillingRequest(t *testing.T) {
+	weeklyJSON := `{"config":{"currentPeriod":{"type":"weekly","end":"2026-07-13T00:00:00Z"},"creditUsagePercent":10}}`
 	xaiBillingJSON := `{"config":{"monthlyLimit":{"val":20000},"used":{"val":167},"onDemandCap":{"val":0},"billingPeriodStart":"2026-06-01T00:00:00+00:00","billingPeriodEnd":"2026-07-01T00:00:00+00:00","history":[{"billingCycle":{"year":2026,"month":5},"includedUsed":{"val":0},"onDemandUsed":{"val":0},"totalUsed":{"val":0}}]}}`
-	caller := &recordingManagementCaller{responses: []*apicall.Response{{
-		StatusCode: 200,
-		BodyText:   xaiBillingJSON,
-		Body:       json.RawMessage(xaiBillingJSON),
-	}}}
-	provider := quota.NewXAIProvider(caller, quota.DefaultProviderConfigs().XAI)
+	caller := newXAIManagementCaller(
+		&apicall.Response{StatusCode: 200, BodyText: weeklyJSON, Body: json.RawMessage(weeklyJSON)},
+		&apicall.Response{StatusCode: 200, BodyText: xaiBillingJSON, Body: json.RawMessage(xaiBillingJSON)},
+	)
+	configs := quota.DefaultProviderConfigs()
+	provider := quota.NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly)
 
 	output, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "xai-auth"}})
 	if err != nil {
@@ -31,22 +40,23 @@ func TestXAIProviderCallsBillingRequest(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected xai result type, got %T", output.Result)
 	}
-	if result.Billing == nil || result.Billing.Config == nil || result.Billing.Config.MonthlyLimit.Val != 20000 || result.Billing.Config.Used.Val != 167 || result.Billing.Config.OnDemandCap.Val != 0 || len(result.Billing.Config.History) != 1 {
-		t.Fatalf("expected parsed xai billing payload, got %#v", result.Billing)
+	if result.Monthly == nil || result.Monthly.Config == nil || result.Monthly.Config.MonthlyLimit.Val == nil || *result.Monthly.Config.MonthlyLimit.Val != 20000 || result.Monthly.Config.Used.Val == nil || *result.Monthly.Config.Used.Val != 167 || result.Monthly.Config.OnDemandCap.Val == nil || *result.Monthly.Config.OnDemandCap.Val != 0 || len(result.Monthly.Config.History) != 1 {
+		t.Fatalf("expected parsed xai monthly payload, got %#v", result.Monthly)
 	}
 	encoded, err := json.Marshal(output.Result)
 	if err != nil {
 		t.Fatalf("marshal xai result: %v", err)
 	}
 	body := string(encoded)
-	if !contains(body, `"billing":{"config"`) || contains(body, "bodyText") || contains(body, "statusCode") {
+	if !contains(body, `"weekly":{"config"`) || !contains(body, `"monthly":{"config"`) || contains(body, "bodyText") || contains(body, "statusCode") {
 		t.Fatalf("unexpected xai result JSON: %s", body)
 	}
-	if len(caller.requests) != 1 {
-		t.Fatalf("expected one api-call request, got %d", len(caller.requests))
+	requests := caller.requestsSnapshot()
+	if len(requests) != 2 {
+		t.Fatalf("expected two api-call requests, got %d", len(requests))
 	}
-	request := caller.requests[0]
-	if request.AuthIndex != "xai-auth" || request.Method != "GET" || request.URL != "https://cli-chat-proxy.grok.com/v1/billing" {
+	request, ok := caller.requestForURL(xaiMonthlyBillingURL)
+	if !ok || request.AuthIndex != "xai-auth" || request.Method != "GET" {
 		t.Fatalf("unexpected api-call request: %+v", request)
 	}
 	if request.Header["Authorization"] != "Bearer $TOKEN$" {
@@ -57,15 +67,15 @@ func TestXAIProviderCallsBillingRequest(t *testing.T) {
 	}
 }
 
-func TestXAIProviderParsesNestedBodyTextBillingResponse(t *testing.T) {
-	inner := `{"config":{"monthlyLimit":{"val":1000},"used":{"val":250},"billingPeriodStart":"2026-06-01T00:00:00+00:00","billingPeriodEnd":"2026-07-01T00:00:00+00:00"}}`
-	wrapped := `{"status_code":200,"body":` + strconv.Quote(inner) + `}`
-	caller := &recordingManagementCaller{responses: []*apicall.Response{{
-		StatusCode: 200,
-		BodyText:   wrapped,
-		Body:       json.RawMessage(wrapped),
-	}}}
-	provider := quota.NewXAIProvider(caller, quota.DefaultProviderConfigs().XAI)
+func TestXAIProviderCallsWeeklyThenMonthlyWithIndependentHeaders(t *testing.T) {
+	weeklyJSON := `{"config":{"currentPeriod":{"type":"weekly","start":"2026-07-06T00:00:00Z","end":"2026-07-13T00:00:00Z"},"creditUsagePercent":25}}`
+	monthlyJSON := `{"config":{"monthlyLimit":{"val":20000},"used":{"val":167},"billingPeriodEnd":"2026-08-01T00:00:00Z"}}`
+	caller := newXAIManagementCaller(
+		&apicall.Response{StatusCode: 200, BodyText: weeklyJSON, Body: json.RawMessage(weeklyJSON)},
+		&apicall.Response{StatusCode: 200, BodyText: monthlyJSON, Body: json.RawMessage(monthlyJSON)},
+	)
+	configs := quota.DefaultProviderConfigs()
+	provider := quota.NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly)
 
 	output, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "xai-auth"}})
 	if err != nil {
@@ -75,8 +85,317 @@ func TestXAIProviderParsesNestedBodyTextBillingResponse(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected xai result type, got %T", output.Result)
 	}
-	if result.Billing == nil || result.Billing.Config == nil || result.Billing.Config.Used.Val != 250 {
-		t.Fatalf("expected nested body xai billing payload, got %#v", result.Billing)
+	if result.Weekly == nil || result.Weekly.Config == nil || result.Monthly == nil || result.Monthly.Config == nil {
+		t.Fatalf("expected both weekly and monthly payloads, got %#v", result)
+	}
+	requests := caller.requestsSnapshot()
+	if len(requests) != 2 {
+		t.Fatalf("expected weekly and monthly requests, got %d", len(requests))
+	}
+	seenURLs := make(map[string]bool, 2)
+	for index, request := range requests {
+		if request.AuthIndex != "xai-auth" || request.Method != "GET" || (request.URL != xaiWeeklyBillingURL && request.URL != xaiMonthlyBillingURL) {
+			t.Fatalf("unexpected request %d: %+v", index+1, request)
+		}
+		seenURLs[request.URL] = true
+		if request.Header["Authorization"] != "Bearer $TOKEN$" ||
+			request.Header["x-xai-token-auth"] != "xai-grok-cli" ||
+			request.Header["x-grok-client-version"] != "0.2.93" {
+			t.Fatalf("unexpected request %d headers: %+v", index+1, request.Header)
+		}
+		if _, ok := request.Header["x-userid"]; ok {
+			t.Fatalf("request %d must not include an unverified x-userid: %+v", index+1, request.Header)
+		}
+		if request.Data != nil {
+			t.Fatalf("expected request %d to have no data body, got %#v", index+1, request.Data)
+		}
+	}
+	if !seenURLs[xaiWeeklyBillingURL] || !seenURLs[xaiMonthlyBillingURL] {
+		t.Fatalf("expected both billing endpoint URLs, got %+v", seenURLs)
+	}
+}
+
+func TestXAIProviderCompletesWithEitherValidBillingResult(t *testing.T) {
+	weeklyJSON := `{"config":{"currentPeriod":{"type":"weekly","end":"2026-07-13T00:00:00Z"},"creditUsagePercent":25}}`
+	monthlyJSON := `{"config":{"monthlyLimit":{"val":20000},"used":{"val":167},"billingPeriodEnd":"2026-08-01T00:00:00Z"}}`
+	tests := []struct {
+		name        string
+		weekly      *apicall.Response
+		monthly     *apicall.Response
+		wantWeekly  bool
+		wantMonthly bool
+	}{
+		{
+			name:        "weekly fails and monthly succeeds",
+			weekly:      &apicall.Response{StatusCode: 500, BodyText: "weekly unavailable"},
+			monthly:     &apicall.Response{StatusCode: 200, BodyText: monthlyJSON, Body: json.RawMessage(monthlyJSON)},
+			wantMonthly: true,
+		},
+		{
+			name:       "weekly succeeds and monthly fails",
+			weekly:     &apicall.Response{StatusCode: 200, BodyText: weeklyJSON, Body: json.RawMessage(weeklyJSON)},
+			monthly:    &apicall.Response{StatusCode: 500, BodyText: "monthly unavailable"},
+			wantWeekly: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			caller := newXAIManagementCaller(tt.weekly, tt.monthly)
+			configs := quota.DefaultProviderConfigs()
+			provider := quota.NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly)
+
+			output, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "xai-auth"}})
+			if err != nil {
+				t.Fatalf("Check returned error for a partial success: %v", err)
+			}
+			result, ok := output.Result.(quota.XAIResult)
+			if !ok {
+				t.Fatalf("expected xai result type, got %T", output.Result)
+			}
+			if (result.Weekly != nil) != tt.wantWeekly || (result.Monthly != nil) != tt.wantMonthly {
+				t.Fatalf("unexpected partial result: %#v", result)
+			}
+			if requests := caller.requestsSnapshot(); len(requests) != 2 {
+				t.Fatalf("expected both endpoints to be attempted, got %d requests", len(requests))
+			}
+		})
+	}
+}
+
+func TestXAIProviderPreservesCacheableHTTPStatusWhenBothBillingRequestsFail(t *testing.T) {
+	caller := newXAIManagementCaller(
+		&apicall.Response{StatusCode: 500, BodyText: "weekly unavailable"},
+		&apicall.Response{StatusCode: 401, BodyText: "token expired"},
+	)
+	configs := quota.DefaultProviderConfigs()
+	provider := quota.NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly)
+
+	_, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "xai-auth"}})
+	if err == nil {
+		t.Fatal("expected both failed billing requests to fail the provider check")
+	}
+	var httpErr quota.ProviderHTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != 401 {
+		t.Fatalf("expected cacheable HTTP 401 to be preserved, got %v", err)
+	}
+	if requests := caller.requestsSnapshot(); len(requests) != 2 {
+		t.Fatalf("expected both endpoints to be attempted, got %d requests", len(requests))
+	}
+}
+
+func TestXAIProviderParsesWeeklyAndMonthlyBillingShapes(t *testing.T) {
+	weeklyJSON := `{"config":{"current_period":{"type":"weekly","start":"2026-07-06T00:00:00Z","end":"2026-07-13T00:00:00Z"},"credit_usage_percent":"37.5","product_usage":[{"product":"Grok 4","usage_percent":80},{"product":"Grok Code","usagePercent":"25"},{"product":"No Data","usage_percent":null}]}}`
+	monthlyJSON := `{"config":{"monthly_limit":{"val":"1000"},"used":1250,"on_demand_cap":{"val":500},"on_demand_used":{"val":"250"},"billing_period_start":"2026-07-01T00:00:00Z","billing_period_end":"2026-08-01T00:00:00Z"}}`
+	caller := newXAIManagementCaller(
+		&apicall.Response{StatusCode: 200, BodyText: weeklyJSON, Body: json.RawMessage(weeklyJSON)},
+		&apicall.Response{StatusCode: 200, BodyText: monthlyJSON, Body: json.RawMessage(monthlyJSON)},
+	)
+	configs := quota.DefaultProviderConfigs()
+	provider := quota.NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly)
+
+	output, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "xai-auth"}})
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	result := output.Result.(quota.XAIResult)
+	weekly := result.Weekly.Config
+	if weekly.CurrentPeriod == nil || weekly.CurrentPeriod.Type != "weekly" || weekly.CurrentPeriod.End != "2026-07-13T00:00:00Z" {
+		t.Fatalf("unexpected weekly period: %#v", weekly.CurrentPeriod)
+	}
+	if weekly.CreditUsagePercent == nil || *weekly.CreditUsagePercent != 37.5 {
+		t.Fatalf("unexpected weekly usage percent: %#v", weekly.CreditUsagePercent)
+	}
+	if len(weekly.ProductUsage) != 3 || weekly.ProductUsage[0].UsagePercent == nil || *weekly.ProductUsage[0].UsagePercent != 80 || weekly.ProductUsage[1].UsagePercent == nil || *weekly.ProductUsage[1].UsagePercent != 25 || weekly.ProductUsage[2].UsagePercent != nil {
+		t.Fatalf("unexpected weekly product usage: %#v", weekly.ProductUsage)
+	}
+	monthly := result.Monthly.Config
+	if monthly.MonthlyLimit.Val == nil || *monthly.MonthlyLimit.Val != 1000 || monthly.Used.Val == nil || *monthly.Used.Val != 1250 || monthly.OnDemandCap.Val == nil || *monthly.OnDemandCap.Val != 500 || monthly.OnDemandUsed.Val == nil || *monthly.OnDemandUsed.Val != 250 {
+		t.Fatalf("unexpected monthly money values: %#v", monthly)
+	}
+	if monthly.BillingPeriodStart != "2026-07-01T00:00:00Z" || monthly.BillingPeriodEnd != "2026-08-01T00:00:00Z" {
+		t.Fatalf("unexpected monthly billing period: %#v", monthly)
+	}
+}
+
+func TestXAIProviderDistinguishesEmptyBillingFromExplicitZeroQuota(t *testing.T) {
+	t.Run("both empty responses fail", func(t *testing.T) {
+		caller := newXAIManagementCaller(
+			&apicall.Response{StatusCode: 200, BodyText: `{"config":{}}`, Body: json.RawMessage(`{"config":{}}`)},
+			&apicall.Response{StatusCode: 200, BodyText: `{"config":null}`, Body: json.RawMessage(`{"config":null}`)},
+		)
+		configs := quota.DefaultProviderConfigs()
+		provider := quota.NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly)
+
+		if _, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "xai-auth"}}); err == nil {
+			t.Fatal("expected empty weekly and monthly billing responses to fail")
+		}
+	})
+
+	t.Run("explicit zero weekly usage is valid", func(t *testing.T) {
+		weeklyJSON := `{"config":{"current_period":{"type":"weekly","end":"2026-07-13T00:00:00Z"},"credit_usage_percent":0}}`
+		caller := newXAIManagementCaller(
+			&apicall.Response{StatusCode: 200, BodyText: weeklyJSON, Body: json.RawMessage(weeklyJSON)},
+			&apicall.Response{StatusCode: 500, BodyText: "monthly unavailable"},
+		)
+		configs := quota.DefaultProviderConfigs()
+		provider := quota.NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly)
+
+		output, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "xai-auth"}})
+		if err != nil {
+			t.Fatalf("explicit zero quota must remain a valid partial result: %v", err)
+		}
+		result := output.Result.(quota.XAIResult)
+		if result.Weekly == nil || result.Weekly.Config == nil || result.Weekly.Config.CreditUsagePercent == nil || *result.Weekly.Config.CreditUsagePercent != 0 {
+			t.Fatalf("unexpected explicit zero weekly result: %#v", result.Weekly)
+		}
+	})
+}
+
+func TestXAIProviderStartsBothEqualBillingSourcesWithoutBlocking(t *testing.T) {
+	monthlyJSON := `{"config":{"monthlyLimit":{"val":1000},"used":{"val":250}}}`
+	caller := &blockingWeeklyManagementCaller{
+		weeklyStarted:  make(chan struct{}),
+		monthlyStarted: make(chan struct{}),
+		releaseWeekly:  make(chan struct{}),
+		monthlyResponse: &apicall.Response{
+			StatusCode: 200,
+			BodyText:   monthlyJSON,
+			Body:       json.RawMessage(monthlyJSON),
+		},
+	}
+	configs := quota.DefaultProviderConfigs()
+	provider := quota.NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly)
+	type checkResult struct {
+		output quota.ProviderOutput
+		err    error
+	}
+	resultCh := make(chan checkResult, 1)
+	go func() {
+		output, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "xai-auth"}})
+		resultCh <- checkResult{output: output, err: err}
+	}()
+
+	select {
+	case <-caller.weeklyStarted:
+	case <-time.After(time.Second):
+		t.Fatal("weekly billing request did not start")
+	}
+	select {
+	case <-caller.monthlyStarted:
+		close(caller.releaseWeekly)
+	case <-time.After(200 * time.Millisecond):
+		close(caller.releaseWeekly)
+		<-resultCh
+		t.Fatal("monthly billing request was blocked behind weekly")
+	}
+	result := <-resultCh
+	if result.err != nil {
+		t.Fatalf("expected monthly partial success, got %v", result.err)
+	}
+	xaiResult := result.output.Result.(quota.XAIResult)
+	if xaiResult.Monthly == nil || xaiResult.Weekly != nil {
+		t.Fatalf("unexpected concurrent partial result: %#v", xaiResult)
+	}
+}
+
+func TestXAIProviderParsesNestedBodyTextBillingResponse(t *testing.T) {
+	inner := `{"config":{"monthlyLimit":{"val":1000},"used":{"val":250},"billingPeriodStart":"2026-06-01T00:00:00+00:00","billingPeriodEnd":"2026-07-01T00:00:00+00:00"}}`
+	wrapped := `{"status_code":200,"body":` + strconv.Quote(inner) + `}`
+	caller := newXAIManagementCaller(
+		&apicall.Response{StatusCode: 500, BodyText: "weekly unavailable"},
+		&apicall.Response{StatusCode: 200, BodyText: wrapped, Body: json.RawMessage(wrapped)},
+	)
+	configs := quota.DefaultProviderConfigs()
+	provider := quota.NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly)
+
+	output, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "xai-auth"}})
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	result, ok := output.Result.(quota.XAIResult)
+	if !ok {
+		t.Fatalf("expected xai result type, got %T", output.Result)
+	}
+	if result.Monthly == nil || result.Monthly.Config == nil || result.Monthly.Config.Used.Val == nil || *result.Monthly.Config.Used.Val != 250 {
+		t.Fatalf("expected nested body xai monthly payload, got %#v", result.Monthly)
+	}
+}
+
+func TestXAIProviderAddsXAIUserIDToBothBillingRequests(t *testing.T) {
+	weeklyJSON := `{"config":{"currentPeriod":{"type":"weekly","end":"2026-07-13T00:00:00Z"},"creditUsagePercent":10}}`
+	monthlyJSON := `{"config":{"monthlyLimit":{"val":20000},"used":{"val":167},"billingPeriodEnd":"2026-08-01T00:00:00Z"}}`
+	caller := newXAIManagementCaller(
+		&apicall.Response{StatusCode: 200, BodyText: weeklyJSON, Body: json.RawMessage(weeklyJSON)},
+		&apicall.Response{StatusCode: 200, BodyText: monthlyJSON, Body: json.RawMessage(monthlyJSON)},
+	)
+	configs := quota.DefaultProviderConfigs()
+	provider := quota.NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly)
+	xaiUserID := "  xai-user-123  "
+
+	if _, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{
+		Identity:  "xai-auth",
+		XAIUserID: &xaiUserID,
+	}}); err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	requests := caller.requestsSnapshot()
+	if len(requests) != 2 {
+		t.Fatalf("expected weekly and monthly requests, got %d", len(requests))
+	}
+	for _, request := range requests {
+		if request.Header["x-userid"] != "xai-user-123" {
+			t.Fatalf("expected %s request to include trimmed x-userid, got %+v", request.URL, request.Header)
+		}
+	}
+	if _, ok := configs.XAIWeekly.Headers["x-userid"]; ok {
+		t.Fatalf("weekly config header template must remain unchanged: %+v", configs.XAIWeekly.Headers)
+	}
+	if _, ok := configs.XAIMonthly.Headers["x-userid"]; ok {
+		t.Fatalf("monthly config header template must remain unchanged: %+v", configs.XAIMonthly.Headers)
+	}
+}
+
+func TestXAIProviderDoesNotLeakXAIUserIDBetweenIdentities(t *testing.T) {
+	weeklyJSON := `{"config":{"currentPeriod":{"type":"weekly","end":"2026-07-13T00:00:00Z"},"creditUsagePercent":10}}`
+	monthlyJSON := `{"config":{"monthlyLimit":{"val":20000},"used":{"val":167},"billingPeriodEnd":"2026-08-01T00:00:00Z"}}`
+	caller := newXAIManagementCaller(
+		&apicall.Response{StatusCode: 200, BodyText: weeklyJSON, Body: json.RawMessage(weeklyJSON)},
+		&apicall.Response{StatusCode: 200, BodyText: monthlyJSON, Body: json.RawMessage(monthlyJSON)},
+	)
+	configs := quota.DefaultProviderConfigs()
+	provider := quota.NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly)
+	firstUserID := "first-user"
+
+	if _, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{
+		Identity:  "first-auth",
+		XAIUserID: &firstUserID,
+	}}); err != nil {
+		t.Fatalf("first Check returned error: %v", err)
+	}
+	if _, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{
+		Identity: "second-auth",
+	}}); err != nil {
+		t.Fatalf("second Check returned error: %v", err)
+	}
+
+	requests := caller.requestsSnapshot()
+	if len(requests) != 4 {
+		t.Fatalf("expected four billing requests, got %d", len(requests))
+	}
+	for _, request := range requests {
+		switch request.AuthIndex {
+		case "first-auth":
+			if request.Header["x-userid"] != firstUserID {
+				t.Fatalf("expected first identity header on %s, got %+v", request.URL, request.Header)
+			}
+		case "second-auth":
+			if _, ok := request.Header["x-userid"]; ok {
+				t.Fatalf("second identity must not inherit x-userid on %s: %+v", request.URL, request.Header)
+			}
+		default:
+			t.Fatalf("unexpected auth index in request: %+v", request)
+		}
 	}
 }
 
@@ -87,15 +406,16 @@ func TestXAIProviderCopiesHeadersForEachBillingRequest(t *testing.T) {
 		BodyText:   xaiBillingJSON,
 		Body:       json.RawMessage(xaiBillingJSON),
 	}}
-	provider := quota.NewXAIProvider(caller, quota.DefaultProviderConfigs().XAI)
+	configs := quota.DefaultProviderConfigs()
+	provider := quota.NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly)
 
 	for index := 0; index < 2; index++ {
 		if _, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "xai-auth"}}); err != nil {
 			t.Fatalf("Check %d returned error: %v", index+1, err)
 		}
 	}
-	if len(caller.authorizations) != 2 {
-		t.Fatalf("expected two xai billing requests, got %d", len(caller.authorizations))
+	if len(caller.authorizations) != 4 {
+		t.Fatalf("expected four xai billing requests, got %d", len(caller.authorizations))
 	}
 	for index, authorization := range caller.authorizations {
 		if authorization != "Bearer $TOKEN$" {
@@ -104,13 +424,72 @@ func TestXAIProviderCopiesHeadersForEachBillingRequest(t *testing.T) {
 	}
 }
 
+type xaiManagementCaller struct {
+	mu        sync.Mutex
+	requests  []apicall.Request
+	responses map[string]*apicall.Response
+}
+
+func newXAIManagementCaller(weekly *apicall.Response, monthly *apicall.Response) *xaiManagementCaller {
+	return &xaiManagementCaller{responses: map[string]*apicall.Response{
+		xaiWeeklyBillingURL:  weekly,
+		xaiMonthlyBillingURL: monthly,
+	}}
+}
+
+func (c *xaiManagementCaller) CallManagementAPI(_ context.Context, request apicall.Request) (*apicall.Response, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.requests = append(c.requests, request)
+	response := c.responses[request.URL]
+	if response == nil {
+		return &apicall.Response{StatusCode: 500, BodyText: "missing test response"}, nil
+	}
+	return response, nil
+}
+
+func (c *xaiManagementCaller) requestsSnapshot() []apicall.Request {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]apicall.Request(nil), c.requests...)
+}
+
+func (c *xaiManagementCaller) requestForURL(targetURL string) (apicall.Request, bool) {
+	for _, request := range c.requestsSnapshot() {
+		if request.URL == targetURL {
+			return request, true
+		}
+	}
+	return apicall.Request{}, false
+}
+
 type mutatingHeaderManagementCaller struct {
+	mu             sync.Mutex
 	authorizations []string
 	response       *apicall.Response
 }
 
 func (c *mutatingHeaderManagementCaller) CallManagementAPI(ctx context.Context, request apicall.Request) (*apicall.Response, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.authorizations = append(c.authorizations, request.Header["Authorization"])
 	request.Header["Authorization"] = "Bearer leaked-token"
 	return c.response, nil
+}
+
+type blockingWeeklyManagementCaller struct {
+	weeklyStarted   chan struct{}
+	monthlyStarted  chan struct{}
+	releaseWeekly   chan struct{}
+	monthlyResponse *apicall.Response
+}
+
+func (c *blockingWeeklyManagementCaller) CallManagementAPI(_ context.Context, request apicall.Request) (*apicall.Response, error) {
+	if request.URL == "https://cli-chat-proxy.grok.com/v1/billing?format=credits" {
+		close(c.weeklyStarted)
+		<-c.releaseWeekly
+		return &apicall.Response{StatusCode: 500, BodyText: "weekly unavailable"}, nil
+	}
+	close(c.monthlyStarted)
+	return c.monthlyResponse, nil
 }

--- a/internal/quota/test/xai_test.go
+++ b/internal/quota/test/xai_test.go
@@ -184,6 +184,86 @@ func TestXAIProviderPreservesCacheableHTTPStatusWhenBothBillingRequestsFail(t *t
 	}
 }
 
+func TestXAIProviderSelectsSinglePrimaryErrorWhenBothBillingRequestsFail(t *testing.T) {
+	weeklyFailure := errors.New("weekly failure")
+	monthlyFailure := errors.New("monthly failure")
+	tests := []struct {
+		name       string
+		weeklyErr  error
+		monthlyErr error
+		assert     func(*testing.T, error)
+	}{
+		{
+			name:       "401 beats timeout",
+			weeklyErr:  context.DeadlineExceeded,
+			monthlyErr: quota.ProviderHTTPError{StatusCode: 401, Message: "token expired"},
+			assert: func(t *testing.T, err error) {
+				var httpErr quota.ProviderHTTPError
+				if !errors.As(err, &httpErr) || httpErr.StatusCode != 401 {
+					t.Fatalf("expected HTTP 401 primary error, got %v", err)
+				}
+				if errors.Is(err, context.DeadlineExceeded) {
+					t.Fatalf("timeout must not remain a second primary classification: %v", err)
+				}
+			},
+		},
+		{
+			name:       "402 beats cancellation",
+			weeklyErr:  context.Canceled,
+			monthlyErr: quota.ProviderHTTPError{StatusCode: 402, Message: "payment required"},
+			assert: func(t *testing.T, err error) {
+				var httpErr quota.ProviderHTTPError
+				if !errors.As(err, &httpErr) || httpErr.StatusCode != 402 {
+					t.Fatalf("expected HTTP 402 primary error, got %v", err)
+				}
+				if errors.Is(err, context.Canceled) {
+					t.Fatalf("cancellation must not remain a second primary classification: %v", err)
+				}
+			},
+		},
+		{
+			name:       "timeout beats other HTTP error",
+			weeklyErr:  quota.ProviderHTTPError{StatusCode: 500, Message: "weekly unavailable"},
+			monthlyErr: context.DeadlineExceeded,
+			assert: func(t *testing.T, err error) {
+				if !errors.Is(err, context.DeadlineExceeded) {
+					t.Fatalf("expected timeout primary error, got %v", err)
+				}
+				var httpErr quota.ProviderHTTPError
+				if errors.As(err, &httpErr) {
+					t.Fatalf("HTTP 500 must not remain a second primary classification: %v", err)
+				}
+			},
+		},
+		{
+			name:       "first other error wins",
+			weeklyErr:  weeklyFailure,
+			monthlyErr: monthlyFailure,
+			assert: func(t *testing.T, err error) {
+				if !errors.Is(err, weeklyFailure) || errors.Is(err, monthlyFailure) {
+					t.Fatalf("expected only the first other error, got %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configs := quota.DefaultProviderConfigs()
+			provider := quota.NewXAIProvider(xaiErrorManagementCaller{
+				weeklyErr:  tt.weeklyErr,
+				monthlyErr: tt.monthlyErr,
+			}, configs.XAIWeekly, configs.XAIMonthly)
+
+			_, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "xai-auth"}})
+			if err == nil {
+				t.Fatal("expected both failed billing requests to fail the provider check")
+			}
+			tt.assert(t, err)
+		})
+	}
+}
+
 func TestXAIProviderParsesWeeklyAndMonthlyBillingShapes(t *testing.T) {
 	weeklyJSON := `{"config":{"current_period":{"type":"weekly","start":"2026-07-06T00:00:00Z","end":"2026-07-13T00:00:00Z"},"credit_usage_percent":"37.5","product_usage":[{"product":"Grok 4","usage_percent":80},{"product":"Grok Code","usagePercent":"25"},{"product":"No Data","usage_percent":null}]}}`
 	monthlyJSON := `{"config":{"monthly_limit":{"val":"1000"},"used":1250,"on_demand_cap":{"val":500},"on_demand_used":{"val":"250"},"billing_period_start":"2026-07-01T00:00:00Z","billing_period_end":"2026-08-01T00:00:00Z"}}`
@@ -215,6 +295,42 @@ func TestXAIProviderParsesWeeklyAndMonthlyBillingShapes(t *testing.T) {
 	}
 	if monthly.BillingPeriodStart != "2026-07-01T00:00:00Z" || monthly.BillingPeriodEnd != "2026-08-01T00:00:00Z" {
 		t.Fatalf("unexpected monthly billing period: %#v", monthly)
+	}
+}
+
+func TestXAIProviderRejectsNonFiniteBillingNumbers(t *testing.T) {
+	tests := []struct {
+		name    string
+		weekly  *apicall.Response
+		monthly *apicall.Response
+	}{
+		{
+			name:    "weekly usage percent NaN",
+			weekly:  xaiJSONResponse(`{"config":{"creditUsagePercent":"NaN"}}`),
+			monthly: &apicall.Response{StatusCode: 500, BodyText: "monthly unavailable"},
+		},
+		{
+			name:    "product usage percent infinity",
+			weekly:  xaiJSONResponse(`{"config":{"productUsage":[{"product":"Grok Code","usagePercent":"+Inf"}]}}`),
+			monthly: &apicall.Response{StatusCode: 500, BodyText: "monthly unavailable"},
+		},
+		{
+			name:    "monthly money negative infinity",
+			weekly:  &apicall.Response{StatusCode: 500, BodyText: "weekly unavailable"},
+			monthly: xaiJSONResponse(`{"config":{"monthlyLimit":{"val":"-Inf"}}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			caller := newXAIManagementCaller(tt.weekly, tt.monthly)
+			configs := quota.DefaultProviderConfigs()
+			provider := quota.NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly)
+
+			if _, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "xai-auth"}}); err == nil {
+				t.Fatal("expected non-finite xAI billing data to be rejected")
+			}
+		})
 	}
 }
 
@@ -250,6 +366,37 @@ func TestXAIProviderDistinguishesEmptyBillingFromExplicitZeroQuota(t *testing.T)
 			t.Fatalf("unexpected explicit zero weekly result: %#v", result.Weekly)
 		}
 	})
+}
+
+func TestXAIProviderRejectsPeriodOnlyBillingResponses(t *testing.T) {
+	tests := []struct {
+		name    string
+		weekly  *apicall.Response
+		monthly *apicall.Response
+	}{
+		{
+			name:    "weekly period only",
+			weekly:  xaiJSONResponse(`{"config":{"currentPeriod":{"type":"weekly","start":"2026-07-06T00:00:00Z","end":"2026-07-13T00:00:00Z"}}}`),
+			monthly: &apicall.Response{StatusCode: 500, BodyText: "monthly unavailable"},
+		},
+		{
+			name:    "monthly reset only",
+			weekly:  &apicall.Response{StatusCode: 500, BodyText: "weekly unavailable"},
+			monthly: xaiJSONResponse(`{"config":{"billingPeriodStart":"2026-07-01T00:00:00Z","billingPeriodEnd":"2026-08-01T00:00:00Z"}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			caller := newXAIManagementCaller(tt.weekly, tt.monthly)
+			configs := quota.DefaultProviderConfigs()
+			provider := quota.NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly)
+
+			if _, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "xai-auth"}}); err == nil {
+				t.Fatal("expected period-only xAI billing data to be rejected")
+			}
+		})
+	}
 }
 
 func TestXAIProviderStartsBothEqualBillingSourcesWithoutBlocking(t *testing.T) {
@@ -430,11 +577,27 @@ type xaiManagementCaller struct {
 	responses map[string]*apicall.Response
 }
 
+type xaiErrorManagementCaller struct {
+	weeklyErr  error
+	monthlyErr error
+}
+
+func (c xaiErrorManagementCaller) CallManagementAPI(_ context.Context, request apicall.Request) (*apicall.Response, error) {
+	if request.URL == xaiWeeklyBillingURL {
+		return nil, c.weeklyErr
+	}
+	return nil, c.monthlyErr
+}
+
 func newXAIManagementCaller(weekly *apicall.Response, monthly *apicall.Response) *xaiManagementCaller {
 	return &xaiManagementCaller{responses: map[string]*apicall.Response{
 		xaiWeeklyBillingURL:  weekly,
 		xaiMonthlyBillingURL: monthly,
 	}}
+}
+
+func xaiJSONResponse(body string) *apicall.Response {
+	return &apicall.Response{StatusCode: 200, BodyText: body, Body: json.RawMessage(body)}
 }
 
 func (c *xaiManagementCaller) CallManagementAPI(_ context.Context, request apicall.Request) (*apicall.Response, error) {

--- a/internal/quota/types.go
+++ b/internal/quota/types.go
@@ -234,7 +234,18 @@ type KimiUsagePayload struct {
 }
 
 type XAIMoneyValue struct {
-	Val float64 `json:"val,omitempty"`
+	Val *float64 `json:"val,omitempty"`
+}
+
+type XAIBillingPeriod struct {
+	Type  string `json:"type,omitempty"`
+	Start string `json:"start,omitempty"`
+	End   string `json:"end,omitempty"`
+}
+
+type XAIBillingProductUsage struct {
+	Product      string   `json:"product,omitempty"`
+	UsagePercent *float64 `json:"usagePercent,omitempty"`
 }
 
 type XAIBillingCycle struct {
@@ -250,12 +261,16 @@ type XAIBillingHistoryItem struct {
 }
 
 type XAIBillingConfig struct {
-	MonthlyLimit       XAIMoneyValue           `json:"monthlyLimit,omitempty"`
-	Used               XAIMoneyValue           `json:"used,omitempty"`
-	OnDemandCap        XAIMoneyValue           `json:"onDemandCap,omitempty"`
-	BillingPeriodStart string                  `json:"billingPeriodStart,omitempty"`
-	BillingPeriodEnd   string                  `json:"billingPeriodEnd,omitempty"`
-	History            []XAIBillingHistoryItem `json:"history,omitempty"`
+	CurrentPeriod      *XAIBillingPeriod        `json:"currentPeriod,omitempty"`
+	CreditUsagePercent *float64                 `json:"creditUsagePercent,omitempty"`
+	ProductUsage       []XAIBillingProductUsage `json:"productUsage,omitempty"`
+	MonthlyLimit       XAIMoneyValue            `json:"monthlyLimit,omitempty"`
+	Used               XAIMoneyValue            `json:"used,omitempty"`
+	OnDemandCap        XAIMoneyValue            `json:"onDemandCap,omitempty"`
+	OnDemandUsed       XAIMoneyValue            `json:"onDemandUsed,omitempty"`
+	BillingPeriodStart string                   `json:"billingPeriodStart,omitempty"`
+	BillingPeriodEnd   string                   `json:"billingPeriodEnd,omitempty"`
+	History            []XAIBillingHistoryItem  `json:"history,omitempty"`
 }
 
 type XAIBillingPayload struct {
@@ -285,7 +300,8 @@ type KimiResult struct {
 }
 
 type XAIResult struct {
-	Billing *XAIBillingPayload `json:"billing"`
+	Weekly  *XAIBillingPayload `json:"weekly,omitempty"`
+	Monthly *XAIBillingPayload `json:"monthly,omitempty"`
 }
 
 type ProviderHandler interface {

--- a/internal/quota/xai.go
+++ b/internal/quota/xai.go
@@ -2,33 +2,115 @@ package quota
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 
 	"cpa-usage-keeper/internal/cpa/dto/apicall"
 )
 
 type xaiProvider struct {
-	caller ManagementAPICaller
-	config APICallConfig
+	caller        ManagementAPICaller
+	weeklyConfig  APICallConfig
+	monthlyConfig APICallConfig
 }
 
-func NewXAIProvider(caller ManagementAPICaller, config APICallConfig) ProviderHandler {
-	return xaiProvider{caller: caller, config: config}
+func NewXAIProvider(caller ManagementAPICaller, weeklyConfig APICallConfig, monthlyConfig APICallConfig) ProviderHandler {
+	return xaiProvider{caller: caller, weeklyConfig: weeklyConfig, monthlyConfig: monthlyConfig}
 }
 
 func (p xaiProvider) Check(ctx context.Context, input ProviderInput) (ProviderOutput, error) {
-	// xAI billing 只需要当前 auth_index 调用 Grok billing endpoint，金额字段保留 cents 口径交给前端展示。
+	// weekly 与 monthly 是同级限额来源；任一请求失败都不能阻止另一请求继续尝试。
+	weeklyCh := make(chan xaiBillingAttempt, 1)
+	monthlyCh := make(chan xaiBillingAttempt, 1)
+	go func() {
+		billing, err := p.requestBilling(ctx, input, p.weeklyConfig, "weekly")
+		weeklyCh <- xaiBillingAttempt{billing: billing, err: err}
+	}()
+	go func() {
+		billing, err := p.requestBilling(ctx, input, p.monthlyConfig, "monthly")
+		monthlyCh <- xaiBillingAttempt{billing: billing, err: err}
+	}()
+	weeklyAttempt := <-weeklyCh
+	monthlyAttempt := <-monthlyCh
+	weekly, weeklyErr := weeklyAttempt.billing, weeklyAttempt.err
+	monthly, monthlyErr := monthlyAttempt.billing, monthlyAttempt.err
+	if weekly != nil || monthly != nil {
+		return ProviderOutput{Provider: "xai", Result: XAIResult{
+			Weekly:  weekly,
+			Monthly: monthly,
+		}}, nil
+	}
+	return ProviderOutput{}, joinXAIBillingErrors(weeklyErr, monthlyErr)
+}
+
+type xaiBillingAttempt struct {
+	billing *XAIBillingPayload
+	err     error
+}
+
+func joinXAIBillingErrors(billingErrors ...error) error {
+	// 两个来源都失败时，优先保留 401/402，让现有失败缓存继续使用正确的 HTTP TTL。
+	for preferredIndex, err := range billingErrors {
+		var httpErr ProviderHTTPError
+		if err == nil || !errors.As(err, &httpErr) || !isRefreshCacheableHTTPStatus(httpErr.StatusCode) {
+			continue
+		}
+		ordered := make([]error, 0, len(billingErrors))
+		ordered = append(ordered, err)
+		for index, candidate := range billingErrors {
+			if index != preferredIndex && candidate != nil {
+				ordered = append(ordered, candidate)
+			}
+		}
+		return errors.Join(ordered...)
+	}
+	return errors.Join(billingErrors...)
+}
+
+func (p xaiProvider) requestBilling(ctx context.Context, input ProviderInput, config APICallConfig, period string) (*XAIBillingPayload, error) {
+	headers := copyHeaders(config.Headers)
+	if input.Identity.XAIUserID != nil {
+		if xaiUserID := strings.TrimSpace(*input.Identity.XAIUserID); xaiUserID != "" {
+			headers = mergeHeaders(headers, map[string]string{"x-userid": xaiUserID})
+		}
+	}
 	response, err := p.caller.CallManagementAPI(ctx, apicall.Request{
 		AuthIndex: input.Identity.Identity,
-		Method:    p.config.Method,
-		URL:       p.config.URL,
-		Header:    copyHeaders(p.config.Headers),
+		Method:    config.Method,
+		URL:       config.URL,
+		Header:    headers,
 	})
 	if err != nil {
-		return ProviderOutput{}, err
+		return nil, err
 	}
 	billing, err := parseXAIBillingPayload(response)
 	if err != nil {
-		return ProviderOutput{}, err
+		return nil, err
 	}
-	return ProviderOutput{Provider: "xai", Result: XAIResult{Billing: billing}}, nil
+	if billing == nil || !hasXAIBillingData(billing.Config) {
+		return nil, fmt.Errorf("empty xAI %s billing response", period)
+	}
+	return billing, nil
+}
+
+func hasXAIBillingData(config *XAIBillingConfig) bool {
+	if config == nil {
+		return false
+	}
+	if config.CreditUsagePercent != nil || config.MonthlyLimit.Val != nil || config.Used.Val != nil || config.OnDemandCap.Val != nil || config.OnDemandUsed.Val != nil {
+		return true
+	}
+	if strings.TrimSpace(config.BillingPeriodStart) != "" || strings.TrimSpace(config.BillingPeriodEnd) != "" {
+		return true
+	}
+	if period := config.CurrentPeriod; period != nil && (strings.TrimSpace(period.Type) != "" || strings.TrimSpace(period.Start) != "" || strings.TrimSpace(period.End) != "") {
+		return true
+	}
+	for _, product := range config.ProductUsage {
+		if strings.TrimSpace(product.Product) != "" && product.UsagePercent != nil {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/quota/xai.go
+++ b/internal/quota/xai.go
@@ -41,7 +41,7 @@ func (p xaiProvider) Check(ctx context.Context, input ProviderInput) (ProviderOu
 			Monthly: monthly,
 		}}, nil
 	}
-	return ProviderOutput{}, joinXAIBillingErrors(weeklyErr, monthlyErr)
+	return ProviderOutput{}, selectXAIBillingError(weeklyErr, monthlyErr)
 }
 
 type xaiBillingAttempt struct {
@@ -49,23 +49,26 @@ type xaiBillingAttempt struct {
 	err     error
 }
 
-func joinXAIBillingErrors(billingErrors ...error) error {
-	// 两个来源都失败时，优先保留 401/402，让现有失败缓存继续使用正确的 HTTP TTL。
-	for preferredIndex, err := range billingErrors {
+func selectXAIBillingError(billingErrors ...error) error {
+	// 只返回一个主错误，确保提示、HTTP 状态和失败缓存 TTL 来自同一分类。
+	for _, err := range billingErrors {
 		var httpErr ProviderHTTPError
 		if err == nil || !errors.As(err, &httpErr) || !isRefreshCacheableHTTPStatus(httpErr.StatusCode) {
 			continue
 		}
-		ordered := make([]error, 0, len(billingErrors))
-		ordered = append(ordered, err)
-		for index, candidate := range billingErrors {
-			if index != preferredIndex && candidate != nil {
-				ordered = append(ordered, candidate)
-			}
-		}
-		return errors.Join(ordered...)
+		return err
 	}
-	return errors.Join(billingErrors...)
+	for _, err := range billingErrors {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			return err
+		}
+	}
+	for _, err := range billingErrors {
+		if err != nil {
+			return err
+		}
+	}
+	return errors.New("xAI billing requests failed")
 }
 
 func (p xaiProvider) requestBilling(ctx context.Context, input ProviderInput, config APICallConfig, period string) (*XAIBillingPayload, error) {
@@ -88,29 +91,21 @@ func (p xaiProvider) requestBilling(ctx context.Context, input ProviderInput, co
 	if err != nil {
 		return nil, err
 	}
-	if billing == nil || !hasXAIBillingData(billing.Config) {
+	if !hasXAIBillingQuotaRows(billing, period) {
 		return nil, fmt.Errorf("empty xAI %s billing response", period)
 	}
 	return billing, nil
 }
 
-func hasXAIBillingData(config *XAIBillingConfig) bool {
-	if config == nil {
+func hasXAIBillingQuotaRows(billing *XAIBillingPayload, period string) bool {
+	result := XAIResult{}
+	switch period {
+	case "weekly":
+		result.Weekly = billing
+	case "monthly":
+		result.Monthly = billing
+	default:
 		return false
 	}
-	if config.CreditUsagePercent != nil || config.MonthlyLimit.Val != nil || config.Used.Val != nil || config.OnDemandCap.Val != nil || config.OnDemandUsed.Val != nil {
-		return true
-	}
-	if strings.TrimSpace(config.BillingPeriodStart) != "" || strings.TrimSpace(config.BillingPeriodEnd) != "" {
-		return true
-	}
-	if period := config.CurrentPeriod; period != nil && (strings.TrimSpace(period.Type) != "" || strings.TrimSpace(period.Start) != "" || strings.TrimSpace(period.End) != "") {
-		return true
-	}
-	for _, product := range config.ProductUsage {
-		if strings.TrimSpace(product.Product) != "" && product.UsagePercent != nil {
-			return true
-		}
-	}
-	return false
+	return len(normalizeXAIQuotaRows(result)) > 0
 }

--- a/internal/repository/migration/20260711_usage_identity_xai_user_id.go
+++ b/internal/repository/migration/20260711_usage_identity_xai_user_id.go
@@ -1,0 +1,19 @@
+package migration
+
+import (
+	"fmt"
+
+	"cpa-usage-keeper/internal/entities"
+
+	"gorm.io/gorm"
+)
+
+func addUsageIdentityXAIUserIDMigration(tx *gorm.DB) error {
+	if !tx.Migrator().HasTable(&entities.UsageIdentity{}) || tx.Migrator().HasColumn(&entities.UsageIdentity{}, "xai_user_id") {
+		return nil
+	}
+	if err := tx.Migrator().AddColumn(&entities.UsageIdentity{}, "XAIUserID"); err != nil {
+		return fmt.Errorf("add usage_identities.xai_user_id column: %w", err)
+	}
+	return nil
+}

--- a/internal/repository/migration/migration.go
+++ b/internal/repository/migration/migration.go
@@ -54,6 +54,7 @@ const (
 	migrationModelPriceMultiplier                   = "20260702_model_price_multiplier"
 	migrationCreateAppSettings                      = "20260702_create_app_settings"
 	migrationBackfillCacheReadTokens                = "20260710_backfill_cache_read_tokens"
+	migrationAddUsageIdentityXAIUserID              = "20260711_add_usage_identity_xai_user_id"
 )
 
 type schemaMigration struct {
@@ -152,6 +153,7 @@ func orderedMigrations() []databaseMigration {
 		{version: migrationModelPriceMultiplier, run: addModelPriceMultiplierMigration},
 		{version: migrationCreateAppSettings, run: createAppSettingsMigration},
 		{version: migrationBackfillCacheReadTokens, run: backfillCacheReadTokensMigration},
+		{version: migrationAddUsageIdentityXAIUserID, run: addUsageIdentityXAIUserIDMigration},
 	}
 }
 

--- a/internal/repository/migration/migration_test.go
+++ b/internal/repository/migration/migration_test.go
@@ -64,6 +64,7 @@ func TestOrderedMigrationsPreservesExecutionOrder(t *testing.T) {
 		"20260702_model_price_multiplier",
 		"20260702_create_app_settings",
 		"20260710_backfill_cache_read_tokens",
+		"20260711_add_usage_identity_xai_user_id",
 	}
 	assertStringSlicesEqual(t, want, got)
 }

--- a/internal/repository/migration/test/xai_user_id_test.go
+++ b/internal/repository/migration/test/xai_user_id_test.go
@@ -1,0 +1,77 @@
+package test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"cpa-usage-keeper/internal/config"
+	"cpa-usage-keeper/internal/repository"
+	"cpa-usage-keeper/internal/repository/migration"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const xaiUserIDMigrationVersion = "20260711_add_usage_identity_xai_user_id"
+
+func TestUsageIdentityXAIUserIDMigrationSupportsFreshAndExistingDatabases(t *testing.T) {
+	t.Run("fresh database", func(t *testing.T) {
+		db, err := repository.OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "fresh.db")})
+		if err != nil {
+			t.Fatalf("OpenDatabase returned error: %v", err)
+		}
+		closeMigrationTestDatabase(t, db)
+
+		assertXAIUserIDMigrationApplied(t, db)
+	})
+
+	t.Run("existing database", func(t *testing.T) {
+		db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "existing.db")), &gorm.Config{})
+		if err != nil {
+			t.Fatalf("open existing database: %v", err)
+		}
+		closeMigrationTestDatabase(t, db)
+		if err := db.Exec("CREATE TABLE usage_identities (id INTEGER PRIMARY KEY, identity TEXT)").Error; err != nil {
+			t.Fatalf("create legacy usage_identities table: %v", err)
+		}
+		if err := migration.MarkAllAsApplied(db); err != nil {
+			t.Fatalf("mark historical migrations applied: %v", err)
+		}
+		if err := db.Table("schema_migrations").Where("version = ?", xaiUserIDMigrationVersion).Delete(nil).Error; err != nil {
+			t.Fatalf("make xAI user id migration pending: %v", err)
+		}
+
+		if err := migration.Run(db); err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+
+		assertXAIUserIDMigrationApplied(t, db)
+	})
+}
+
+func assertXAIUserIDMigrationApplied(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	if !db.Migrator().HasColumn("usage_identities", "xai_user_id") {
+		t.Fatal("expected usage_identities.xai_user_id column")
+	}
+	var count int64
+	if err := db.Table("schema_migrations").Where("version = ?", xaiUserIDMigrationVersion).Count(&count).Error; err != nil {
+		t.Fatalf("count xAI user id migration record: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected one xAI user id migration record, got %d", count)
+	}
+}
+
+func closeMigrationTestDatabase(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("load sql database: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Fatalf("close sql database: %v", err)
+		}
+	})
+}

--- a/internal/repository/test/usage_identity_xai_user_id_test.go
+++ b/internal/repository/test/usage_identity_xai_user_id_test.go
@@ -1,0 +1,94 @@
+package test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/config"
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+
+	"gorm.io/gorm"
+)
+
+func TestUsageIdentityXAIUserIDPersistsAndReads(t *testing.T) {
+	db := openXAIUserIDRepositoryDatabase(t)
+	ctx := context.Background()
+	xaiUserID := "xai-user-123"
+
+	if err := repository.ReplaceUsageIdentitiesForAuthType(ctx, db, []entities.UsageIdentity{{
+		Name:      "xAI Auth",
+		Identity:  "xai-auth",
+		Type:      "xai",
+		XAIUserID: &xaiUserID,
+	}}, entities.UsageIdentityAuthTypeAuthFile, time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("ReplaceUsageIdentitiesForAuthType returned error: %v", err)
+	}
+
+	row, err := repository.GetActiveAuthFileUsageIdentityByAuthIndex(ctx, db, "xai-auth")
+	if err != nil {
+		t.Fatalf("GetActiveAuthFileUsageIdentityByAuthIndex returned error: %v", err)
+	}
+	if row.XAIUserID == nil || *row.XAIUserID != xaiUserID {
+		t.Fatalf("expected persisted xAI user id %q, got %+v", xaiUserID, row.XAIUserID)
+	}
+}
+
+func TestUsageIdentityXAIUserIDRefreshesAndClearsAcrossSync(t *testing.T) {
+	db := openXAIUserIDRepositoryDatabase(t)
+	ctx := context.Background()
+	now := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	initialUserID := "xai-user-old"
+	updatedUserID := "xai-user-new"
+
+	replaceXAIUsageIdentity(t, ctx, db, &initialUserID, now)
+	replaceXAIUsageIdentity(t, ctx, db, &updatedUserID, now.Add(time.Minute))
+	row, err := repository.GetActiveAuthFileUsageIdentityByAuthIndex(ctx, db, "xai-auth")
+	if err != nil {
+		t.Fatalf("read updated xAI usage identity: %v", err)
+	}
+	if row.XAIUserID == nil || *row.XAIUserID != updatedUserID {
+		t.Fatalf("expected refreshed xAI user id %q, got %+v", updatedUserID, row.XAIUserID)
+	}
+
+	replaceXAIUsageIdentity(t, ctx, db, nil, now.Add(2*time.Minute))
+	row, err = repository.GetActiveAuthFileUsageIdentityByAuthIndex(ctx, db, "xai-auth")
+	if err != nil {
+		t.Fatalf("read cleared xAI usage identity: %v", err)
+	}
+	if row.XAIUserID != nil {
+		t.Fatalf("expected a successful sync without xAI user id to clear the column, got %q", *row.XAIUserID)
+	}
+}
+
+func replaceXAIUsageIdentity(t *testing.T, ctx context.Context, db *gorm.DB, xaiUserID *string, now time.Time) {
+	t.Helper()
+	if err := repository.ReplaceUsageIdentitiesForAuthType(ctx, db, []entities.UsageIdentity{{
+		Name:      "xAI Auth",
+		Identity:  "xai-auth",
+		Type:      "xai",
+		XAIUserID: xaiUserID,
+	}}, entities.UsageIdentityAuthTypeAuthFile, now); err != nil {
+		t.Fatalf("ReplaceUsageIdentitiesForAuthType returned error: %v", err)
+	}
+}
+
+func openXAIUserIDRepositoryDatabase(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := repository.OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "xai-user-id.db")})
+	if err != nil {
+		t.Fatalf("OpenDatabase returned error: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("load sql database: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Fatalf("close sql database: %v", err)
+		}
+	})
+	return db
+}

--- a/internal/repository/usage_identities.go
+++ b/internal/repository/usage_identities.go
@@ -93,7 +93,7 @@ const (
 	UsageIdentityPageSortLastUsedAt    = "last_used_at"
 )
 
-const usageIdentityReadColumns = "id, name, alias, auth_type, auth_type_name, identity, type, provider, lookup_key, prefix, base_url, file_name, file_path, priority, disabled, note, account_id, project_id, active_start, active_until, plan_type, total_requests, success_count, failure_count, input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, total_tokens, last_aggregated_usage_event_id, first_used_at, last_used_at, stats_updated_at, is_deleted, created_at, updated_at, deleted_at"
+const usageIdentityReadColumns = "id, name, alias, auth_type, auth_type_name, identity, type, provider, lookup_key, prefix, base_url, file_name, file_path, priority, disabled, note, account_id, project_id, xai_user_id, active_start, active_until, plan_type, total_requests, success_count, failure_count, input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, total_tokens, last_aggregated_usage_event_id, first_used_at, last_used_at, stats_updated_at, is_deleted, created_at, updated_at, deleted_at"
 
 const usageIdentityAggregationColumns = "id, auth_type, identity, total_requests, success_count, failure_count, input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, total_tokens, last_aggregated_usage_event_id, first_used_at, last_used_at"
 
@@ -639,6 +639,7 @@ func usageIdentityMetadataUpdates(identity entities.UsageIdentity) map[string]an
 		"note":           identity.Note,
 		"account_id":     identity.AccountID,
 		"project_id":     identity.ProjectID,
+		"xai_user_id":    identity.XAIUserID,
 		"active_start":   identity.ActiveStart,
 		"active_until":   identity.ActiveUntil,
 		"plan_type":      identity.PlanType,

--- a/internal/service/auth_file_to_usage_identity_fields.go
+++ b/internal/service/auth_file_to_usage_identity_fields.go
@@ -42,6 +42,63 @@ func resolveCodexPlanType(file authfiles.AuthFile) *string {
 	)
 }
 
+func resolveXAIUserID(file authfiles.AuthFile) *string {
+	var metadata authfiles.AuthFileClaims
+	if file.Metadata != nil {
+		metadata = *file.Metadata
+	}
+	var attributes authfiles.AuthFileClaims
+	if file.Attributes != nil {
+		attributes = *file.Attributes
+	}
+	oauth := file.OAuth
+	if oauth == nil {
+		oauth = metadata.OAuth
+	}
+	if oauth == nil {
+		oauth = attributes.OAuth
+	}
+	user := file.User
+	if user == nil {
+		user = metadata.User
+	}
+	if user == nil {
+		user = attributes.User
+	}
+
+	var oauthSub *authfiles.AuthFileXAIUserIDValue
+	var oauthSubject *authfiles.AuthFileXAIUserIDValue
+	if oauth != nil {
+		oauthSub = oauth.Sub
+		oauthSubject = oauth.Subject
+	}
+	var userSub *authfiles.AuthFileXAIUserIDValue
+	var userID *authfiles.AuthFileXAIUserIDValue
+	if user != nil {
+		userSub = user.Sub
+		userID = user.ID
+	}
+
+	return firstNonEmptyXAIUserIDValue(
+		file.Sub,
+		file.Subject,
+		file.UserID,
+		file.UserIDCamel,
+		metadata.Sub,
+		metadata.Subject,
+		metadata.UserID,
+		metadata.UserIDCamel,
+		attributes.Sub,
+		attributes.Subject,
+		attributes.UserID,
+		attributes.UserIDCamel,
+		oauthSub,
+		oauthSubject,
+		userSub,
+		userID,
+	)
+}
+
 func resolveCodexActiveStart(file authfiles.AuthFile) *time.Time {
 	if file.IDToken == nil {
 		return nil
@@ -72,6 +129,20 @@ func firstNonEmptyStringPtr(values ...*string) *string {
 			continue
 		}
 		trimmed := strings.TrimSpace(*value)
+		if trimmed == "" {
+			continue
+		}
+		return &trimmed
+	}
+	return nil
+}
+
+func firstNonEmptyXAIUserIDValue(values ...*authfiles.AuthFileXAIUserIDValue) *string {
+	for _, value := range values {
+		if value == nil {
+			continue
+		}
+		trimmed := strings.TrimSpace(string(*value))
 		if trimmed == "" {
 			continue
 		}

--- a/internal/service/auth_file_to_usage_identity_fields.go
+++ b/internal/service/auth_file_to_usage_identity_fields.go
@@ -51,20 +51,8 @@ func resolveXAIUserID(file authfiles.AuthFile) *string {
 	if file.Attributes != nil {
 		attributes = *file.Attributes
 	}
-	oauth := file.OAuth
-	if oauth == nil {
-		oauth = metadata.OAuth
-	}
-	if oauth == nil {
-		oauth = attributes.OAuth
-	}
-	user := file.User
-	if user == nil {
-		user = metadata.User
-	}
-	if user == nil {
-		user = attributes.User
-	}
+	oauth := file.ResolvedXAIOAuth()
+	user := file.ResolvedXAIUser()
 
 	var oauthSub *authfiles.AuthFileXAIUserIDValue
 	var oauthSubject *authfiles.AuthFileXAIUserIDValue

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -680,6 +680,7 @@ type authFileUsageIdentityExtension func(authfiles.AuthFile, *entities.UsageIden
 
 var authFileUsageIdentityExtensions = map[string]authFileUsageIdentityExtension{
 	"codex": extendCodexAuthFileUsageIdentity,
+	"xai":   extendXAIAuthFileUsageIdentity,
 }
 
 // auth_files 先走通用身份映射，再按 type 追加各来源特有字段，方便后续扩展新类型。
@@ -716,6 +717,11 @@ func extendCodexAuthFileUsageIdentity(file authfiles.AuthFile, identity *entitie
 	identity.ActiveStart = resolveCodexActiveStart(file)
 	identity.ActiveUntil = resolveCodexActiveUntil(file)
 	identity.PlanType = resolveCodexPlanType(file)
+}
+
+// xAI user id 仅来自 CPA auth file claims；未命中候选时保持 nil，让成功重同步清掉旧值。
+func extendXAIAuthFileUsageIdentity(file authfiles.AuthFile, identity *entities.UsageIdentity) {
+	identity.XAIUserID = resolveXAIUserID(file)
 }
 
 // fetchProviderMetadata 分别拉取各 AI provider 配置，并记录本轮实际成功返回的 provider 类型。

--- a/internal/service/test/xai_user_id_sync_test.go
+++ b/internal/service/test/xai_user_id_sync_test.go
@@ -1,0 +1,206 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"cpa-usage-keeper/internal/config"
+	"cpa-usage-keeper/internal/cpa/dto/authfiles"
+	"cpa-usage-keeper/internal/cpa/dto/response"
+	"cpa-usage-keeper/internal/repository"
+	"cpa-usage-keeper/internal/service"
+
+	"gorm.io/gorm"
+)
+
+func TestSyncMetadataWritesXAIUserIDCandidatesOnlyForXAI(t *testing.T) {
+	tests := []struct {
+		authIndex string
+		claims    string
+		want      string
+	}{
+		{authIndex: "top-sub", claims: `{"sub":" top-sub ","subject":"lower"}`, want: "top-sub"},
+		{authIndex: "top-subject", claims: `{"sub":" ","subject":" top-subject ","user_id":"lower"}`, want: "top-subject"},
+		{authIndex: "top-user-id", claims: `{"user_id":" top-user-id ","userId":"lower"}`, want: "top-user-id"},
+		{authIndex: "top-user-id-camel", claims: `{"userId":" top-user-id-camel ","metadata":{"sub":"lower"}}`, want: "top-user-id-camel"},
+		{authIndex: "metadata-sub", claims: `{"metadata":{"sub":" metadata-sub ","subject":"lower"}}`, want: "metadata-sub"},
+		{authIndex: "metadata-subject", claims: `{"metadata":{"subject":" metadata-subject ","user_id":"lower"}}`, want: "metadata-subject"},
+		{authIndex: "metadata-user-id", claims: `{"metadata":{"user_id":" metadata-user-id ","userId":"lower"}}`, want: "metadata-user-id"},
+		{authIndex: "metadata-user-id-camel", claims: `{"metadata":{"userId":" metadata-user-id-camel "},"attributes":{"sub":"lower"}}`, want: "metadata-user-id-camel"},
+		{authIndex: "attributes-sub", claims: `{"attributes":{"sub":" attributes-sub ","subject":"lower"}}`, want: "attributes-sub"},
+		{authIndex: "attributes-subject", claims: `{"attributes":{"subject":" attributes-subject ","user_id":"lower"}}`, want: "attributes-subject"},
+		{authIndex: "attributes-user-id", claims: `{"attributes":{"user_id":" attributes-user-id ","userId":"lower"}}`, want: "attributes-user-id"},
+		{authIndex: "attributes-user-id-camel", claims: `{"attributes":{"userId":" attributes-user-id-camel "},"oauth":{"sub":"lower"}}`, want: "attributes-user-id-camel"},
+		{authIndex: "oauth-sub", claims: `{"oauth":{"sub":" oauth-sub ","subject":"lower"}}`, want: "oauth-sub"},
+		{authIndex: "oauth-subject", claims: `{"oauth":{"subject":" oauth-subject "},"user":{"sub":"lower"}}`, want: "oauth-subject"},
+		{authIndex: "user-sub", claims: `{"user":{"sub":" user-sub ","id":"lower"}}`, want: "user-sub"},
+		{authIndex: "user-id", claims: `{"user":{"id":" user-id "}}`, want: "user-id"},
+		{authIndex: "metadata-oauth", claims: `{"metadata":{"oauth":{"sub":" metadata-oauth-sub "}},"attributes":{"oauth":{"sub":"lower"}}}`, want: "metadata-oauth-sub"},
+		{authIndex: "attributes-oauth", claims: `{"attributes":{"oauth":{"subject":" attributes-oauth-subject "}},"user":{"sub":"lower"}}`, want: "attributes-oauth-subject"},
+		{authIndex: "metadata-user", claims: `{"metadata":{"user":{"sub":" metadata-user-sub "}},"attributes":{"user":{"sub":"lower"}}}`, want: "metadata-user-sub"},
+		{authIndex: "attributes-user", claims: `{"attributes":{"user":{"id":" attributes-user-id "}}}`, want: "attributes-user-id"},
+		{authIndex: "numeric-sub", claims: `{"sub":12345,"subject":"lower"}`, want: "12345"},
+	}
+
+	files := make([]authfiles.AuthFile, 0, len(tests)+1)
+	for _, tt := range tests {
+		file := decodeXAIAuthFile(t, tt.authIndex, "xai", tt.claims)
+		files = append(files, file)
+	}
+	files = append(files, decodeXAIAuthFile(t, "non-xai", "claude", `{"sub":"must-not-sync"}`))
+
+	db := openXAIUserIDSyncDatabase(t)
+	fetcher := &xaiUserIDMetadataFetcher{files: files}
+	syncer := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{
+		BaseURL:         "https://cpa.example.com",
+		MetadataFetcher: fetcher,
+	})
+	if err := syncer.SyncMetadata(context.Background()); err != nil {
+		t.Fatalf("SyncMetadata returned error: %v", err)
+	}
+
+	for _, tt := range tests {
+		row, err := repository.GetActiveAuthFileUsageIdentityByAuthIndex(context.Background(), db, tt.authIndex)
+		if err != nil {
+			t.Fatalf("read %s usage identity: %v", tt.authIndex, err)
+		}
+		if row.XAIUserID == nil || *row.XAIUserID != tt.want {
+			t.Fatalf("expected %s xAI user id %q, got %+v", tt.authIndex, tt.want, row.XAIUserID)
+		}
+	}
+	nonXAI, err := repository.GetActiveAuthFileUsageIdentityByAuthIndex(context.Background(), db, "non-xai")
+	if err != nil {
+		t.Fatalf("read non-xAI usage identity: %v", err)
+	}
+	if nonXAI.XAIUserID != nil {
+		t.Fatalf("expected non-xAI auth file to ignore xAI user id candidates, got %q", *nonXAI.XAIUserID)
+	}
+}
+
+func TestSyncMetadataClearsXAIUserIDAfterSuccessfulResponseOmitsIt(t *testing.T) {
+	db := openXAIUserIDSyncDatabase(t)
+	fetcher := &xaiUserIDMetadataFetcher{files: []authfiles.AuthFile{
+		decodeXAIAuthFile(t, "xai-auth", "xai", `{"sub":"xai-user-old"}`),
+	}}
+	syncer := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{
+		BaseURL:         "https://cpa.example.com",
+		MetadataFetcher: fetcher,
+	})
+	if err := syncer.SyncMetadata(context.Background()); err != nil {
+		t.Fatalf("initial SyncMetadata returned error: %v", err)
+	}
+	initial, err := repository.GetActiveAuthFileUsageIdentityByAuthIndex(context.Background(), db, "xai-auth")
+	if err != nil {
+		t.Fatalf("read initial xAI usage identity: %v", err)
+	}
+	if initial.XAIUserID == nil || *initial.XAIUserID != "xai-user-old" {
+		t.Fatalf("expected initial xAI user id to persist, got %+v", initial.XAIUserID)
+	}
+
+	fetcher.files = []authfiles.AuthFile{{AuthIndex: "xai-auth", Type: "xai"}}
+	if err := syncer.SyncMetadata(context.Background()); err != nil {
+		t.Fatalf("clearing SyncMetadata returned error: %v", err)
+	}
+	row, err := repository.GetActiveAuthFileUsageIdentityByAuthIndex(context.Background(), db, "xai-auth")
+	if err != nil {
+		t.Fatalf("read cleared xAI usage identity: %v", err)
+	}
+	if row.XAIUserID != nil {
+		t.Fatalf("expected successful sync without a candidate to clear xAI user id, got %q", *row.XAIUserID)
+	}
+}
+
+func TestSyncMetadataPreservesXAIUserIDWhenAuthFilesFetchFails(t *testing.T) {
+	db := openXAIUserIDSyncDatabase(t)
+	fetcher := &xaiUserIDMetadataFetcher{files: []authfiles.AuthFile{
+		decodeXAIAuthFile(t, "xai-auth", "xai", `{"sub":"xai-user-stable"}`),
+	}}
+	syncer := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{
+		BaseURL:         "https://cpa.example.com",
+		MetadataFetcher: fetcher,
+	})
+	if err := syncer.SyncMetadata(context.Background()); err != nil {
+		t.Fatalf("initial SyncMetadata returned error: %v", err)
+	}
+
+	fetcher.files = nil
+	fetcher.authErr = errors.New("auth files unavailable")
+	if err := syncer.SyncMetadata(context.Background()); err == nil {
+		t.Fatal("expected failed auth files fetch to return an error")
+	}
+	row, err := repository.GetActiveAuthFileUsageIdentityByAuthIndex(context.Background(), db, "xai-auth")
+	if err != nil {
+		t.Fatalf("read preserved xAI usage identity: %v", err)
+	}
+	if row.XAIUserID == nil || *row.XAIUserID != "xai-user-stable" {
+		t.Fatalf("expected failed fetch to preserve xAI user id, got %+v", row.XAIUserID)
+	}
+}
+
+func decodeXAIAuthFile(t *testing.T, authIndex, authType, claims string) authfiles.AuthFile {
+	t.Helper()
+	var file authfiles.AuthFile
+	if err := json.Unmarshal([]byte(claims), &file); err != nil {
+		t.Fatalf("decode %s claims: %v", authIndex, err)
+	}
+	file.AuthIndex = authIndex
+	file.Type = authType
+	return file
+}
+
+type xaiUserIDMetadataFetcher struct {
+	files   []authfiles.AuthFile
+	authErr error
+}
+
+func (f *xaiUserIDMetadataFetcher) FetchAuthFiles(context.Context) (*response.AuthFilesResult, error) {
+	if f.authErr != nil {
+		return nil, f.authErr
+	}
+	return &response.AuthFilesResult{StatusCode: 200, Payload: authfiles.AuthFilesResponse{Files: f.files}}, nil
+}
+
+func (*xaiUserIDMetadataFetcher) FetchManagementAPIKeys(context.Context) (*response.ManagementAPIKeysResult, error) {
+	return &response.ManagementAPIKeysResult{StatusCode: 200}, nil
+}
+
+func (*xaiUserIDMetadataFetcher) FetchGeminiAPIKeys(context.Context) (*response.ProviderKeyConfigResult, error) {
+	return &response.ProviderKeyConfigResult{StatusCode: 200}, nil
+}
+
+func (*xaiUserIDMetadataFetcher) FetchClaudeAPIKeys(context.Context) (*response.ProviderKeyConfigResult, error) {
+	return &response.ProviderKeyConfigResult{StatusCode: 200}, nil
+}
+
+func (*xaiUserIDMetadataFetcher) FetchCodexAPIKeys(context.Context) (*response.ProviderKeyConfigResult, error) {
+	return &response.ProviderKeyConfigResult{StatusCode: 200}, nil
+}
+
+func (*xaiUserIDMetadataFetcher) FetchVertexAPIKeys(context.Context) (*response.ProviderKeyConfigResult, error) {
+	return &response.ProviderKeyConfigResult{StatusCode: 200}, nil
+}
+
+func (*xaiUserIDMetadataFetcher) FetchOpenAICompatibility(context.Context) (*response.OpenAICompatibilityResult, error) {
+	return &response.OpenAICompatibilityResult{StatusCode: 200}, nil
+}
+
+func openXAIUserIDSyncDatabase(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := repository.OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "xai-user-id-sync.db")})
+	if err != nil {
+		t.Fatalf("OpenDatabase returned error: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("load sql database: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Fatalf("close sql database: %v", err)
+		}
+	})
+	return db
+}

--- a/internal/service/test/xai_user_id_sync_test.go
+++ b/internal/service/test/xai_user_id_sync_test.go
@@ -80,6 +80,49 @@ func TestSyncMetadataWritesXAIUserIDCandidatesOnlyForXAI(t *testing.T) {
 	}
 }
 
+func TestSyncMetadataMirrorsXAINullishNestedRecordFallback(t *testing.T) {
+	tests := []struct {
+		authIndex string
+		claims    string
+		want      string
+	}{
+		{authIndex: "null-oauth-fallback", claims: `{"oauth":null,"metadata":{"oauth":{"sub":"metadata-oauth"}}}`, want: "metadata-oauth"},
+		{authIndex: "invalid-oauth-blocks", claims: `{"oauth":false,"metadata":{"oauth":{"sub":"must-not-fallback"}}}`},
+		{authIndex: "invalid-metadata-oauth-blocks", claims: `{"metadata":{"oauth":[]},"attributes":{"oauth":{"sub":"must-not-fallback"}}}`},
+		{authIndex: "null-user-fallback", claims: `{"user":null,"metadata":{"user":{"id":"metadata-user"}}}`, want: "metadata-user"},
+		{authIndex: "invalid-user-blocks", claims: `{"user":123,"metadata":{"user":{"id":"must-not-fallback"}}}`},
+	}
+
+	files := make([]authfiles.AuthFile, 0, len(tests))
+	for _, tt := range tests {
+		files = append(files, decodeXAIAuthFile(t, tt.authIndex, "xai", tt.claims))
+	}
+	db := openXAIUserIDSyncDatabase(t)
+	syncer := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{
+		BaseURL:         "https://cpa.example.com",
+		MetadataFetcher: &xaiUserIDMetadataFetcher{files: files},
+	})
+	if err := syncer.SyncMetadata(context.Background()); err != nil {
+		t.Fatalf("SyncMetadata returned error: %v", err)
+	}
+
+	for _, tt := range tests {
+		row, err := repository.GetActiveAuthFileUsageIdentityByAuthIndex(context.Background(), db, tt.authIndex)
+		if err != nil {
+			t.Fatalf("read %s usage identity: %v", tt.authIndex, err)
+		}
+		if tt.want == "" {
+			if row.XAIUserID != nil {
+				t.Fatalf("expected invalid %s container to block fallback, got %q", tt.authIndex, *row.XAIUserID)
+			}
+			continue
+		}
+		if row.XAIUserID == nil || *row.XAIUserID != tt.want {
+			t.Fatalf("expected %s fallback %q, got %+v", tt.authIndex, tt.want, row.XAIUserID)
+		}
+	}
+}
+
 func TestSyncMetadataClearsXAIUserIDAfterSuccessfulResponseOmitsIt(t *testing.T) {
 	db := openXAIUserIDSyncDatabase(t)
 	fetcher := &xaiUserIDMetadataFetcher{files: []authfiles.AuthFile{

--- a/web/src/components/usage/credentials/test/AuthFileCredentialsSection.test.ts
+++ b/web/src/components/usage/credentials/test/AuthFileCredentialsSection.test.ts
@@ -329,6 +329,24 @@ describe('AuthFileCredentialsSection quota usage mode rendering', () => {
     expect(html.indexOf('<img')).toBeLessThan(html.indexOf('$1.67'))
     expect(html).not.toContain('1.00M')
   })
+
+  it('renders xai weekly before monthly in the existing quota grid', () => {
+    const xaiRow = {
+      ...row,
+      displayQuotas: [
+        { ...quota, key: 'billing.weekly', label: 'Weekly', percent: 25, barPercent: 75 },
+        { ...quota, key: 'billing.monthly', label: 'Monthly Spend', percent: 50, barPercent: 50, billingUsage: { used: '$5.00', limit: '$10.00', remaining: '$5.00' }, windowUsage: undefined },
+        { ...quota, key: 'billing.on_demand', label: 'Pay-as-you-go', percent: 20, barPercent: 80, billingUsage: { used: '$1.00', limit: '$5.00', remaining: '$4.00' }, windowUsage: undefined },
+        { ...quota, key: 'billing.weekly.product.grok+4', label: 'Grok 4 Usage', percent: 80, barPercent: 20 },
+      ],
+    } as AuthFileCredentialRow
+
+    const html = renderToStaticMarkup(createElement(AuthFileQuotaPanel, { row: xaiRow, quotaUsageMode: 'current' }))
+
+    expect(html.indexOf('Weekly')).toBeLessThan(html.indexOf('Monthly Spend'))
+    expect(html.indexOf('Monthly Spend')).toBeLessThan(html.indexOf('Pay-as-you-go'))
+    expect(html.indexOf('Pay-as-you-go')).toBeLessThan(html.indexOf('Grok 4 Usage'))
+  })
 })
 
 describe('AuthFileCredentialsSection quota error display', () => {

--- a/web/src/components/usage/credentials/test/credentialViewModels.test.ts
+++ b/web/src/components/usage/credentials/test/credentialViewModels.test.ts
@@ -249,6 +249,32 @@ describe('credentialViewModels', () => {
     })
   })
 
+  it('keeps xai weekly, monthly, pay-as-you-go, and product rows in provider order', () => {
+    const quotas = new Map<string, UsageQuotaCheckResponse>([
+      ['xai-auth', quotaResponse('xai-auth', [
+        { key: 'billing.weekly', label: 'Weekly', scope: 'billing', metric: 'weekly', usedPercent: 25, window: { seconds: 604800 }, resetAt: '2026-07-13T00:00:00Z' },
+        { key: 'billing.monthly', label: 'Monthly Spend', scope: 'billing', metric: 'usd_cents', used: 500, limit: 1000, remaining: 500, usedPercent: 50, window: { seconds: 2592000 }, resetAt: '2026-08-01T00:00:00Z' },
+        { key: 'billing.on_demand', label: 'Pay-as-you-go', scope: 'billing', metric: 'usd_cents', used: 100, limit: 500, remaining: 400, usedPercent: 20, window: { seconds: 2592000 }, resetAt: '2026-08-01T00:00:00Z' },
+        { key: 'billing.weekly.product.grok+4', label: 'Grok 4 Usage', scope: 'product', metric: 'Grok 4', usedPercent: 80, window: { seconds: 604800 }, resetAt: '2026-07-13T00:00:00Z' },
+      ])],
+    ])
+
+    const rows = buildAuthFileCredentialRows([identity({ identity: 'xai-auth', type: 'xai', provider: 'xAI' })], quotas)
+
+    expect(rows[0].displayQuotas.map((quota) => quota.label)).toEqual([
+      'Weekly',
+      'Monthly Spend',
+      'Pay-as-you-go',
+      'Grok 4 Usage',
+    ])
+    expect(rows[0].displayQuotas.map((quota) => quota.billingUsage)).toEqual([
+      undefined,
+      { used: '$5.00', limit: '$10.00', remaining: '$5.00' },
+      { used: '$1.00', limit: '$5.00', remaining: '$4.00' },
+      undefined,
+    ])
+  })
+
   it('estimates quota window usage only from positive current usage and a partial used percent', () => {
     const quotas = new Map<string, UsageQuotaCheckResponse>([
       ['auth-1', quotaResponse('auth-1', [


### PR DESCRIPTION
## Summary

- Query the xAI weekly and monthly billing endpoints concurrently while preserving Weekly then Monthly display order.
- Sync xAI user IDs from supported CPA auth-file claims and inject x-userid per request when available.
- Reuse the existing quota normalization, refresh, cache, inspection, and credential UI paths with targeted parsing and error validation.
- Keep the two quota endpoints as peers: either valid response succeeds, while both failures produce one consistent primary error.

## Validation

- TZ=UTC GOCACHE=/tmp/cpa-usage-keeper-go-build GOFLAGS=-count=1 make verify