### PR TITLE
Filter prewarm usage from latency metrics

### DIFF
--- a/internal/entities/usage_event.go
+++ b/internal/entities/usage_event.go
@@ -21,6 +21,7 @@ type UsageEvent struct {
 	Source              string
 	AuthIndex           string `gorm:"index:idx_usage_events_auth_index;index:idx_usage_events_auth_type_auth_index_id,priority:2;index:idx_usage_events_auth_index_timestamp_id,priority:1"`
 	Failed              bool
+	Generate            *bool `gorm:"column:generate;not null;default:true"`
 	LatencyMS           int64
 	TTFTMS              *int64 `gorm:"column:ttft_ms"`
 	InputTokens         int64

--- a/internal/repository/migration/20260715_usage_event_generate.go
+++ b/internal/repository/migration/20260715_usage_event_generate.go
@@ -1,0 +1,36 @@
+package migration
+
+import (
+	"fmt"
+
+	"cpa-usage-keeper/internal/entities"
+
+	"gorm.io/gorm"
+)
+
+func addUsageEventGenerateMigration(tx *gorm.DB) error {
+	if !tx.Migrator().HasTable(&entities.UsageEvent{}) {
+		return nil
+	}
+	if !tx.Migrator().HasColumn(&entities.UsageEvent{}, "generate") {
+		if err := tx.Migrator().AddColumn(&entities.UsageEvent{}, "Generate"); err != nil {
+			return fmt.Errorf("add usage_events.generate column: %w", err)
+		}
+	}
+
+	// 旧版 CPA 未上报 generate；仅把成功的 WebSocket 全零 token 事件回填为预热。
+	if err := tx.Model(&entities.UsageEvent{}).
+		Where("failed = ?", false).
+		Where("executor_type = ?", "CodexWebsocketsExecutor").
+		Where("input_tokens = ?", 0).
+		Where("output_tokens = ?", 0).
+		Where("reasoning_tokens = ?", 0).
+		Where("cached_tokens = ?", 0).
+		Where("cache_read_tokens = ?", 0).
+		Where("cache_creation_tokens = ?", 0).
+		Where("total_tokens = ?", 0).
+		Update("generate", false).Error; err != nil {
+		return fmt.Errorf("backfill usage_events.generate: %w", err)
+	}
+	return nil
+}

--- a/internal/repository/migration/migration.go
+++ b/internal/repository/migration/migration.go
@@ -56,6 +56,7 @@ const (
 	migrationBackfillCacheReadTokens                = "20260710_backfill_cache_read_tokens"
 	migrationAddUsageIdentityXAIUserID              = "20260711_add_usage_identity_xai_user_id"
 	migrationAddUsageEventResponseServiceTier       = "20260715_add_usage_event_response_service_tier"
+	migrationAddUsageEventGenerate                  = "20260715_add_usage_event_generate"
 )
 
 type schemaMigration struct {
@@ -156,6 +157,7 @@ func orderedMigrations() []databaseMigration {
 		{version: migrationBackfillCacheReadTokens, run: backfillCacheReadTokensMigration},
 		{version: migrationAddUsageIdentityXAIUserID, run: addUsageIdentityXAIUserIDMigration},
 		{version: migrationAddUsageEventResponseServiceTier, run: addUsageEventResponseServiceTierMigration},
+		{version: migrationAddUsageEventGenerate, run: addUsageEventGenerateMigration},
 	}
 }
 

--- a/internal/repository/migration/migration_test.go
+++ b/internal/repository/migration/migration_test.go
@@ -66,6 +66,7 @@ func TestOrderedMigrationsPreservesExecutionOrder(t *testing.T) {
 		"20260710_backfill_cache_read_tokens",
 		"20260711_add_usage_identity_xai_user_id",
 		"20260715_add_usage_event_response_service_tier",
+		"20260715_add_usage_event_generate",
 	}
 	assertStringSlicesEqual(t, want, got)
 }

