### PR TITLE
perf(analysis): decouple latency diagnostics query

### DIFF
--- a/internal/api/test/usage_analysis_split_test.go
+++ b/internal/api/test/usage_analysis_split_test.go
@@ -1,0 +1,143 @@
+package test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	. "cpa-usage-keeper/internal/api"
+	"cpa-usage-keeper/internal/service"
+	servicedto "cpa-usage-keeper/internal/service/dto"
+)
+
+type analysisSplitStub struct {
+	analysis       *servicedto.AnalysisSnapshot
+	latency        *servicedto.AnalysisLatencyDiagnostics
+	analysisCalls  int
+	latencyCalls   int
+	analysisFilter servicedto.UsageFilter
+	latencyFilter  servicedto.UsageFilter
+}
+
+func (s *analysisSplitStub) GetUsageOverview(context.Context, servicedto.UsageFilter) (*servicedto.UsageOverviewSnapshot, error) {
+	return nil, nil
+}
+
+func (s *analysisSplitStub) GetUsageActivity(context.Context, servicedto.UsageFilter) (*servicedto.UsageActivitySnapshot, error) {
+	return nil, nil
+}
+
+func (s *analysisSplitStub) GetUsageOverviewRealtime(context.Context, servicedto.UsageFilter) (*servicedto.UsageOverviewRealtime, error) {
+	return nil, nil
+}
+
+func (s *analysisSplitStub) ListUsageEvents(context.Context, servicedto.UsageFilter) (*servicedto.UsageEventsPage, error) {
+	return nil, nil
+}
+
+func (s *analysisSplitStub) StreamUsageEvents(context.Context, servicedto.UsageFilter, func(servicedto.UsageEventRecord) error) error {
+	return nil
+}
+
+func (s *analysisSplitStub) ListUsageEventFilterOptions(context.Context, servicedto.UsageFilter) (*servicedto.UsageEventFilterOptions, error) {
+	return nil, nil
+}
+
+func (s *analysisSplitStub) GetAnalysis(_ context.Context, filter servicedto.UsageFilter) (*servicedto.AnalysisSnapshot, error) {
+	s.analysisCalls++
+	s.analysisFilter = filter
+	return s.analysis, nil
+}
+
+func (s *analysisSplitStub) GetAnalysisLatency(_ context.Context, filter servicedto.UsageFilter) (*servicedto.AnalysisLatencyDiagnostics, error) {
+	s.latencyCalls++
+	s.latencyFilter = filter
+	return s.latency, nil
+}
+
+func TestUsageAnalysisCoreOmitsLatencyDiagnostics(t *testing.T) {
+	provider := &analysisSplitStub{analysis: &servicedto.AnalysisSnapshot{
+		Granularity: servicedto.AnalysisGranularityHourly,
+		TokenUsage:  []servicedto.AnalysisTokenUsageBucket{},
+	}}
+	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/api/v1/usage/analysis?range=24h", nil))
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", response.Code)
+	}
+	if strings.Contains(response.Body.String(), `"latency_diagnostics"`) {
+		t.Fatalf("expected core analysis payload to omit latency diagnostics, got %s", response.Body.String())
+	}
+	if provider.analysisCalls != 1 || provider.latencyCalls != 0 {
+		t.Fatalf("expected only core analysis call, got analysis=%d latency=%d", provider.analysisCalls, provider.latencyCalls)
+	}
+}
+
+func TestUsageAnalysisLatencyUsesIndependentRoute(t *testing.T) {
+	provider := &analysisSplitStub{latency: &servicedto.AnalysisLatencyDiagnostics{
+		Points:       []servicedto.AnalysisLatencyPoint{{TTFTMS: 120, LatencyMS: 800}},
+		TotalPoints:  1,
+		P95TTFTMS:    120,
+		P95LatencyMS: 800,
+		MaxTTFTMS:    120,
+		MaxLatencyMS: 800,
+	}}
+	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/api/v1/usage/analysis/latency?range=24h", nil))
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", response.Code, response.Body.String())
+	}
+	body := response.Body.String()
+	if !strings.Contains(body, `"p95_ttft_ms":120`) || !strings.Contains(body, `"p95_latency_ms":800`) || !strings.Contains(body, `"ttft_ms":120`) {
+		t.Fatalf("unexpected latency payload: %s", body)
+	}
+	if provider.analysisCalls != 0 || provider.latencyCalls != 1 {
+		t.Fatalf("expected only latency analysis call, got analysis=%d latency=%d", provider.analysisCalls, provider.latencyCalls)
+	}
+	if provider.latencyFilter.Range != "24h" || provider.latencyFilter.StartTime == nil || provider.latencyFilter.EndTime == nil {
+		t.Fatalf("expected resolved latency filter, got %+v", provider.latencyFilter)
+	}
+}
+
+func TestUsageAnalysisRoutesResolveRollingRangesIndependently(t *testing.T) {
+	provider := &analysisSplitStub{
+		analysis: &servicedto.AnalysisSnapshot{},
+		latency:  &servicedto.AnalysisLatencyDiagnostics{},
+	}
+	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "")
+
+	coreResponse := httptest.NewRecorder()
+	router.ServeHTTP(coreResponse, httptest.NewRequest(http.MethodGet, "/api/v1/usage/analysis?range=24h", nil))
+	if coreResponse.Code != http.StatusOK {
+		t.Fatalf("expected core status 200, got %d: %s", coreResponse.Code, coreResponse.Body.String())
+	}
+
+	// 两个无状态接口各自使用服务端收到请求的时间，与 Overview 的并行加载保持一致。
+	time.Sleep(5 * time.Millisecond)
+	latencyResponse := httptest.NewRecorder()
+	router.ServeHTTP(latencyResponse, httptest.NewRequest(http.MethodGet, "/api/v1/usage/analysis/latency?range=24h", nil))
+	if latencyResponse.Code != http.StatusOK {
+		t.Fatalf("expected latency status 200, got %d: %s", latencyResponse.Code, latencyResponse.Body.String())
+	}
+
+	if provider.analysisFilter.StartTime == nil || provider.analysisFilter.EndTime == nil || provider.latencyFilter.StartTime == nil || provider.latencyFilter.EndTime == nil {
+		t.Fatalf("expected both routes to resolve time boundaries, core=%+v latency=%+v", provider.analysisFilter, provider.latencyFilter)
+	}
+	if !provider.analysisFilter.StartTime.Before(*provider.latencyFilter.StartTime) || !provider.analysisFilter.EndTime.Before(*provider.latencyFilter.EndTime) {
+		t.Fatalf("expected independently resolved rolling ranges, core=[%s,%s] latency=[%s,%s]",
+			provider.analysisFilter.StartTime.Format(time.RFC3339Nano),
+			provider.analysisFilter.EndTime.Format(time.RFC3339Nano),
+			provider.latencyFilter.StartTime.Format(time.RFC3339Nano),
+			provider.latencyFilter.EndTime.Format(time.RFC3339Nano),
+		)
+	}
+}
+
+var _ service.UsageProvider = (*analysisSplitStub)(nil)

--- a/internal/api/test/usage_events_test.go
+++ b/internal/api/test/usage_events_test.go
@@ -139,6 +139,10 @@ func (s *usageEventsStub) GetAnalysis(context.Context, servicedto.UsageFilter) (
 	return nil, s.err
 }
 
+func (s *usageEventsStub) GetAnalysisLatency(context.Context, servicedto.UsageFilter) (*servicedto.AnalysisLatencyDiagnostics, error) {
+	return nil, s.err
+}
+
 type authCPAAPIKeyStub struct {
 	row entities.CPAAPIKey
 }

--- a/internal/api/usage_analysis.go
+++ b/internal/api/usage_analysis.go
@@ -14,19 +14,18 @@ import (
 )
 
 type analysisResponse struct {
-	Granularity           string                     `json:"granularity"`
-	Timezone              string                     `json:"timezone"`
-	RangeStart            *time.Time                 `json:"range_start,omitempty"`
-	RangeEnd              *time.Time                 `json:"range_end,omitempty"`
-	TokenUsage            []analysisTokenUsage       `json:"token_usage"`
-	APIKeyComposition     []analysisCompositionItem  `json:"api_key_composition"`
-	ModelComposition      []analysisCompositionItem  `json:"model_composition"`
-	AuthFilesComposition  []analysisCompositionItem  `json:"auth_files_composition"`
-	AIProviderComposition []analysisCompositionItem  `json:"ai_provider_composition"`
-	Heatmap               analysisHeatmap            `json:"heatmap"`
-	CostBreakdown         analysisCostBreakdown      `json:"cost_breakdown"`
-	ModelEfficiency       []analysisModelEfficiency  `json:"model_efficiency"`
-	LatencyDiagnostics    analysisLatencyDiagnostics `json:"latency_diagnostics"`
+	Granularity           string                    `json:"granularity"`
+	Timezone              string                    `json:"timezone"`
+	RangeStart            *time.Time                `json:"range_start,omitempty"`
+	RangeEnd              *time.Time                `json:"range_end,omitempty"`
+	TokenUsage            []analysisTokenUsage      `json:"token_usage"`
+	APIKeyComposition     []analysisCompositionItem `json:"api_key_composition"`
+	ModelComposition      []analysisCompositionItem `json:"model_composition"`
+	AuthFilesComposition  []analysisCompositionItem `json:"auth_files_composition"`
+	AIProviderComposition []analysisCompositionItem `json:"ai_provider_composition"`
+	Heatmap               analysisHeatmap           `json:"heatmap"`
+	CostBreakdown         analysisCostBreakdown     `json:"cost_breakdown"`
+	ModelEfficiency       []analysisModelEfficiency `json:"model_efficiency"`
 }
 
 type analysisTokenUsage struct {
@@ -159,6 +158,30 @@ func registerUsageAnalysisRoute(router gin.IRoutes, usageProvider service.UsageP
 
 		c.JSON(http.StatusOK, buildAnalysisPayload(analysis, apiKeyInfos))
 	})
+
+	router.GET("/usage/analysis/latency", func(c *gin.Context) {
+		if usageProvider == nil {
+			c.JSON(http.StatusOK, emptyAnalysisLatencyDiagnosticsResponse())
+			return
+		}
+
+		filter, err := parseUsageTimeFilterQuery(c.Request, timeutil.NormalizeStorageTime(time.Now()))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		latency, err := usageProvider.GetAnalysisLatency(c.Request.Context(), filter)
+		if err != nil {
+			writeInternalError(c, "get analysis latency failed", err)
+			return
+		}
+		if latency == nil {
+			c.JSON(http.StatusOK, emptyAnalysisLatencyDiagnosticsResponse())
+			return
+		}
+		c.JSON(http.StatusOK, buildAnalysisLatencyDiagnosticsPayload(*latency))
+	})
 }
 
 func emptyAnalysisResponse() analysisResponse {
@@ -173,8 +196,11 @@ func emptyAnalysisResponse() analysisResponse {
 		Heatmap:               analysisHeatmap{APIKeys: []string{}, APIKeyLabels: map[string]string{}, Models: []string{}, Cells: []analysisHeatmapCell{}},
 		CostBreakdown:         analysisCostBreakdown{CostAvailable: true},
 		ModelEfficiency:       []analysisModelEfficiency{},
-		LatencyDiagnostics:    analysisLatencyDiagnostics{Points: []analysisLatencyPoint{}, Density: []analysisLatencyDensityCell{}},
 	}
+}
+
+func emptyAnalysisLatencyDiagnosticsResponse() analysisLatencyDiagnostics {
+	return analysisLatencyDiagnostics{Points: []analysisLatencyPoint{}, Density: []analysisLatencyDensityCell{}}
 }
 
 func loadCPAAPIKeyInfos(c *gin.Context, provider service.CPAAPIKeyProvider) (map[string]analysisAPIKeyInfo, error) {
@@ -238,8 +264,7 @@ func buildAnalysisPayload(snapshot *servicedto.AnalysisSnapshot, apiKeyInfos map
 			TotalCostUSD:         snapshot.CostBreakdown.TotalCostUSD,
 			CostAvailable:        snapshot.CostBreakdown.CostAvailable,
 		},
-		ModelEfficiency:    buildAnalysisModelEfficiencyPayload(snapshot.ModelEfficiency),
-		LatencyDiagnostics: buildAnalysisLatencyDiagnosticsPayload(snapshot.LatencyDiagnostics),
+		ModelEfficiency: buildAnalysisModelEfficiencyPayload(snapshot.ModelEfficiency),
 	}
 }
 

