### PR TITLE
feat(ui): introduce Keeper branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./assets/keeper-logo-dark.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="./assets/keeper-logo-light.svg" />
+    <img src="./assets/keeper-logo-light.svg" alt="Keeper" width="560" />
+  </picture>
+</p>
+
 # CPA Usage Keeper
 
 [中文说明](./README.zh.md)

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,3 +1,11 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./assets/keeper-logo-dark.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="./assets/keeper-logo-light.svg" />
+    <img src="./assets/keeper-logo-light.svg" alt="Keeper" width="560" />
+  </picture>
+</p>
+
 # CPA Usage Keeper
 
 [English README](./README.md)

--- a/assets/keeper-logo-dark.svg
+++ b/assets/keeper-logo-dark.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 170" role="img" aria-labelledby="keeper-logo-title">
+  <title id="keeper-logo-title">Keeper</title>
+  <g transform="translate(12 20)">
+    <rect x="12" y="52" width="52" height="60" rx="10" fill="#2563eb" fill-opacity=".9" transform="rotate(-38 38 82)" />
+    <rect x="29" y="27" width="48" height="64" rx="10" fill="#06b6d4" fill-opacity=".82" transform="rotate(-13 53 59)" />
+    <rect x="61" y="8" width="50" height="68" rx="10" fill="#10b981" fill-opacity=".78" transform="rotate(24 86 42)" />
+    <rect x="96" y="26" width="48" height="64" rx="10" fill="#fbbf24" fill-opacity=".82" transform="rotate(41 120 58)" />
+    <rect x="116" y="51" width="47" height="61" rx="10" fill="#fb5a5a" fill-opacity=".82" transform="rotate(15 139.5 81.5)" />
+    <rect x="94" y="70" width="58" height="40" rx="10" fill="#db2777" fill-opacity=".82" transform="rotate(2 123 90)" />
+  </g>
+  <text x="220" y="111" fill="#ffffff" font-family="Arial, Helvetica, sans-serif" font-size="76" font-weight="800" letter-spacing="10">KEEPER</text>
+</svg>

--- a/assets/keeper-logo-light.svg
+++ b/assets/keeper-logo-light.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 170" role="img" aria-labelledby="keeper-logo-title">
+  <title id="keeper-logo-title">Keeper</title>
+  <g transform="translate(12 20)">
+    <rect x="12" y="52" width="52" height="60" rx="10" fill="#2563eb" fill-opacity=".9" transform="rotate(-38 38 82)" />
+    <rect x="29" y="27" width="48" height="64" rx="10" fill="#06b6d4" fill-opacity=".82" transform="rotate(-13 53 59)" />
+    <rect x="61" y="8" width="50" height="68" rx="10" fill="#10b981" fill-opacity=".78" transform="rotate(24 86 42)" />
+    <rect x="96" y="26" width="48" height="64" rx="10" fill="#fbbf24" fill-opacity=".82" transform="rotate(41 120 58)" />
+    <rect x="116" y="51" width="47" height="61" rx="10" fill="#fb5a5a" fill-opacity=".82" transform="rotate(15 139.5 81.5)" />
+    <rect x="94" y="70" width="58" height="40" rx="10" fill="#db2777" fill-opacity=".82" transform="rotate(2 123 90)" />
+  </g>
+  <text x="220" y="111" fill="#111111" font-family="Arial, Helvetica, sans-serif" font-size="76" font-weight="800" letter-spacing="10">KEEPER</text>
+</svg>

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CPA USAGE KEEPER</title>
+    <title>KEEPER</title>
     <script>
       window.__APP_BASE_PATH__ = "__APP_BASE_PATH__";
     </script>

--- a/web/src/assets/keeper-icon.svg
+++ b/web/src/assets/keeper-icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 132" role="img" aria-label="Keeper">
+  <g>
+    <rect x="12" y="52" width="52" height="60" rx="10" fill="#2563eb" fill-opacity=".9" transform="rotate(-38 38 82)" />
+    <rect x="29" y="27" width="48" height="64" rx="10" fill="#06b6d4" fill-opacity=".82" transform="rotate(-13 53 59)" />
+    <rect x="61" y="8" width="50" height="68" rx="10" fill="#10b981" fill-opacity=".78" transform="rotate(24 86 42)" />
+    <rect x="96" y="26" width="48" height="64" rx="10" fill="#fbbf24" fill-opacity=".82" transform="rotate(41 120 58)" />
+    <rect x="116" y="51" width="47" height="61" rx="10" fill="#fb5a5a" fill-opacity=".82" transform="rotate(15 139.5 81.5)" />
+    <rect x="94" y="70" width="58" height="40" rx="10" fill="#db2777" fill-opacity=".82" transform="rotate(2 123 90)" />
+  </g>
+</svg>

--- a/web/src/components/BrandLink.module.scss
+++ b/web/src/components/BrandLink.module.scss
@@ -1,6 +1,10 @@
 @use '../styles/variables' as *;
 
 .brandLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6em;
+  line-height: 1;
   text-decoration: none;
   transition: border-color 0.15s ease, color 0.15s ease, transform 0.15s ease;
 
@@ -14,4 +18,17 @@
     outline: 2px solid var(--primary-color);
     outline-offset: 3px;
   }
+}
+
+.brandMark {
+  display: block;
+  width: 2.05em;
+  height: 1.45em;
+  flex: 0 0 auto;
+  object-fit: contain;
+}
+
+.brandWord {
+  display: block;
+  line-height: 1;
 }