--- a/internal/repository/migration/test/usage_event_generate_test.go
+++ b/internal/repository/migration/test/usage_event_generate_test.go
@@ -1,0 +1,101 @@
+package test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"cpa-usage-keeper/internal/repository/migration"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const usageEventGenerateMigrationVersion = "20260715_add_usage_event_generate"
+
+func TestUsageEventGenerateMigrationBackfillsLegacyPrewarmEvents(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "existing.db")), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open existing database: %v", err)
+	}
+	closeMigrationTestDatabase(t, db)
+
+	if err := db.Exec(`CREATE TABLE usage_events (
+		id INTEGER PRIMARY KEY,
+		failed NUMERIC NOT NULL DEFAULT 0,
+		executor_type TEXT NOT NULL DEFAULT '',
+		input_tokens INTEGER NOT NULL DEFAULT 0,
+		output_tokens INTEGER NOT NULL DEFAULT 0,
+		reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+		cached_tokens INTEGER NOT NULL DEFAULT 0,
+		cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+		cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+		total_tokens INTEGER NOT NULL DEFAULT 0
+	)`).Error; err != nil {
+		t.Fatalf("create legacy usage_events table: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO usage_events (
+		id, failed, executor_type, input_tokens, output_tokens, reasoning_tokens,
+		cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens
+	) VALUES
+		(1, 0, 'CodexWebsocketsExecutor', 0, 0, 0, 0, 0, 0, 0),
+		(2, 0, 'CodexWebsocketsExecutor', 0, 0, 0, 0, 0, 1, 0),
+		(3, 1, 'CodexWebsocketsExecutor', 0, 0, 0, 0, 0, 0, 0),
+		(4, 0, 'CodexExecutor',           0, 0, 0, 0, 0, 0, 0),
+		(5, 0, 'CodexWebsocketsExecutor', 1, 0, 0, 0, 0, 0, 1)
+	`).Error; err != nil {
+		t.Fatalf("seed legacy usage events: %v", err)
+	}
+	if err := migration.MarkAllAsApplied(db); err != nil {
+		t.Fatalf("mark historical migrations applied: %v", err)
+	}
+	if err := db.Table("schema_migrations").Where("version = ?", usageEventGenerateMigrationVersion).Delete(nil).Error; err != nil {
+		t.Fatalf("make generate migration pending: %v", err)
+	}
+
+	if err := migration.Run(db); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if !db.Migrator().HasColumn("usage_events", "generate") {
+		t.Fatal("expected usage_events.generate column")
+	}
+	type generateRow struct {
+		ID       int64
+		Generate bool
+	}
+	var rows []generateRow
+	if err := db.Table("usage_events").Order("id ASC").Find(&rows).Error; err != nil {
+		t.Fatalf("load migrated usage events: %v", err)
+	}
+	want := []bool{false, true, true, true, true}
+	if len(rows) != len(want) {
+		t.Fatalf("expected %d migrated rows, got %d", len(want), len(rows))
+	}
+	for index, row := range rows {
+		if row.Generate != want[index] {
+			t.Errorf("row %d generate=%v, want %v", row.ID, row.Generate, want[index])
+		}
+	}
+
+	if err := db.Exec("INSERT INTO usage_events (id) VALUES (?)", 6).Error; err != nil {
+		t.Fatalf("insert usage event with default generate: %v", err)
+	}
+	var defaultGenerate bool
+	if err := db.Table("usage_events").Select("generate").Where("id = ?", 6).Scan(&defaultGenerate).Error; err != nil {
+		t.Fatalf("load default generate: %v", err)
+	}
+	if !defaultGenerate {
+		t.Fatal("expected usage_events.generate to default true")
+	}
+	if err := db.Exec("INSERT INTO usage_events (id, generate) VALUES (?, NULL)", 7).Error; err == nil {
+		t.Fatal("expected usage_events.generate to reject NULL")
+	}
+
+	var migrationCount int64
+	if err := db.Table("schema_migrations").Where("version = ?", usageEventGenerateMigrationVersion).Count(&migrationCount).Error; err != nil {
+		t.Fatalf("count generate migration record: %v", err)
+	}
+	if migrationCount != 1 {
+		t.Fatalf("expected one generate migration record, got %d", migrationCount)
+	}
+}

--- a/internal/repository/query_projection_test.go
+++ b/internal/repository/query_projection_test.go
@@ -17,10 +17,10 @@ func TestRepositoryQueriesAvoidKnownFullEntityReads(t *testing.T) {
 	assertFileContains(t, "usage.go",
 		"Select(usageEventProjectionColumns).Order(\"timestamp DESC, id DESC\")",
 		"Select(usageOverviewRawEventProjectionColumns).\n\t\tOrder(\"timestamp asc\")",
-		"usageOverviewRawEventProjectionColumns = \"api_group_key, provider, auth_type, model, model_alias, timestamp, source, auth_index, failed, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cache_read_tokens, cache_creation_tokens, total_tokens\"",
+		"usageOverviewRawEventProjectionColumns = \"api_group_key, provider, auth_type, model, model_alias, timestamp, source, auth_index, failed, generate, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cache_read_tokens, cache_creation_tokens, total_tokens\"",
 	)
 	assertFileContains(t, "usage_recent_event_cache.go",
-		"Select(\"api_group_key, provider, auth_type, model, model_alias, timestamp, source, auth_index, failed, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens\")",
+		"Select(\"api_group_key, provider, auth_type, model, model_alias, timestamp, source, auth_index, failed, generate, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens\")",
 	)
 
 	assertFileDoesNotContain(t, "usage_identities.go",

--- a/internal/repository/test/usage_analysis_generate_test.go
+++ b/internal/repository/test/usage_analysis_generate_test.go
@@ -1,0 +1,39 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+	repodto "cpa-usage-keeper/internal/repository/dto"
+)
+
+func TestBuildAnalysisExcludesPrewarmFromLatencyDiagnostics(t *testing.T) {
+	db := openTestDatabase(t)
+	start := time.Date(2026, 7, 15, 9, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	normalTTFT := int64(120)
+	prewarmTTFT := int64(25)
+	generate := true
+	prewarm := false
+	if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{
+		{EventKey: "normal-latency", Generate: &generate, Timestamp: start.Add(10 * time.Minute), LatencyMS: 900, TTFTMS: &normalTTFT},
+		{EventKey: "prewarm-latency", Generate: &prewarm, Timestamp: start.Add(20 * time.Minute), LatencyMS: 80, TTFTMS: &prewarmTTFT},
+	}); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+
+	analysis, err := repository.BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{StartTime: &start, EndTime: &end})
+	if err != nil {
+		t.Fatalf("BuildAnalysisWithFilter returned error: %v", err)
+	}
+
+	diagnostics := analysis.LatencyDiagnostics
+	if diagnostics.TotalPoints != 1 || len(diagnostics.Points) != 1 {
+		t.Fatalf("expected one normal latency point, got %+v", diagnostics)
+	}
+	if diagnostics.Points[0].TTFTMS != normalTTFT || diagnostics.Points[0].LatencyMS != 900 {
+		t.Fatalf("expected normal latency point to remain, got %+v", diagnostics.Points[0])
+	}
+}

--- a/internal/repository/test/usage_event_generate_persistence_test.go
+++ b/internal/repository/test/usage_event_generate_persistence_test.go
@@ -1,0 +1,41 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+)
+
+func TestInsertUsageEventsPersistsNormalizedGenerateValues(t *testing.T) {
+	db := openTestDatabase(t)
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	generate := true
+	prewarm := false
+	if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{
+		{EventKey: "prewarm", Generate: &prewarm, Timestamp: now},
+		{EventKey: "generate", Generate: &generate, Timestamp: now.Add(time.Second)},
+		{EventKey: "default-generate", Timestamp: now.Add(2 * time.Second)},
+	}); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+
+	type generateRow struct {
+		EventKey string
+		Generate bool
+	}
+	var rows []generateRow
+	if err := db.Table("usage_events").Select("event_key, generate").Order("id ASC").Find(&rows).Error; err != nil {
+		t.Fatalf("load persisted generate values: %v", err)
+	}
+	want := []bool{false, true, true}
+	if len(rows) != len(want) {
+		t.Fatalf("expected %d rows, got %d", len(want), len(rows))
+	}
+	for index, row := range rows {
+		if row.Generate != want[index] {
+			t.Errorf("event %q generate=%v, want %v", row.EventKey, row.Generate, want[index])
+		}
+	}
+}

--- a/internal/repository/test/usage_overview_realtime_response_distribution_test.go
+++ b/internal/repository/test/usage_overview_realtime_response_distribution_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"runtime"
 	"testing"
 	"time"
 
@@ -35,6 +36,106 @@ func TestBuildUsageOverviewRealtimeWithFilterRequiresValidTTFTAndLatencyForBothD
 
 	assertRealtimeResponseDistributionUsesOnlyValidPairs(t, realtime.ResponseDistribution.TTFT, 100)
 	assertRealtimeResponseDistributionUsesOnlyValidPairs(t, realtime.ResponseDistribution.Latency, 500)
+}
+
+func TestBuildUsageOverviewRealtimeExcludesPrewarmFromResponseDistributions(t *testing.T) {
+	testCases := []struct {
+		name     string
+		useCache bool
+	}{
+		{name: "database"},
+		{name: "recent cache", useCache: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			db := openTestDatabase(t)
+			now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+			normalTTFT := int64(100)
+			prewarmTTFT := int64(20)
+			generate := true
+			prewarm := false
+			if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{
+				{EventKey: "normal-response", Generate: &generate, Timestamp: now.Add(-2 * time.Minute), LatencyMS: 500, TTFTMS: &normalTTFT},
+				{EventKey: "prewarm-response", Generate: &prewarm, Timestamp: now.Add(-time.Minute), LatencyMS: 70, TTFTMS: &prewarmTTFT},
+			}); err != nil {
+				t.Fatalf("InsertUsageEvents returned error: %v", err)
+			}
+
+			filter := repodto.UsageQueryFilter{RealtimeWindow: "15m", RealtimeEndTime: &now}
+			var (
+				realtime repodto.UsageOverviewRealtimeRecord
+				err      error
+			)
+			if testCase.useCache {
+				cache, cacheErr := repository.NewUsageRecentEventCache(db, repository.UsageRecentEventCacheOptions{Now: func() time.Time { return now }})
+				if cacheErr != nil {
+					t.Fatalf("NewUsageRecentEventCache returned error: %v", cacheErr)
+				}
+				t.Cleanup(cache.Close)
+				realtime, err = repository.BuildUsageOverviewRealtimeWithFilterAndRecentCache(db, filter, cache)
+			} else {
+				realtime, err = repository.BuildUsageOverviewRealtimeWithFilter(db, filter)
+			}
+			if err != nil {
+				t.Fatalf("build realtime overview: %v", err)
+			}
+
+			assertRealtimeResponseDistributionUsesOnlyValidPairs(t, realtime.ResponseDistribution.TTFT, 100)
+			assertRealtimeResponseDistributionUsesOnlyValidPairs(t, realtime.ResponseDistribution.Latency, 500)
+			var maxRequestCount int64
+			for _, point := range realtime.RequestLevel {
+				if point.Requests > maxRequestCount {
+					maxRequestCount = point.Requests
+				}
+			}
+			if maxRequestCount != 2 {
+				t.Fatalf("expected prewarm to remain in rolling request counts, got max=%d", maxRequestCount)
+			}
+		})
+	}
+}
+
+func TestUsageRecentEventCacheTryAppendCopiesGeneratePointer(t *testing.T) {
+	previousMaxProcs := runtime.GOMAXPROCS(1)
+	t.Cleanup(func() { runtime.GOMAXPROCS(previousMaxProcs) })
+
+	db := openTestDatabase(t)
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	cache, err := repository.NewUsageRecentEventCache(db, repository.UsageRecentEventCacheOptions{Now: func() time.Time { return now }})
+	if err != nil {
+		t.Fatalf("NewUsageRecentEventCache returned error: %v", err)
+	}
+	t.Cleanup(cache.Close)
+
+	generate := false
+	if !cache.TryAppend([]entities.UsageEvent{{
+		EventKey:  "async-prewarm",
+		Timestamp: now,
+		Generate:  &generate,
+	}}) {
+		t.Fatal("expected async append to be accepted")
+	}
+	// TryAppend 返回后调用方可以复用原始事件；缓存必须持有独立的 Generate 值。
+	generate = true
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		events, ok := cache.Events(now.Add(-time.Minute), now.Add(time.Minute), false, "")
+		if !ok {
+			t.Fatal("expected recent cache to remain available")
+		}
+		if len(events) == 1 {
+			if events[0].Generate {
+				t.Fatal("expected async cache append to preserve the original generate=false value")
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for async cache append, got %d events", len(events))
+		}
+		runtime.Gosched()
+	}
 }
 
 func assertRealtimeResponseDistributionUsesOnlyValidPairs(t *testing.T, series repodto.RealtimeResponseDistributionSeriesRecord, wantMS int64) {

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -20,7 +20,7 @@ const usageEventProjectionColumns = "id, api_group_key, provider, auth_type, req
 const analysisLatencyMaxDisplayPoints = 2500
 
 // usageOverviewRawEventProjectionColumns 是 Overview 边界补偿和 realtime DB 兜底的最小事件投影。
-const usageOverviewRawEventProjectionColumns = "api_group_key, provider, auth_type, model, model_alias, timestamp, source, auth_index, failed, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cache_read_tokens, cache_creation_tokens, total_tokens"
+const usageOverviewRawEventProjectionColumns = "api_group_key, provider, auth_type, model, model_alias, timestamp, source, auth_index, failed, generate, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cache_read_tokens, cache_creation_tokens, total_tokens"
 
 // usageEventProjection 是 usage_events 轻量投影，专门承接 select columns 的查询结果。
 type usageEventProjection struct {
@@ -40,6 +40,7 @@ type usageEventProjection struct {
 	Source              string
 	AuthIndex           string
 	Failed              bool
+	Generate            *bool
 	LatencyMS           int64
 	TTFTMS              *int64 `gorm:"column:ttft_ms"`
 	InputTokens         int64
@@ -299,6 +300,7 @@ func usageEventProjectionToEntity(event usageEventProjection) entities.UsageEven
 		Source:              event.Source,
 		AuthIndex:           event.AuthIndex,
 		Failed:              event.Failed,
+		Generate:            event.Generate,
 		LatencyMS:           event.LatencyMS,
 		TTFTMS:              event.TTFTMS,
 		InputTokens:         event.InputTokens,
@@ -481,10 +483,11 @@ type analysisIdentityLookup map[entities.UsageIdentityAuthType]map[string]analys
 
 func buildAnalysisLatencyDiagnosticsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (dto.AnalysisLatencyDiagnosticsRecord, error) {
 	empty := emptyAnalysisLatencyDiagnosticsRecord()
-	// 延迟诊断只统计成功请求；TTFT/Latency 有效性仍在内存过滤，避免依赖未索引列。
+	// 延迟诊断只统计要求实际生成的成功请求；TTFT/Latency 有效性仍在内存过滤，避免依赖未索引列。
 	query := db.Model(&entities.UsageEvent{}).
 		Select("latency_ms, ttft_ms").
-		Where("failed = ?", false)
+		Where("failed = ?", false).
+		Where("generate = ?", true)
 	query = applyUsageAnalysisTabQuery(query, filter)
 
 	rows, err := query.Rows()
@@ -1739,7 +1742,7 @@ func buildUsageOverviewRealtime(db *gorm.DB, filter dto.UsageQueryFilter, costRe
 			// current usage 的请求数同样包含成功和失败，token 后续只由成功请求累计。
 			applyUsageOverviewRealtimeRequest(realtimeEvent, modelUsage, apiKeyUsage, authFileUsage, aiProviderUsage, identityLookup)
 		}
-		if !event.Failed && event.TTFTMS != nil && *event.TTFTMS > 0 && event.LatencyMS > 0 {
+		if !event.Failed && usageEventGenerateEnabled(event.Generate) && event.TTFTMS != nil && *event.TTFTMS > 0 && event.LatencyMS > 0 {
 			// TTFT 和 Latency 共用同一有效请求样本，避免两张响应分布图的统计口径不一致。
 			bucket.ttftSamples = append(bucket.ttftSamples, usageOverviewRealtimeResponseSample{timestamp: timestamp, ms: *event.TTFTMS})
 			bucket.latencySamples = append(bucket.latencySamples, usageOverviewRealtimeResponseSample{timestamp: timestamp, ms: event.LatencyMS})
@@ -1769,6 +1772,10 @@ func buildUsageOverviewRealtime(db *gorm.DB, filter dto.UsageQueryFilter, costRe
 
 	// 最后统一把 bucket、percentile 和 Top5 accumulator 映射成 API DTO。
 	return finalizeUsageOverviewRealtime(window, span, start, end, buckets, warmupBucketCount, modelUsage, apiKeyUsage, authFileUsage, aiProviderUsage), nil
+}
+
+func usageEventGenerateEnabled(generate *bool) bool {
+	return generate == nil || *generate
 }
 
 func usageOverviewRealtimeWindow(value string) (time.Duration, time.Duration) {

--- a/internal/repository/usage_recent_event_cache.go
+++ b/internal/repository/usage_recent_event_cache.go
@@ -48,6 +48,8 @@ type RecentUsageEvent struct {
 	IdentityFallbackLabel string
 	// Failed 保留请求成功状态，realtime 请求水平统计需要成功和失败总量。
 	Failed bool
+	// Generate 标记请求是否要求实际生成；预热事件只保留请求计数，不参与延迟分布。
+	Generate bool
 	// LatencyMS 保留响应耗时样本，用于 Response Level 滑动聚合。
 	LatencyMS int64
 	// TTFTMS 保留可空首 token 延迟样本，用指针区分缺失和 0。
@@ -110,6 +112,7 @@ type recentUsageEventLoadRow struct {
 	Source              string
 	AuthIndex           string
 	Failed              bool
+	Generate            bool
 	LatencyMS           int64
 	TTFTMS              *int64 `gorm:"column:ttft_ms"`
 	InputTokens         int64
@@ -322,6 +325,7 @@ func (c *UsageRecentEventCache) appendEvents(events []entities.UsageEvent) {
 			Source:              event.Source,
 			AuthIndex:           event.AuthIndex,
 			Failed:              event.Failed,
+			Generate:            usageEventGenerateEnabled(event.Generate),
 			LatencyMS:           event.LatencyMS,
 			TTFTMS:              cloneInt64Ptr(event.TTFTMS),
 			InputTokens:         event.InputTokens,
@@ -432,7 +436,7 @@ func loadUsageRecentEventCacheRows(db *gorm.DB, start time.Time) ([]recentUsageE
 	var rows []recentUsageEventLoadRow
 	// 只 select 最近缓存和 realtime 必需字段，避免大字段进入 70 分钟内存窗口。
 	if err := db.Model(&entities.UsageEvent{}).
-		Select("api_group_key, provider, auth_type, model, model_alias, timestamp, source, auth_index, failed, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens").
+		Select("api_group_key, provider, auth_type, model, model_alias, timestamp, source, auth_index, failed, generate, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens").
 		// 启动加载只取 retention 左边界之后的数据。
 		Where("timestamp >= ?", timeutil.FormatStorageTime(start)).
 		// 按时间排序让后续剪枝和调试输出更直观。
@@ -466,6 +470,7 @@ func (c *UsageRecentEventCache) recentEventFromRowLocked(row recentUsageEventLoa
 		IdentityFallbackKind:  identityKind,
 		IdentityFallbackLabel: c.pool.intern(fallbackLabel),
 		Failed:                row.Failed,
+		Generate:              row.Generate,
 		LatencyMS:             row.LatencyMS,
 		TTFTMS:                cloneInt64Ptr(row.TTFTMS),
 		InputTokens:           row.InputTokens,
@@ -579,6 +584,7 @@ func cloneUsageEventsForRecentCache(events []entities.UsageEvent) []entities.Usa
 		result[index] = events[index]
 		// 指针字段需要深拷贝避免跨 goroutine 共享。
 		result[index].ModelAlias = cloneStringPtr(events[index].ModelAlias)
+		result[index].Generate = cloneBoolPtr(events[index].Generate)
 		result[index].TTFTMS = cloneInt64Ptr(events[index].TTFTMS)
 	}
 	return result
@@ -590,14 +596,24 @@ func cloneRecentUsageEvent(event RecentUsageEvent) RecentUsageEvent {
 	return event
 }
 
+func cloneBoolPtr(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
 func recentUsageEventToEntity(event RecentUsageEvent) entities.UsageEvent {
 	// Overview 聚合已有实体处理函数，这里把缓存投影还原成最小 UsageEvent。
+	generate := event.Generate
 	result := entities.UsageEvent{
 		APIGroupKey:         event.APIGroupKey,
 		Model:               event.Model,
 		Timestamp:           event.Timestamp,
 		AuthIndex:           event.AuthIndex,
 		Failed:              event.Failed,
+		Generate:            &generate,
 		LatencyMS:           event.LatencyMS,
 		TTFTMS:              cloneInt64Ptr(event.TTFTMS),
 		InputTokens:         event.InputTokens,

--- a/internal/service/redis_usage.go
+++ b/internal/service/redis_usage.go
@@ -43,6 +43,7 @@ type queuedUsageDetail struct {
 	AuthIndex           string          `json:"auth_index"`
 	Tokens              dto.TokenStats  `json:"tokens"`
 	Failed              bool            `json:"failed"`
+	Generate            *bool           `json:"generate"`
 	Provider            string          `json:"provider"`
 	Model               string          `json:"model"`
 	Alias               *string         `json:"alias"`
@@ -76,6 +77,27 @@ func trimRedisOptionalString(value *string) *string {
 	return &trimmed
 }
 
+func normalizeRedisGenerate(value *bool, failed bool, executorType string, tokens dto.TokenStats) *bool {
+	generate := true
+	if value != nil {
+		generate = *value
+	} else if !failed && strings.TrimSpace(executorType) == "CodexWebsocketsExecutor" && redisTokenStatsAllZero(tokens) {
+		// 旧版 CPA 没有 generate；只把成功的 WebSocket 全零 token 消息兼容为预热。
+		generate = false
+	}
+	return &generate
+}
+
+func redisTokenStatsAllZero(tokens dto.TokenStats) bool {
+	return tokens.InputTokens == 0 &&
+		tokens.OutputTokens == 0 &&
+		tokens.ReasoningTokens == 0 &&
+		tokens.CachedTokens == 0 &&
+		tokens.CacheReadTokens == 0 &&
+		tokens.CacheCreationTokens == 0 &&
+		tokens.TotalTokens == 0
+}
+
 // toUsageEvent 保持 Redis payload 的 model/request_id 语义，缺失时间才用本地拉取时间兜底。
 func (d queuedUsageDetail) toUsageEvent(fetchedAt time.Time) entities.UsageEvent {
 	apiGroupKey := firstNonEmpty(d.APIKey, d.Provider, d.Endpoint, "unknown")
@@ -104,6 +126,7 @@ func (d queuedUsageDetail) toUsageEvent(fetchedAt time.Time) entities.UsageEvent
 		Source:              source,
 		AuthIndex:           authIndex,
 		Failed:              d.Failed,
+		Generate:            normalizeRedisGenerate(d.Generate, d.Failed, d.ExecutorType, d.Tokens),
 		LatencyMS:           max(d.LatencyMS, 0),
 		TTFTMS:              d.TTFTMS,
 		InputTokens:         d.Tokens.InputTokens,

--- a/internal/service/redis_usage.go
+++ b/internal/service/redis_usage.go
@@ -78,10 +78,11 @@ func trimRedisOptionalString(value *string) *string {
 }
 
 func normalizeRedisGenerate(value *bool, failed bool, executorType string, tokens dto.TokenStats) *bool {
-	generate := true
 	if value != nil {
-		generate = *value
-	} else if !failed && strings.TrimSpace(executorType) == "CodexWebsocketsExecutor" && redisTokenStatsAllZero(tokens) {
+		return value
+	}
+	generate := true
+	if !failed && strings.TrimSpace(executorType) == "CodexWebsocketsExecutor" && redisTokenStatsAllZero(tokens) {
 		// 旧版 CPA 没有 generate；只把成功的 WebSocket 全零 token 消息兼容为预热。
 		generate = false
 	}

--- a/internal/service/test/redis_usage_generate_test.go
+++ b/internal/service/test/redis_usage_generate_test.go
@@ -1,0 +1,62 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/service"
+)
+
+func TestDecodeRedisUsageMessageNormalizesGenerate(t *testing.T) {
+	testCases := []struct {
+		name         string
+		message      string
+		wantGenerate bool
+	}{
+		{
+			name:         "explicit false wins over token values",
+			message:      `{"request_id":"explicit-false","generate":false,"tokens":{"input_tokens":1,"total_tokens":1}}`,
+			wantGenerate: false,
+		},
+		{
+			name:         "explicit true wins over legacy signature",
+			message:      `{"request_id":"explicit-true","generate":true,"failed":false,"executor_type":"CodexWebsocketsExecutor","tokens":{}}`,
+			wantGenerate: true,
+		},
+		{
+			name:         "missing field recognizes legacy prewarm",
+			message:      `{"request_id":"legacy-prewarm","failed":false,"executor_type":"CodexWebsocketsExecutor","tokens":{}}`,
+			wantGenerate: false,
+		},
+		{
+			name:         "missing field keeps websocket event with token detail",
+			message:      `{"request_id":"legacy-cache-write","failed":false,"executor_type":"CodexWebsocketsExecutor","tokens":{"cache_creation_tokens":1}}`,
+			wantGenerate: true,
+		},
+		{
+			name:         "missing field keeps non-websocket zero token event",
+			message:      `{"request_id":"legacy-http","failed":false,"executor_type":"CodexExecutor","tokens":{}}`,
+			wantGenerate: true,
+		},
+		{
+			name:         "missing field keeps failed websocket event",
+			message:      `{"request_id":"legacy-failed","failed":true,"executor_type":"CodexWebsocketsExecutor","tokens":{}}`,
+			wantGenerate: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			event, _, err := service.DecodeRedisUsageMessage(testCase.message, time.Date(2026, 7, 15, 1, 0, 0, 0, time.UTC))
+			if err != nil {
+				t.Fatalf("DecodeRedisUsageMessage returned error: %v", err)
+			}
+			if event.Generate == nil {
+				t.Fatal("expected generate to be normalized to a non-nil value")
+			}
+			if *event.Generate != testCase.wantGenerate {
+				t.Fatalf("generate=%v, want %v", *event.Generate, testCase.wantGenerate)
+			}
+		})
+	}
+}

--- a/internal/service/test/redis_usage_generate_test.go
+++ b/internal/service/test/redis_usage_generate_test.go
@@ -60,3 +60,29 @@ func TestDecodeRedisUsageMessageNormalizesGenerate(t *testing.T) {
 		})
 	}
 }
+
+func TestDecodeRedisUsageMessageReusesExplicitGenerateAllocation(t *testing.T) {
+	fetchedAt := time.Date(2026, 7, 15, 1, 0, 0, 0, time.UTC)
+	explicitMessage := `{"request_id":"allocation-check","generate":true,"executor_type":"CodexExecutor","tokens":{"input_tokens":1,"total_tokens":1}}`
+	missingMessage := `{"request_id":"allocation-check","executor_type":"CodexExecutor","tokens":{"input_tokens":1,"total_tokens":1}}`
+
+	decodeAllocs := func(message string) (float64, error) {
+		var decodeErr error
+		allocs := testing.AllocsPerRun(1000, func() {
+			_, _, decodeErr = service.DecodeRedisUsageMessage(message, fetchedAt)
+		})
+		return allocs, decodeErr
+	}
+
+	explicitAllocs, err := decodeAllocs(explicitMessage)
+	if err != nil {
+		t.Fatalf("decode explicit generate message: %v", err)
+	}
+	missingAllocs, err := decodeAllocs(missingMessage)
+	if err != nil {
+		t.Fatalf("decode missing generate message: %v", err)
+	}
+	if explicitAllocs > missingAllocs {
+		t.Fatalf("explicit generate allocations=%v, missing generate allocations=%v; explicit value should reuse its decoded pointer", explicitAllocs, missingAllocs)
+	}
+}


### PR DESCRIPTION
## Summary

- persist the CPA generate flag and backfill legacy Codex WebSocket zero-token prewarm events
- exclude prewarm samples from Overview TTFT/latency distributions and Analysis latency diagnostics while retaining request counts and Request Event Log entries
- carry generate through database and recent-cache paths, including safe async pointer ownership

## Validation

- rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build make verify