--- a/internal/api/usage_analysis_test.go
+++ b/internal/api/usage_analysis_test.go
@@ -72,6 +72,10 @@ func (s *usageAnalysisStub) GetAnalysis(_ context.Context, filter servicedto.Usa
 	return s.analysis, s.err
 }
 
+func (s *usageAnalysisStub) GetAnalysisLatency(_ context.Context, _ servicedto.UsageFilter) (*servicedto.AnalysisLatencyDiagnostics, error) {
+	return nil, s.err
+}
+
 func TestUsageAnalysisReturnsAggregatedRows(t *testing.T) {
 	bucket := time.Date(2026, 4, 22, 10, 0, 0, 0, time.Local)
 	provider := &usageAnalysisStub{analysis: &servicedto.AnalysisSnapshot{
@@ -154,26 +158,6 @@ func TestUsageAnalysisReturnsAggregatedRows(t *testing.T) {
 			OutputTokensPerRequest: 5.5,
 			CacheReadRate:          1.0 / 30.0,
 		}},
-		LatencyDiagnostics: servicedto.AnalysisLatencyDiagnostics{
-			TotalPoints:  2,
-			Sampled:      false,
-			P95TTFTMS:    240,
-			P95LatencyMS: 1200,
-			MaxTTFTMS:    240,
-			MaxLatencyMS: 1200,
-			Points: []servicedto.AnalysisLatencyPoint{
-				{TTFTMS: 120, LatencyMS: 800},
-				{TTFTMS: 240, LatencyMS: 1200},
-			},
-			Density: []servicedto.AnalysisLatencyDensityCell{{
-				TTFTMinMS:    0,
-				TTFTMaxMS:    250,
-				LatencyMinMS: 0,
-				LatencyMaxMS: 1300,
-				Count:        2,
-				Intensity:    1,
-			}},
-		},
 	}}
 	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "")
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/analysis?range=24h", nil)
@@ -212,8 +196,8 @@ func TestUsageAnalysisReturnsAggregatedRows(t *testing.T) {
 	if !contains(body, `"model_efficiency":`) || !contains(body, `"cost_per_request_usd":0.615`) || !contains(body, `"output_tokens_per_request":5.5`) || !contains(body, `"cache_read_rate":0.03333333333333333`) {
 		t.Fatalf("expected model efficiency in response body: %s", body)
 	}
-	if !contains(body, `"latency_diagnostics":`) || !contains(body, `"p95_ttft_ms":240`) || !contains(body, `"p95_latency_ms":1200`) || !contains(body, `"ttft_ms":120`) || !contains(body, `"count":2`) {
-		t.Fatalf("expected latency diagnostics in response body: %s", body)
+	if contains(body, `"latency_diagnostics":`) {
+		t.Fatalf("expected latency diagnostics to use the independent endpoint, got %s", body)
 	}
 	if provider.analysisCalls != 1 {
 		t.Fatalf("expected GetAnalysis to be called once, got %d", provider.analysisCalls)

--- a/internal/api/usage_overview_test.go
+++ b/internal/api/usage_overview_test.go
@@ -58,6 +58,10 @@ func (s *usageFilterStub) GetAnalysis(context.Context, servicedto.UsageFilter) (
 	return nil, s.err
 }
 
+func (s *usageFilterStub) GetAnalysisLatency(context.Context, servicedto.UsageFilter) (*servicedto.AnalysisLatencyDiagnostics, error) {
+	return nil, s.err
+}
+
 func mustParseTime(t *testing.T, value string) time.Time {
 	t.Helper()
 	parsed, err := time.Parse(time.RFC3339, value)

--- a/internal/repository/dto/analysis.go
+++ b/internal/repository/dto/analysis.go
@@ -112,5 +112,4 @@ type AnalysisRecord struct {
 	Heatmap               []AnalysisHeatmapRecord
 	CostBreakdown         AnalysisCostBreakdownRecord
 	ModelEfficiency       []AnalysisModelEfficiencyRecord
-	LatencyDiagnostics    AnalysisLatencyDiagnosticsRecord
 }

--- a/internal/repository/percentile/nearest_rank.go
+++ b/internal/repository/percentile/nearest_rank.go
@@ -1,0 +1,102 @@
+package percentile
+
+import (
+	"math"
+	"slices"
+)
+
+const (
+	partitionWorkMultiplier = 4
+	smallRangeSortThreshold = 32
+)
+
+// NearestRank 原地选择最近秩百分位；累计分区工作超过 4n 前回退排序当前活动区间。
+func NearestRank(values []int64, target float64) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+
+	index := nearestRankIndex(len(values), target)
+	selectIndex(values, index)
+	return values[index]
+}
+
+func nearestRankIndex(length int, target float64) int {
+	if math.IsNaN(target) || target <= 0 {
+		return 0
+	}
+	if target >= 1 {
+		return length - 1
+	}
+	return int(math.Ceil(target*float64(length))) - 1
+}
+
+func selectIndex(values []int64, targetIndex int) {
+	left, right := 0, len(values)
+	remainingWork := partitionWorkBudget(len(values))
+
+	for right-left > smallRangeSortThreshold {
+		activeLength := right - left
+		// 下一轮无法在预算内完成时直接排序，避免先支付一轮注定越界的分区成本。
+		if activeLength > remainingWork {
+			slices.Sort(values[left:right])
+			return
+		}
+		remainingWork -= activeLength
+
+		lowerEnd, upperStart := partitionThreeWay(values, left, right, medianOfThreePivot(values, left, right))
+		switch {
+		case targetIndex < lowerEnd:
+			right = lowerEnd
+		case targetIndex >= upperStart:
+			left = upperStart
+		default:
+			return
+		}
+	}
+
+	slices.Sort(values[left:right])
+}
+
+func partitionWorkBudget(length int) int {
+	maxInt := int(^uint(0) >> 1)
+	if length > maxInt/partitionWorkMultiplier {
+		return maxInt
+	}
+	return length * partitionWorkMultiplier
+}
+
+func medianOfThreePivot(values []int64, left, right int) int64 {
+	first := values[left]
+	middle := values[left+(right-left)/2]
+	last := values[right-1]
+	if first > middle {
+		first, middle = middle, first
+	}
+	if middle > last {
+		middle, last = last, middle
+	}
+	if first > middle {
+		middle = first
+	}
+	return middle
+}
+
+// partitionThreeWay 把活动区间分成小于、等于和大于 pivot 的三段，并返回等值段边界。
+func partitionThreeWay(values []int64, left, right int, pivot int64) (int, int) {
+	lowerEnd, index, upperStart := left, left, right
+	for index < upperStart {
+		switch {
+		case values[index] < pivot:
+			values[lowerEnd], values[index] = values[index], values[lowerEnd]
+			lowerEnd++
+			index++
+		case values[index] > pivot:
+			upperStart--
+			values[index], values[upperStart] = values[upperStart], values[index]
+		default:
+			index++
+		}
+	}
+	return lowerEnd, upperStart
+}

--- a/internal/repository/percentile/test/nearest_rank_test.go
+++ b/internal/repository/percentile/test/nearest_rank_test.go
@@ -1,0 +1,66 @@
+package test
+
+import (
+	"math"
+	"slices"
+	"testing"
+
+	"cpa-usage-keeper/internal/repository/percentile"
+)
+
+func TestNearestRankMatchesSortedReference(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		values     []int64
+		percentile float64
+	}{
+		{name: "empty", percentile: 0.95},
+		{name: "single", values: []int64{42}, percentile: 0.95},
+		{name: "unordered", values: []int64{900, 120, 450, 450, 300}, percentile: 0.95},
+		{name: "many equal values", values: []int64{400, 400, 400, 100, 900, 400, 400}, percentile: 0.95},
+		{name: "lower bound", values: []int64{9, 1, 5, 3, 7}, percentile: 0},
+		{name: "upper bound", values: []int64{9, 1, 5, 3, 7}, percentile: 1},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			values := slices.Clone(testCase.values)
+			got := percentile.NearestRank(values, testCase.percentile)
+			want := sortedNearestRank(testCase.values, testCase.percentile)
+			if got != want {
+				t.Fatalf("NearestRank(%v, %v) = %d, want %d", testCase.values, testCase.percentile, got, want)
+			}
+		})
+	}
+}
+
+func TestNearestRankHandlesAdversarialOrder(t *testing.T) {
+	t.Parallel()
+
+	const count = 200000
+	values := make([]int64, count)
+	for index := range values {
+		value := int64(index*2 + 1)
+		if index >= count/2 {
+			value = int64((index - count/2 + 1) * 2)
+		}
+		values[index] = value
+	}
+
+	if got := percentile.NearestRank(values, 0.95); got != 190000 {
+		t.Fatalf("NearestRank adversarial p95 = %d, want 190000", got)
+	}
+}
+
+func sortedNearestRank(values []int64, target float64) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := slices.Clone(values)
+	slices.Sort(sorted)
+	index := int(math.Ceil(target*float64(len(sorted)))) - 1
+	index = max(0, min(index, len(sorted)-1))
+	return sorted[index]
+}

--- a/internal/repository/test/usage_analysis_generate_test.go
+++ b/internal/repository/test/usage_analysis_generate_test.go
@@ -9,7 +9,7 @@ import (
 	repodto "cpa-usage-keeper/internal/repository/dto"
 )
 
