### PR TITLE
fix(storage): retain usage events for 90 days

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,8 +112,8 @@ LOG_FILE_ENABLED=true
 # Number of days to retain log files; 0 disables cleanup. Required: no. Default: 7.
 LOG_RETENTION_DAYS=7
 
-# 是否在每日维护中删除过期 usage_events 原始事件；默认不清理，设为 true 后会删除上个月 1 日 00:00 之前的数据。必填：否。默认值：false。
-# Whether daily maintenance deletes expired raw usage_events; disabled by default. When true, rows before 00:00 on the first day of the previous month are deleted. Required: no. Default: false.
+# 是否在每日维护中删除过期 usage_events 原始事件；默认不清理，设为 true 后会删除早于 90 个本地自然日前 00:00 的数据。必填：否。默认值：false。
+# Whether daily maintenance deletes expired raw usage_events; disabled by default. When true, rows earlier than local midnight 90 calendar days ago are deleted. Required: no. Default: false.
 CLEANUP_USAGE_EVENTS_ENABLED=false
 
 # 是否启用 SQLite 数据库备份。必填：否。默认值：true。

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Scheduled Auth Files quota refresh is configured from the gear button in the Aut
 | `LOG_LEVEL` | No | `info` | Log level |
 | `LOG_FILE_ENABLED` | No | `true` | Write persistent log files |
 | `LOG_RETENTION_DAYS` | No | `7` | Log retention days; `0` disables cleanup |
-| `CLEANUP_USAGE_EVENTS_ENABLED` | No | `false` | Delete expired raw `usage_events` during daily maintenance; when enabled, rows before 00:00 on the first day of the previous month are deleted |
+| `CLEANUP_USAGE_EVENTS_ENABLED` | No | `false` | Delete expired raw `usage_events` during daily maintenance; when enabled, rows earlier than local midnight 90 calendar days ago are deleted |
 | `BACKUP_ENABLED` | No | `true` | Enable SQLite database backups |
 | `BACKUP_INTERVAL` | No | `24h` | Database backup interval |
 | `BACKUP_RETENTION_DAYS` | No | `7` | Backup retention days |

--- a/README.zh.md
+++ b/README.zh.md
@@ -323,7 +323,7 @@ Auth Files 定时限额刷新在 Auth Files 巡检弹窗的小齿轮中配置。
 | `LOG_LEVEL` | 否 | `info` | 日志级别 |
 | `LOG_FILE_ENABLED` | 否 | `true` | 是否写入持久化日志文件 |
 | `LOG_RETENTION_DAYS` | 否 | `7` | 日志保留天数；`0` 表示不自动清理 |
-| `CLEANUP_USAGE_EVENTS_ENABLED` | 否 | `false` | 是否在每日维护中删除过期 `usage_events` 原始事件；启用后会删除上个月 1 日 00:00 之前的数据 |
+| `CLEANUP_USAGE_EVENTS_ENABLED` | 否 | `false` | 是否在每日维护中删除过期 `usage_events` 原始事件；启用后会删除早于 90 个本地自然日前 00:00 的数据 |
 | `BACKUP_ENABLED` | 否 | `true` | 是否启用 SQLite 数据库备份 |
 | `BACKUP_INTERVAL` | 否 | `24h` | 数据库备份间隔 |
 | `BACKUP_RETENTION_DAYS` | 否 | `7` | 备份保留天数 |

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -155,6 +155,8 @@ type CleanupStorageOptions struct {
 	CleanupUsageEvents bool
 }
 
