### PR TITLE
fix(request-events): combine speed mode values

### DIFF
--- a/web/src/components/usage/RequestEventsDetailsCard.test.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.test.tsx
@@ -89,8 +89,7 @@ describe('RequestEventsDetailsCard pagination', () => {
     expect(html.indexOf('>Source</th>')).toBeLessThan(html.indexOf('>Model</th>'));
     expect(html.indexOf('>Model</th>')).toBeLessThan(html.indexOf('title="Reasoning Effort">Effort</th>'));
     expect(html.indexOf('title="Reasoning Effort">Effort</th>')).toBeLessThan(html.indexOf('>Speed Mode</th>'));
-    expect(html.indexOf('>Speed Mode</th>')).toBeLessThan(html.indexOf('>Response Speed Mode</th>'));
-    expect(html.indexOf('>Response Speed Mode</th>')).toBeLessThan(html.indexOf('>Result</th>'));
+    expect(html.indexOf('>Speed Mode</th>')).toBeLessThan(html.indexOf('>Result</th>'));
     expect(html.indexOf('>Result</th>')).toBeLessThan(html.indexOf('>Type</th>'));
     expect(html.indexOf('>Type</th>')).toBeLessThan(html.indexOf('>Endpoint</th>'));
     expect(html.indexOf('>Endpoint</th>')).toBeLessThan(html.indexOf('title="Time to First Token">TTFT</th>'));
@@ -100,7 +99,7 @@ describe('RequestEventsDetailsCard pagination', () => {
     expect(html).toContain('class="_requestEventsAPIKeyCell_');
     expect(html).toContain('title="Production Key">Production Key</td>');
     expect(html).toMatch(/<td class="[^"]*requestEventsNoWrapCell[^"]*">medium<\/td>/);
-    expect(html).toMatch(/<td class="[^"]*requestEventsNoWrapCell[^"]*">Auto<\/td>/);
+    expect(html).toContain('>Auto / Fast</td>');
     expect(html).toMatch(/<td class="[^"]*requestEventsNoWrapCell[^"]*">SSE<\/td><td class="[^"]*requestEventsNoWrapCell[^"]*" title="\/messages">\/messages<\/td>/);
     expect(html.indexOf('>45ms</td>')).toBeLessThan(html.indexOf('>120ms</td>'));
     expect(html).toMatch(/<td class="[^"]*requestEventsNoWrapCell[^"]*">30\.0 t\/s<\/td>/);
@@ -115,7 +114,7 @@ describe('RequestEventsDetailsCard pagination', () => {
     expect(html).toContain('disabled');
   });
 
-  it('maps request speed mode values without using the response tier', () => {
+  it('maps request speed mode values before the independently mapped response mode', () => {
     const html = renderCard({
       visibleColumnIds: ['reasoning_effort', 'service_tier', 'result'],
       events: [
@@ -130,28 +129,12 @@ describe('RequestEventsDetailsCard pagination', () => {
       ],
     });
 
-    expect(html).toContain('>Auto</td>');
-    expect(countOccurrences(html, '>Standard</td>')).toBe(2);
-    expect(countOccurrences(html, '>Fast</td>')).toBe(2);
-    expect(html).toContain('>Flex</td>');
-    expect(html).toMatch(/medium<\/td><td class="[^"]*requestEventsNoWrapCell[^"]*">-<\/td><td class="[^"]*requestEventsNoWrapCell/);
-    expect(html).toMatch(/medium<\/td><td class="[^"]*requestEventsNoWrapCell[^"]*">batch<\/td><td class="[^"]*requestEventsNoWrapCell/);
-  });
-
-  it('maps the response speed mode from the response service tier', () => {
-    const html = renderCard({
-      visibleColumnIds: ['service_tier', 'response_service_tier'],
-      events: [
-        { ...events[0], id: 'priority', service_tier: 'auto', response_service_tier: 'priority' },
-        { ...events[0], id: 'default', service_tier: 'priority', response_service_tier: 'default' },
-        { ...events[0], id: 'empty', service_tier: 'flex', response_service_tier: '' },
-      ],
-    });
-
-    expect(html).toContain('>Response Speed Mode</th>');
-    expect(html).toMatch(/>Auto<\/td><td class="[^"]*requestEventsNoWrapCell[^"]*">Fast<\/td>/);
-    expect(html).toMatch(/>Fast<\/td><td class="[^"]*requestEventsNoWrapCell[^"]*">Standard<\/td>/);
-    expect(html).toMatch(/>Flex<\/td><td class="[^"]*requestEventsNoWrapCell[^"]*">-<\/td>/);
+    expect(html).toContain('>Auto / Fast</td>');
+    expect(countOccurrences(html, '>Standard / Fast</td>')).toBe(2);
+    expect(countOccurrences(html, '>Fast / Standard</td>')).toBe(2);
+    expect(html).toContain('>Flex / Standard</td>');
+    expect(html).toContain('>- / Fast</td>');
+    expect(html).toContain('>batch / Standard</td>');
   });
 
   it('formats timestamps with compact numeric date and time', () => {

--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -51,7 +51,6 @@ export const REQUEST_EVENT_COLUMN_IDS = [
   'model_alias',
   'reasoning_effort',
   'service_tier',
-  'response_service_tier',
   'result',
   'request_type',
   'endpoint',
@@ -1137,13 +1136,15 @@ export function RequestEventsDetailsCard({
         id: 'service_tier',
         label: t('usage_stats.speed_mode'),
         header: <th className={styles.requestEventsNoWrapCell}>{t('usage_stats.speed_mode')}</th>,
-        renderCell: (row) => <td className={styles.requestEventsNoWrapCell}>{row.speedMode}</td>,
-      },
-      {
-        id: 'response_service_tier',
-        label: t('usage_stats.response_speed_mode'),
-        header: <th className={styles.requestEventsNoWrapCell}>{t('usage_stats.response_speed_mode')}</th>,
-        renderCell: (row) => <td className={styles.requestEventsNoWrapCell}>{row.responseSpeedMode}</td>,
+        renderCell: (row) => (
+          <td
+            className={styles.requestEventsNoWrapCell}
+            title={`${t('usage_stats.speed_mode')}: ${row.speedMode}\n${t('usage_stats.response_speed_mode')}: ${row.responseSpeedMode}`}
+            aria-label={`${t('usage_stats.speed_mode')}: ${row.speedMode}; ${t('usage_stats.response_speed_mode')}: ${row.responseSpeedMode}`}
+          >
+            {`${row.speedMode} / ${row.responseSpeedMode}`}
+          </td>
+        ),
       },
       {
         id: 'result',

--- a/web/src/components/usage/test/RequestEventsDetailsCardSpeedMode.test.tsx
+++ b/web/src/components/usage/test/RequestEventsDetailsCardSpeedMode.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import {
+  REQUEST_EVENT_COLUMN_IDS,
+  RequestEventsDetailsCard,
+} from '../RequestEventsDetailsCard';
+import type { UsageEvent } from '@/lib/types';
+
+const baseEvent: UsageEvent = {
+  id: '101',
+  timestamp: '2026-04-23T02:00:00.000Z',
+  api_key: 'Production Key',
+  model: 'claude-sonnet',
+  source: 'Provider A',
+  source_raw: 'source-a',
+  source_type: 'openai',
+  auth_index: '1',
+  failed: false,
+  latency_ms: 120,
+  ttft_ms: 45,
+  speed_tps: 30,
+  tokens: {
+    input_tokens: 100,
+    output_tokens: 60,
+    reasoning_tokens: 20,
+    cache_read_tokens: 20,
+    cache_creation_tokens: 0,
+    total_tokens: 200,
+  },
+  cost_usd: 0.1234,
+  cost_available: true,
+  pricing_style: 'claude',
+};
+
+const renderCard = (events: UsageEvent[]) => renderToStaticMarkup(
+  <RequestEventsDetailsCard
+    events={events}
+    loading={false}
+    page={1}
+    pageSize={20}
+    pageSizeOptions={[20, 50, 100, 500, 1000]}
+    totalCount={events.length}
+    totalPages={1}
+    modelOptions={['claude-sonnet']}
+    sourceOptions={[{ value: 'source-a', label: 'Provider A' }]}
+    modelFilter="__all__"
+    sourceFilter="__all__"
+    resultFilter="__all__"
+    visibleColumnIds={['service_tier']}
+    onPageChange={() => undefined}
+    onPageSizeChange={() => undefined}
+    onModelFilterChange={() => undefined}
+    onSourceFilterChange={() => undefined}
+    onResultFilterChange={() => undefined}
+  />,
+);
+
+const extractSpeedModeCells = (html: string) => (
+  Array.from(html.matchAll(/<tr><td\b[^>]*>(.*?)<\/td><\/tr>/gs), (match) => match[1])
+);
+
+describe('RequestEventsDetailsCard Speed Mode column', () => {
+  it('shows mapped request and response modes in one column with a labeled tooltip', () => {
+    const html = renderCard([
+      { ...baseEvent, service_tier: 'auto', response_service_tier: 'default' },
+      { ...baseEvent, id: '102', service_tier: 'standard', response_service_tier: 'standard' },
+    ]);
+
+    expect(REQUEST_EVENT_COLUMN_IDS).not.toContain('response_service_tier');
+    expect(html).toContain('>Speed Mode</th>');
+    expect(html).not.toContain('>Response Speed Mode</th>');
+    expect(extractSpeedModeCells(html)).toEqual(['Auto / Standard', 'Standard / Standard']);
+    expect(html).toContain('title="Speed Mode: Auto\nResponse Speed Mode: Standard"');
+    expect(html).toContain('aria-label="Speed Mode: Auto; Response Speed Mode: Standard"');
+  });
+
+  it('keeps a dash for each missing request or response mode in the cell and tooltip', () => {
+    const html = renderCard([
+      { ...baseEvent, service_tier: 'priority', response_service_tier: '' },
+      { ...baseEvent, id: '102', service_tier: '', response_service_tier: 'default' },
+      { ...baseEvent, id: '103', service_tier: '', response_service_tier: '' },
+    ]);
+
+    expect(extractSpeedModeCells(html)).toEqual(['Fast / -', '- / Standard', '- / -']);
+    expect(html).toContain('title="Speed Mode: Fast\nResponse Speed Mode: -"');
+    expect(html).toContain('title="Speed Mode: -\nResponse Speed Mode: Standard"');
+    expect(html).toContain('title="Speed Mode: -\nResponse Speed Mode: -"');
+  });
+});

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -82,7 +82,7 @@ const DEFAULT_USAGE_TAB: UsageTab = 'overview';
 const USAGE_TAB_STORAGE_KEY = 'cli-proxy-usage-tab-v1';
 const REQUEST_EVENTS_PAGE_SIZES = [20, 50, 100, 500, 1000] as const;
 const REQUEST_EVENTS_DEFAULT_PAGE_SIZE = 100;
-const REQUEST_EVENTS_PREFERENCES_VERSION = 6;
+const REQUEST_EVENTS_PREFERENCES_VERSION = 5;
 const ALL_REQUEST_EVENTS_FILTER = '__all__';
 const OVERVIEW_AUTO_REFRESH_INTERVAL_MS = 10_000;
 export const CUSTOM_DATE_RANGE_BOUNDS_REFRESH_INTERVAL_MS = 60_000;
@@ -199,30 +199,6 @@ const buildDefaultRequestEventsPreferences = (): RequestEventsPreferences => ({
   filters: { ...DEFAULT_REQUEST_EVENT_FILTERS },
   visibleColumnIds: [...REQUEST_EVENT_COLUMN_IDS],
 });
-
-const LEGACY_REQUEST_EVENT_COLUMN_IDS_V5 = [
-  'timestamp',
-  'api_key',
-  'source',
-  'model',
-  'model_alias',
-  'reasoning_effort',
-  'service_tier',
-  'result',
-  'request_type',
-  'endpoint',
-  'ttft',
-  'latency',
-  'speed',
-  'input_tokens',
-  'output_tokens',
-  'reasoning_tokens',
-  'cache_read_tokens',
-  'cache_creation_tokens',
-  'cache_read_rate',
-  'total_tokens',
-  'total_cost',
-] as const;
 
 const LEGACY_REQUEST_EVENT_COLUMN_IDS_V3 = [
   'timestamp',
@@ -373,6 +349,7 @@ const hasSameRequestEventColumnOrder = (
 const migrateRequestEventColumnId = (value: unknown): RequestEventColumnId | null => {
   if (value === 'cached_tokens') return 'cache_read_tokens';
   if (value === 'cache_rate') return 'cache_read_rate';
+  if (value === 'response_service_tier') return 'service_tier';
   return isRequestEventColumnId(value) ? value : null;
 };
 
@@ -383,7 +360,6 @@ const normalizeRequestEventPreferenceColumnIds = (value: unknown, version: unkno
 
   const rawColumnIds = value.filter((columnId): columnId is string => typeof columnId === 'string');
   const legacyFullSelection = version !== REQUEST_EVENTS_PREFERENCES_VERSION && (
-    (version === 5 && hasSameRequestEventColumnOrder(rawColumnIds, LEGACY_REQUEST_EVENT_COLUMN_IDS_V5)) ||
     (version === 4 && hasSameRequestEventColumnOrder(rawColumnIds, LEGACY_REQUEST_EVENT_COLUMN_IDS_V4)) ||
     (version === 3 && hasSameRequestEventColumnOrder(rawColumnIds, LEGACY_REQUEST_EVENT_COLUMN_IDS_V3)) ||
     (version === 2 && hasSameRequestEventColumnOrder(rawColumnIds, LEGACY_REQUEST_EVENT_COLUMN_IDS_V2)) ||

--- a/web/src/pages/test/UsagePage.logic.test.ts
+++ b/web/src/pages/test/UsagePage.logic.test.ts
@@ -441,7 +441,7 @@ describe('UsagePage request event preferences', () => {
     });
 
     expect(preferences).toEqual({
-      version: 6,
+      version: 5,
       pageSize: 500,
       filters: {
         model: 'claude-opus',
@@ -521,7 +521,7 @@ describe('UsagePage request event preferences', () => {
     const hiddenSpeedColumnIds = REQUEST_EVENT_COLUMN_IDS.filter((columnId) => columnId !== 'speed');
 
     saveRequestEventsPreferences({
-      version: 6,
+      version: 5,
       pageSize: 100,
       filters: {
         model: '__all__',
@@ -533,7 +533,7 @@ describe('UsagePage request event preferences', () => {
 
     const stored = JSON.parse(storage.value(REQUEST_EVENTS_PREFERENCES_STORAGE_KEY) ?? '');
     expect(stored).toEqual({
-      version: 6,
+      version: 5,
       pageSize: 100,
       filters: {
         model: '__all__',
@@ -550,7 +550,7 @@ describe('UsagePage request event preferences', () => {
     const hiddenSpeedModeColumnIds = REQUEST_EVENT_COLUMN_IDS.filter((columnId) => columnId !== 'service_tier');
 
     saveRequestEventsPreferences({
-      version: 6,
+      version: 5,
       pageSize: 100,
       filters: {
         model: '__all__',
@@ -583,7 +583,7 @@ describe('UsagePage request event preferences', () => {
 
     expect(storage.setItem).toHaveBeenCalledTimes(1);
     expect(JSON.parse(storage.value(REQUEST_EVENTS_PREFERENCES_STORAGE_KEY) ?? '')).toEqual({
-      version: 6,
+      version: 5,
       pageSize: 50,
       filters: {
         model: 'gpt-4.1',

--- a/web/src/pages/test/UsagePageRequestEventsPreferences.test.ts
+++ b/web/src/pages/test/UsagePageRequestEventsPreferences.test.ts
@@ -31,32 +31,45 @@ const LEGACY_V2_FULL_COLUMNS = LEGACY_V3_FULL_COLUMNS.filter((columnId) => colum
 const LEGACY_V1_FULL_COLUMNS = LEGACY_V2_FULL_COLUMNS.filter((columnId) => columnId !== 'service_tier');
 const LEGACY_V4_FULL_COLUMNS = REQUEST_EVENT_COLUMN_IDS.map((columnId) => (
   columnId === 'cache_read_rate' ? 'cache_rate' : columnId
-)).filter((columnId) => columnId !== 'response_service_tier');
+));
+const MERGED_V6_FULL_COLUMNS = REQUEST_EVENT_COLUMN_IDS.flatMap((columnId) => (
+  columnId === 'service_tier' ? [columnId, 'response_service_tier'] : [columnId]
+));
 
 describe('UsagePage request event cache column preferences', () => {
-  it('upgrades a v3 full selection to all v6 columns including cache write', () => {
+  it('upgrades a v3 full selection to all v5 columns including cache write', () => {
     const preferences = normalizeRequestEventsPreferences({
       version: 3,
       pageSize: 100,
       visibleColumnIds: LEGACY_V3_FULL_COLUMNS,
     });
 
-    expect(preferences.version).toBe(6);
+    expect(preferences.version).toBe(5);
     expect(preferences.visibleColumnIds).toEqual(REQUEST_EVENT_COLUMN_IDS);
     expect(preferences.visibleColumnIds).toContain('cache_read_tokens');
     expect(preferences.visibleColumnIds).toContain('cache_creation_tokens');
   });
 
-  it('adds the response speed mode to a v5 full selection', () => {
-    const legacyV5FullColumns = REQUEST_EVENT_COLUMN_IDS.filter((columnId) => columnId !== 'response_service_tier');
+  it('normalizes a merged v6 full selection back to the combined v5 column', () => {
     const preferences = normalizeRequestEventsPreferences({
-      version: 5,
+      version: 6,
       pageSize: 100,
-      visibleColumnIds: legacyV5FullColumns,
+      visibleColumnIds: MERGED_V6_FULL_COLUMNS,
     });
 
+    expect(preferences.version).toBe(5);
     expect(preferences.visibleColumnIds).toEqual(REQUEST_EVENT_COLUMN_IDS);
-    expect(preferences.visibleColumnIds).toContain('response_service_tier');
+    expect(preferences.visibleColumnIds).not.toContain('response_service_tier' as never);
+  });
+
+  it('maps a merged v6 response-only selection to the combined Speed Mode column', () => {
+    const preferences = normalizeRequestEventsPreferences({
+      version: 6,
+      pageSize: 100,
+      visibleColumnIds: ['timestamp', 'response_service_tier', 'total_tokens'],
+    });
+
+    expect(preferences.visibleColumnIds).toEqual(['timestamp', 'service_tier', 'total_tokens']);
   });
 
   it('upgrades a v4 full selection and maps cache rate to cache read rate', () => {


### PR DESCRIPTION
## Summary

- combine request and response service tiers in the existing Speed Mode column as request / response
- add localized tooltip and accessible labels while preserving dash placeholders
- migrate the unpublished response-column preference back to the combined column without losing custom selections

## Validation

- rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build make verify

Follow-up to #318.