-func TestBuildAnalysisExcludesPrewarmFromLatencyDiagnostics(t *testing.T) {
+func TestBuildAnalysisLatencyDiagnosticsExcludesPrewarm(t *testing.T) {
 	db := openTestDatabase(t)
 	start := time.Date(2026, 7, 15, 9, 0, 0, 0, time.UTC)
 	end := start.Add(time.Hour)
@@ -24,12 +24,10 @@ func TestBuildAnalysisExcludesPrewarmFromLatencyDiagnostics(t *testing.T) {
 		t.Fatalf("InsertUsageEvents returned error: %v", err)
 	}
 
-	analysis, err := repository.BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{StartTime: &start, EndTime: &end})
+	diagnostics, err := repository.BuildAnalysisLatencyDiagnosticsWithFilter(db, repodto.UsageQueryFilter{StartTime: &start, EndTime: &end})
 	if err != nil {
-		t.Fatalf("BuildAnalysisWithFilter returned error: %v", err)
+		t.Fatalf("BuildAnalysisLatencyDiagnosticsWithFilter returned error: %v", err)
 	}
-
-	diagnostics := analysis.LatencyDiagnostics
 	if diagnostics.TotalPoints != 1 || len(diagnostics.Points) != 1 {
 		t.Fatalf("expected one normal latency point, got %+v", diagnostics)
 	}

--- a/internal/repository/test/usage_analysis_latency_test.go
+++ b/internal/repository/test/usage_analysis_latency_test.go
@@ -1,0 +1,251 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+	repodto "cpa-usage-keeper/internal/repository/dto"
+)
+
+func TestBuildAnalysisLatencyDiagnosticsHandlesBoundarySamples(t *testing.T) {
+	t.Run("no valid samples", func(t *testing.T) {
+		generate := true
+		prewarm := false
+		zero := int64(0)
+		negative := int64(-1)
+		validTTFT := int64(100)
+		diagnostics := buildAnalysisLatencyDiagnosticsForTest(t, []entities.UsageEvent{
+			{EventKey: "missing-ttft", Generate: &generate, LatencyMS: 1000},
+			{EventKey: "zero-ttft", Generate: &generate, LatencyMS: 1000, TTFTMS: &zero},
+			{EventKey: "negative-ttft", Generate: &generate, LatencyMS: 1000, TTFTMS: &negative},
+			{EventKey: "zero-latency", Generate: &generate, LatencyMS: 0, TTFTMS: &validTTFT},
+			{EventKey: "failed", Generate: &generate, Failed: true, LatencyMS: 1000, TTFTMS: &validTTFT},
+			{EventKey: "prewarm", Generate: &prewarm, LatencyMS: 1000, TTFTMS: &validTTFT},
+		})
+
+		if diagnostics.TotalPoints != 0 || diagnostics.Sampled || diagnostics.P95TTFTMS != 0 || diagnostics.P95LatencyMS != 0 || diagnostics.MaxTTFTMS != 0 || diagnostics.MaxLatencyMS != 0 {
+			t.Fatalf("expected empty diagnostics for invalid samples, got %+v", diagnostics)
+		}
+		if len(diagnostics.Points) != 0 || len(diagnostics.Density) != 0 {
+			t.Fatalf("expected empty point and density arrays, got %+v", diagnostics)
+		}
+	})
+
+	t.Run("single sample", func(t *testing.T) {
+		generate := true
+		ttftMS := int64(42)
+		diagnostics := buildAnalysisLatencyDiagnosticsForTest(t, []entities.UsageEvent{{
+			EventKey: "single", Generate: &generate, LatencyMS: 420, TTFTMS: &ttftMS,
+		}})
+
+		if diagnostics.TotalPoints != 1 || diagnostics.Sampled || diagnostics.P95TTFTMS != 42 || diagnostics.P95LatencyMS != 420 || diagnostics.MaxTTFTMS != 42 || diagnostics.MaxLatencyMS != 420 {
+			t.Fatalf("expected single sample to define p95 and max, got %+v", diagnostics)
+		}
+		if len(diagnostics.Points) != 1 || diagnostics.Points[0].TTFTMS != 42 || diagnostics.Points[0].LatencyMS != 420 {
+			t.Fatalf("expected the single pair to remain unchanged, got %+v", diagnostics.Points)
+		}
+	})
+
+	t.Run("many equal values", func(t *testing.T) {
+		generate := true
+		maxTTFT := int64(900)
+		equalTTFT := int64(400)
+		minTTFT := int64(100)
+		events := make([]entities.UsageEvent, 0, 259)
+		events = append(events, entities.UsageEvent{EventKey: "max", Generate: &generate, LatencyMS: 9000, TTFTMS: &maxTTFT})
+		for index := 0; index < 257; index++ {
+			events = append(events, entities.UsageEvent{
+				EventKey: fmt.Sprintf("equal-%03d", index), Generate: &generate, LatencyMS: 4000, TTFTMS: &equalTTFT,
+			})
+		}
+		events = append(events, entities.UsageEvent{EventKey: "min", Generate: &generate, LatencyMS: 1000, TTFTMS: &minTTFT})
+
+		diagnostics := buildAnalysisLatencyDiagnosticsForTest(t, events)
+		if diagnostics.TotalPoints != 259 || diagnostics.Sampled || diagnostics.P95TTFTMS != 400 || diagnostics.P95LatencyMS != 4000 {
+			t.Fatalf("expected exact nearest-rank p95 through the equal-value partition, got %+v", diagnostics)
+		}
+		if diagnostics.MaxTTFTMS != 900 || diagnostics.MaxLatencyMS != 9000 {
+			t.Fatalf("expected max to remain based on the full scan, got %+v", diagnostics)
+		}
+		if len(diagnostics.Points) != 259 {
+			t.Fatalf("expected all 259 unsampled points, got %d", len(diagnostics.Points))
+		}
+		if diagnostics.Points[0].TTFTMS != 900 || diagnostics.Points[0].LatencyMS != 9000 || diagnostics.Points[258].TTFTMS != 100 || diagnostics.Points[258].LatencyMS != 1000 {
+			t.Fatalf("expected point order and pairs to precede in-place selection, got first=%+v last=%+v", diagnostics.Points[0], diagnostics.Points[len(diagnostics.Points)-1])
+		}
+	})
+}
+
+func TestBuildAnalysisLatencyDiagnosticsPreservesFilteredExactResults(t *testing.T) {
+	db := openTestDatabase(t)
+	start := time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	generate := true
+	prewarm := false
+
+	ttft900 := int64(900)
+	ttft120 := int64(120)
+	ttft450 := int64(450)
+	ttft300 := int64(300)
+	ttftZero := int64(0)
+	ttftNegative := int64(-1)
+	ttftInvalid := int64(2500)
+	events := []entities.UsageEvent{
+		{EventKey: "valid-unordered-max", APIGroupKey: "sk-target", Generate: &generate, Timestamp: start.Add(1 * time.Minute), LatencyMS: 5000, TTFTMS: &ttft900},
+		{EventKey: "valid-low", APIGroupKey: "sk-target", Generate: &generate, Timestamp: start.Add(2 * time.Minute), LatencyMS: 1000, TTFTMS: &ttft120},
+		{EventKey: "valid-duplicate-a", APIGroupKey: "sk-target", Generate: &generate, Timestamp: start.Add(3 * time.Minute), LatencyMS: 2300, TTFTMS: &ttft450},
+		{EventKey: "valid-duplicate-b", APIGroupKey: "sk-target", Generate: &generate, Timestamp: start.Add(4 * time.Minute), LatencyMS: 2300, TTFTMS: &ttft450},
+		{EventKey: "valid-middle", APIGroupKey: "sk-target", Generate: &generate, Timestamp: start.Add(5 * time.Minute), LatencyMS: 1600, TTFTMS: &ttft300},
+		{EventKey: "invalid-null-ttft", APIGroupKey: "sk-target", Generate: &generate, Timestamp: start.Add(6 * time.Minute), LatencyMS: 6000},
+		{EventKey: "invalid-zero-ttft", APIGroupKey: "sk-target", Generate: &generate, Timestamp: start.Add(7 * time.Minute), LatencyMS: 6000, TTFTMS: &ttftZero},
+		{EventKey: "invalid-negative-ttft", APIGroupKey: "sk-target", Generate: &generate, Timestamp: start.Add(8 * time.Minute), LatencyMS: 6000, TTFTMS: &ttftNegative},
+		{EventKey: "invalid-zero-latency", APIGroupKey: "sk-target", Generate: &generate, Timestamp: start.Add(9 * time.Minute), LatencyMS: 0, TTFTMS: &ttftInvalid},
+		{EventKey: "invalid-negative-latency", APIGroupKey: "sk-target", Generate: &generate, Timestamp: start.Add(10 * time.Minute), LatencyMS: -1, TTFTMS: &ttftInvalid},
+		{EventKey: "invalid-failed", APIGroupKey: "sk-target", Generate: &generate, Timestamp: start.Add(11 * time.Minute), Failed: true, LatencyMS: 9000, TTFTMS: &ttftInvalid},
+		{EventKey: "invalid-prewarm", APIGroupKey: "sk-target", Generate: &prewarm, Timestamp: start.Add(12 * time.Minute), LatencyMS: 9000, TTFTMS: &ttftInvalid},
+		{EventKey: "invalid-outside", APIGroupKey: "sk-target", Generate: &generate, Timestamp: start.Add(-time.Second), LatencyMS: 9000, TTFTMS: &ttftInvalid},
+		{EventKey: "invalid-other-key", APIGroupKey: "sk-other", Generate: &generate, Timestamp: start.Add(13 * time.Minute), LatencyMS: 9000, TTFTMS: &ttftInvalid},
+	}
+	if _, _, err := repository.InsertUsageEvents(db, events); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+
+	diagnostics, err := repository.BuildAnalysisLatencyDiagnosticsWithFilter(db, repodto.UsageQueryFilter{
+		StartTime: &start, EndTime: &end, APIGroupKey: "sk-target",
+	})
+	if err != nil {
+		t.Fatalf("BuildAnalysisLatencyDiagnosticsWithFilter returned error: %v", err)
+	}
+	if diagnostics.TotalPoints != 5 || diagnostics.Sampled {
+		t.Fatalf("expected five unsampled valid pairs, got %+v", diagnostics)
+	}
+	if diagnostics.P95TTFTMS != 900 || diagnostics.P95LatencyMS != 5000 {
+		t.Fatalf("expected exact nearest-rank p95 from all valid pairs, got %+v", diagnostics)
+	}
+	if diagnostics.MaxTTFTMS != 900 || diagnostics.MaxLatencyMS != 5000 {
+		t.Fatalf("expected max values from all valid pairs, got %+v", diagnostics)
+	}
+	wantPoints := [][2]int64{{900, 5000}, {120, 1000}, {450, 2300}, {450, 2300}, {300, 1600}}
+	if len(diagnostics.Points) != len(wantPoints) {
+		t.Fatalf("expected %d points, got %+v", len(wantPoints), diagnostics.Points)
+	}
+	for index, want := range wantPoints {
+		got := diagnostics.Points[index]
+		if got.TTFTMS != want[0] || got.LatencyMS != want[1] {
+			t.Fatalf("point %d = %+v, want ttft=%d latency=%d", index, got, want[0], want[1])
+		}
+	}
+}
+
+func TestBuildAnalysisLatencyDiagnosticsPreservesSampleOrderAndPairs(t *testing.T) {
+	db := openTestDatabase(t)
+	start := time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	generate := true
+	const count = 2601
+	events := make([]entities.UsageEvent, 0, count)
+	for sourceIndex := 0; sourceIndex < count; sourceIndex++ {
+		ttftMS := int64(count - sourceIndex)
+		latencyMS := ttftMS*10000 + int64(sourceIndex)
+		events = append(events, entities.UsageEvent{
+			EventKey: fmt.Sprintf("latency-%04d", sourceIndex), APIGroupKey: "sk-target", Generate: &generate,
+			Timestamp: start.Add(time.Duration(sourceIndex) * time.Millisecond), LatencyMS: latencyMS, TTFTMS: &ttftMS,
+		})
+	}
+	if _, _, err := repository.InsertUsageEvents(db, events); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+
+	diagnostics, err := repository.BuildAnalysisLatencyDiagnosticsWithFilter(db, repodto.UsageQueryFilter{
+		StartTime: &start, EndTime: &end, APIGroupKey: "sk-target",
+	})
+	if err != nil {
+		t.Fatalf("BuildAnalysisLatencyDiagnosticsWithFilter returned error: %v", err)
+	}
+	if diagnostics.TotalPoints != count || !diagnostics.Sampled || len(diagnostics.Points) != 2500 {
+		t.Fatalf("expected %d total samples and 2500 deterministic points, got total=%d sampled=%v points=%d", count, diagnostics.TotalPoints, diagnostics.Sampled, len(diagnostics.Points))
+	}
+	if diagnostics.P95TTFTMS != 2471 || diagnostics.P95LatencyMS != 24710130 {
+		t.Fatalf("expected exact nearest-rank p95 from all samples, got ttft=%d latency=%d", diagnostics.P95TTFTMS, diagnostics.P95LatencyMS)
+	}
+	if diagnostics.MaxTTFTMS != count || diagnostics.MaxLatencyMS != 26010000 {
+		t.Fatalf("expected max values from all samples, got ttft=%d latency=%d", diagnostics.MaxTTFTMS, diagnostics.MaxLatencyMS)
+	}
+
+	// 固定几个等距抽样位置，确保选择算法不会先打乱原始顺序或拆散 TTFT/Latency 配对。
+	wantSourceIndexes := map[int]int{0: 0, 1: 1, 1249: 1299, 1250: 1300, 2498: 2598, 2499: 2600}
+	for pointIndex, sourceIndex := range wantSourceIndexes {
+		wantTTFT := int64(count - sourceIndex)
+		wantLatency := wantTTFT*10000 + int64(sourceIndex)
+		got := diagnostics.Points[pointIndex]
+		if got.TTFTMS != wantTTFT || got.LatencyMS != wantLatency {
+			t.Fatalf("sample point %d = %+v, want source %d pair ttft=%d latency=%d", pointIndex, got, sourceIndex, wantTTFT, wantLatency)
+		}
+	}
+}
+
+func TestBuildAnalysisLatencyDiagnosticsAvoidsQuadraticAdversarialOrder(t *testing.T) {
+	db := openTestDatabase(t)
+	start := time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC)
+	end := start.Add(time.Second)
+	generate := true
+	const count = 200000
+	events := make([]entities.UsageEvent, 0, count)
+	for sourceIndex := 0; sourceIndex < count; sourceIndex++ {
+		value := int64(sourceIndex*2 + 1)
+		if sourceIndex >= count/2 {
+			value = int64((sourceIndex - count/2 + 1) * 2)
+		}
+		events = append(events, entities.UsageEvent{
+			EventKey: fmt.Sprintf("adversarial-%06d", sourceIndex), APIGroupKey: "sk-target", Generate: &generate,
+			Timestamp: start.Add(time.Duration(sourceIndex) * time.Microsecond), LatencyMS: value, TTFTMS: &value,
+		})
+	}
+	if _, _, err := repository.InsertUsageEvents(db, events); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+
+	diagnostics, err := repository.BuildAnalysisLatencyDiagnosticsWithFilter(db, repodto.UsageQueryFilter{
+		StartTime: &start, EndTime: &end, APIGroupKey: "sk-target",
+	})
+	if err != nil {
+		t.Fatalf("BuildAnalysisLatencyDiagnosticsWithFilter returned error: %v", err)
+	}
+	if diagnostics.P95TTFTMS != 190000 || diagnostics.P95LatencyMS != 190000 {
+		t.Fatalf("expected exact p95 190000, got %+v", diagnostics)
+	}
+	if !diagnostics.Sampled || len(diagnostics.Points) != 2500 {
+		t.Fatalf("expected 2500 sampled adversarial points, got %+v", diagnostics)
+	}
+	wantPoints := map[int]int64{0: 1, 1249: 199919, 1250: 80, 2499: 200000}
+	for pointIndex, want := range wantPoints {
+		got := diagnostics.Points[pointIndex]
+		if got.TTFTMS != want || got.LatencyMS != want {
+			t.Fatalf("point %d = %+v, want adversarial value %d", pointIndex, got, want)
+		}
+	}
+}
+
+func buildAnalysisLatencyDiagnosticsForTest(t *testing.T, events []entities.UsageEvent) repodto.AnalysisLatencyDiagnosticsRecord {
+	t.Helper()
+	db := openTestDatabase(t)
+	start := time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	for index := range events {
+		events[index].APIGroupKey = "sk-target"
+		events[index].Timestamp = start.Add(time.Duration(index+1) * time.Second)
+	}
+	if _, _, err := repository.InsertUsageEvents(db, events); err != nil {
+		t.Fatalf("InsertUsageEvents returned error: %v", err)
+	}
+	diagnostics, err := repository.BuildAnalysisLatencyDiagnosticsWithFilter(db, repodto.UsageQueryFilter{
+		StartTime: &start, EndTime: &end, APIGroupKey: "sk-target",
+	})
+	if err != nil {
+		t.Fatalf("BuildAnalysisLatencyDiagnosticsWithFilter returned error: %v", err)
+	}
+	return diagnostics
+}

