### PR TITLE
feat(analysis): add heatmap token and cost summaries

### DIFF
--- a/web/src/components/usage/analysis/AnalysisPanel.module.scss
+++ b/web/src/components/usage/analysis/AnalysisPanel.module.scss
@@ -674,13 +674,23 @@
 .heatmapScroller {
   overflow-x: auto;
   padding-bottom: 2px;
+  scrollbar-gutter: stable;
+
+  @include mobile {
+    padding-bottom: 10px;
+  }
 }
 
 .heatmapGrid {
+  --heatmap-key-column-width: 160px;
+  --heatmap-summary-column-width: 88px;
+  --heatmap-grid-gap: 4px;
+
   display: grid;
-  gap: 4px;
+  gap: var(--heatmap-grid-gap, 4px);
   width: 100%;
   min-width: 680px;
+  isolation: isolate;
 }
 
 .heatmapRowContents {
@@ -736,9 +746,27 @@
   align-items: center;
 }
 
-.heatmapTooltipTarget {
-  position: relative;
-  overflow: visible;
+.heatmapKeyColumn {
+  position: sticky;
+  left: 0;
+  z-index: 3;
+  background: var(--bg-primary);
+  box-shadow: 12px 0 22px -20px rgba(15, 23, 42, 0.72);
+}
+
+.heatmapKeyColumn::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: 0;
+  background: inherit;
+  pointer-events: none;
+}
+
+.heatmapTotalTokensColumn,
+.heatmapTotalCostColumn {
+  min-width: 0;
 }
 
 .heatmapTruncatedLabel {
@@ -764,40 +792,38 @@
   overflow-wrap: anywhere;
 }
 
-.heatmapTooltipTarget:hover::after {
-  content: attr(data-full-name);
-  position: absolute;
-  left: 0;
-  bottom: calc(100% + 6px);
-  z-index: 20;
-  max-width: min(360px, 80vw);
-  padding: 6px 8px;
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.16);
-  white-space: normal;
-  overflow-wrap: anywhere;
-  pointer-events: none;
-}
-
 .heatmapRowLabel {
-  height: 30px;
-  min-height: 30px;
+  height: 34px;
+  min-height: 34px;
   align-self: center;
   display: flex;
   align-items: center;
-  border: 0;
-  background: transparent;
-  padding-top: 0;
-  padding-bottom: 0;
+  gap: 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 5px;
+  background: var(--bg-primary);
+  padding: 0 10px;
+  outline: none;
+}
+
+.heatmapKeyMarker {
+  width: 3px;
+  height: 16px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #fb923c, #ef4444);
+}
+
+.heatmapKeyLabel {
+  color: var(--text-primary);
+  font-size: 11px;
+  font-weight: 800;
 }
 
 .heatmapCell {
   position: relative;
-  height: 30px;
-  min-height: 30px;
+  height: 34px;
+  min-height: 34px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -806,6 +832,69 @@
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.10);
   font-variant-numeric: tabular-nums;
   outline: none;
