### PR TITLE
fix(login): remove footer background seam

### DIFF
--- a/web/src/pages/LoginPage.module.scss
+++ b/web/src/pages/LoginPage.module.scss
@@ -11,7 +11,6 @@
   background:
     linear-gradient(115deg, rgba(17, 24, 39, 0.08) 0 1px, transparent 1px 100%) 0 0 / 28px 28px,
     radial-gradient(900px 480px at 12% 0%, rgba($primary-color, 0.16), transparent 58%),
-    radial-gradient(760px 420px at 100% 100%, rgba(34, 197, 94, 0.1), transparent 60%),
     var(--bg-secondary);
 }
 

--- a/web/src/pages/test/LoginPage.styles.test.ts
+++ b/web/src/pages/test/LoginPage.styles.test.ts
@@ -3,8 +3,19 @@ import { describe, expect, it } from 'vitest'
 
 const loginPageStyles = readFileSync(new URL('../LoginPage.module.scss', import.meta.url), 'utf8').replace(/\r\n/g, '\n')
 const themeStyles = readFileSync(new URL('../../styles/themes.scss', import.meta.url), 'utf8').replace(/\r\n/g, '\n')
+const pageShellRules = loginPageStyles.match(/\.pageShell\s*\{[\s\S]*?\n\}/g) ?? []
+const pageShellStyles = pageShellRules[0] ?? ''
+const pageShellBackground = pageShellStyles.match(/background:\s*([\s\S]*?);/)?.[1] ?? ''
 
 describe('LoginPage layout styles', () => {
+  it('ends the login surface on the base theme background without an edge glow', () => {
+    expect(pageShellRules).toHaveLength(1)
+    expect(pageShellBackground.match(/radial-gradient\(/g)).toHaveLength(1)
+    expect(pageShellBackground).toContain('radial-gradient(900px 480px at 12% 0%')
+    expect(pageShellBackground.trim()).toMatch(/var\(--bg-secondary\)$/)
+    expect(pageShellStyles).not.toMatch(/\bbackground-image\s*:/)
+  })
+
   it('gives the desktop login columns enough room without relying on shared app zoom', () => {
     expect(loginPageStyles).toMatch(/\.frame\s*\{[\s\S]*?width:\s*min\(1180px, 100%\);/)
     expect(loginPageStyles).toMatch(/\.frame\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1\.15fr\) minmax\(360px, 440px\);/)


### PR DESCRIPTION
## Summary

- Remove the lower-right login gradient that tinted dark mode and ended abruptly above the footer.
- Keep the remaining login background layers on the shared theme surface.
- Add regression coverage for the background-layer invariant.

## Testing

- rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build make verify