### PR TITLE
fix: respect cache read presence by executor contract

### DIFF
--- a/internal/entities/usage_event.go
+++ b/internal/entities/usage_event.go
@@ -27,6 +27,7 @@ type UsageEvent struct {
 	ReasoningTokens     int64
 	CachedTokens        int64
 	CacheReadTokens     int64 `gorm:"not null;default:0"`
+	CacheReadPresent    bool  `gorm:"-" json:"-"` // 仅在 Redis 入库归一化期间区分 CPA canonical zero 与旧 payload。
 	CacheCreationTokens int64 `gorm:"not null;default:0"`
 	TotalTokens         int64
 	CreatedAt           time.Time `gorm:"serializer:storageTime"`

--- a/internal/repository/dto/usage_snapshot.go
+++ b/internal/repository/dto/usage_snapshot.go
@@ -15,6 +15,7 @@ type TokenStats struct {
 	ReasoningTokens     int64 `json:"reasoning_tokens"`
 	CachedTokens        int64 `json:"cached_tokens"`
 	CacheReadTokens     int64 `json:"cache_read_tokens"`
+	CacheReadPresent    bool  `json:"cache_read_tokens_present"`
 	CacheCreationTokens int64 `json:"cache_creation_tokens"`
 	TotalTokens         int64 `json:"total_tokens"`
 }

--- a/internal/service/redis_usage.go
+++ b/internal/service/redis_usage.go
@@ -109,6 +109,7 @@ func (d queuedUsageDetail) toUsageEvent(fetchedAt time.Time) entities.UsageEvent
 		ReasoningTokens:     d.Tokens.ReasoningTokens,
 		CachedTokens:        d.Tokens.CachedTokens,
 		CacheReadTokens:     d.Tokens.CacheReadTokens,
+		CacheReadPresent:    d.Tokens.CacheReadPresent,
 		CacheCreationTokens: d.Tokens.CacheCreationTokens,
 		TotalTokens:         d.Tokens.TotalTokens,
 	}

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -541,6 +541,7 @@ func tokenValuesFromUsageEvent(event entities.UsageEvent) tokenprocessor.TokenVa
 		ReasoningTokens:     event.ReasoningTokens,
 		CachedTokens:        event.CachedTokens,
 		CacheReadTokens:     event.CacheReadTokens,
+		CacheReadPresent:    event.CacheReadPresent,
 		CacheCreationTokens: event.CacheCreationTokens,
 		TotalTokens:         event.TotalTokens,
 	}

--- a/internal/service/test/openai_token_normalization_test.go
+++ b/internal/service/test/openai_token_normalization_test.go
@@ -122,6 +122,88 @@ func TestProcessRedisUsageInboxBackfillsCodexCacheReadFromCachedTokens(t *testin
 	}
 }
 