+}
+
+.heatmapSummaryHeaderCell {
+  justify-content: center;
+  padding: 8px 6px;
+  color: var(--text-primary);
+  text-align: center;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.heatmapSummaryCell {
+  height: 34px;
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--bg-secondary) 72%, var(--bg-primary));
+  color: var(--text-primary);
+  padding: 0 5px;
+  font-variant-numeric: tabular-nums;
+  outline: none;
+}
+
+.heatmapRowLabel:focus-visible,
+.heatmapSummaryCell:focus-visible {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--heatmap-focus-color, #d86a4a) 70%, transparent);
+}
+
+.heatmapTotalTokenValue,
+.heatmapTotalCostValue {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 10px;
+  font-weight: 900;
+}
+
+.heatmapCardDark {
+  .heatmapKeyColumn {
+    background: var(--bg-secondary);
+  }
+
+  .heatmapRowLabel,
+  .heatmapSummaryCell {
+    background: color-mix(in srgb, var(--bg-tertiary) 74%, var(--bg-primary));
+  }
+
+}
+
+@include mobile {
+  .heatmapKeyColumn {
+    position: static;
+    box-shadow: none;
+  }
+
+  .heatmapKeyColumn::before {
+    content: none;
+  }
 }
 
 .heatmapCell:focus-visible {

--- a/web/src/components/usage/analysis/AnalysisPanel.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.tsx
@@ -186,6 +186,11 @@ const FULL_CIRCLE = Math.PI * 2;
 const HEATMAP_TOOLTIP_MAX_WIDTH = 280;
 const HEATMAP_TOOLTIP_VIEWPORT_PADDING = 8;
 const HEATMAP_TOOLTIP_CURSOR_OFFSET = 14;
+const HEATMAP_KEY_COLUMN_WIDTH = 160;
+const HEATMAP_MODEL_COLUMN_MIN_WIDTH = 82;
+const HEATMAP_SUMMARY_COLUMN_WIDTH = 88;
+const HEATMAP_GRID_GAP = 4;
+const HEATMAP_GRID_BASE_MIN_WIDTH = 680;
 const MODEL_EFFICIENCY_TOOLTIP_ID = 'analysis-model-efficiency-tooltip';
 const MODEL_EFFICIENCY_TOOLTIP_MAX_WIDTH = 320;
 const MODEL_EFFICIENCY_TOOLTIP_VIEWPORT_PADDING = 8;
@@ -1857,10 +1862,30 @@ function Heatmap({ cells, apiKeys, apiKeyLabels, models, loading, isDark }: { ce
   const { t } = useTranslation();
   const [tooltip, setTooltip] = useState<FloatingTooltipState | null>(null);
   const cellMap = useMemo(() => new Map(cells.map((cell) => [`${cell.api_key}\0${cell.model}`, cell])), [cells]);
+  // 固定汇总列按 API Key 聚合所有模型，确保与中间热力单元格使用同一数据口径。
+  const rowTotals = useMemo(() => {
+    const totals = new Map<string, { totalTokens: number; totalCost: number; costAvailable: boolean }>();
+    apiKeys.forEach((apiKey) => totals.set(apiKey, { totalTokens: 0, totalCost: 0, costAvailable: true }));
+    cells.forEach((cell) => {
+      const total = totals.get(cell.api_key) ?? { totalTokens: 0, totalCost: 0, costAvailable: true };
+      total.totalTokens += toNumber(cell.total_tokens);
+      total.totalCost += toNumber(cell.cost_usd);
+      total.costAvailable = total.costAvailable && cell.cost_available !== false;
+      totals.set(cell.api_key, total);
+    });
+    return totals;
+  }, [apiKeys, cells]);
   const hasUnavailableCost = useMemo(() => cells.some((cell) => cell.cost_available === false), [cells]);
   const maxHeatmapTokens = useMemo(
     () => cells.reduce((max, cell) => Math.max(max, toNumber(cell.total_tokens)), 0),
     [cells],
+  );
+  const heatmapGridMinWidth = Math.max(
+    HEATMAP_GRID_BASE_MIN_WIDTH,
+    HEATMAP_KEY_COLUMN_WIDTH
+      + models.length * HEATMAP_MODEL_COLUMN_MIN_WIDTH
+      + HEATMAP_SUMMARY_COLUMN_WIDTH * 2
+      + (models.length + 2) * HEATMAP_GRID_GAP,
   );
   const getAPIKeyLabel = (apiKey: string) => apiKeyLabels[apiKey] || apiKey;
   const buildTooltipLines = (apiKey: string, model: string, cell: AnalysisHeatmapCell | undefined) => {
@@ -1918,8 +1943,14 @@ function Heatmap({ cells, apiKeys, apiKeyLabels, models, loading, isDark }: { ce
         <>
           <div className={styles.analysisChartSurface}>
             <div className={styles.heatmapScroller}>
-              <div className={styles.heatmapGrid} style={{ gridTemplateColumns: `150px repeat(${models.length}, minmax(82px, 1fr))` }}>
-                <div className={styles.heatmapCorner}>{t('usage_stats.analysis_heatmap_api_key')}</div>
+              <div
+                className={styles.heatmapGrid}
+                style={{
+                  gridTemplateColumns: `var(--heatmap-key-column-width) repeat(${models.length}, minmax(${HEATMAP_MODEL_COLUMN_MIN_WIDTH}px, 1fr)) repeat(2, var(--heatmap-summary-column-width))`,
+                  minWidth: heatmapGridMinWidth,
+                } as CSSProperties}
+              >
+                <div className={`${styles.heatmapCorner} ${styles.heatmapKeyColumn}`}>{t('usage_stats.analysis_heatmap_api_key')}</div>
                 {models.map((model) => (
                   <div
                     key={model}
@@ -1936,12 +1967,40 @@ function Heatmap({ cells, apiKeys, apiKeyLabels, models, loading, isDark }: { ce
                     <span className={`${styles.heatmapTruncatedLabel} ${styles.heatmapModelLabel}`}>{model}</span>
                   </div>
                 ))}
+                <div className={`${styles.heatmapHeaderCell} ${styles.heatmapSummaryHeaderCell} ${styles.heatmapTotalTokensColumn}`}>
+                  {t('usage_stats.total_tokens')}
+                </div>
+                <div className={`${styles.heatmapHeaderCell} ${styles.heatmapSummaryHeaderCell} ${styles.heatmapTotalCostColumn}`}>
+                  {t('usage_stats.total_cost')}
+                </div>
                 {apiKeys.map((apiKey) => {
                   const apiKeyLabel = getAPIKeyLabel(apiKey);
+                  const rowTotal = rowTotals.get(apiKey) ?? { totalTokens: 0, totalCost: 0, costAvailable: true };
+                  const formattedTotalTokens = formatCompactNumber(rowTotal.totalTokens);
+                  const formattedTotalCost = formatUsd(rowTotal.totalCost);
+                  const apiKeyColumnLabel = t('usage_stats.analysis_heatmap_api_key');
+                  const summaryTooltipLines = [
+                    apiKeyLabel,
+                    `${t('usage_stats.total_tokens')}: ${formattedTotalTokens}`,
+                    `${t('usage_stats.total_cost')}: ${formattedTotalCost}`,
+                  ];
+                  const apiKeyAriaLabel = `${apiKeyColumnLabel}: ${apiKeyLabel}, ${summaryTooltipLines.slice(1).join(', ')}`;
+                  const totalTokensAriaLabel = `${t('usage_stats.total_tokens')}: ${formattedTotalTokens}, ${apiKeyColumnLabel}: ${apiKeyLabel}`;
+                  const totalCostAriaLabel = `${t('usage_stats.total_cost')}: ${formattedTotalCost}, ${apiKeyColumnLabel}: ${apiKeyLabel}`;
                   return (
                     <div key={apiKey} className={styles.heatmapRowContents}>
-                      <div className={`${styles.heatmapRowLabel} ${styles.heatmapTooltipTarget}`} data-full-name={apiKeyLabel}>
-                        <span className={styles.heatmapTruncatedLabel}>{apiKeyLabel}</span>
+                      <div
+                        className={`${styles.heatmapRowLabel} ${styles.heatmapKeyColumn}`}
+                        tabIndex={0}
+                        aria-label={apiKeyAriaLabel}
+                        onMouseEnter={(event) => showTooltip(summaryTooltipLines, event)}
+                        onMouseMove={(event) => showTooltip(summaryTooltipLines, event)}
+                        onMouseLeave={hideTooltip}
+                        onFocus={(event) => showTooltip(summaryTooltipLines, event)}
+                        onBlur={hideTooltip}
+                      >
+                        <span className={styles.heatmapKeyMarker} aria-hidden="true" />
+                        <span className={`${styles.heatmapTruncatedLabel} ${styles.heatmapKeyLabel}`}>{apiKeyLabel}</span>
                       </div>
                       {models.map((model) => {
                         const cell = cellMap.get(`${apiKey}\0${model}`);
@@ -1971,6 +2030,31 @@ function Heatmap({ cells, apiKeys, apiKeyLabels, models, loading, isDark }: { ce
                           </div>
                         );
                       })}
+                      <div
+                        className={`${styles.heatmapSummaryCell} ${styles.heatmapTotalTokensColumn}`}
+                        tabIndex={0}
+                        aria-label={totalTokensAriaLabel}
+                        onMouseEnter={(event) => showTooltip(summaryTooltipLines, event)}
+                        onMouseMove={(event) => showTooltip(summaryTooltipLines, event)}
+                        onMouseLeave={hideTooltip}
+                        onFocus={(event) => showTooltip(summaryTooltipLines, event)}
+                        onBlur={hideTooltip}
+                      >
+                        <span className={styles.heatmapTotalTokenValue}>{formattedTotalTokens}</span>
+                      </div>
+                      <div
+                        className={`${styles.heatmapSummaryCell} ${styles.heatmapTotalCostColumn}`}
+                        data-cost-available={rowTotal.costAvailable}
+                        tabIndex={0}
+                        aria-label={totalCostAriaLabel}
+                        onMouseEnter={(event) => showTooltip(summaryTooltipLines, event)}
+                        onMouseMove={(event) => showTooltip(summaryTooltipLines, event)}
+                        onMouseLeave={hideTooltip}
+                        onFocus={(event) => showTooltip(summaryTooltipLines, event)}
+                        onBlur={hideTooltip}
+                      >
+                        <span className={styles.heatmapTotalCostValue}>{formattedTotalCost}</span>
+                      </div>
                     </div>
                   );
                 })}

--- a/web/src/components/usage/analysis/test/AnalysisPanel.heatmap-fixed-columns.test.tsx
+++ b/web/src/components/usage/analysis/test/AnalysisPanel.heatmap-fixed-columns.test.tsx
@@ -1,0 +1,169 @@
+import { readFileSync } from 'node:fs';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import type { AnalysisResponse } from '@/lib/types';
+
+vi.mock('react-chartjs-2', () => ({
+  Bar: () => React.createElement('div'),
+  Doughnut: () => React.createElement('div'),
+  Scatter: () => React.createElement('div'),
+}));
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: () => {},
+  },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+import { AnalysisPanel } from '../AnalysisPanel';
+
+const analysisPanelStyles = readFileSync(new URL('../AnalysisPanel.module.scss', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+
+const styleRuleBlock = (selector: string) => {
+  const start = analysisPanelStyles.indexOf(selector);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const open = analysisPanelStyles.indexOf('{', start);
+  const close = analysisPanelStyles.indexOf('\n}', open);
+  expect(open).toBeGreaterThanOrEqual(0);
+  expect(close).toBeGreaterThan(open);
+  return analysisPanelStyles.slice(open + 1, close);
+};
+
+const analysis: AnalysisResponse = {
+  granularity: 'hourly',
+  timezone: 'UTC',
+  token_usage: [],
+  api_key_composition: [],
+  model_composition: [],
+  auth_files_composition: [],
+  ai_provider_composition: [],
+  cost_breakdown: {
+    uncached_input_cost_usd: 0,
+    cache_read_cost_usd: 0,
+    cache_write_cost_usd: 0,
+    output_cost_usd: 0,
+    total_cost_usd: 0,
+    cost_available: true,
+  },
+  model_efficiency: [],
+  latency_diagnostics: {
+    points: [],
+    density: [],
+    total_points: 0,
+    sampled: false,
+    p95_ttft_ms: 0,
+    p95_latency_ms: 0,
+    max_ttft_ms: 0,
+    max_latency_ms: 0,
+  },
+  heatmap: {
+    api_keys: ['key-1'],
+    api_key_labels: { 'key-1': 'Primary Production Key' },
+    models: ['model-a', 'model-b'],
+    cells: [
+      {
+        api_key: 'key-1',
+        model: 'model-a',
+        input_tokens: 800,
+        output_tokens: 200,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+        reasoning_tokens: 0,
+        total_tokens: 1_000,
+        requests: 2,
+        cost_usd: 0.25,
+        cost_available: true,
+        intensity: 0.4,
+      },
+      {
+        api_key: 'key-1',
+        model: 'model-b',
+        input_tokens: 2_000,
+        output_tokens: 500,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+        reasoning_tokens: 0,
+        total_tokens: 2_500,
+        requests: 3,
+        cost_usd: 0.5,
+        cost_available: true,
+        intensity: 1,
+      },
+    ],
+  },
+};
+
+describe('AnalysisPanel fixed heatmap columns demo', () => {
+  it('keeps the API key and two compact totals outside the scrolling model matrix', () => {
+    const markup = renderToStaticMarkup(
+      <AnalysisPanel analysis={analysis} loading={false} isDark isMobile={false} />,
+    );
+
+    expect(markup).toContain('heatmapKeyColumn');
+    expect(markup).toContain('heatmapTotalTokensColumn');
+    expect(markup).toContain('heatmapTotalCostColumn');
+    expect(markup).not.toContain('heatmapSummaryColumn');
+    expect(markup).toContain('heatmapKeyMarker');
+    expect(markup).not.toContain('heatmapCostSummaryCell');
+    expect(markup).not.toContain('usage_stats.analysis_heatmap_total');
+    expect(markup).toContain('Primary Production Key');
+    expect(markup).toContain('3.50K');
+    expect(markup).toContain('$0.7500');
+    const rowMarkup = markup.slice(markup.indexOf('heatmapRowContents'));
+    expect(rowMarkup).toContain('aria-label="usage_stats.analysis_heatmap_api_key: Primary Production Key, usage_stats.total_tokens: 3.50K, usage_stats.total_cost: $0.7500"');
+    expect(rowMarkup).toContain('aria-label="usage_stats.total_tokens: 3.50K, usage_stats.analysis_heatmap_api_key: Primary Production Key"');
+    expect(rowMarkup).toContain('aria-label="usage_stats.total_cost: $0.7500, usage_stats.analysis_heatmap_api_key: Primary Production Key"');
+    expect(rowMarkup).not.toContain('aria-label="Primary Production Key, usage_stats.total_tokens: 3.50K, usage_stats.total_cost: $0.7500"');
+    expect(rowMarkup.indexOf('Primary Production Key')).toBeLessThan(rowMarkup.indexOf('1.00K'));
+    expect(rowMarkup.lastIndexOf('3.50K')).toBeGreaterThan(rowMarkup.lastIndexOf('2.50K'));
+    expect(rowMarkup.lastIndexOf('$0.7500')).toBeGreaterThan(rowMarkup.lastIndexOf('3.50K'));
+  });
+
+  it('masks only the rounded key column footprint without pinning the grid gap', () => {
+    const heatmapScroller = styleRuleBlock('.heatmapScroller');
+    expect(heatmapScroller).toContain('padding-bottom: 2px;');
+    expect(heatmapScroller).toContain('scrollbar-gutter: stable;');
+    expect(heatmapScroller).toMatch(/@include mobile\s*\{[\s\S]*?padding-bottom:\s*10px;/);
+    expect(analysisPanelStyles).toContain('\n.heatmapGrid {\n  --heatmap-key-column-width: 160px;');
+    expect(analysisPanelStyles).toContain('--heatmap-summary-column-width: 88px;');
+    const keyColumn = styleRuleBlock('.heatmapKeyColumn');
+    expect(keyColumn).toContain('position: sticky;');
+    expect(keyColumn).toContain('left: 0;');
+    expect(keyColumn).not.toContain('var(--heatmap-grid-gap) 0 0');
+    expect(analysisPanelStyles).not.toContain('--heatmap-pinned-gap-color');
+    const keyColumnMask = styleRuleBlock('.heatmapKeyColumn::before');
+    expect(keyColumnMask).toContain('position: absolute;');
+    expect(keyColumnMask).toContain('inset: 0;');
+    expect(keyColumnMask).toContain('z-index: -1;');
+    expect(keyColumnMask).toContain('background: inherit;');
+    expect(keyColumnMask).not.toContain('var(--heatmap-grid-gap)');
+    expect(analysisPanelStyles).toContain(`@include mobile {
+  .heatmapKeyColumn {
+    position: static;
+    box-shadow: none;
+  }
+
+  .heatmapKeyColumn::before {
+    content: none;
+  }
+}`);
+    const keyMarker = styleRuleBlock('.heatmapKeyMarker');
+    expect(keyMarker).toContain('width: 3px;');
+    expect(keyMarker).toContain('height: 16px;');
+    expect(keyMarker).not.toContain('box-shadow:');
+    expect(analysisPanelStyles).toMatch(/\.heatmapRowLabel\s*\{[\s\S]*?height:\s*34px;[\s\S]*?border:\s*1px solid var\(--border-color\);[\s\S]*?background:\s*var\(--bg-primary\);/);
+    expect(analysisPanelStyles).toContain('.heatmapRowLabel:focus-visible,\n.heatmapSummaryCell:focus-visible {');
+    const summaryCell = styleRuleBlock('.heatmapSummaryCell');
+    expect(summaryCell).toContain('display: flex;');
+    expect(summaryCell).toContain('justify-content: center;');
+    expect(summaryCell).toContain('font-variant-numeric: tabular-nums;');
+    expect(analysisPanelStyles).not.toContain('.heatmapSummaryMetric');
+    expect(analysisPanelStyles).not.toContain('.heatmapCostSummaryCell');
+    expect(analysisPanelStyles).not.toContain('.heatmapTooltipTarget');
+  });
+});

--- a/web/src/i18n/index.test.ts
+++ b/web/src/i18n/index.test.ts
@@ -150,6 +150,9 @@ describe('i18n resources', () => {
     expect(i18n.getResource('en', 'translation', 'usage_stats.analysis_heatmap_subtitle')).toBe('Token distribution across API keys and models with hover details.');
     expect(i18n.getResource('zh', 'translation', 'usage_stats.analysis_heatmap_subtitle')).toBe('展示 API Key 与模型组合下的 Token 分布，悬浮查看明细。');
     expect(i18n.getResource('zh-TW', 'translation', 'usage_stats.analysis_heatmap_subtitle')).toBe('顯示 API Key 與模型組合下的 Token 分布，懸浮查看明細。');
+    expect(i18n.getResource('en', 'translation', 'usage_stats.analysis_heatmap_total')).toBeUndefined();
+    expect(i18n.getResource('zh', 'translation', 'usage_stats.analysis_heatmap_total')).toBeUndefined();
+    expect(i18n.getResource('zh-TW', 'translation', 'usage_stats.analysis_heatmap_total')).toBeUndefined();
   });
 
   it('labels Analysis cost metrics', () => {

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -798,7 +798,7 @@ describe('UsagePage toolbar styles', () => {
     const heatmapRowLabelBlock = [...analysisPanelStyles.matchAll(/\.heatmapRowLabel\s*\{([\s\S]*?)\n\}/g)]
       .map((match) => match[1])
       .find((block) => block.includes('display: flex;')) ?? ''
-    expect(heatmapRowLabelBlock).toContain('height: 30px;')
+    expect(heatmapRowLabelBlock).toContain('height: 34px;')
     expect(heatmapRowLabelBlock).toContain('align-self: center;')
     expect(analysisPanelStyles).toMatch(/\.heatmapModelLabel\s*\{[\s\S]*?-webkit-line-clamp:\s*2;/)
     expect(analysisPanelStyles).toMatch(/\.heatmapModelLabel\s*\{[\s\S]*?overflow-wrap:\s*anywhere;/)


### PR DESCRIPTION
## Summary

- add Total Tokens and Total Cost columns for every API key in the Analysis heatmap
- pin the API key rail on desktop while keeping model and summary columns horizontally scrollable
- align neutral summary styling, shared tooltips, keyboard labels, focus states, and mobile scrollbar spacing

## Validation

- `rtk env GOCACHE=/tmp/cpa-usage-keeper-go-build make verify`
- backend test suite
- 72 frontend test files / 697 tests
- lint, typecheck, and production build

Fixes #308