### PR TITLE
perf(request-events): remove redundant model query

### DIFF
--- a/internal/repository/dto/usage_events.go
+++ b/internal/repository/dto/usage_events.go
@@ -5,7 +5,6 @@ import "time"
 // UsageEventsPageRecord 是 usage events 列表的仓储查询结果。
 type UsageEventsPageRecord struct {
 	Events     []UsageEventRecord
-	Models     []string
 	TotalCount int64
 	Page       int
 	PageSize   int

--- a/internal/repository/test/usage_events_query_test.go
+++ b/internal/repository/test/usage_events_query_test.go
@@ -1,0 +1,79 @@
+package test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+	repodto "cpa-usage-keeper/internal/repository/dto"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+type usageEventsSQLRecorder struct {
+	logs strings.Builder
+}
+
+func (r *usageEventsSQLRecorder) Printf(message string, args ...interface{}) {
+	fmt.Fprintf(&r.logs, message, args...)
+	r.logs.WriteByte('\n')
+}
+
+func (r *usageEventsSQLRecorder) String() string {
+	return r.logs.String()
+}
+
+func TestListUsageEventsWithFilterDoesNotLoadModelFilterOptions(t *testing.T) {
+	db := openTestDatabase(t)
+	seedUsageEventModels(t, db)
+	recorder, queryDB := usageEventsQueryRecorder(db)
+
+	page, err := repository.ListUsageEventsWithFilter(queryDB, repodto.UsageQueryFilter{Page: 1, PageSize: 1})
+	if err != nil {
+		t.Fatalf("ListUsageEventsWithFilter returned error: %v", err)
+	}
+	if len(page.Events) != 1 || page.TotalCount != 2 || page.Page != 1 || page.PageSize != 1 || page.TotalPages != 2 {
+		t.Fatalf("unexpected usage events page: %+v", page)
+	}
+	if strings.Contains(strings.ToLower(recorder.String()), "select distinct model") {
+		t.Fatalf("expected list query not to load model filter options, SQL logs:\n%s", recorder.String())
+	}
+}
+
+func TestListUsageEventFilterOptionsWithFilterStillLoadsModels(t *testing.T) {
+	db := openTestDatabase(t)
+	seedUsageEventModels(t, db)
+	recorder, queryDB := usageEventsQueryRecorder(db)
+
+	options, err := repository.ListUsageEventFilterOptionsWithFilter(queryDB, repodto.UsageQueryFilter{})
+	if err != nil {
+		t.Fatalf("ListUsageEventFilterOptionsWithFilter returned error: %v", err)
+	}
+	if got, want := strings.Join(options.Models, ","), "model-alpha,model-beta"; got != want {
+		t.Fatalf("expected actual usage event models %q, got %q", want, got)
+	}
+	if !strings.Contains(strings.ToLower(recorder.String()), "select distinct model") {
+		t.Fatalf("expected model filter options query to use SELECT DISTINCT model, SQL logs:\n%s", recorder.String())
+	}
+}
+
+func seedUsageEventModels(t *testing.T, db *gorm.DB) {
+	t.Helper()
+
+	events := []entities.UsageEvent{
+		{EventKey: "usage-events-query-alpha", Model: "model-alpha", Timestamp: time.Date(2026, 7, 21, 8, 0, 0, 0, time.UTC)},
+		{EventKey: "usage-events-query-beta", Model: "model-beta", Timestamp: time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC)},
+	}
+	if _, _, err := repository.InsertUsageEvents(db, events); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+}
+
+func usageEventsQueryRecorder(db *gorm.DB) (*usageEventsSQLRecorder, *gorm.DB) {
+	recorder := &usageEventsSQLRecorder{}
+	queryLogger := gormlogger.New(recorder, gormlogger.Config{LogLevel: gormlogger.Info})
+	return recorder, db.Session(&gorm.Session{Logger: queryLogger})
+}

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -51,7 +51,7 @@ type usageEventProjection struct {
 	TotalTokens         int64
 }
 
-// Request Event Log Tab：先按列表条件统计总数，再加载当前页和筛选项。
+// Request Event Log Tab：先按列表条件统计总数，再加载当前页。
 func ListUsageEventsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (*dto.UsageEventsPageRecord, error) {
 	if db == nil {
 		return nil, fmt.Errorf("database is nil")
@@ -64,12 +64,6 @@ func ListUsageEventsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (*dto.U
 	var totalCount int64
 	if err := baseQuery.Count(&totalCount).Error; err != nil {
 		return nil, fmt.Errorf("count usage events: %w", err)
-	}
-
-	// 第二步：model 筛选项只跟随时间窗口，不跟随当前列表筛选。
-	modelOptions, err := listUsageEventModelFilterOptions(db, filter)
-	if err != nil {
-		return nil, err
 	}
 
 	page := filter.Page
@@ -102,7 +96,7 @@ func ListUsageEventsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (*dto.U
 	if totalCount > 0 {
 		totalPages = int((totalCount + int64(pageSize) - 1) / int64(pageSize))
 	}
-	return &dto.UsageEventsPageRecord{Events: rows, Models: modelOptions, TotalCount: totalCount, Page: page, PageSize: pageSize, TotalPages: totalPages}, nil
+	return &dto.UsageEventsPageRecord{Events: rows, TotalCount: totalCount, Page: page, PageSize: pageSize, TotalPages: totalPages}, nil
 }
 
 // ExportUsageEventsWithFilter 使用 Request Event Log 相同筛选，但不应用分页。

--- a/internal/service/dto/usage.go
+++ b/internal/service/dto/usage.go
@@ -37,7 +37,6 @@ type UsageFilter struct {
 // UsageEventsPage 是 usage events 列表的服务层结果。
 type UsageEventsPage struct {
 	Events     []UsageEventRecord
-	Models     []string
 	TotalCount int64
 	Page       int
 	PageSize   int

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -557,7 +557,7 @@ func (s *usageService) ListUsageEvents(ctx context.Context, filter servicedto.Us
 			PricingStyle:        row.PricingStyle,
 		})
 	}
-	return &servicedto.UsageEventsPage{Events: result, Models: page.Models, TotalCount: page.TotalCount, Page: page.Page, PageSize: page.PageSize, TotalPages: page.TotalPages}, nil
+	return &servicedto.UsageEventsPage{Events: result, TotalCount: page.TotalCount, Page: page.Page, PageSize: page.PageSize, TotalPages: page.TotalPages}, nil
 }
 
 // StreamUsageEvents 使用 Request Event Log 相同筛选条件逐行导出，不应用分页。


### PR DESCRIPTION
## Summary
- remove the redundant model aggregation from Request Events page queries
- keep model options on the dedicated filter endpoint
- add regression coverage for page and filter query separation

## Performance
- 650,012 matching rows: 913.492 ms to 66.521 ms median
- normalized result checksum unchanged

## Testing
- make verify