--- a/internal/repository/test/usage_analysis_latency_test.go
+++ b/internal/repository/test/usage_analysis_latency_test.go
@@ -144,6 +144,8 @@ func TestBuildAnalysisLatencyDiagnosticsPreservesSampleOrderAndPairs(t *testing.
 	db := openTestDatabase(t)
 	start := time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC)
 	end := start.Add(time.Hour)
+	// 把样本放在查询窗口内部，使本测试只验证抽样顺序和配对，不依赖时间边界表示。
+	sampleStart := start.Add(time.Second)
 	generate := true
 	const count = 2601
 	events := make([]entities.UsageEvent, 0, count)
@@ -152,7 +154,7 @@ func TestBuildAnalysisLatencyDiagnosticsPreservesSampleOrderAndPairs(t *testing.
 		latencyMS := ttftMS*10000 + int64(sourceIndex)
 		events = append(events, entities.UsageEvent{
 			EventKey: fmt.Sprintf("latency-%04d", sourceIndex), APIGroupKey: "sk-target", Generate: &generate,
-			Timestamp: start.Add(time.Duration(sourceIndex) * time.Millisecond), LatencyMS: latencyMS, TTFTMS: &ttftMS,
+			Timestamp: sampleStart.Add(time.Duration(sourceIndex) * time.Millisecond), LatencyMS: latencyMS, TTFTMS: &ttftMS,
 		})
 	}
 	if _, _, err := repository.InsertUsageEvents(db, events); err != nil {
@@ -190,7 +192,9 @@ func TestBuildAnalysisLatencyDiagnosticsPreservesSampleOrderAndPairs(t *testing.
 func TestBuildAnalysisLatencyDiagnosticsAvoidsQuadraticAdversarialOrder(t *testing.T) {
 	db := openTestDatabase(t)
 	start := time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC)
-	end := start.Add(time.Second)
+	end := start.Add(2 * time.Second)
+	// 把样本放在查询窗口内部，使本测试只验证选择算法的退化保护。
+	sampleStart := start.Add(time.Second)
 	generate := true
 	const count = 200000
 	events := make([]entities.UsageEvent, 0, count)
@@ -201,7 +205,7 @@ func TestBuildAnalysisLatencyDiagnosticsAvoidsQuadraticAdversarialOrder(t *testi
 		}
 		events = append(events, entities.UsageEvent{
 			EventKey: fmt.Sprintf("adversarial-%06d", sourceIndex), APIGroupKey: "sk-target", Generate: &generate,
-			Timestamp: start.Add(time.Duration(sourceIndex) * time.Microsecond), LatencyMS: value, TTFTMS: &value,
+			Timestamp: sampleStart.Add(time.Duration(sourceIndex) * time.Microsecond), LatencyMS: value, TTFTMS: &value,
 		})
 	}
 	if _, _, err := repository.InsertUsageEvents(db, events); err != nil {

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -11,6 +11,7 @@ import (
 	"cpa-usage-keeper/internal/entities"
 	"cpa-usage-keeper/internal/helper"
 	"cpa-usage-keeper/internal/repository/dto"
+	"cpa-usage-keeper/internal/repository/percentile"
 	"cpa-usage-keeper/internal/timeutil"
 	"gorm.io/gorm"
 )
@@ -393,11 +394,6 @@ func BuildAnalysisWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (*dto.Ana
 			CostAvailable: true,
 		},
 	}
-	latencyDiagnostics, err := buildAnalysisLatencyDiagnosticsWithFilter(db, filter)
-	if err != nil {
-		return nil, err
-	}
-	record.LatencyDiagnostics = latencyDiagnostics
 
 	fullStart, fullEnd := usageOverviewFullHourWindow(*filter.StartTime, *filter.EndTime)
 	fullEnd = analysisHourlyStatsEnd(filter, fullEnd)
@@ -480,13 +476,22 @@ type analysisIdentityInfo struct {
 
 type analysisIdentityLookup map[entities.UsageIdentityAuthType]map[string]analysisIdentityInfo
 
-func buildAnalysisLatencyDiagnosticsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (dto.AnalysisLatencyDiagnosticsRecord, error) {
+// BuildAnalysisLatencyDiagnosticsWithFilter 从 raw usage_events 独立构建延迟诊断，不阻塞聚合表分析结果。
+func BuildAnalysisLatencyDiagnosticsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (dto.AnalysisLatencyDiagnosticsRecord, error) {
 	empty := emptyAnalysisLatencyDiagnosticsRecord()
-	// 延迟诊断只统计要求实际生成的成功请求；TTFT/Latency 有效性仍在内存过滤，避免依赖未索引列。
+	if db == nil {
+		return empty, fmt.Errorf("database is nil")
+	}
+	if filter.StartTime == nil || filter.EndTime == nil {
+		return empty, fmt.Errorf("analysis latency requires start_time and end_time")
+	}
+	// SQL 先减少无效行的扫描传输；Go 侧继续做空值和正数防御，避免异常数据进入统计。
 	query := db.Model(&entities.UsageEvent{}).
 		Select("latency_ms, ttft_ms").
 		Where("failed = ?", false).
-		Where("generate = ?", true)
+		Where("generate = ?", true).
+		Where("ttft_ms > 0").
+		Where("latency_ms > 0")
 	query = applyUsageAnalysisTabQuery(query, filter)
 
 	rows, err := query.Rows()
@@ -500,6 +505,8 @@ func buildAnalysisLatencyDiagnosticsWithFilter(db *gorm.DB, filter dto.UsageQuer
 
 	ttftValues := []int64{}
 	latencyValues := []int64{}
+	var maxTTFTMS int64
+	var maxLatencyMS int64
 	for rows.Next() {
 		var latencyMS int64
 		var ttftMS sql.NullInt64
@@ -512,11 +519,17 @@ func buildAnalysisLatencyDiagnosticsWithFilter(db *gorm.DB, filter dto.UsageQuer
 		// 保留原始 int64 值，避免为毫秒字段引入额外 int32 转换。
 		ttftValues = append(ttftValues, ttftMS.Int64)
 		latencyValues = append(latencyValues, latencyMS)
+		if ttftMS.Int64 > maxTTFTMS {
+			maxTTFTMS = ttftMS.Int64
+		}
+		if latencyMS > maxLatencyMS {
+			maxLatencyMS = latencyMS
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return empty, fmt.Errorf("iterate analysis latency diagnostics: %w", err)
 	}
-	return buildAnalysisLatencyDiagnostics(ttftValues, latencyValues), nil
+	return buildAnalysisLatencyDiagnostics(ttftValues, latencyValues, maxTTFTMS, maxLatencyMS), nil
 }
 
 func emptyAnalysisLatencyDiagnosticsRecord() dto.AnalysisLatencyDiagnosticsRecord {
@@ -534,44 +547,21 @@ func isMissingUsageEventsTableError(err error) bool {
 	return strings.Contains(message, "usage_events") && (strings.Contains(message, "no such table") || strings.Contains(message, "doesn't exist"))
 }
 
-func buildAnalysisLatencyDiagnostics(ttftValues, latencyValues []int64) dto.AnalysisLatencyDiagnosticsRecord {
+func buildAnalysisLatencyDiagnostics(ttftValues, latencyValues []int64, maxTTFTMS, maxLatencyMS int64) dto.AnalysisLatencyDiagnosticsRecord {
 	result := emptyAnalysisLatencyDiagnosticsRecord()
 	if len(ttftValues) == 0 {
 		return result
 	}
 
-	for index, ttft := range ttftValues {
-		latency := latencyValues[index]
-		if ttft > result.MaxTTFTMS {
-			result.MaxTTFTMS = ttft
-		}
-		if latency > result.MaxLatencyMS {
-			result.MaxLatencyMS = latency
-		}
-	}
-
 	// p95 基于完整样本计算；前端散点只做确定性抽样，避免浏览器绘制过多点。
 	result.TotalPoints = int64(len(ttftValues))
-	result.P95TTFTMS = analysisNearestRankPercentile(ttftValues, 0.95)
-	result.P95LatencyMS = analysisNearestRankPercentile(latencyValues, 0.95)
+	result.MaxTTFTMS = maxTTFTMS
+	result.MaxLatencyMS = maxLatencyMS
+	// p95 选择会原地重排切片，必须先复制确定性散点以保留查询顺序和样本配对。
 	result.Points, result.Sampled = sampleAnalysisLatencyPoints(ttftValues, latencyValues)
+	result.P95TTFTMS = percentile.NearestRank(ttftValues, 0.95)
+	result.P95LatencyMS = percentile.NearestRank(latencyValues, 0.95)
 	return result
-}
-
-func analysisNearestRankPercentile(values []int64, percentile float64) int64 {
-	if len(values) == 0 {
-		return 0
-	}
-	sortedValues := append([]int64(nil), values...)
-	sort.Slice(sortedValues, func(i, j int) bool { return sortedValues[i] < sortedValues[j] })
-	index := int(math.Ceil(percentile*float64(len(sortedValues)))) - 1
-	if index < 0 {
-		index = 0
-	}
-	if index >= len(sortedValues) {
-		index = len(sortedValues) - 1
-	}
-	return sortedValues[index]
 }
 
 func sampleAnalysisLatencyPoints(ttftValues, latencyValues []int64) ([]dto.AnalysisLatencyPointRecord, bool) {

--- a/internal/repository/usage_test.go
+++ b/internal/repository/usage_test.go
@@ -123,12 +123,9 @@ func TestBuildAnalysisWithFilterUsesOverviewStatsWithoutUsageEvents(t *testing.T
 	if len(analysis.APIKeyComposition) != 1 || analysis.APIKeyComposition[0].Key != "sk-target-key" {
 		t.Fatalf("expected API composition from overview stats, got %+v", analysis.APIKeyComposition)
 	}
-	if analysis.LatencyDiagnostics.TotalPoints != 0 || len(analysis.LatencyDiagnostics.Points) != 0 {
-		t.Fatalf("expected empty latency diagnostics when usage_events is unavailable, got %+v", analysis.LatencyDiagnostics)
-	}
 }
 
-func TestBuildAnalysisWithFilterBuildsLatencyDiagnosticsFromUsageEvents(t *testing.T) {
+func TestBuildAnalysisLatencyDiagnosticsWithFilterBuildsFromUsageEvents(t *testing.T) {
 	db := openUsageTestDatabase(t)
 	start := time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC)
 	end := start.Add(time.Hour)
@@ -160,12 +157,10 @@ func TestBuildAnalysisWithFilterBuildsLatencyDiagnosticsFromUsageEvents(t *testi
 		t.Fatalf("InsertUsageEvents returned error: %v", err)
 	}
 
-	analysis, err := BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{StartTime: &start, EndTime: &end, APIGroupKey: "sk-target-key"})
+	diagnostics, err := BuildAnalysisLatencyDiagnosticsWithFilter(db, repodto.UsageQueryFilter{StartTime: &start, EndTime: &end, APIGroupKey: "sk-target-key"})
 	if err != nil {
-		t.Fatalf("BuildAnalysisWithFilter returned error: %v", err)
+		t.Fatalf("BuildAnalysisLatencyDiagnosticsWithFilter returned error: %v", err)
 	}
-
-	diagnostics := analysis.LatencyDiagnostics
 	if diagnostics.TotalPoints != 4 || diagnostics.Sampled {
 		t.Fatalf("expected four unsampled latency points, got %+v", diagnostics)
 	}
@@ -193,7 +188,7 @@ func TestBuildAnalysisLatencyDiagnosticsSamplesDisplayPointsFromFullValues(t *te
 		latencyValues = append(latencyValues, value*10)
 	}
 
-	diagnostics := buildAnalysisLatencyDiagnostics(ttftValues, latencyValues)
+	diagnostics := buildAnalysisLatencyDiagnostics(ttftValues, latencyValues, int64(count), int64(count*10))
 
 	if diagnostics.TotalPoints != int64(count) || !diagnostics.Sampled {
 		t.Fatalf("expected full count with sampled display points, got %+v", diagnostics)

--- a/internal/service/dto/analysis.go
+++ b/internal/service/dto/analysis.go
@@ -112,5 +112,4 @@ type AnalysisSnapshot struct {
 	Heatmap               []AnalysisHeatmapCell
 	CostBreakdown         AnalysisCostBreakdown
 	ModelEfficiency       []AnalysisModelEfficiencyItem
-	LatencyDiagnostics    AnalysisLatencyDiagnostics
 }

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -383,6 +383,27 @@ func (s *usageService) GetAnalysis(ctx context.Context, filter servicedto.UsageF
 	return mapAnalysisRecord(record), nil
 }
 
+func (s *usageService) GetAnalysisLatency(ctx context.Context, filter servicedto.UsageFilter) (*servicedto.AnalysisLatencyDiagnostics, error) {
+	ctx = usageServiceContext(ctx)
+	apiGroupKey, err := s.resolveAPIGroupKey(ctx, filter.APIKeyID)
+	if err != nil {
+		return nil, err
+	}
+	record, err := repository.BuildAnalysisLatencyDiagnosticsWithFilter(s.db.WithContext(ctx), repodto.UsageQueryFilter{
+		Range:        filter.Range,
+		CustomUnit:   filter.CustomUnit,
+		StartTime:    filter.StartTime,
+		EndTime:      filter.EndTime,
+		EndExclusive: filter.EndExclusive,
+		APIGroupKey:  apiGroupKey,
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := mapAnalysisLatencyDiagnosticsRecord(record)
+	return &result, nil
+}
+
 func mapAnalysisRecord(record *repodto.AnalysisRecord) *servicedto.AnalysisSnapshot {
 	if record == nil {
 		return &servicedto.AnalysisSnapshot{}
@@ -452,24 +473,6 @@ func mapAnalysisRecord(record *repodto.AnalysisRecord) *servicedto.AnalysisSnaps
 			CacheReadRate:          item.CacheReadRate,
 		})
 	}
-	latencyPoints := make([]servicedto.AnalysisLatencyPoint, 0, len(record.LatencyDiagnostics.Points))
-	for _, point := range record.LatencyDiagnostics.Points {
-		latencyPoints = append(latencyPoints, servicedto.AnalysisLatencyPoint{
-			TTFTMS:    point.TTFTMS,
-			LatencyMS: point.LatencyMS,
-		})
-	}
-	latencyDensity := make([]servicedto.AnalysisLatencyDensityCell, 0, len(record.LatencyDiagnostics.Density))
-	for _, cell := range record.LatencyDiagnostics.Density {
-		latencyDensity = append(latencyDensity, servicedto.AnalysisLatencyDensityCell{
-			TTFTMinMS:    cell.TTFTMinMS,
-			TTFTMaxMS:    cell.TTFTMaxMS,
-			LatencyMinMS: cell.LatencyMinMS,
-			LatencyMaxMS: cell.LatencyMaxMS,
-			Count:        cell.Count,
-			Intensity:    cell.Intensity,
-		})
-	}
 	return &servicedto.AnalysisSnapshot{
 		Granularity:           servicedto.AnalysisGranularity(record.Granularity),
 		RangeStart:            record.RangeStart,
@@ -489,16 +492,37 @@ func mapAnalysisRecord(record *repodto.AnalysisRecord) *servicedto.AnalysisSnaps
 			CostAvailable:        record.CostBreakdown.CostAvailable,
 		},
 		ModelEfficiency: modelEfficiency,
-		LatencyDiagnostics: servicedto.AnalysisLatencyDiagnostics{
-			Points:       latencyPoints,
-			Density:      latencyDensity,
-			TotalPoints:  record.LatencyDiagnostics.TotalPoints,
-			Sampled:      record.LatencyDiagnostics.Sampled,
-			P95TTFTMS:    record.LatencyDiagnostics.P95TTFTMS,
-			P95LatencyMS: record.LatencyDiagnostics.P95LatencyMS,
-			MaxTTFTMS:    record.LatencyDiagnostics.MaxTTFTMS,
-			MaxLatencyMS: record.LatencyDiagnostics.MaxLatencyMS,
-		},
+	}
+}
+
+func mapAnalysisLatencyDiagnosticsRecord(record repodto.AnalysisLatencyDiagnosticsRecord) servicedto.AnalysisLatencyDiagnostics {
+	points := make([]servicedto.AnalysisLatencyPoint, 0, len(record.Points))
+	for _, point := range record.Points {
+		points = append(points, servicedto.AnalysisLatencyPoint{
+			TTFTMS:    point.TTFTMS,
+			LatencyMS: point.LatencyMS,
+		})
+	}
+	density := make([]servicedto.AnalysisLatencyDensityCell, 0, len(record.Density))
+	for _, cell := range record.Density {
+		density = append(density, servicedto.AnalysisLatencyDensityCell{
+			TTFTMinMS:    cell.TTFTMinMS,
+			TTFTMaxMS:    cell.TTFTMaxMS,
+			LatencyMinMS: cell.LatencyMinMS,
+			LatencyMaxMS: cell.LatencyMaxMS,
+			Count:        cell.Count,
+			Intensity:    cell.Intensity,
+		})
+	}
+	return servicedto.AnalysisLatencyDiagnostics{
+		Points:       points,
+		Density:      density,
+		TotalPoints:  record.TotalPoints,
+		Sampled:      record.Sampled,
+		P95TTFTMS:    record.P95TTFTMS,
+		P95LatencyMS: record.P95LatencyMS,
+		MaxTTFTMS:    record.MaxTTFTMS,
+		MaxLatencyMS: record.MaxLatencyMS,
 	}
 }
 

--- a/internal/service/usage_service.go
+++ b/internal/service/usage_service.go
@@ -14,4 +14,5 @@ type UsageProvider interface {
 	StreamUsageEvents(context.Context, servicedto.UsageFilter, func(servicedto.UsageEventRecord) error) error
 	ListUsageEventFilterOptions(context.Context, servicedto.UsageFilter) (*servicedto.UsageEventFilterOptions, error)
 	GetAnalysis(context.Context, servicedto.UsageFilter) (*servicedto.AnalysisSnapshot, error)
+	GetAnalysisLatency(context.Context, servicedto.UsageFilter) (*servicedto.AnalysisLatencyDiagnostics, error)
 }

--- a/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
@@ -3,7 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Interaction, Tooltip } from 'chart.js';
 import type { ChartData, ChartOptions, Plugin } from 'chart.js';
-import type { AnalysisResponse } from '@/lib/types';
+import type { AnalysisLatencyDiagnostics, AnalysisResponse } from '@/lib/types';
 
 type TokenAverageLinePluginOptions = {
   value: number;
@@ -138,16 +138,6 @@ const emptyAnalysis: AnalysisResponse = {
     api_key_labels: {},
     models: [],
     cells: [],
-  },
-  latency_diagnostics: {
-    points: [],
-    density: [],
-    total_points: 0,
-    sampled: false,
-    p95_ttft_ms: 0,
-    p95_latency_ms: 0,
-    max_ttft_ms: 0,
-    max_latency_ms: 0,
   },
 };
 
@@ -746,32 +736,29 @@ describe('AnalysisPanel token chart data', () => {
   });
 
   it('renders latency diagnostics scatter before usage distribution', () => {
-    const analysis: AnalysisResponse = {
-      ...emptyAnalysis,
-      latency_diagnostics: {
-        total_points: 3,
-        sampled: false,
-        p95_ttft_ms: 300,
-        p95_latency_ms: 1400,
-        max_ttft_ms: 900,
-        max_latency_ms: 3600,
-        points: [
-          { ttft_ms: 120, latency_ms: 800 },
-          { ttft_ms: 300, latency_ms: 1400 },
-          { ttft_ms: 900, latency_ms: 3600 },
-        ],
-        density: [{
-          ttft_min_ms: 0,
-          ttft_max_ms: 400,
-          latency_min_ms: 0,
-          latency_max_ms: 1800,
-          count: 2,
-          intensity: 1,
-        }],
-      },
+    const latencyDiagnostics: AnalysisLatencyDiagnostics = {
+      total_points: 3,
+      sampled: false,
+      p95_ttft_ms: 300,
+      p95_latency_ms: 1400,
+      max_ttft_ms: 900,
+      max_latency_ms: 3600,
+      points: [
+        { ttft_ms: 120, latency_ms: 800 },
+        { ttft_ms: 300, latency_ms: 1400 },
+        { ttft_ms: 900, latency_ms: 3600 },
+      ],
+      density: [{
+        ttft_min_ms: 0,
+        ttft_max_ms: 400,
+        latency_min_ms: 0,
+        latency_max_ms: 1800,
+        count: 2,
+        intensity: 1,
+      }],
     };
 
-    const markup = renderToStaticMarkup(<AnalysisPanel analysis={analysis} loading={false} isDark={false} isMobile={false} />);
+    const markup = renderToStaticMarkup(<AnalysisPanel analysis={emptyAnalysis} loading={false} latencyDiagnostics={latencyDiagnostics} isDark={false} isMobile={false} />);
 
     expect(markup).toContain('usage_stats.analysis_latency_title');
     expect(markup.indexOf('usage_stats.analysis_latency_title')).toBeLessThan(markup.indexOf('usage_stats.analysis_composition_title'));
@@ -949,21 +936,18 @@ describe('AnalysisPanel token chart data', () => {
       ttft_ms: index + 1,
       latency_ms: (index + 1) * 2,
     }));
-    const analysis: AnalysisResponse = {
-      ...emptyAnalysis,
-      latency_diagnostics: {
-        total_points: points.length,
-        sampled: true,
-        p95_ttft_ms: 142_500,
-        p95_latency_ms: 285_000,
-        max_ttft_ms: 150_000,
-        max_latency_ms: 300_000,
-        points,
-        density: [],
-      },
+    const latencyDiagnostics: AnalysisLatencyDiagnostics = {
+      total_points: points.length,
+      sampled: true,
+      p95_ttft_ms: 142_500,
+      p95_latency_ms: 285_000,
+      max_ttft_ms: 150_000,
+      max_latency_ms: 300_000,
+      points,
+      density: [],
     };
 
-    expect(() => renderToStaticMarkup(<AnalysisPanel analysis={analysis} loading={false} isDark={false} isMobile={false} />)).not.toThrow();
+    expect(() => renderToStaticMarkup(<AnalysisPanel analysis={emptyAnalysis} loading={false} latencyDiagnostics={latencyDiagnostics} isDark={false} isMobile={false} />)).not.toThrow();
     const latencyScatterIndex = chartCapture.scatterData.findIndex((data) => data.datasets[0]?.label === 'usage_stats.analysis_latency_samples');
     expect(latencyScatterIndex).toBeGreaterThanOrEqual(0);
     const latencyScatterOptions = chartCapture.scatterOptions[latencyScatterIndex];
@@ -972,28 +956,25 @@ describe('AnalysisPanel token chart data', () => {
   });
 
   it('uses theme-aware lighter colors for latency diagnostics', () => {
-    const analysis: AnalysisResponse = {
-      ...emptyAnalysis,
-      latency_diagnostics: {
-        total_points: 1,
-        sampled: false,
-        p95_ttft_ms: 240,
-        p95_latency_ms: 1200,
-        max_ttft_ms: 240,
-        max_latency_ms: 1200,
-        points: [{ ttft_ms: 240, latency_ms: 1200 }],
-        density: [{
-          ttft_min_ms: 100,
-          ttft_max_ms: 300,
-          latency_min_ms: 800,
-          latency_max_ms: 1400,
-          count: 1,
-          intensity: 1,
-        }],
-      },
+    const latencyDiagnostics: AnalysisLatencyDiagnostics = {
+      total_points: 1,
+      sampled: false,
+      p95_ttft_ms: 240,
+      p95_latency_ms: 1200,
+      max_ttft_ms: 240,
+      max_latency_ms: 1200,
+      points: [{ ttft_ms: 240, latency_ms: 1200 }],
+      density: [{
+        ttft_min_ms: 100,
+        ttft_max_ms: 300,
+        latency_min_ms: 800,
+        latency_max_ms: 1400,
+        count: 1,
+        intensity: 1,
+      }],
     };
 
-    renderToStaticMarkup(<AnalysisPanel analysis={analysis} loading={false} isDark={false} isMobile={false} />);
+    renderToStaticMarkup(<AnalysisPanel analysis={emptyAnalysis} loading={false} latencyDiagnostics={latencyDiagnostics} isDark={false} isMobile={false} />);
     const lightScatterIndex = chartCapture.scatterData.findIndex((data) => data.datasets[0]?.label === 'usage_stats.analysis_latency_samples');
     const lightData = chartCapture.scatterData[lightScatterIndex];
     const lightOptions = chartCapture.scatterOptions[lightScatterIndex];
@@ -1001,7 +982,7 @@ describe('AnalysisPanel token chart data', () => {
     chartCapture.scatterData = [];
     chartCapture.scatterOptions = [];
     chartCapture.scatterPlugins = [];
-    renderToStaticMarkup(<AnalysisPanel analysis={analysis} loading={false} isDark isMobile={false} />);
+    renderToStaticMarkup(<AnalysisPanel analysis={emptyAnalysis} loading={false} latencyDiagnostics={latencyDiagnostics} isDark isMobile={false} />);
     const darkScatterIndex = chartCapture.scatterData.findIndex((data) => data.datasets[0]?.label === 'usage_stats.analysis_latency_samples');
     const darkData = chartCapture.scatterData[darkScatterIndex];
     const darkOptions = chartCapture.scatterOptions[darkScatterIndex];

--- a/web/src/components/usage/analysis/AnalysisPanel.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.tsx
@@ -11,6 +11,9 @@ import styles from './AnalysisPanel.module.scss';
 interface AnalysisPanelProps {
   analysis: AnalysisResponse | null;
   loading: boolean;
+  latencyDiagnostics?: AnalysisLatencyDiagnostics | null;
+  latencyLoading?: boolean;
+  latencyError?: string;
   isDark: boolean;
   isMobile: boolean;
 }
@@ -1249,7 +1252,7 @@ function buildLatencyDiagnosticsChartOptions({
   };
 }
 
-function LatencyDiagnosticsCard({ diagnostics, loading, isDark, isMobile }: { diagnostics: AnalysisLatencyDiagnostics | undefined; loading: boolean; isDark: boolean; isMobile: boolean }) {
+function LatencyDiagnosticsCard({ diagnostics, loading, error, isDark, isMobile }: { diagnostics: AnalysisLatencyDiagnostics | null | undefined; loading: boolean; error: string; isDark: boolean; isMobile: boolean }) {
   const { t } = useTranslation();
   const safeDiagnostics = diagnostics ?? emptyLatencyDiagnostics();
   const chartTheme = useMemo(() => getChartTheme(isDark), [isDark]);
@@ -1280,6 +1283,8 @@ function LatencyDiagnosticsCard({ diagnostics, loading, isDark, isMobile }: { di
       />
       {loading ? (
         <div className={styles.emptyState}>{t('common.loading')}</div>
+      ) : error ? (
+        <div className={styles.emptyState}>{error}</div>
       ) : !hasData ? (
         <div className={styles.emptyState}>{t('usage_stats.no_data')}</div>
       ) : (
@@ -2087,7 +2092,7 @@ function Heatmap({ cells, apiKeys, apiKeyLabels, models, loading, isDark }: { ce
   );
 }
 
-export function AnalysisPanel({ analysis, loading, isDark, isMobile }: AnalysisPanelProps) {
+export function AnalysisPanel({ analysis, loading, latencyDiagnostics, latencyLoading = false, latencyError = '', isDark, isMobile }: AnalysisPanelProps) {
   const { t } = useTranslation();
   const tokenRows = useMemo(() => buildTokenUsageRows(analysis?.token_usage ?? [], analysis?.granularity ?? 'hourly', analysis?.timezone), [analysis]);
   const apiComposition = useMemo(() => takeMajorComposition(analysis?.api_key_composition ?? [], t('usage_stats.analysis_others')), [analysis, t]);
@@ -2109,7 +2114,7 @@ export function AnalysisPanel({ analysis, loading, isDark, isMobile }: AnalysisP
         <CostBreakdownCard breakdown={analysis?.cost_breakdown} rows={tokenRows} loading={loading} />
         <ModelEfficiencyCard rows={analysis?.model_efficiency ?? []} loading={loading} isDark={isDark} isMobile={isMobile} />
       </div>
-      <LatencyDiagnosticsCard diagnostics={analysis?.latency_diagnostics} loading={loading} isDark={isDark} isMobile={isMobile} />
+      <LatencyDiagnosticsCard diagnostics={latencyDiagnostics} loading={latencyLoading} error={latencyError} isDark={isDark} isMobile={isMobile} />
       <CompositionPanel tabs={compositionTabs} loading={loading} isDark={isDark} windowMinutes={analysisWindowMinutes} />
       <Heatmap cells={analysis?.heatmap?.cells ?? []} apiKeys={analysis?.heatmap?.api_keys ?? []} apiKeyLabels={analysis?.heatmap?.api_key_labels ?? {}} models={analysis?.heatmap?.models ?? []} loading={loading} isDark={isDark} />
     </div>

--- a/web/src/components/usage/analysis/test/AnalysisPanel.cost-breakdown.test.tsx
+++ b/web/src/components/usage/analysis/test/AnalysisPanel.cost-breakdown.test.tsx
@@ -69,16 +69,6 @@ const analysis: AnalysisResponse = {
     models: [],
     cells: [],
   },
-  latency_diagnostics: {
-    points: [],
-    density: [],
-    total_points: 0,
-    sampled: false,
-    p95_ttft_ms: 0,
-    p95_latency_ms: 0,
-    max_ttft_ms: 0,
-    max_latency_ms: 0,
-  },
 };
 
 describe('AnalysisPanel cost breakdown summary', () => {

--- a/web/src/components/usage/analysis/test/AnalysisPanel.heatmap-fixed-columns.test.tsx
+++ b/web/src/components/usage/analysis/test/AnalysisPanel.heatmap-fixed-columns.test.tsx
@@ -51,16 +51,6 @@ const analysis: AnalysisResponse = {
     cost_available: true,
   },
   model_efficiency: [],
-  latency_diagnostics: {
-    points: [],
-    density: [],
-    total_points: 0,
-    sampled: false,
-    p95_ttft_ms: 0,
-    p95_latency_ms: 0,
-    max_ttft_ms: 0,
-    max_latency_ms: 0,
-  },
   heatmap: {
     api_keys: ['key-1'],
     api_key_labels: { 'key-1': 'Primary Production Key' },

--- a/web/src/components/usage/analysis/test/AnalysisPanel.latency.test.tsx
+++ b/web/src/components/usage/analysis/test/AnalysisPanel.latency.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import type { AnalysisResponse } from '@/lib/types';
+
+vi.mock('react-chartjs-2', () => ({
+  Bar: () => React.createElement('div'),
+  Doughnut: () => React.createElement('div'),
+  Scatter: () => React.createElement('div'),
+}));
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { AnalysisPanel } from '../AnalysisPanel';
+
+const analysis: AnalysisResponse = {
+  granularity: 'hourly',
+  timezone: 'UTC',
+  token_usage: [],
+  api_key_composition: [],
+  model_composition: [],
+  auth_files_composition: [],
+  ai_provider_composition: [],
+  cost_breakdown: {
+    uncached_input_cost_usd: 0,
+    cache_read_cost_usd: 0,
+    cache_write_cost_usd: 0,
+    output_cost_usd: 0,
+    total_cost_usd: 0,
+    cost_available: true,
+  },
+  model_efficiency: [],
+  heatmap: { api_keys: [], api_key_labels: {}, models: [], cells: [] },
+};
+
+describe('AnalysisPanel latency loading boundary', () => {
+  it('keeps core cards settled while only the latency card is loading', () => {
+    const markup = renderToStaticMarkup(
+      <AnalysisPanel
+        analysis={analysis}
+        loading={false}
+        latencyDiagnostics={null}
+        latencyLoading
+        latencyError=""
+        isDark={false}
+        isMobile={false}
+      />,
+    );
+
+    const latencyStart = markup.indexOf('usage_stats.analysis_latency_title');
+    const compositionStart = markup.indexOf('usage_stats.analysis_composition_title', latencyStart);
+    const latencyMarkup = markup.slice(latencyStart, compositionStart);
+    expect(latencyStart).toBeGreaterThan(-1);
+    expect(latencyMarkup).toContain('common.loading');
+    expect(markup.slice(0, latencyStart)).not.toContain('common.loading');
+  });
+
+  it('shows a latency-only error without replacing the core panel', () => {
+    const markup = renderToStaticMarkup(
+      <AnalysisPanel
+        analysis={analysis}
+        loading={false}
+        latencyDiagnostics={null}
+        latencyLoading={false}
+        latencyError="latency failed"
+        isDark={false}
+        isMobile={false}
+      />,
+    );
+
+    expect(markup).toContain('usage_stats.analysis_token_usage_title');
+    expect(markup).toContain('usage_stats.analysis_latency_title');
+    expect(markup).toContain('latency failed');
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { type AnalysisResponse, type AuthFilesManagementResponse, type AuthManagedSessionsResponse, type AuthSessionResponse, type CpaApiKeyDisplayItem, type CpaApiKeyOptionsResponse, type CpaApiKeySettingsResponse, type CpaApiKeysResponse, type OverviewRealtimeBlock, type OverviewRealtimeWindow, type PricingEntry, type PricingResponse, type PricingSyncPreviewResponse, type QuotaAutoRefreshSettings, type StatusResponse, type UpdateCheckResponse, type UsageActivityRequest, type UsageActivityResponse, type UsageEventModelFilterOptionsResponse, type UsageEventRequestLogResponse, type UsageEventSourceFilterOptionsResponse, type UsageRangeRequest, type UsedModelsResponse, type UsageIdentitiesPageResponse, type UsageIdentitiesResponse, type UsageEventsResponse, type UsageIdentity, type UsageIdentityAuthType, type UsageOverviewResponse, type UsageQuotaCacheResponse, type UsageQuotaInspectionStatusResponse, type UsageQuotaRefreshResponse, type UsageQuotaRefreshTaskResponse, type UsageQuotaResetCreditsResponse, type UsageQuotaResetResponse, type VersionResponse } from './types'
+import { type AnalysisLatencyDiagnostics, type AnalysisResponse, type AuthFilesManagementResponse, type AuthManagedSessionsResponse, type AuthSessionResponse, type CpaApiKeyDisplayItem, type CpaApiKeyOptionsResponse, type CpaApiKeySettingsResponse, type CpaApiKeysResponse, type OverviewRealtimeBlock, type OverviewRealtimeWindow, type PricingEntry, type PricingResponse, type PricingSyncPreviewResponse, type QuotaAutoRefreshSettings, type StatusResponse, type UpdateCheckResponse, type UsageActivityRequest, type UsageActivityResponse, type UsageEventModelFilterOptionsResponse, type UsageEventRequestLogResponse, type UsageEventSourceFilterOptionsResponse, type UsageRangeRequest, type UsedModelsResponse, type UsageIdentitiesPageResponse, type UsageIdentitiesResponse, type UsageEventsResponse, type UsageIdentity, type UsageIdentityAuthType, type UsageOverviewResponse, type UsageQuotaCacheResponse, type UsageQuotaInspectionStatusResponse, type UsageQuotaRefreshResponse, type UsageQuotaRefreshTaskResponse, type UsageQuotaResetCreditsResponse, type UsageQuotaResetResponse, type VersionResponse } from './types'
 import { isCPAMCEmbed } from '@/embed/cpamcEmbed'
 import { resolveUsageRequestRange } from '@/utils/usage/rangeQuery'
 
@@ -704,6 +704,19 @@ export async function fetchAnalysis(request: UsageRangeRequest, signal?: AbortSi
   return response.json()
 }
 
+export async function fetchAnalysisLatency(request: UsageRangeRequest, signal?: AbortSignal, apiKeyId?: string): Promise<AnalysisLatencyDiagnostics> {
+  const params = buildUsageRangeParams(request)
+  const selectedAPIKeyId = apiKeyId?.trim()
+  if (selectedAPIKeyId) {
+    params.set('api_key_id', selectedAPIKeyId)
+  }
+  const query = params.toString()
+  const response = await apiFetch(`${apiPath('/usage/analysis/latency')}${query ? `?${query}` : ''}`, { signal })
+  if (!response.ok) {
+    await parseApiError(response, `Failed to load analysis latency: ${response.status}`)
+  }
+  return response.json()
+}
 
 export async function fetchCpaApiKeyOptions(signal?: AbortSignal): Promise<CpaApiKeyOptionsResponse> {
   const response = await apiFetch(apiPath('/usage/api-keys/options'), { signal, cache: 'no-store' })

--- a/web/src/lib/test/api.test.ts
+++ b/web/src/lib/test/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { appPath, createUsageEventRequestLogDownloadURL, deleteAuthFiles, exportUsageEvents, fetchAnalysis, fetchAuthSessions, fetchCpaApiKeyOptions, fetchCpaApiKeys, fetchCpaApiKeySettings, fetchKeyActivity, fetchKeyOverview, fetchKeyOverviewRealtime, fetchQuotaAutoRefreshSettings, fetchUsageActivity, fetchUsageOverview, fetchUsageOverviewRealtime, fetchUsageQuotaCache, fetchUsageQuotaInspectionStatus, fetchUsageQuotaResetCredits, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventRequestLog, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchUsageIdentities, fetchUsageIdentitiesPage, fetchUsageQuotaRefreshTask, fetchVersion, loginWithCPAAPIKey, logout, refreshUsageQuotas, resetUsageQuota, revokeAuthSession, setAuthFilesDisabled, startUsageQuotaInspection, updateCpaApiKeyAlias, updateQuotaAutoRefreshSettings } from '../api';
+import { appPath, createUsageEventRequestLogDownloadURL, deleteAuthFiles, exportUsageEvents, fetchAnalysis, fetchAnalysisLatency, fetchAuthSessions, fetchCpaApiKeyOptions, fetchCpaApiKeys, fetchCpaApiKeySettings, fetchKeyActivity, fetchKeyOverview, fetchKeyOverviewRealtime, fetchQuotaAutoRefreshSettings, fetchUsageActivity, fetchUsageOverview, fetchUsageOverviewRealtime, fetchUsageQuotaCache, fetchUsageQuotaInspectionStatus, fetchUsageQuotaResetCredits, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventRequestLog, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchUsageIdentities, fetchUsageIdentitiesPage, fetchUsageQuotaRefreshTask, fetchVersion, loginWithCPAAPIKey, logout, refreshUsageQuotas, resetUsageQuota, revokeAuthSession, setAuthFilesDisabled, startUsageQuotaInspection, updateCpaApiKeyAlias, updateQuotaAutoRefreshSettings } from '../api';
 
 const headerValue = (init: RequestInit | undefined, name: string): string | null => new Headers(init?.headers).get(name);
 
@@ -489,6 +489,28 @@ describe('fetchUsageEvents', () => {
     expect(analysisUrl.searchParams.get('start')).toBe('2026-04-20');
     expect(analysisUrl.searchParams.get('end')).toBe('2026-04-21');
     expect(analysisUrl.searchParams.get('api_key_id')).toBe('9007199254740993');
+    expect(Array.from(analysisUrl.searchParams.keys())).toEqual(['range', 'unit', 'start', 'end', 'api_key_id']);
+    expect(fetchAnalysis).toHaveLength(3);
+  });
+
+  it('loads Analysis latency from its independent endpoint with the same filters', async () => {
+    vi.stubGlobal('window', { __APP_BASE_PATH__: undefined });
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ points: [], density: [], total_points: 0 }),
+    } as Response);
+    const signal = new AbortController().signal;
+
+    await fetchAnalysisLatency({ range: 'custom', unit: 'day', start: '2026-04-20', end: '2026-04-21' }, signal, '9007199254740993');
+
+    const latencyUrl = new URL(String(fetchMock.mock.calls[0][0]), 'http://localhost');
+    expect(latencyUrl.pathname).toBe('/api/v1/usage/analysis/latency');
+    expect(latencyUrl.searchParams.get('range')).toBe('custom');
+    expect(latencyUrl.searchParams.get('start')).toBe('2026-04-20');
+    expect(latencyUrl.searchParams.get('end')).toBe('2026-04-21');
+    expect(latencyUrl.searchParams.get('api_key_id')).toBe('9007199254740993');
+    expect(Array.from(latencyUrl.searchParams.keys())).toEqual(['range', 'unit', 'start', 'end', 'api_key_id']);
+    expect(fetchAnalysisLatency).toHaveLength(3);
   });
 
   it('loads a usage event request log by event id', async () => {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -628,7 +628,6 @@ export interface AnalysisResponse {
   heatmap: AnalysisHeatmapPayload
   cost_breakdown: AnalysisCostBreakdown
   model_efficiency: AnalysisModelEfficiencyItem[]
-  latency_diagnostics: AnalysisLatencyDiagnostics
 }
 
 export interface CpaApiKeyDisplayItem {

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ApiError, createUsageEventRequestLogDownloadURL, exportUsageEvents, fetchAnalysis, fetchAuthSessions, fetchCpaApiKeyOptions, fetchCpaApiKeySettings, fetchStatus, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventRequestLog, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchVersion, logout, revokeAuthSession, updateCpaApiKeyAlias, type UsageEventsExportFormat } from '@/lib/api';
-import type { AnalysisResponse, AuthManagedSessionItem, CpaApiKeyOption, CpaApiKeySettingsItem, OverviewRealtimeWindow, StatusResponse, UsageCustomRange, UsageEvent, UsageEventRequestLogResponse, UsageSourceFilterOption, UsageTimeRange, VersionResponse } from '@/lib/types';
+import { ApiError, createUsageEventRequestLogDownloadURL, exportUsageEvents, fetchAnalysis, fetchAnalysisLatency, fetchAuthSessions, fetchCpaApiKeyOptions, fetchCpaApiKeySettings, fetchStatus, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventRequestLog, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchVersion, logout, revokeAuthSession, updateCpaApiKeyAlias, type UsageEventsExportFormat } from '@/lib/api';
+import type { AnalysisLatencyDiagnostics, AnalysisResponse, AuthManagedSessionItem, CpaApiKeyOption, CpaApiKeySettingsItem, OverviewRealtimeWindow, StatusResponse, UsageCustomRange, UsageEvent, UsageEventRequestLogResponse, UsageSourceFilterOption, UsageTimeRange, VersionResponse } from '@/lib/types';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { LanguageSwitcher } from '@/components/ui/LanguageSwitcher';
 import { Select } from '@/components/ui/Select';
@@ -78,6 +78,29 @@ const CPA_MANAGEMENT_PAGE = 'management.html';
 const ABSOLUTE_HTTP_URL_PATTERN = /^https?:\/\//i;
 const EXPLICIT_URL_SCHEME_PATTERN = /^[a-z][a-z\d+.-]*:/i;
 const BARE_HOST_WITH_PORT_PATTERN = /^[a-z0-9.-]+:\d+(?:[/?#]|$)/i;
+
+type AnalysisSectionLoadOptions<TCore, TLatency> = {
+  loadCore: () => Promise<TCore>;
+  loadLatency: () => Promise<TLatency>;
+  onCoreLoaded: (value: TCore) => void;
+  onCoreError: (error: unknown) => void;
+  onLatencyLoaded: (value: TLatency) => void;
+  onLatencyError: (error: unknown) => void;
+};
+
+// 两个 Analysis 数据源同时启动，但各自完成后立即更新对应卡片，避免慢接口阻塞快接口展示。
+export const loadAnalysisSections = async <TCore, TLatency>({
+  loadCore,
+  loadLatency,
+  onCoreLoaded,
+  onCoreError,
+  onLatencyLoaded,
+  onLatencyError,
+}: AnalysisSectionLoadOptions<TCore, TLatency>) => {
+  const coreRequest = loadCore().then(onCoreLoaded, onCoreError);
+  const latencyRequest = loadLatency().then(onLatencyLoaded, onLatencyError);
+  await Promise.all([coreRequest, latencyRequest]);
+};
 
 export const getCredentialSectionVisibility = (tab: UsageTab) => ({
   enabled: tab === 'auth-files' || tab === 'ai-provider',
@@ -884,6 +907,9 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   const [analysisLoading, setAnalysisLoading] = useState(false);
   const [analysisError, setAnalysisError] = useState('');
   const [analysisData, setAnalysisData] = useState<AnalysisResponse | null>(null);
+  const [analysisLatencyLoading, setAnalysisLatencyLoading] = useState(false);
+  const [analysisLatencyError, setAnalysisLatencyError] = useState('');
+  const [analysisLatencyData, setAnalysisLatencyData] = useState<AnalysisLatencyDiagnostics | null>(null);
   const analysisRequestControllerRef = useRef<AbortController | null>(null);
 
   const tabOptions = useMemo(() => getUsageTabOptions(t), [t]);
@@ -1062,29 +1088,47 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     setAnalysisLoading(true);
     setAnalysisError('');
     setAnalysisData(null);
-    try {
-      const response = await fetchAnalysis(usageRangeQuery, controller.signal, selectedApiKeyId);
-      if (analysisRequestControllerRef.current !== controller) {
-        return;
-      }
-      setAnalysisData(response);
-    } catch (error) {
-      if (controller.signal.aborted) {
-        return;
-      }
-      if (analysisRequestControllerRef.current === controller) {
-        setAnalysisData(null);
-      }
-      if (error instanceof ApiError && error.status === 401) {
-        onAuthRequired?.();
-        return;
-      }
-      setAnalysisError(error instanceof Error ? error.message : 'Failed to load usage analysis');
-    } finally {
-      if (analysisRequestControllerRef.current === controller) {
+    setAnalysisLatencyLoading(true);
+    setAnalysisLatencyError('');
+    setAnalysisLatencyData(null);
+
+    await loadAnalysisSections({
+      loadCore: () => fetchAnalysis(usageRangeQuery, controller.signal, selectedApiKeyId),
+      loadLatency: () => fetchAnalysisLatency(usageRangeQuery, controller.signal, selectedApiKeyId),
+      onCoreLoaded: (response) => {
+        if (analysisRequestControllerRef.current !== controller) return;
+        setAnalysisData(response);
         setAnalysisLoading(false);
-        analysisRequestControllerRef.current = null;
-      }
+      },
+      onCoreError: (error) => {
+        if (controller.signal.aborted || analysisRequestControllerRef.current !== controller) return;
+        setAnalysisData(null);
+        setAnalysisLoading(false);
+        if (error instanceof ApiError && error.status === 401) {
+          onAuthRequired?.();
+          return;
+        }
+        setAnalysisError(error instanceof Error ? error.message : 'Failed to load usage analysis');
+      },
+      onLatencyLoaded: (response) => {
+        if (analysisRequestControllerRef.current !== controller) return;
+        setAnalysisLatencyData(response);
+        setAnalysisLatencyLoading(false);
+      },
+      onLatencyError: (error) => {
+        if (controller.signal.aborted || analysisRequestControllerRef.current !== controller) return;
+        setAnalysisLatencyData(null);
+        setAnalysisLatencyLoading(false);
+        if (error instanceof ApiError && error.status === 401) {
+          onAuthRequired?.();
+          return;
+        }
+        setAnalysisLatencyError(error instanceof Error ? error.message : 'Failed to load analysis latency');
+      },
+    });
+
+    if (analysisRequestControllerRef.current === controller) {
+      analysisRequestControllerRef.current = null;
     }
   }, [onAuthRequired, selectedApiKeyId, usageRangeQuery]);
 
@@ -1589,6 +1633,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
       analysisRequestControllerRef.current?.abort();
       analysisRequestControllerRef.current = null;
       setAnalysisLoading(false);
+      setAnalysisLatencyLoading(false);
       return;
     }
     void loadAnalysis();
@@ -1918,7 +1963,15 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
             {activeTab === 'analysis' && (
               <>
                 {analysisError && <div className={styles.errorBox}>{analysisError}</div>}
-                <AnalysisPanel analysis={analysisData} loading={analysisLoading} isDark={isDark} isMobile={isMobile} />
+                <AnalysisPanel
+                  analysis={analysisData}
+                  loading={analysisLoading}
+                  latencyDiagnostics={analysisLatencyData}
+                  latencyLoading={analysisLatencyLoading}
+                  latencyError={analysisLatencyError}
+                  isDark={isDark}
+                  isMobile={isMobile}
+                />
               </>
             )}
 

--- a/web/src/pages/test/UsagePage.logic.test.ts
+++ b/web/src/pages/test/UsagePage.logic.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getBackToCPALinkURL, getCredentialSectionVisibility, getOverviewDisplayLoading, getUsageTabOptions, isUsagePageVisible, loadRequestEventsPreferences, loadUsagePageVersionInfo, normalizeRequestEventsPreferences, normalizeUsageTabValue, refreshPageData, REQUEST_EVENTS_PREFERENCES_STORAGE_KEY, runUsageEventRequestLogDownload, sanitizeRequestEventFilters, saveRequestEventsPreferences, scheduleOverviewAutoRefresh, shouldAutoRefreshUsageTab, shouldShowApiKeyFilter, shouldShowRangeControls, shouldShowUpdateCheckButton, getUpdateCheckToastDuration } from '../UsagePage';
+import { getBackToCPALinkURL, getCredentialSectionVisibility, getOverviewDisplayLoading, getUsageTabOptions, isUsagePageVisible, loadAnalysisSections, loadRequestEventsPreferences, loadUsagePageVersionInfo, normalizeRequestEventsPreferences, normalizeUsageTabValue, refreshPageData, REQUEST_EVENTS_PREFERENCES_STORAGE_KEY, runUsageEventRequestLogDownload, sanitizeRequestEventFilters, saveRequestEventsPreferences, scheduleOverviewAutoRefresh, shouldAutoRefreshUsageTab, shouldShowApiKeyFilter, shouldShowRangeControls, shouldShowUpdateCheckButton, getUpdateCheckToastDuration } from '../UsagePage';
 import { REQUEST_EVENT_COLUMN_IDS } from '@/components/usage/RequestEventsDetailsCard';
 import { ApiError } from '@/lib/api';
 import type { UsageFilterWindow, VersionResponse } from '@/lib/types';
@@ -47,6 +47,46 @@ describe('UsagePage Overview loading display', () => {
 
   it('shows loading before Overview data has loaded', () => {
     expect(getOverviewDisplayLoading({ loading: true, hasUsage: false })).toBe(true);
+  });
+});
+
+describe('UsagePage Analysis section loading', () => {
+  it('starts core and latency requests together and publishes each result independently', async () => {
+    let resolveCore: (value: 'core') => void = () => undefined;
+    let rejectLatency: (reason: Error) => void = () => undefined;
+    const loadCore = vi.fn(() => new Promise<'core'>((resolve) => {
+      resolveCore = resolve;
+    }));
+    const loadLatency = vi.fn(() => new Promise<'latency'>((_resolve, reject) => {
+      rejectLatency = reject;
+    }));
+    const onCoreLoaded = vi.fn();
+    const onCoreError = vi.fn();
+    const onLatencyLoaded = vi.fn();
+    const onLatencyError = vi.fn();
+
+    const loading = loadAnalysisSections({
+      loadCore,
+      loadLatency,
+      onCoreLoaded,
+      onCoreError,
+      onLatencyLoaded,
+      onLatencyError,
+    });
+
+    expect(loadCore).toHaveBeenCalledOnce();
+    expect(loadLatency).toHaveBeenCalledOnce();
+
+    resolveCore('core');
+    await flushPromises();
+    expect(onCoreLoaded).toHaveBeenCalledWith('core');
+    expect(onLatencyLoaded).not.toHaveBeenCalled();
+
+    const latencyError = new Error('latency failed');
+    rejectLatency(latencyError);
+    await loading;
+    expect(onCoreError).not.toHaveBeenCalled();
+    expect(onLatencyError).toHaveBeenCalledWith(latencyError);
   });
 });
 

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -122,6 +122,7 @@ describe('UsagePage toolbar styles', () => {
     expect(usagePageSource).toContain('customRange={customRange}')
     expect(usagePageSource).toContain('onChange={handleTimeRangeChange}')
     expect(usagePageSource).toContain('fetchAnalysis(usageRangeQuery, controller.signal, selectedApiKeyId)')
+    expect(usagePageSource).toContain('fetchAnalysisLatency(usageRangeQuery, controller.signal, selectedApiKeyId)')
     expect(usagePageSource).toContain('fetchUsageEvents(usageRangeQuery, controller.signal, {')
     expect(usagePageSource).toContain('exportUsageEvents(usageRangeQuery, format, {')
 
@@ -530,15 +531,21 @@ describe('UsagePage toolbar styles', () => {
     expect(usagePageStyles).not.toContain('.apiKeyFilterGroupHidden')
   })
 
-  it('uses the new Analysis panel and endpoint instead of the old detail tables', () => {
+  it('loads core and latency Analysis sections through independent endpoints', () => {
     expect(usagePageSource).toContain('fetchAnalysis')
+    expect(usagePageSource).toContain('fetchAnalysisLatency')
     expect(usagePageSource).toContain('<AnalysisPanel')
+    expect(usagePageSource).toContain('latencyDiagnostics={analysisLatencyData}')
+    expect(usagePageSource).toContain('latencyLoading={analysisLatencyLoading}')
+    expect(usagePageSource).toContain('latencyError={analysisLatencyError}')
     expect(usagePageSource).not.toContain('fetchUsageAnalysis')
     expect(usagePageSource).not.toContain('<ApiDetailsCard')
     expect(usagePageSource).not.toContain('<ModelStatsCard')
     expect(apiIndexSource).not.toContain('ApiDetailsCard')
     expect(apiIndexSource).not.toContain('ModelStatsCard')
     expect(apiClientSource).toContain("apiPath('/usage/analysis')")
+    expect(apiClientSource).toContain("apiPath('/usage/analysis/latency')")
+    expect(typesSource).not.toContain('latency_diagnostics: AnalysisLatencyDiagnostics')
   })
 
   it('renames the Analysis tab label and places it before Request Events', () => {


### PR DESCRIPTION
## Summary

- split latency diagnostics into /api/v1/usage/analysis/latency so aggregated Analysis data no longer performs the raw usage_events scan
- compute exact nearest-rank P95 with bounded selection and preserve deterministic sample pairing
- load core and latency sections concurrently with independent loading and error states, while keeping both APIs stateless

## Validation

- rtk env TZ=UTC GOCACHE=/tmp/cpa-usage-keeper-go-build GOFLAGS=-count=1 make verify
- targeted latency diagnostics tests under TZ=UTC and TZ=Asia/Shanghai

## Notes

- keeps the existing SQLite single-connection configuration unchanged