--- a/web/src/components/BrandLink.tsx
+++ b/web/src/components/BrandLink.tsx
@@ -1,4 +1,5 @@
 import { GITHUB_REPOSITORY_URL } from '@/utils/constants';
+import keeperIconUrl from '@/assets/keeper-icon.svg';
 import styles from './BrandLink.module.scss';
 
 type BrandLinkProps = {
@@ -10,7 +11,8 @@ export function BrandLink({ className = '' }: BrandLinkProps) {
 
   return (
     <a className={linkClassName} href={GITHUB_REPOSITORY_URL} target="_blank" rel="noreferrer">
-      CPA Usage Keeper
+      <img className={styles.brandMark} src={keeperIconUrl} alt="" aria-hidden="true" />
+      <span className={styles.brandWord}>KEEPER</span>
     </a>
   );
 }

--- a/web/src/components/test/BrandLink.test.tsx
+++ b/web/src/components/test/BrandLink.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { BrandLink } from '../BrandLink';
+
+describe('BrandLink', () => {
+  it('renders the Keeper icon and wordmark', () => {
+    const html = renderToStaticMarkup(<BrandLink />);
+
+    expect(html).toContain('<img');
+    expect(html).toContain('alt=""');
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).toContain('>KEEPER</span>');
+    expect(html).not.toContain('CPA Usage Keeper');
+  });
+});

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { I18nextProvider } from 'react-i18next';
 import App from './App';
 import i18n from './i18n';
-import faviconUrl from './assets/cli-proxy-api-favicon.png';
+import faviconUrl from './assets/keeper-icon.svg';
 import './styles/reset.scss';
 import './styles/variables.scss';
 import './styles/themes.scss';
@@ -14,7 +14,7 @@ import { useThemeStore } from './stores';
 
 const faviconEl = document.querySelector<HTMLLinkElement>('link[rel="icon"]') ?? document.createElement('link');
 faviconEl.rel = 'icon';
-faviconEl.type = 'image/png';
+faviconEl.type = 'image/svg+xml';
 faviconEl.href = faviconUrl;
 if (!faviconEl.parentNode) {
   document.head.appendChild(faviconEl);

--- a/web/src/test/brandingAssets.test.ts
+++ b/web/src/test/brandingAssets.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const mainSource = readFileSync(new URL('../main.tsx', import.meta.url), 'utf8');
@@ -7,8 +7,8 @@ const readmeEnglish = readFileSync(new URL('../../../README.md', import.meta.url
 const readmeChinese = readFileSync(new URL('../../../README.zh.md', import.meta.url), 'utf8');
 const lightLogoUrl = new URL('../../../assets/keeper-logo-light.svg', import.meta.url);
 const darkLogoUrl = new URL('../../../assets/keeper-logo-dark.svg', import.meta.url);
-const lightLogo = existsSync(lightLogoUrl) ? readFileSync(lightLogoUrl, 'utf8') : '';
-const darkLogo = existsSync(darkLogoUrl) ? readFileSync(darkLogoUrl, 'utf8') : '';
+const lightLogo = readFileSync(lightLogoUrl, 'utf8');
+const darkLogo = readFileSync(darkLogoUrl, 'utf8');
 
 describe('Keeper branding assets', () => {
   it('uses the Keeper SVG as the browser favicon', () => {

--- a/web/src/test/brandingAssets.test.ts
+++ b/web/src/test/brandingAssets.test.ts
@@ -1,0 +1,37 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const mainSource = readFileSync(new URL('../main.tsx', import.meta.url), 'utf8');
+const indexHtml = readFileSync(new URL('../../index.html', import.meta.url), 'utf8');
+const readmeEnglish = readFileSync(new URL('../../../README.md', import.meta.url), 'utf8');
+const readmeChinese = readFileSync(new URL('../../../README.zh.md', import.meta.url), 'utf8');
+const lightLogoUrl = new URL('../../../assets/keeper-logo-light.svg', import.meta.url);
+const darkLogoUrl = new URL('../../../assets/keeper-logo-dark.svg', import.meta.url);
+const lightLogo = existsSync(lightLogoUrl) ? readFileSync(lightLogoUrl, 'utf8') : '';
+const darkLogo = existsSync(darkLogoUrl) ? readFileSync(darkLogoUrl, 'utf8') : '';
+
+describe('Keeper branding assets', () => {
+  it('uses the Keeper SVG as the browser favicon', () => {
+    expect(mainSource).toContain("import faviconUrl from './assets/keeper-icon.svg'");
+    expect(mainSource).toContain("faviconEl.type = 'image/svg+xml'");
+  });
+
+  it('uses KEEPER as the browser tab title', () => {
+    expect(indexHtml).toContain('<title>KEEPER</title>');
+  });
+
+  it('keeps the theme-aware centered logo in both public READMEs', () => {
+    for (const readme of [readmeEnglish, readmeChinese]) {
+      expect(readme).toContain('<p align="center">');
+      expect(readme).toContain('<picture>');
+      expect(readme).toContain('media="(prefers-color-scheme: dark)"');
+      expect(readme).toContain('./assets/keeper-logo-dark.svg');
+      expect(readme).toContain('./assets/keeper-logo-light.svg');
+    }
+  });
+
+  it('uses black and white wordmarks for light and dark README themes', () => {
+    expect(lightLogo).toContain('fill="#111111"');
+    expect(darkLogo).toContain('fill="#ffffff"');
+  });
+});


### PR DESCRIPTION
## Summary

- add the Keeper card-fan icon and wordmark to the app header and browser favicon
- add theme-aware light and dark README logos
- rename the browser tab title to KEEPER

## Validation

- `rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build make verify`