### PR TITLE
fix(ui): contain scrolling within data cards

### DIFF
--- a/web/src/components/usage/ApiKeySettingsCard.tsx
+++ b/web/src/components/usage/ApiKeySettingsCard.tsx
@@ -4,6 +4,7 @@ import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { IconEye, IconEyeOff } from '@/components/ui/icons';
+import { useScrollBoundaryContainment } from '@/hooks/useScrollBoundaryContainment';
 import type { CpaApiKeySettingsItem } from '@/lib/types';
 import styles from '@/pages/UsagePage.module.scss';
 
@@ -129,6 +130,8 @@ export function ApiKeySettingsCard({ apiKeys, loading = false, savingId = null, 
   const [showFullApiKeys, setShowFullApiKeys] = useState(false);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const apiKeySettingsBodyRef = useRef<HTMLDivElement | null>(null);
+  useScrollBoundaryContainment(apiKeySettingsBodyRef);
   const initialAliases = useMemo(
     () => Object.fromEntries(apiKeys.map((item) => [item.id, item.keyAlias])),
     [apiKeys],
@@ -174,7 +177,7 @@ export function ApiKeySettingsCard({ apiKeys, loading = false, savingId = null, 
       }
       className={`${styles.detailsFixedCard} ${styles.apiKeySettingsCard}`}
     >
-      <div className={styles.apiKeySettingsBody}>
+      <div ref={apiKeySettingsBodyRef} className={styles.apiKeySettingsBody}>
         {loading && apiKeys.length === 0 ? (
           <div className={styles.hint}>{t('common.loading')}</div>
         ) : apiKeys.length === 0 ? (

--- a/web/src/components/usage/PriceSettingsCard.tsx
+++ b/web/src/components/usage/PriceSettingsCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/Input';
 import { Modal } from '@/components/ui/Modal';
 import { Select, type SelectOption } from '@/components/ui/Select';
 import { IconCheck, IconCircleAlert, IconRefreshCw } from '@/components/ui/icons';
+import { useScrollBoundaryContainment } from '@/hooks/useScrollBoundaryContainment';
 import type { ModelPrice, PricingSaveResult, PricingStyle, PricingSyncMatch, PricingSyncPreviewResponse } from '@/lib/types';
 import styles from '@/pages/UsagePage.module.scss';
 
@@ -285,6 +286,7 @@ export function PriceSettingsCard({
   loading = false
 }: PriceSettingsCardProps) {
   const { t } = useTranslation();
+  const pricesGridRef = useRef<HTMLDivElement | null>(null);
 
   // 新增价格表单先暂存输入值，保存成功后再合并当前模型的价格。
   const [selectedModel, setSelectedModel] = useState('');
@@ -540,6 +542,7 @@ export function PriceSettingsCard({
       .sort(([left], [right]) => compareModelNamesDescending(left, right)),
     [modelPrices]
   );
+  useScrollBoundaryContainment(pricesGridRef, sortedModelPrices.length > 0);
   const selectedSyncCount = useMemo(
     () => syncDrafts.filter((draft) => draft.selected).length,
     [syncDrafts]
@@ -670,7 +673,7 @@ export function PriceSettingsCard({
               <div className={styles.pricesList}>
                 <h4 className={styles.pricesTitle}>{t('usage_stats.saved_prices')}</h4>
                 {sortedModelPrices.length > 0 ? (
-                  <div className={styles.pricesGrid}>
+                  <div ref={pricesGridRef} className={styles.pricesGrid}>
                     {sortedModelPrices.map(([model, price]) => (
                       <div key={model} className={styles.priceItem}>
                         <div className={styles.priceInfo}>

--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -19,6 +19,7 @@ import { Modal } from '@/components/ui/Modal';
 import { Select } from '@/components/ui/Select';
 import { IconCheck, IconChevronDown, IconCopy, IconDownload, IconScrollText } from '@/components/ui/icons';
 import type { UsageEvent, UsageEventRequestLogResponse, UsageSourceFilterOption } from '@/lib/types';
+import { useScrollBoundaryContainment } from '@/hooks/useScrollBoundaryContainment';
 import {
   calculateCacheReadRate,
   formatDurationMs,
@@ -739,6 +740,7 @@ function RequestLogSectionDisclosure({
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
   const panelId = useId();
   const scrollerRef = useRef<HTMLDivElement | null>(null);
+  useScrollBoundaryContainment(scrollerRef);
   const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const chunks = useMemo(
     () => hasOpened ? splitRequestLogVirtualChunks(content) : [],
@@ -960,6 +962,7 @@ export function RequestEventsDetailsCard({
   const [speedModeTooltip, setSpeedModeTooltip] = useState<RequestEventSpeedModeTooltipState | null>(null);
   const speedModeHoverTargetRef = useRef<RequestEventSpeedModeTooltipTarget | null>(null);
   const speedModeFocusTargetRef = useRef<RequestEventSpeedModeTooltipTarget | null>(null);
+  const requestEventsTableWrapperRef = useRef<HTMLDivElement | null>(null);
   const resultLocale = t('usage_stats.success') === 'Success' ? 'en' : 'zh';
   const latencyHint = t('usage_stats.latency_unit_hint', {
     field: LATENCY_SOURCE_FIELD,
@@ -1124,6 +1127,7 @@ export function RequestEventsDetailsCard({
       };
     });
   }, [events, t]);
+  useScrollBoundaryContainment(requestEventsTableWrapperRef, rows.length > 0);
 
   const [internalVisibleColumnIds, setInternalVisibleColumnIds] = useState<RequestEventColumnId[]>(() => (
     normalizeRequestEventVisibleColumnIds(initialVisibleColumnIds ?? visibleColumnIds ?? REQUEST_EVENT_COLUMN_IDS)
@@ -1537,7 +1541,7 @@ export function RequestEventsDetailsCard({
           />
         ) : (
           <>
-            <div className={styles.requestEventsTableWrapper}>
+            <div ref={requestEventsTableWrapperRef} className={styles.requestEventsTableWrapper}>
               <table className={styles.table}>
                 <thead>
                   <tr>

--- a/web/src/components/usage/SessionSettingsCard.tsx
+++ b/web/src/components/usage/SessionSettingsCard.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { Modal } from '@/components/ui/Modal';
+import { useScrollBoundaryContainment } from '@/hooks/useScrollBoundaryContainment';
 import type { AuthManagedSessionItem } from '@/lib/types';
 import styles from '@/pages/UsagePage.module.scss';
 
@@ -38,6 +39,8 @@ function getSessionDisplayName(session: AuthManagedSessionItem, t: (key: string)
 export function SessionSettingsCard({ sessions, loading = false, revokingId = null, onLogout }: SessionSettingsCardProps) {
   const { t } = useTranslation();
   const [confirmingSession, setConfirmingSession] = useState<AuthManagedSessionItem | null>(null);
+  const sessionSettingsBodyRef = useRef<HTMLDivElement | null>(null);
+  useScrollBoundaryContainment(sessionSettingsBodyRef);
   const confirmationKeys = confirmingSession ? getSessionLogoutConfirmationKeys(confirmingSession) : null;
   const confirmingLabel = confirmingSession ? getSessionDisplayName(confirmingSession, t) : '';
   const confirmingRevoking = confirmingSession ? revokingId === confirmingSession.id : false;
@@ -60,7 +63,7 @@ export function SessionSettingsCard({ sessions, loading = false, revokingId = nu
       }
       className={`${styles.detailsFixedCard} ${styles.sessionSettingsCard}`}
     >
-      <div className={styles.sessionSettingsBody}>
+      <div ref={sessionSettingsBodyRef} className={styles.sessionSettingsBody}>
         {loading && sessions.length === 0 ? (
           <div className={styles.hint}>{t('common.loading')}</div>
         ) : sessions.length === 0 ? (

--- a/web/src/hooks/test/useScrollBoundaryContainment.test.tsx
+++ b/web/src/hooks/test/useScrollBoundaryContainment.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment happy-dom
+
+import React, { act, useRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useScrollBoundaryContainment } from '../useScrollBoundaryContainment';
+
+type ScrollMetrics = {
+  clientHeight: number;
+  scrollHeight: number;
+};
+
+const resizeObservers: TestResizeObserver[] = [];
+const mutationObservers: TestMutationObserver[] = [];
+
+class TestResizeObserver implements ResizeObserver {
+  private readonly observedTargets = new Set<Element>();
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    resizeObservers.push(this);
+  }
+
+  observe(target: Element) {
+    this.observedTargets.add(target);
+  }
+
+  disconnect() {
+    this.observedTargets.clear();
+  }
+
+  unobserve(target: Element) {
+    this.observedTargets.delete(target);
+  }
+
+  isObserving(target: Element) {
+    return this.observedTargets.has(target);
+  }
+
+  trigger(target: Element) {
+    if (!this.observedTargets.has(target)) return;
+    this.callback([{ target } as ResizeObserverEntry], this);
+  }
+}
+
+class TestMutationObserver implements MutationObserver {
+  private readonly observations = new Map<Node, MutationObserverInit>();
+
+  constructor(private readonly callback: MutationCallback) {
+    mutationObservers.push(this);
+  }
+
+  observe(target: Node, options: MutationObserverInit = {}) {
+    this.observations.set(target, options);
+  }
+
+  disconnect() {
+    this.observations.clear();
+  }
+
+  takeRecords(): MutationRecord[] {
+    return [];
+  }
+
+  optionsFor(target: Node) {
+    return this.observations.get(target);
+  }
+
+  trigger() {
+    if (this.observations.size === 0) return;
+    this.callback([], this);
+  }
+}
+
+function ScrollRegion({ metrics, visible = true, childKey = 'content' }: { metrics: ScrollMetrics; visible?: boolean; childKey?: string }) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  useScrollBoundaryContainment(scrollRef, visible);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      ref={(node) => {
+        scrollRef.current = node;
+        if (!node) return;
+        Object.defineProperties(node, {
+          clientHeight: { configurable: true, get: () => metrics.clientHeight },
+          scrollHeight: { configurable: true, get: () => metrics.scrollHeight },
+        });
+      }}
+    >
+      <div key={childKey}>content</div>
+    </div>
+  );
+}
+
+describe('useScrollBoundaryContainment', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    resizeObservers.length = 0;
+    mutationObservers.length = 0;
+    vi.stubGlobal('ResizeObserver', TestResizeObserver);
+    vi.stubGlobal('MutationObserver', TestMutationObserver);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('contains scroll chaining only while the region has vertical overflow', () => {
+    const metrics = { clientHeight: 100, scrollHeight: 240 };
+
+    act(() => root.render(<ScrollRegion metrics={metrics} />));
+
+    const scrollRegion = container.firstElementChild as HTMLElement;
+    expect(scrollRegion?.getAttribute('data-scroll-boundary-contained')).toBe('true');
+    expect(resizeObservers.some((observer) => observer.isObserving(scrollRegion))).toBe(true);
+
+    metrics.scrollHeight = 100;
+    resizeObservers.forEach((observer) => observer.trigger(scrollRegion));
+
+    expect(scrollRegion?.hasAttribute('data-scroll-boundary-contained')).toBe(false);
+  });
+
+  it('contains a real one-pixel overflow', () => {
+    const metrics = { clientHeight: 100, scrollHeight: 101 };
+
+    act(() => root.render(<ScrollRegion metrics={metrics} />));
+
+    expect(container.firstElementChild?.getAttribute('data-scroll-boundary-contained')).toBe('true');
+  });
+
+  it('stops observing direct children after they are removed', () => {
+    const metrics = { clientHeight: 100, scrollHeight: 240 };
+
+    act(() => root.render(<ScrollRegion metrics={metrics} childKey="first" />));
+    const firstChild = container.firstElementChild?.firstElementChild as Element;
+
+    act(() => root.render(<ScrollRegion metrics={metrics} childKey="second" />));
+    mutationObservers.forEach((observer) => observer.trigger());
+    const secondChild = container.firstElementChild?.firstElementChild as Element;
+
+    expect(resizeObservers.some((observer) => observer.isObserving(secondChild))).toBe(true);
+    expect(resizeObservers.some((observer) => observer.isObserving(firstChild))).toBe(false);
+  });
+
+  it('observes nested fallback mutations when ResizeObserver is unavailable', () => {
+    vi.stubGlobal('ResizeObserver', undefined);
+    const metrics = { clientHeight: 100, scrollHeight: 100 };
+
+    act(() => root.render(<ScrollRegion metrics={metrics} />));
+    const scrollRegion = container.firstElementChild as HTMLElement;
+    const fallbackOptions = mutationObservers
+      .map((observer) => observer.optionsFor(scrollRegion))
+      .find(Boolean);
+
+    expect(fallbackOptions).toMatchObject({
+      attributes: true,
+      characterData: true,
+      childList: true,
+      subtree: true,
+    });
+
+    metrics.scrollHeight = 101;
+    mutationObservers.forEach((observer) => observer.trigger());
+
+    expect(scrollRegion.getAttribute('data-scroll-boundary-contained')).toBe('true');
+  });
+
+  it('starts observing when a conditional scroll region mounts', () => {
+    const metrics = { clientHeight: 100, scrollHeight: 240 };
+
+    act(() => root.render(<ScrollRegion metrics={metrics} visible={false} />));
+    expect(container.firstElementChild).toBeNull();
+
+    act(() => root.render(<ScrollRegion metrics={metrics} visible />));
+    expect(container.firstElementChild?.getAttribute('data-scroll-boundary-contained')).toBe('true');
+  });
+});

--- a/web/src/hooks/test/useScrollBoundaryContainment.test.tsx
+++ b/web/src/hooks/test/useScrollBoundaryContainment.test.tsx
@@ -65,15 +65,29 @@ class TestMutationObserver implements MutationObserver {
     return this.observations.get(target);
   }
 
+  isObserving(target: Node) {
+    return this.observations.has(target);
+  }
+
   trigger() {
     if (this.observations.size === 0) return;
     this.callback([], this);
   }
 }
 
-function ScrollRegion({ metrics, visible = true, childKey = 'content' }: { metrics: ScrollMetrics; visible?: boolean; childKey?: string }) {
+function ScrollRegion({
+  metrics,
+  visible = true,
+  active = visible,
+  childKey = 'content',
+}: {
+  metrics: ScrollMetrics;
+  visible?: boolean;
+  active?: boolean;
+  childKey?: string;
+}) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
-  useScrollBoundaryContainment(scrollRef, visible);
+  useScrollBoundaryContainment(scrollRef, active);
 
   if (!visible) return null;
 
@@ -111,6 +125,7 @@ describe('useScrollBoundaryContainment', () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -182,5 +197,47 @@ describe('useScrollBoundaryContainment', () => {
 
     act(() => root.render(<ScrollRegion metrics={metrics} visible />));
     expect(container.firstElementChild?.getAttribute('data-scroll-boundary-contained')).toBe('true');
+  });
+
+  it('cleans up containment resources when boundary tracking is disabled', () => {
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+    const metrics = { clientHeight: 100, scrollHeight: 240 };
+
+    act(() => root.render(<ScrollRegion metrics={metrics} active />));
+    const scrollRegion = container.firstElementChild as HTMLElement;
+    const resizeListener = addEventListenerSpy.mock.calls
+      .find(([eventName]) => eventName === 'resize')?.[1];
+
+    expect(resizeListener).toBeTypeOf('function');
+    expect(scrollRegion.getAttribute('data-scroll-boundary-contained')).toBe('true');
+    expect(resizeObservers.some((observer) => observer.isObserving(scrollRegion))).toBe(true);
+    expect(mutationObservers.some((observer) => observer.isObserving(scrollRegion))).toBe(true);
+
+    act(() => root.render(<ScrollRegion metrics={metrics} active={false} />));
+
+    expect(scrollRegion.hasAttribute('data-scroll-boundary-contained')).toBe(false);
+    expect(resizeObservers.some((observer) => observer.isObserving(scrollRegion))).toBe(false);
+    expect(mutationObservers.some((observer) => observer.isObserving(scrollRegion))).toBe(false);
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', resizeListener);
+  });
+
+  it('cleans up containment resources when the scroll region unmounts', () => {
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+    const metrics = { clientHeight: 100, scrollHeight: 240 };
+
+    act(() => root.render(<ScrollRegion metrics={metrics} />));
+    const scrollRegion = container.firstElementChild as HTMLElement;
+    const resizeListener = addEventListenerSpy.mock.calls
+      .find(([eventName]) => eventName === 'resize')?.[1];
+
+    expect(resizeListener).toBeTypeOf('function');
+    act(() => root.render(<></>));
+
+    expect(scrollRegion.hasAttribute('data-scroll-boundary-contained')).toBe(false);
+    expect(resizeObservers.some((observer) => observer.isObserving(scrollRegion))).toBe(false);
+    expect(mutationObservers.some((observer) => observer.isObserving(scrollRegion))).toBe(false);
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', resizeListener);
   });
 });

--- a/web/src/hooks/useScrollBoundaryContainment.ts
+++ b/web/src/hooks/useScrollBoundaryContainment.ts
@@ -1,0 +1,74 @@
+import { useLayoutEffect, type RefObject } from 'react';
+
+const SCROLL_BOUNDARY_ATTRIBUTE = 'data-scroll-boundary-contained';
+
+const hasVerticalOverflow = (element: HTMLElement) => (
+  element.scrollHeight > element.clientHeight
+);
+
+const syncScrollBoundaryAttribute = (element: HTMLElement) => {
+  if (hasVerticalOverflow(element)) {
+    element.setAttribute(SCROLL_BOUNDARY_ATTRIBUTE, 'true');
+    return;
+  }
+  element.removeAttribute(SCROLL_BOUNDARY_ATTRIBUTE);
+};
+
+export function useScrollBoundaryContainment<T extends HTMLElement>(
+  scrollRef: RefObject<T | null>,
+  active = true,
+) {
+  useLayoutEffect(() => {
+    if (!active) return;
+    const element = scrollRef.current;
+    if (!element) return;
+
+    const update = () => syncScrollBoundaryAttribute(element);
+    const resizeObserver = typeof ResizeObserver === 'undefined'
+      ? null
+      : new ResizeObserver(update);
+    const observedChildren = new Set<Element>();
+    const syncObservedChildren = () => {
+      if (!resizeObserver) return;
+      const currentChildren = new Set(element.children);
+      for (const child of observedChildren) {
+        if (currentChildren.has(child)) continue;
+        resizeObserver.unobserve(child);
+        observedChildren.delete(child);
+      }
+      for (const child of element.children) {
+        if (observedChildren.has(child)) continue;
+        observedChildren.add(child);
+        resizeObserver.observe(child);
+      }
+    };
+
+    update();
+    resizeObserver?.observe(element);
+    syncObservedChildren();
+
+    const mutationObserver = typeof MutationObserver === 'undefined'
+      ? null
+      : new MutationObserver(() => {
+        syncObservedChildren();
+        update();
+      });
+    mutationObserver?.observe(element, resizeObserver
+      ? { childList: true }
+      : {
+          attributes: true,
+          attributeFilter: ['class', 'style'],
+          characterData: true,
+          childList: true,
+          subtree: true,
+        });
+    window.addEventListener('resize', update);
+
+    return () => {
+      window.removeEventListener('resize', update);
+      mutationObserver?.disconnect();
+      resizeObserver?.disconnect();
+      element.removeAttribute(SCROLL_BOUNDARY_ATTRIBUTE);
+    };
+  }, [active, scrollRef]);
+}

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -1614,6 +1614,14 @@
   box-shadow: var(--shadow-lg);
 }
 
+.requestEventsTableWrapper[data-scroll-boundary-contained='true'],
+.requestEventsLogSectionPanelInner[data-scroll-boundary-contained='true'],
+.apiKeySettingsBody[data-scroll-boundary-contained='true'],
+.sessionSettingsBody[data-scroll-boundary-contained='true'],
+.pricesGrid[data-scroll-boundary-contained='true'] {
+  overscroll-behavior-y: contain;
+}
+
 // Pricing Section (80%比例)
 .pricingFixedCard {
   height: auto;

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -599,6 +599,21 @@ describe('UsagePage toolbar styles', () => {
     expect(sessionSettingsSource).toContain('styles.settingsCompactAction')
   })
 
+  it('contains wheel scrolling at overflowing card boundaries without trapping short lists', () => {
+    expect(requestEventsSource).toContain('useScrollBoundaryContainment(requestEventsTableWrapperRef, rows.length > 0);')
+    expect(requestEventsSource).toContain('useScrollBoundaryContainment(scrollerRef);')
+    expect(apiKeySettingsSource).toContain('useScrollBoundaryContainment(apiKeySettingsBodyRef);')
+    expect(sessionSettingsSource).toContain('useScrollBoundaryContainment(sessionSettingsBodyRef);')
+    expect(priceSettingsSource).toContain('useScrollBoundaryContainment(pricesGridRef, sortedModelPrices.length > 0);')
+    expect(requestEventsSource).toContain('ref={requestEventsTableWrapperRef} className={styles.requestEventsTableWrapper}')
+    expect(requestEventsSource).toContain('className={styles.requestEventsLogSectionPanelInner} ref={scrollerRef}')
+    expect(apiKeySettingsSource).toContain('ref={apiKeySettingsBodyRef} className={styles.apiKeySettingsBody}')
+    expect(sessionSettingsSource).toContain('ref={sessionSettingsBodyRef} className={styles.sessionSettingsBody}')
+    expect(priceSettingsSource).toContain('ref={pricesGridRef} className={styles.pricesGrid}')
+    expect(usagePageStyles).toMatch(/\.requestEventsTableWrapper\[data-scroll-boundary-contained='true'\],[\s\S]*?\.requestEventsLogSectionPanelInner\[data-scroll-boundary-contained='true'\],[\s\S]*?\.apiKeySettingsBody\[data-scroll-boundary-contained='true'\],[\s\S]*?\.sessionSettingsBody\[data-scroll-boundary-contained='true'\],[\s\S]*?\.pricesGrid\[data-scroll-boundary-contained='true'\]\s*\{[\s\S]*?overscroll-behavior-y:\s*contain;/)
+    expect(credentialStyles).not.toContain('data-scroll-boundary-contained')
+  })
+
   it('keeps Model Pricing Settings list viewport aligned with API Key Settings without shrinking it behind the form', () => {
     const settingsSectionsBlock = usagePageStyles.slice(
       usagePageStyles.indexOf('.settingsSections {'),


### PR DESCRIPTION
## Summary

- contain scroll chaining inside overflowing Request Event Log and settings data lists
- enable containment only when actual vertical overflow exists so short lists still scroll the page
- preserve Auth Files and AI Provider behavior and add lifecycle cleanup coverage

## Validation

- rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build make verify