+func TestProcessRedisUsageInboxPreservesCanonicalZeroCacheRead(t *testing.T) {
+	db := openOpenAITokenNormalizationTestDatabase(t)
+	_, err := repository.InsertRedisUsageInboxMessages(db, []repodto.RedisInboxInsert{{
+		Source: "usage",
+		RawMessage: `{
+			"timestamp":"2026-07-15T08:00:00Z",
+			"provider":"OpenAI Compatible",
+			"auth_type":"api_key",
+			"auth_index":"canonical-zero-auth-index",
+			"model":"gpt-5.4",
+			"request_id":"canonical-zero-cache-read",
+			"executor_type":"OpenAICompatExecutor",
+			"tokens":{
+				"input_tokens":100,
+				"output_tokens":20,
+				"cached_tokens":30,
+				"cache_read_tokens":0,
+				"cache_read_tokens_present":true,
+				"total_tokens":120
+			}
+		}`,
+		PoppedAt: time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC),
+	}})
+	if err != nil {
+		t.Fatalf("seed inbox row: %v", err)
+	}
+	syncService := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{BaseURL: "https://cpa.example.com"})
+
+	result, err := syncService.ProcessRedisUsageInbox(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessRedisUsageInbox returned error: %v", err)
+	}
+	if result == nil || result.InsertedEvents != 1 {
+		t.Fatalf("expected one inserted event, got %+v", result)
+	}
+	event := loadOpenAITokenNormalizationEvent(t, db, "canonical-zero-cache-read")
+	if event.CachedTokens != 30 || event.CacheReadTokens != 0 {
+		t.Fatalf("expected canonical zero cache read to remain zero, got %+v", event)
+	}
+}
+
+func TestProcessRedisUsageInboxBackfillsCustomCacheReadDespiteQueuePresence(t *testing.T) {
+	db := openOpenAITokenNormalizationTestDatabase(t)
+	_, err := repository.InsertRedisUsageInboxMessages(db, []repodto.RedisInboxInsert{{
+		Source: "usage",
+		RawMessage: `{
+			"timestamp":"2026-07-15T08:00:00Z",
+			"provider":"External Provider",
+			"auth_type":"api_key",
+			"auth_index":"external-auth-index",
+			"model":"external-model",
+			"request_id":"custom-cache-read-fallback",
+			"executor_type":"ExternalExecutor",
+			"tokens":{
+				"input_tokens":100,
+				"output_tokens":20,
+				"cached_tokens":30,
+				"cache_read_tokens":0,
+				"cache_read_tokens_present":true,
+				"total_tokens":120
+			}
+		}`,
+		PoppedAt: time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC),
+	}})
+	if err != nil {
+		t.Fatalf("seed inbox row: %v", err)
+	}
+	syncService := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{BaseURL: "https://cpa.example.com"})
+
+	result, err := syncService.ProcessRedisUsageInbox(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessRedisUsageInbox returned error: %v", err)
+	}
+	if result == nil || result.InsertedEvents != 1 {
+		t.Fatalf("expected one inserted event, got %+v", result)
+	}
+	event := loadOpenAITokenNormalizationEvent(t, db, "custom-cache-read-fallback")
+	if event.CachedTokens != 30 || event.CacheReadTokens != 30 {
+		t.Fatalf("expected custom executor cached tokens to backfill cache read despite queue presence, got %+v", event)
+	}
+}
+
 func TestProcessRedisUsageInboxUsesDefaultTokensWhenUsageIdentityMissing(t *testing.T) {
 	db := openOpenAITokenNormalizationTestDatabase(t)
 	_, err := repository.InsertRedisUsageInboxMessages(db, []repodto.RedisInboxInsert{{

--- a/internal/service/tokenprocessor/handler.go
+++ b/internal/service/tokenprocessor/handler.go
@@ -63,6 +63,10 @@ func normalizeNonClaudeCacheRead(context normalizationContext) (TokenValues, []A
 		// 损坏的显式 read 不能被 cached 覆盖，否则会把 clamp 伪装成“字段缺失”的正常 alias。
 		return tokens, nil, []Violation{{Code: ViolationAmbiguousTotalMismatch, Fields: []string{"cached_tokens", "cache_read_tokens"}, Reason: "cache read alias depends on a clamped read field"}}
 	}
+	if tokens.CacheReadPresent && context.resolution.evidenceStrength == EvidenceParserContract {
+		// 只有已登记 CPA executor 的 parser 合同能证明显式零值是 canonical；custom/unknown 仍需 legacy 兜底。
+		return tokens, nil, nil
+	}
 	// 非 Claude 只有在显式 read 缺失时才允许 legacy cached 单向回填，避免覆盖更精确的 read。
 	if tokens.CacheReadTokens != 0 || tokens.CachedTokens <= 0 {
 		return tokens, nil, nil

--- a/internal/service/tokenprocessor/types.go
+++ b/internal/service/tokenprocessor/types.go
@@ -47,6 +47,7 @@ type TokenValues struct {
 	ReasoningTokens     int64
 	CachedTokens        int64
 	CacheReadTokens     int64
+	CacheReadPresent    bool
 	CacheCreationTokens int64
 	TotalTokens         int64
 }


### PR DESCRIPTION
## Summary

- propagate CPA cache_read_tokens_present through Redis usage normalization
- preserve explicit zero cache-read values for registered CPA executor parser contracts
- keep cached_tokens fallback compatibility for legacy payloads and custom or unknown executors

## Testing

- make verify