### PR TITLE
fix(logging): reduce startup log noise

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -127,10 +127,10 @@ func configureGinLogging() {
 	gin.DefaultWriter = logrusWriter{level: logrus.InfoLevel}
 	gin.DefaultErrorWriter = logrusWriter{level: logrus.ErrorLevel}
 	gin.DebugPrintFunc = func(format string, values ...interface{}) {
-		logrus.Infof("[GIN-debug] "+strings.TrimRight(format, "\r\n"), values...)
+		logrus.Debugf("[GIN-debug] "+strings.TrimRight(format, "\r\n"), values...)
 	}
 	gin.DebugPrintRouteFunc = func(httpMethod, absolutePath, handlerName string, nuHandlers int) {
-		logrus.Infof("[GIN-debug] %-6s %s --> %s (%d handlers)", httpMethod, absolutePath, handlerName, nuHandlers)
+		logrus.Debugf("[GIN-debug] %-6s %s --> %s (%d handlers)", httpMethod, absolutePath, handlerName, nuHandlers)
 	}
 }
 

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -173,51 +173,68 @@ func TestConfigureRoutesStdlibLogAndSlogToFile(t *testing.T) {
 	}
 }
 
-func TestConfigureRoutesGinDebugToTimestampedLogrusOutput(t *testing.T) {
-	reset := captureGlobalLogState(t)
-	defer reset()
+func TestConfigureFiltersGinDebugByLogLevel(t *testing.T) {
+	for _, testCase := range []struct {
+		name        string
+		logLevel    string
+		wantVisible bool
+	}{
+		{name: "info hides debug output", logLevel: "info", wantVisible: false},
+		{name: "debug shows debug output", logLevel: "debug", wantVisible: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			reset := captureGlobalLogState(t)
+			defer reset()
 
-	previousStderr := os.Stderr
-	reader, writer, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("create stderr pipe: %v", err)
-	}
-	os.Stderr = writer
-	defer func() {
-		os.Stderr = previousStderr
-		_ = reader.Close()
-	}()
+			previousStderr := os.Stderr
+			reader, writer, err := os.Pipe()
+			if err != nil {
+				t.Fatalf("create stderr pipe: %v", err)
+			}
+			os.Stderr = writer
+			defer func() {
+				os.Stderr = previousStderr
+				_ = reader.Close()
+			}()
 
-	closer, err := Configure(config.Config{
-		LogLevel:         "info",
-		LogFileEnabled:   false,
-		LogRetentionDays: 7,
-	})
-	if err != nil {
-		t.Fatalf("Configure returned error: %v", err)
-	}
+			closer, err := Configure(config.Config{
+				LogLevel:         testCase.logLevel,
+				LogFileEnabled:   false,
+				LogRetentionDays: 7,
+			})
+			if err != nil {
+				t.Fatalf("Configure returned error: %v", err)
+			}
 
-	if gin.DebugPrintFunc == nil {
-		t.Fatal("expected Configure to install Gin debug print function")
-	}
-	gin.DebugPrintFunc("GET %s", "/api/v1/status")
-	if err := closer.Close(); err != nil {
-		t.Fatalf("Close returned error: %v", err)
-	}
-	if err := writer.Close(); err != nil {
-		t.Fatalf("close stderr writer: %v", err)
-	}
+			if gin.DebugPrintFunc == nil || gin.DebugPrintRouteFunc == nil {
+				t.Fatal("expected Configure to install Gin debug print functions")
+			}
+			gin.DebugPrintFunc("GET %s", "/api/v1/status")
+			gin.DebugPrintRouteFunc("POST", "/api/v1/events", "handler", 3)
+			if err := closer.Close(); err != nil {
+				t.Fatalf("Close returned error: %v", err)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatalf("close stderr writer: %v", err)
+			}
 
-	var output bytes.Buffer
-	if _, err := output.ReadFrom(reader); err != nil {
-		t.Fatalf("read stderr output: %v", err)
-	}
-	content := output.String()
-	if !strings.Contains(content, "[GIN-debug] GET /api/v1/status") {
-		t.Fatalf("expected Gin debug output to be routed through logrus, got %q", content)
-	}
-	if !logLineHasTimestamp(content) {
-		t.Fatalf("expected Gin debug output to include timestamp, got %q", content)
+			var output bytes.Buffer
+			if _, err := output.ReadFrom(reader); err != nil {
+				t.Fatalf("read stderr output: %v", err)
+			}
+			content := output.String()
+			for _, message := range []string{
+				"[GIN-debug] GET /api/v1/status",
+				"[GIN-debug] POST   /api/v1/events --> handler (3 handlers)",
+			} {
+				if visible := strings.Contains(content, message); visible != testCase.wantVisible {
+					t.Fatalf("expected Gin debug visibility %v for %q, got %q", testCase.wantVisible, message, content)
+				}
+			}
+			if testCase.wantVisible && !logLineHasTimestamp(content) {
+				t.Fatalf("expected visible Gin debug output to include timestamp, got %q", content)
+			}
+		})
 	}
 }
 

--- a/internal/repository/migration/migration.go
+++ b/internal/repository/migration/migration.go
@@ -182,7 +182,7 @@ func runSchemaMigrationBody(db *gorm.DB, migration databaseMigration) error {
 		return fmt.Errorf("check schema migration %s: %w", migration.version, err)
 	}
 	if count > 0 {
-		logger.Info("schema migration skipped")
+		logger.Debug("schema migration skipped")
 		return nil
 	}
 	logger.Info("schema migration started")

--- a/internal/repository/migration/migration_test.go
+++ b/internal/repository/migration/migration_test.go
@@ -226,7 +226,6 @@ func TestOpenDatabaseLogsSchemaMigrations(t *testing.T) {
 		"level=info",
 		"msg=\"schema migration started\"",
 		"msg=\"schema migration applied\"",
-		"msg=\"schema migration skipped\"",
 		"version=20260503_add_usage_event_redis_fields",
 		"version=20260504_migrate_usage_identities_metadata",
 		"version=20260504_drop_legacy_metadata_tables",
@@ -234,6 +233,19 @@ func TestOpenDatabaseLogsSchemaMigrations(t *testing.T) {
 		if !strings.Contains(content, want) {
 			t.Fatalf("expected migration logs to contain %q, got:\n%s", want, content)
 		}
+	}
+	if strings.Contains(content, "msg=\"schema migration skipped\"") {
+		t.Fatalf("expected info logs to hide skipped migrations, got:\n%s", content)
+	}
+
+	logrus.SetLevel(logrus.DebugLevel)
+	db = openMigratedDatabase(t, dbPath)
+	closeOpenedDatabase(t, db)
+
+	content = logs.String()
+	want := "level=debug msg=\"schema migration skipped\" version=20260503_add_usage_event_redis_fields"
+	if !strings.Contains(content, want) {
+		t.Fatalf("expected debug migration logs to contain %q, got:\n%s", want, content)
 	}
 }
 


### PR DESCRIPTION
## Summary

- hide Gin debug and route registration output at the default info log level
- hide already-applied schema migration skip logs while keeping debug diagnostics available
- preserve Gin error and recovery output plus migration start, apply, and failure logs

## Testing

- rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build make verify