+const usageEventsRetentionDays = 90
+
 // CleanupStorage 是每日维护任务的统一仓储清理入口：先清 Redis inbox，按配置清过期 usage_events，再清 Activity 短粒度统计，最后执行 VACUUM。
 // VACUUM 必须在删除完成后单独执行，任何一步失败都会停止后续步骤并把已完成部分的结果返回给上层日志。
 func CleanupStorage(db *gorm.DB, now time.Time, options ...CleanupStorageOptions) (dto.StorageCleanupResult, error) {
@@ -184,7 +186,7 @@ func CleanupStorage(db *gorm.DB, now time.Time, options ...CleanupStorageOptions
 	return dto.StorageCleanupResult{RedisInbox: redisResult, UsageEventsDeleted: usageEventsDeleted}, nil
 }
 
-// cleanupUsageEvents 删除当前页面查询窗口外的原始 usage_events，保留从上个月 1 日本地零点开始的数据。
+// cleanupUsageEvents 严格删除早于“time.Local 当日零点向前 90 个自然日”边界的原始 usage_events。
 func cleanupUsageEvents(db *gorm.DB, now time.Time) (int64, error) {
 	if db == nil {
 		return 0, fmt.Errorf("database is nil")
@@ -204,7 +206,7 @@ func cleanupUsageEvents(db *gorm.DB, now time.Time) (int64, error) {
 		}
 		// 只有安全水位已经覆盖当前最大 ID 时才计算时间保留线。
 		cutoff := usageEventsCleanupCutoff(now)
-		// timestamp 条件保持 main 的原始保留语义，不扩大本次修复范围。
+		// DELETE 保持严格小于 cutoff，边界时刻本身必须保留。
 		result := tx.Unscoped().Where("timestamp < ?", timeutil.FormatStorageTime(cutoff)).Delete(&entities.UsageEvent{})
 		if result.Error != nil {
 			return fmt.Errorf("cleanup usage events: %w", result.Error)
@@ -276,8 +278,8 @@ func usageEventAggregationsCaughtUp(tx *gorm.DB) (bool, error) {
 
 func usageEventsCleanupCutoff(now time.Time) time.Time {
 	localNow := now.In(time.Local)
-	currentMonthStart := time.Date(localNow.Year(), localNow.Month(), 1, 0, 0, 0, 0, time.Local)
-	return currentMonthStart.AddDate(0, -1, 0)
+	localDayStart := time.Date(localNow.Year(), localNow.Month(), localNow.Day(), 0, 0, 0, 0, time.Local)
+	return localDayStart.AddDate(0, 0, -usageEventsRetentionDays)
 }
 
 // Vacuum 提供单独的 SQLite 收缩入口，供需要只做文件整理的调用方使用。

--- a/internal/repository/test/db_test.go
+++ b/internal/repository/test/db_test.go
@@ -508,7 +508,7 @@ func TestCleanupStorageCleansRedisInboxAndVacuums(t *testing.T) {
 	}
 }
 
-func TestCleanupStorageCleansUsageEventsBeforePreviousMonthStart(t *testing.T) {
+func TestCleanupStorageRetainsNinetyLocalDays(t *testing.T) {
 	previousLocal := time.Local
 	location, err := time.LoadLocation("Asia/Shanghai")
 	if err != nil {
@@ -517,12 +517,14 @@ func TestCleanupStorageCleansUsageEventsBeforePreviousMonthStart(t *testing.T) {
 	time.Local = location
 	t.Cleanup(func() { time.Local = previousLocal })
 	db := openTestDatabase(t)
-	now := time.Date(2026, 6, 16, 9, 0, 0, 0, time.Local)
+	now := time.Date(2026, 6, 16, 15, 0, 0, 0, time.Local)
+	cutoff := time.Date(2026, 3, 18, 0, 0, 0, 0, time.Local)
 
 	if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{
-		{EventKey: "old", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 30, 23, 59, 59, 0, time.Local), TotalTokens: 1},
-		{EventKey: "boundary", Model: "claude-sonnet", Timestamp: time.Date(2026, 5, 1, 0, 0, 0, 0, time.Local), TotalTokens: 2},
-		{EventKey: "recent", Model: "claude-sonnet", Timestamp: time.Date(2026, 6, 16, 8, 0, 0, 0, time.Local), TotalTokens: 3},
+		{EventKey: "before-cutoff", Model: "claude-sonnet", Timestamp: cutoff.Add(-time.Nanosecond), TotalTokens: 1},
+		{EventKey: "at-cutoff", Model: "claude-sonnet", Timestamp: cutoff, TotalTokens: 2},
+		{EventKey: "after-cutoff", Model: "claude-sonnet", Timestamp: cutoff.Add(time.Nanosecond), TotalTokens: 3},
+		{EventKey: "current-day", Model: "claude-sonnet", Timestamp: time.Date(2026, 6, 16, 9, 0, 0, 0, time.Local), TotalTokens: 4},
 	}); err != nil {
 		t.Fatalf("InsertUsageEvents returned error: %v", err)
 	}
@@ -547,7 +549,55 @@ func TestCleanupStorageCleansUsageEventsBeforePreviousMonthStart(t *testing.T) {
 	if err := db.Model(&entities.UsageEvent{}).Order("event_key asc").Pluck("event_key", &remainingKeys).Error; err != nil {
 		t.Fatalf("load remaining usage events: %v", err)
 	}
-	expectedKeys := []string{"boundary", "recent"}
+	expectedKeys := []string{"after-cutoff", "at-cutoff", "current-day"}
+	if fmt.Sprint(remainingKeys) != fmt.Sprint(expectedKeys) {
+		t.Fatalf("expected remaining usage events %v, got %v", expectedKeys, remainingKeys)
+	}
+}
+
+func TestCleanupStorageUsesLocalCalendarDaysAcrossDST(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	time.Local = location
+	t.Cleanup(func() { time.Local = previousLocal })
+	db := openTestDatabase(t)
+	now := time.Date(2026, 5, 15, 15, 0, 0, 0, time.Local)
+	localDayStart := time.Date(2026, 5, 15, 0, 0, 0, 0, time.Local)
+	cutoff := localDayStart.AddDate(0, 0, -90)
+	if elapsed := localDayStart.Sub(cutoff); elapsed != 90*24*time.Hour-time.Hour {
+		t.Fatalf("expected fixture to cross spring DST in 2159 hours, got %s", elapsed)
+	}
+
+	if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{
+		{EventKey: "before-dst-cutoff", Model: "claude-sonnet", Timestamp: cutoff.Add(-time.Nanosecond), TotalTokens: 1},
+		{EventKey: "at-dst-cutoff", Model: "claude-sonnet", Timestamp: cutoff, TotalTokens: 2},
+		{EventKey: "after-dst-cutoff", Model: "claude-sonnet", Timestamp: cutoff.Add(time.Nanosecond), TotalTokens: 3},
+	}); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+	if err := repository.AggregateUsageOverviewStats(context.Background(), db, now); err != nil {
+		t.Fatalf("aggregate overview before cleanup: %v", err)
+	}
+	if err := repository.AggregateUsageActivityStats(context.Background(), db, now); err != nil {
+		t.Fatalf("aggregate activity before cleanup: %v", err)
+	}
+
+	result, err := repository.CleanupStorage(db, now, repository.CleanupStorageOptions{CleanupUsageEvents: true})
+	if err != nil {
+		t.Fatalf("CleanupStorage returned error: %v", err)
+	}
+	if result.UsageEventsDeleted != 1 {
+		t.Fatalf("expected only the event before the local calendar cutoff to be deleted, got %+v", result)
+	}
+
+	var remainingKeys []string
+	if err := db.Model(&entities.UsageEvent{}).Order("event_key asc").Pluck("event_key", &remainingKeys).Error; err != nil {
+		t.Fatalf("load remaining usage events: %v", err)
+	}
+	expectedKeys := []string{"after-dst-cutoff", "at-dst-cutoff"}
 	if fmt.Sprint(remainingKeys) != fmt.Sprint(expectedKeys) {
 		t.Fatalf("expected remaining usage events %v, got %v", expectedKeys, remainingKeys)
 	}
@@ -559,8 +609,8 @@ func TestCleanupStorageDefersUsageEventsUntilOverviewAndActivityCatchUp(t *testi
 	now := time.Date(2026, 6, 16, 9, 0, 0, 0, time.Local)
 
 	if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{
-		{EventKey: "old-without-checkpoint", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 29, 10, 0, 0, 0, time.Local), TotalTokens: 1},
-		{EventKey: "old-beyond-checkpoint", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 30, 10, 0, 0, 0, time.Local), TotalTokens: 2},
+		{EventKey: "old-without-checkpoint", Model: "claude-sonnet", Timestamp: now.AddDate(0, 0, -92), TotalTokens: 1},
+		{EventKey: "old-beyond-checkpoint", Model: "claude-sonnet", Timestamp: now.AddDate(0, 0, -91), TotalTokens: 2},
 	}); err != nil {
 		t.Fatalf("InsertUsageEvents returned error: %v", err)
 	}
@@ -590,8 +640,8 @@ func TestCleanupStorageDefersUsageEventsUntilIdentityCatchUp(t *testing.T) {
 	now := time.Date(2026, 6, 16, 9, 0, 0, 0, time.Local)
 
 	if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{
-		{EventKey: "identity-aggregated-old", AuthType: "oauth", AuthIndex: "auth-1", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 29, 10, 0, 0, 0, time.Local), TotalTokens: 1},
-		{EventKey: "identity-pending-old", AuthType: "oauth", AuthIndex: "auth-1", Model: "claude-sonnet", Timestamp: time.Date(2026, 4, 30, 10, 0, 0, 0, time.Local), TotalTokens: 2},
+		{EventKey: "identity-aggregated-old", AuthType: "oauth", AuthIndex: "auth-1", Model: "claude-sonnet", Timestamp: now.AddDate(0, 0, -92), TotalTokens: 1},
+		{EventKey: "identity-pending-old", AuthType: "oauth", AuthIndex: "auth-1", Model: "claude-sonnet", Timestamp: now.AddDate(0, 0, -91), TotalTokens: 2},
 	}); err != nil {
 		t.Fatalf("InsertUsageEvents returned error: %v", err)
 	}

--- a/internal/service/test/sync_cleanup_test.go
+++ b/internal/service/test/sync_cleanup_test.go
@@ -16,7 +16,7 @@ import (
 func TestSyncServiceCleanupStorageSkipsUsageEventsByDefault(t *testing.T) {
 	db := openSyncCleanupTestDatabase(t)
 	now := time.Date(2026, 6, 16, 9, 0, 0, 0, time.Local)
-	seedSyncCleanupUsageEvents(t, db)
+	seedSyncCleanupUsageEventsAt(t, db, now.AddDate(0, 0, -91), now.Add(-time.Hour))
 	syncer := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{
 		Now: func() time.Time { return now },
 	})
@@ -38,7 +38,7 @@ func TestSyncServiceCleanupStorageDeletesUsageEventsWhenEnabled(t *testing.T) {
 	// 准备：写入一条过期和一条近期事件，并先追平两个全局聚合 checkpoint。
 	db := openSyncCleanupTestDatabase(t)
 	now := time.Date(2026, 6, 16, 9, 0, 0, 0, time.Local)
-	seedSyncCleanupUsageEvents(t, db)
+	seedSyncCleanupUsageEventsAt(t, db, now.AddDate(0, 0, -91), now.Add(-time.Hour))
 	catchUpSyncCleanupAggregations(t, db, now)
 	syncer := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{
 		Now:                       func() time.Time { return now },
@@ -50,7 +50,7 @@ func TestSyncServiceCleanupStorageDeletesUsageEventsWhenEnabled(t *testing.T) {
 		t.Fatalf("CleanupStorage returned error: %v", err)
 	}
 
-	// 断言：安全水位满足后仍保持 main 的时间保留语义，只删除过期事件。
+	// 断言：安全水位满足后只删除早于 90 天边界的过期事件。
 	var remainingKeys []string
 	if err := db.Model(&entities.UsageEvent{}).Order("event_key asc").Pluck("event_key", &remainingKeys).Error; err != nil {
 		t.Fatalf("load remaining usage events: %v", err)
@@ -64,7 +64,7 @@ func TestNewSyncServiceCleanupStorageReadsCleanupFlagFromConfig(t *testing.T) {
 	// 准备：通过生产构造器配置清理开关，并让两个全局聚合 checkpoint 先追平。
 	db := openSyncCleanupTestDatabase(t)
 	now := time.Now().In(time.Local)
-	seedSyncCleanupUsageEventsAt(t, db, now.AddDate(0, -3, 0), now)
+	seedSyncCleanupUsageEventsAt(t, db, now.AddDate(0, 0, -91), now)
 	catchUpSyncCleanupAggregations(t, db, now)
 	syncer := service.NewSyncService(db, config.Config{
 		CPABaseURL:                "https://cpa.example.com",
@@ -104,14 +104,6 @@ func openSyncCleanupTestDatabase(t *testing.T) *gorm.DB {
 		}
 	})
 	return db
-}
-
-func seedSyncCleanupUsageEvents(t *testing.T, db *gorm.DB) {
-	t.Helper()
-	seedSyncCleanupUsageEventsAt(t, db,
-		time.Date(2026, 4, 30, 23, 59, 59, 0, time.Local),
-		time.Date(2026, 6, 16, 8, 0, 0, 0, time.Local),
-	)
 }
 
 func seedSyncCleanupUsageEventsAt(t *testing.T, db *gorm.DB, oldAt, recentAt time.Time) {


### PR DESCRIPTION
## Summary
- change optional raw usage_events cleanup from the previous-month boundary to 90 local calendar days
- preserve the default-disabled configuration and aggregation safety gates
- cover the exact cutoff, a DST-spanning calendar window, and cleanup flag behavior

## Testing
- make verify