### PR TITLE
perf(overview): optimize custom range queries

### DIFF
--- a/internal/api/test/usage_overview_long_custom_range_test.go
+++ b/internal/api/test/usage_overview_long_custom_range_test.go
@@ -1,0 +1,99 @@
+package test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	. "cpa-usage-keeper/internal/api"
+	"cpa-usage-keeper/internal/auth"
+	"cpa-usage-keeper/internal/entities"
+)
+
+func TestUsageOverviewAloneAcceptsCustomDayRangeOlderThanThirtyDays(t *testing.T) {
+	now := time.Now().In(time.Local)
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
+	startDay := today.AddDate(0, 0, -120)
+	query := url.Values{
+		"range": {"custom"},
+		"unit":  {"day"},
+		"start": {startDay.Format(time.DateOnly)},
+		"end":   {today.Format(time.DateOnly)},
+	}
+	provider := &usageEventsStub{}
+	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "")
+
+	overviewResponse := httptest.NewRecorder()
+	overviewRequest := httptest.NewRequest(http.MethodGet, "/api/v1/usage/overview?"+query.Encode(), nil)
+	router.ServeHTTP(overviewResponse, overviewRequest)
+
+	if overviewResponse.Code != http.StatusOK {
+		t.Fatalf("expected long custom Overview range to return 200, got %d body=%s", overviewResponse.Code, overviewResponse.Body.String())
+	}
+	if provider.overviewCalls != 1 {
+		t.Fatalf("expected Overview provider to be called once, got %d", provider.overviewCalls)
+	}
+	if provider.lastFilter.StartTime == nil || !provider.lastFilter.StartTime.Equal(startDay) {
+		t.Fatalf("expected custom day start %s, got %+v", startDay, provider.lastFilter)
+	}
+	expectedEnd := today.AddDate(0, 0, 1)
+	if provider.lastFilter.EndTime == nil || !provider.lastFilter.EndTime.Equal(expectedEnd) || !provider.lastFilter.EndExclusive {
+		t.Fatalf("expected exclusive custom day end %s, got %+v", expectedEnd, provider.lastFilter)
+	}
+	if provider.lastFilter.CustomUnit != "day" || provider.lastFilter.RangeCount != 121 {
+		t.Fatalf("expected 121 complete custom day buckets, got %+v", provider.lastFilter)
+	}
+
+	eventsResponse := httptest.NewRecorder()
+	eventsRequest := httptest.NewRequest(http.MethodGet, "/api/v1/usage/events?"+query.Encode(), nil)
+	router.ServeHTTP(eventsResponse, eventsRequest)
+
+	if eventsResponse.Code != http.StatusBadRequest {
+		t.Fatalf("expected the same long custom Events range to remain rejected, got %d body=%s", eventsResponse.Code, eventsResponse.Body.String())
+	}
+	if provider.filterCalls != 0 {
+		t.Fatalf("expected invalid Events range not to reach provider, got %d calls", provider.filterCalls)
+	}
+}
+
+func TestKeyOverviewAcceptsCustomDayRangeOlderThanThirtyDays(t *testing.T) {
+	now := time.Now().In(time.Local)
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
+	startDay := today.AddDate(0, 0, -120)
+	query := url.Values{
+		"range": {"custom"},
+		"unit":  {"day"},
+		"start": {startDay.Format(time.DateOnly)},
+		"end":   {today.Format(time.DateOnly)},
+	}
+	provider := &usageEventsStub{}
+	keyProvider := &authCPAAPIKeyStub{row: entities.CPAAPIKey{ID: 42, APIKey: "sk-cpa-viewer", DisplayKey: "sk-...viewer"}}
+	sessions := auth.NewSessionManager(time.Hour)
+	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
+	router := NewRouter(nil, nil, provider, nil, config, NewAuthHandler(config, sessions), "", OptionalProviders{CPAAPIKeys: keyProvider})
+	token, _, err := sessions.CreateAPIKeyViewerWithSource(42, auth.SessionSourceStandard)
+	if err != nil {
+		t.Fatalf("create API key viewer session: %v", err)
+	}
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/key-overview?"+query.Encode(), nil)
+	request.AddCookie(&http.Cookie{Name: standardSessionCookieName, Value: token})
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected long custom Key Overview range to return 200, got %d body=%s", response.Code, response.Body.String())
+	}
+	if provider.overviewCalls != 1 || provider.lastFilter.APIKeyID != "42" {
+		t.Fatalf("expected Key Overview to query viewer key once, calls=%d filter=%+v", provider.overviewCalls, provider.lastFilter)
+	}
+	if provider.lastFilter.StartTime == nil || !provider.lastFilter.StartTime.Equal(startDay) {
+		t.Fatalf("expected custom day start %s, got %+v", startDay, provider.lastFilter)
+	}
+	expectedEnd := today.AddDate(0, 0, 1)
+	if provider.lastFilter.EndTime == nil || !provider.lastFilter.EndTime.Equal(expectedEnd) || !provider.lastFilter.EndExclusive {
+		t.Fatalf("expected exclusive custom day end %s, got %+v", expectedEnd, provider.lastFilter)
+	}
+}

--- a/internal/api/test/usage_overview_series_response_test.go
+++ b/internal/api/test/usage_overview_series_response_test.go
@@ -1,0 +1,95 @@
+package test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "cpa-usage-keeper/internal/api"
+	"cpa-usage-keeper/internal/config"
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+	repositorydto "cpa-usage-keeper/internal/repository/dto"
+	"cpa-usage-keeper/internal/service"
+)
+
+type overviewSeriesJSON struct {
+	Buckets       []string   `json:"buckets"`
+	Requests      []int64    `json:"requests"`
+	Tokens        []int64    `json:"tokens"`
+	RPM           []float64  `json:"rpm"`
+	TPM           []float64  `json:"tpm"`
+	Cost          []float64  `json:"cost"`
+	CacheReadRate []*float64 `json:"cache_read_rate"`
+}
+
+func TestLongCustomDayOverviewCapsAlignedSeriesAtNinetyPoints(t *testing.T) {
+	db, err := repository.OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "overview-series.db")})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("resolve sql database: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	now := time.Now().In(time.Local)
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
+	start := today.AddDate(0, 0, -120)
+	rows := make([]entities.UsageOverviewDailyStat, 0, 121)
+	for bucket := start; !bucket.After(today); bucket = bucket.AddDate(0, 0, 1) {
+		rows = append(rows, entities.UsageOverviewDailyStat{
+			BucketStart: bucket, APIGroupKey: "provider-a", Model: "model-a",
+			RequestCount: 1, SuccessCount: 1, InputTokens: 10, TotalTokens: 10,
+		})
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("seed daily rollups: %v", err)
+	}
+
+	query := url.Values{
+		"range": {"custom"}, "unit": {"day"},
+		"start": {start.Format(time.DateOnly)}, "end": {today.Format(time.DateOnly)},
+	}
+	router := NewRouter(nil, nil, service.NewUsageService(db), nil, AuthConfig{}, nil, "")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/api/v1/usage/overview?"+query.Encode(), nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("Overview status=%d body=%s", response.Code, response.Body.String())
+	}
+
+	var payload struct {
+		Usage  repositorydto.StatisticsSnapshot `json:"usage"`
+		Series overviewSeriesJSON               `json:"series"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode long Overview response: %v body=%s", err, response.Body.String())
+	}
+	if payload.Usage.TotalRequests != 121 || payload.Usage.TotalTokens != 1210 {
+		t.Fatalf("top totals must use the complete range, got %+v", payload.Usage)
+	}
+	if len(payload.Series.Buckets) != 90 {
+		t.Fatalf("expected exactly 90 merged points, got %d", len(payload.Series.Buckets))
+	}
+	for name, length := range map[string]int{
+		"requests": len(payload.Series.Requests), "tokens": len(payload.Series.Tokens),
+		"rpm": len(payload.Series.RPM), "tpm": len(payload.Series.TPM),
+		"cost": len(payload.Series.Cost), "cache_read_rate": len(payload.Series.CacheReadRate),
+	} {
+		if length != len(payload.Series.Buckets) {
+			t.Fatalf("%s length=%d, buckets=%d", name, length, len(payload.Series.Buckets))
+		}
+	}
+	var seriesRequests int64
+	for _, requests := range payload.Series.Requests {
+		seriesRequests += requests
+	}
+	if seriesRequests != 121 {
+		t.Fatalf("merged series lost requests: %d", seriesRequests)
+	}
+}

--- a/internal/api/usage_filter.go
+++ b/internal/api/usage_filter.go
@@ -29,17 +29,31 @@ func parseKeyUsageTimeFilterQuery(req *http.Request, anchor time.Time) (serviced
 	return parseUsageTimeFilterQueryWithClientAPIKey(req, anchor, false)
 }
 
+// Overview 的 Custom 日范围只依赖 daily 汇总，因此可以独立放开历史跨度。
+func parseUsageOverviewTimeFilterQuery(req *http.Request, anchor time.Time) (servicedto.UsageFilter, error) {
+	return parseUsageTimeFilterQueryWithOptions(req, anchor, true, timeutil.UsageQueryRangeOptions{AllowLongCustomDayRange: true})
+}
+
+func parseKeyUsageOverviewTimeFilterQuery(req *http.Request, anchor time.Time) (servicedto.UsageFilter, error) {
+	return parseUsageTimeFilterQueryWithOptions(req, anchor, false, timeutil.UsageQueryRangeOptions{AllowLongCustomDayRange: true})
+}
+
 func parseUsageTimeFilterQueryWithClientAPIKey(req *http.Request, anchor time.Time, includeClientAPIKey bool) (servicedto.UsageFilter, error) {
+	return parseUsageTimeFilterQueryWithOptions(req, anchor, includeClientAPIKey, timeutil.UsageQueryRangeOptions{})
+}
+
+func parseUsageTimeFilterQueryWithOptions(req *http.Request, anchor time.Time, includeClientAPIKey bool, options timeutil.UsageQueryRangeOptions) (servicedto.UsageFilter, error) {
 	if req == nil {
 		return servicedto.UsageFilter{}, nil
 	}
 	query := req.URL.Query()
-	normalizedRange, err := timeutil.ParseUsageQueryRange(
+	normalizedRange, err := timeutil.ParseUsageQueryRangeWithOptions(
 		query.Get("range"),
 		query.Get("unit"),
 		query.Get("start"),
 		query.Get("end"),
 		anchor,
+		options,
 	)
 	if err != nil {
 		return servicedto.UsageFilter{}, err

--- a/internal/api/usage_overview.go
+++ b/internal/api/usage_overview.go
@@ -17,12 +17,10 @@ import (
 )
 
 type usageOverviewResponse struct {
-	Usage      usageOverviewPayload `json:"usage"`
-	Summary    usageOverviewSummary `json:"summary"`
-	Series     usageOverviewSeries  `json:"series"`
-	Timezone   string               `json:"timezone"`
-	RangeStart *time.Time           `json:"range_start,omitempty"`
-	RangeEnd   *time.Time           `json:"range_end,omitempty"`
+	Usage    usageOverviewPayload `json:"usage"`
+	Summary  usageOverviewSummary `json:"summary"`
+	Series   usageOverviewSeries  `json:"series"`
+	Timezone string               `json:"timezone"`
 }
 
 type usageOverviewPayload struct {
@@ -33,9 +31,6 @@ type usageOverviewPayload struct {
 }
 
 type usageOverviewSummary struct {
-	RequestCount          int64    `json:"request_count"`
-	TokenCount            int64    `json:"token_count"`
-	WindowMinutes         int64    `json:"window_minutes"`
 	RPM                   float64  `json:"rpm"`
 	TPM                   float64  `json:"tpm"`
 	TotalCost             float64  `json:"total_cost"`
@@ -51,12 +46,13 @@ type usageOverviewSummary struct {
 }
 
 type usageOverviewSeries struct {
-	Requests      map[string]int64    `json:"requests"`
-	Tokens        map[string]int64    `json:"tokens"`
-	RPM           map[string]float64  `json:"rpm"`
-	TPM           map[string]float64  `json:"tpm"`
-	Cost          map[string]float64  `json:"cost"`
-	CacheReadRate map[string]*float64 `json:"cache_read_rate"`
+	Buckets       []string   `json:"buckets"`
+	Requests      []int64    `json:"requests"`
+	Tokens        []int64    `json:"tokens"`
+	RPM           []float64  `json:"rpm"`
+	TPM           []float64  `json:"tpm"`
+	Cost          []float64  `json:"cost"`
+	CacheReadRate []*float64 `json:"cache_read_rate"`
 }
 
 type usageOverviewRealtime struct {
@@ -195,7 +191,7 @@ func registerKeyOverviewRoute(router gin.IRoutes, usageProvider service.UsagePro
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
 			return
 		}
-		filter, err := parseKeyUsageTimeFilterQuery(c.Request, timeutil.NormalizeStorageTime(time.Now()))
+		filter, err := parseKeyUsageOverviewTimeFilterQuery(c.Request, timeutil.NormalizeStorageTime(time.Now()))
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
@@ -247,7 +243,7 @@ func registerUsageOverviewRoute(router gin.IRoutes, usageProvider service.UsageP
 			writeUsageOverviewResponse(c, usageProvider, servicedto.UsageFilter{})
 			return
 		}
-		filter, err := parseUsageTimeFilterQuery(c.Request, timeutil.NormalizeStorageTime(time.Now()))
+		filter, err := parseUsageOverviewTimeFilterQuery(c.Request, timeutil.NormalizeStorageTime(time.Now()))
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
@@ -267,12 +263,10 @@ func registerUsageOverviewRoute(router gin.IRoutes, usageProvider service.UsageP
 func writeUsageOverviewResponse(c *gin.Context, usageProvider service.UsageProvider, filter servicedto.UsageFilter) {
 	if usageProvider == nil {
 		c.JSON(http.StatusOK, usageOverviewResponse{
-			Usage:      buildUsageOverviewPayload(nil),
-			Summary:    usageOverviewSummary{},
-			Series:     emptyUsageOverviewSeries(),
-			Timezone:   time.Local.String(),
-			RangeStart: filter.StartTime,
-			RangeEnd:   filter.EndTime,
+			Usage:    buildUsageOverviewPayload(nil),
+			Summary:  usageOverviewSummary{},
+			Series:   emptyUsageOverviewSeries(),
+			Timezone: time.Local.String(),
 		})
 		return
 	}
@@ -288,12 +282,10 @@ func writeUsageOverviewResponse(c *gin.Context, usageProvider service.UsageProvi
 		usage = overview.Usage
 	}
 	c.JSON(http.StatusOK, usageOverviewResponse{
-		Usage:      buildUsageOverviewPayload(usage),
-		Summary:    buildUsageOverviewSummary(overview),
-		Series:     buildUsageOverviewSeries(overview),
-		Timezone:   time.Local.String(),
-		RangeStart: filter.StartTime,
-		RangeEnd:   filter.EndTime,
+		Usage:    buildUsageOverviewPayload(usage),
+		Summary:  buildUsageOverviewSummary(overview),
+		Series:   buildUsageOverviewSeries(overview),
+		Timezone: time.Local.String(),
 	})
 }
 
@@ -359,9 +351,6 @@ func buildUsageOverviewSummary(overview *servicedto.UsageOverviewSnapshot) usage
 		return usageOverviewSummary{}
 	}
 	return usageOverviewSummary{
-		RequestCount:          overview.Summary.RequestCount,
-		TokenCount:            overview.Summary.TokenCount,
-		WindowMinutes:         overview.Summary.WindowMinutes,
 		RPM:                   overview.Summary.RPM,
 		TPM:                   overview.Summary.TPM,
 		TotalCost:             overview.Summary.TotalCost,
@@ -379,31 +368,29 @@ func buildUsageOverviewSummary(overview *servicedto.UsageOverviewSnapshot) usage
 
 func emptyUsageOverviewSeries() usageOverviewSeries {
 	return usageOverviewSeries{
-		Requests:      map[string]int64{},
-		Tokens:        map[string]int64{},
-		RPM:           map[string]float64{},
-		TPM:           map[string]float64{},
-		Cost:          map[string]float64{},
-		CacheReadRate: map[string]*float64{},
-	}
-}
-
-func mapUsageOverviewSeries(series servicedto.UsageOverviewSeries) usageOverviewSeries {
-	return usageOverviewSeries{
-		Requests:      cloneInt64Map(series.Requests),
-		Tokens:        cloneInt64Map(series.Tokens),
-		RPM:           cloneFloat64Map(series.RPM),
-		TPM:           cloneFloat64Map(series.TPM),
-		Cost:          cloneFloat64Map(series.Cost),
-		CacheReadRate: cloneFloat64PtrMap(series.CacheReadRate),
+		Buckets:       []string{},
+		Requests:      []int64{},
+		Tokens:        []int64{},
+		RPM:           []float64{},
+		TPM:           []float64{},
+		Cost:          []float64{},
+		CacheReadRate: []*float64{},
 	}
 }
 
 func buildUsageOverviewSeries(overview *servicedto.UsageOverviewSnapshot) usageOverviewSeries {
-	if overview == nil {
+	if overview == nil || overview.Series.Buckets == nil {
 		return emptyUsageOverviewSeries()
 	}
-	return mapUsageOverviewSeries(overview.Series)
+	return usageOverviewSeries{
+		Buckets:       overview.Series.Buckets,
+		Requests:      overview.Series.Requests,
+		Tokens:        overview.Series.Tokens,
+		RPM:           overview.Series.RPM,
+		TPM:           overview.Series.TPM,
+		Cost:          overview.Series.Cost,
+		CacheReadRate: overview.Series.CacheReadRate,
+	}
 }
 
 func emptyUsageOverviewRealtime(window string) usageOverviewRealtime {
@@ -695,42 +682,4 @@ func mapUsageOverviewRealtimeAPIKeyTopItems(items []servicedto.RealtimeUsageTopI
 		})
 	}
 	return result
-}
-
-func cloneInt64Map(source map[string]int64) map[string]int64 {
-	if len(source) == 0 {
-		return map[string]int64{}
-	}
-	cloned := make(map[string]int64, len(source))
-	for key, value := range source {
-		cloned[key] = value
-	}
-	return cloned
-}
-
-func cloneFloat64Map(source map[string]float64) map[string]float64 {
-	if len(source) == 0 {
-		return map[string]float64{}
-	}
-	cloned := make(map[string]float64, len(source))
-	for key, value := range source {
-		cloned[key] = value
-	}
-	return cloned
-}
-
-func cloneFloat64PtrMap(source map[string]*float64) map[string]*float64 {
-	if len(source) == 0 {
-		return map[string]*float64{}
-	}
-	cloned := make(map[string]*float64, len(source))
-	for key, value := range source {
-		if value == nil {
-			cloned[key] = nil
-			continue
-		}
-		copied := *value
-		cloned[key] = &copied
-	}
-	return cloned
 }

--- a/internal/api/usage_overview_test.go
+++ b/internal/api/usage_overview_test.go
@@ -242,7 +242,7 @@ func TestKeyOverviewClearsInactiveViewerSession(t *testing.T) {
 	}
 }
 
-func TestUsageOverviewResponseIncludesResolvedRangeAndTimezone(t *testing.T) {
+func TestUsageOverviewResponseKeepsResolvedFilterAndTimezone(t *testing.T) {
 	previousLocal := time.Local
 	location, err := time.LoadLocation("Asia/Shanghai")
 	if err != nil {
@@ -266,11 +266,13 @@ func TestUsageOverviewResponseIncludesResolvedRangeAndTimezone(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", resp.Code)
 	}
-	expectedStart := startDay.Format(time.RFC3339Nano)
-	expectedEnd := today.AddDate(0, 0, 1).Format(time.RFC3339Nano)
 	body := resp.Body.String()
-	if !contains(body, `"timezone":"Asia/Shanghai"`) || !contains(body, `"range_start":"`+expectedStart+`"`) || !contains(body, `"range_end":"`+expectedEnd+`"`) {
-		t.Fatalf("expected overview response to include resolved range and timezone, got %s", body)
+	if !contains(body, `"timezone":"Asia/Shanghai"`) || contains(body, `"range_start":`) || contains(body, `"range_end":`) {
+		t.Fatalf("expected overview response to retain timezone without redundant range fields, got %s", body)
+	}
+	if provider.lastFilter.StartTime == nil || !provider.lastFilter.StartTime.Equal(startDay) ||
+		provider.lastFilter.EndTime == nil || !provider.lastFilter.EndTime.Equal(today.AddDate(0, 0, 1)) {
+		t.Fatalf("expected resolved range to remain in the service filter, got %+v", provider.lastFilter)
 	}
 }
 
@@ -542,9 +544,6 @@ func TestUsageOverviewReturnsFilteredSnapshot(t *testing.T) {
 			TotalTokens:   20,
 		},
 		Summary: servicedto.UsageOverviewSummary{
-			RequestCount:        1,
-			TokenCount:          20,
-			WindowMinutes:       1440,
 			RPM:                 1.0 / 1440.0,
 			TPM:                 20.0 / 1440.0,
 			TotalCost:           0.123,
@@ -555,12 +554,13 @@ func TestUsageOverviewReturnsFilteredSnapshot(t *testing.T) {
 			ReasoningTokens:     3,
 		},
 		Series: servicedto.UsageOverviewSeries{
-			Requests:      map[string]int64{"2026-04-22T11:00:00Z": 1},
-			Tokens:        map[string]int64{"2026-04-22T11:00:00Z": 20},
-			RPM:           map[string]float64{"2026-04-22T11:00:00Z": 1.0 / 60.0},
-			TPM:           map[string]float64{"2026-04-22T11:00:00Z": 20.0 / 60.0},
-			Cost:          map[string]float64{"2026-04-22T11:00:00Z": 0.123},
-			CacheReadRate: map[string]*float64{"2026-04-22T11:00:00Z": float64Ptr(18.18)},
+			Buckets:       []string{"2026-04-22T11:00:00Z"},
+			Requests:      []int64{1},
+			Tokens:        []int64{20},
+			RPM:           []float64{1.0 / 60.0},
+			TPM:           []float64{20.0 / 60.0},
+			Cost:          []float64{0.123},
+			CacheReadRate: []*float64{float64Ptr(18.18)},
 		},
 	}}
 	router := NewRouter(nil, nil, provider, nil, AuthConfig{}, nil, "")
@@ -576,7 +576,7 @@ func TestUsageOverviewReturnsFilteredSnapshot(t *testing.T) {
 	if !contains(body, `"usage":`) || !contains(body, `"total_requests":1`) {
 		t.Fatalf("unexpected response body: %s", body)
 	}
-	if !contains(body, `"summary":{"request_count":1,"token_count":20`) {
+	if !contains(body, `"summary":{"rpm":`) {
 		t.Fatalf("expected backend summary in response body: %s", body)
 	}
 	if !contains(body, `"cost_available":true`) {
@@ -585,10 +585,10 @@ func TestUsageOverviewReturnsFilteredSnapshot(t *testing.T) {
 	if !contains(body, `"input_tokens":11`) {
 		t.Fatalf("expected summary input tokens in response body: %s", body)
 	}
-	if !contains(body, `"series":{"requests":{"2026-04-22T11:00:00Z":1}`) {
+	if !contains(body, `"series":{"buckets":["2026-04-22T11:00:00Z"],"requests":[1]`) {
 		t.Fatalf("expected backend series in response body: %s", body)
 	}
-	if !contains(body, `"cache_read_rate":{"2026-04-22T11:00:00Z":18.18}`) {
+	if !contains(body, `"cache_read_rate":[18.18]`) {
 		t.Fatalf("expected backend cache-rate series in response body: %s", body)
 	}
 	if contains(body, `"service_health":`) {
@@ -620,9 +620,6 @@ func TestUsageOverviewReturnsDailyAverageSummaryFields(t *testing.T) {
 			TotalTokens:   7000000,
 		},
 		Summary: servicedto.UsageOverviewSummary{
-			RequestCount:          14,
-			TokenCount:            7000000,
-			WindowMinutes:         10080,
 			RPM:                   14.0 / 10080.0,
 			TPM:                   7000000.0 / 10080.0,
 			TotalCost:             56.49,
@@ -664,10 +661,10 @@ func TestUsageOverviewNilProviderReturnsPrunedShape(t *testing.T) {
 		t.Fatalf("expected status 200, got %d", resp.Code)
 	}
 	body := resp.Body.String()
-	if !contains(body, `"summary":{"request_count":0`) || !contains(body, `"input_tokens":0`) {
+	if !contains(body, `"summary":{"rpm":0`) || !contains(body, `"input_tokens":0`) {
 		t.Fatalf("expected empty overview summary to include input_tokens, got %s", body)
 	}
-	if !contains(body, `"series":{"requests":{}`) || !contains(body, `"cache_read_rate":{}`) {
+	if !contains(body, `"series":{"buckets":[]`) || !contains(body, `"cache_read_rate":[]`) {
 		t.Fatalf("expected empty overview series to include cache_read_rate, got %s", body)
 	}
 	assertUsageOverviewResponseShape(t, body)
@@ -679,7 +676,7 @@ func assertUsageOverviewResponseShape(t *testing.T, body string) {
 	if err := json.Unmarshal([]byte(body), &decoded); err != nil {
 		t.Fatalf("failed to decode overview response: %v\n%s", err, body)
 	}
-	assertAllowedJSONKeys(t, decoded, "overview response", body, "usage", "summary", "series", "timezone", "range_start", "range_end")
+	assertAllowedJSONKeys(t, decoded, "overview response", body, "usage", "summary", "series", "timezone")
 
 	usage, ok := decoded["usage"].(map[string]any)
 	if !ok {
@@ -692,7 +689,7 @@ func assertUsageOverviewResponseShape(t *testing.T, body string) {
 		t.Fatalf("expected summary object in response, got %s", body)
 	}
 	assertAllowedJSONKeys(t, summary, "overview summary", body,
-		"request_count", "token_count", "window_minutes", "rpm", "tpm", "total_cost", "cost_available",
+		"rpm", "tpm", "total_cost", "cost_available",
 		"input_tokens", "cache_read_tokens", "cache_creation_tokens", "reasoning_tokens",
 		"daily_average_requests", "daily_average_tokens", "daily_average_cost", "daily_average_range_days",
 	)
@@ -701,7 +698,7 @@ func assertUsageOverviewResponseShape(t *testing.T, body string) {
 	if !ok {
 		t.Fatalf("expected series object in response, got %s", body)
 	}
-	assertAllowedJSONKeys(t, series, "overview series", body, "requests", "tokens", "rpm", "tpm", "cost", "cache_read_rate")
+	assertAllowedJSONKeys(t, series, "overview series", body, "buckets", "requests", "tokens", "rpm", "tpm", "cost", "cache_read_rate")
 
 }
 

--- a/internal/benchmark/test/overview_custom_range_benchmark_test.go
+++ b/internal/benchmark/test/overview_custom_range_benchmark_test.go
@@ -1,0 +1,155 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/api"
+	"cpa-usage-keeper/internal/config"
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+	"cpa-usage-keeper/internal/service"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func BenchmarkUsageOverviewCustomDayRanges(b *testing.B) {
+	db, queryLogger := openCustomOverviewBenchmarkDatabase(b)
+	provider := service.NewUsageService(db)
+	router := api.NewRouter(nil, nil, provider, nil, api.AuthConfig{}, nil, "")
+	lastDay := time.Date(2026, 7, 1, 0, 0, 0, 0, time.Local)
+
+	for _, days := range []int{30, 90, 365} {
+		b.Run(fmt.Sprintf("days_%d", days), func(b *testing.B) {
+			start := lastDay.AddDate(0, 0, -(days - 1))
+			values := url.Values{
+				"range": {"custom"},
+				"unit":  {"day"},
+				"start": {start.Format(time.DateOnly)},
+				"end":   {lastDay.Format(time.DateOnly)},
+			}
+			request := httptest.NewRequest(http.MethodGet, "/api/v1/usage/overview?"+values.Encode(), nil)
+			warmup := httptest.NewRecorder()
+			queryLogger.rollupRows = 0
+			router.ServeHTTP(warmup, request)
+			if warmup.Code != http.StatusOK {
+				b.Fatalf("Overview status=%d body=%s", warmup.Code, warmup.Body.String())
+			}
+			var payload struct {
+				Series struct {
+					Buckets []string `json:"buckets"`
+				} `json:"series"`
+			}
+			if err := json.Unmarshal(warmup.Body.Bytes(), &payload); err != nil {
+				b.Fatalf("decode Overview response: %v", err)
+			}
+			wantPoints := days
+			if wantPoints > 90 {
+				wantPoints = 90
+			}
+			if len(payload.Series.Buckets) != wantPoints {
+				b.Fatalf("series points=%d, want %d", len(payload.Series.Buckets), wantPoints)
+			}
+			wantRollupRows := int64(days * 4)
+			if queryLogger.rollupRows != wantRollupRows {
+				b.Fatalf("daily rollup rows=%d, want %d", queryLogger.rollupRows, wantRollupRows)
+			}
+
+			var responseBytes int
+			var rollupRows int64
+			b.ReportAllocs()
+			b.ResetTimer()
+			for index := 0; index < b.N; index++ {
+				response := httptest.NewRecorder()
+				queryLogger.rollupRows = 0
+				router.ServeHTTP(response, request)
+				if response.Code != http.StatusOK {
+					b.Fatalf("Overview status=%d body=%s", response.Code, response.Body.String())
+				}
+				if queryLogger.rollupRows != wantRollupRows {
+					b.Fatalf("daily rollup rows=%d, want %d", queryLogger.rollupRows, wantRollupRows)
+				}
+				responseBytes = response.Body.Len()
+				rollupRows = queryLogger.rollupRows
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(responseBytes), "response_B")
+			b.ReportMetric(float64(rollupRows), "rollup_rows")
+		})
+	}
+}
+
+type overviewBenchmarkQueryLogger struct {
+	logger.Interface
+	rollupRows int64
+}
+
+func (l *overviewBenchmarkQueryLogger) Trace(_ context.Context, _ time.Time, query func() (string, int64), _ error) {
+	sql, rows := query()
+	if strings.Contains(sql, "usage_overview_daily_stats") {
+		l.rollupRows = rows
+	}
+}
+
+func openCustomOverviewBenchmarkDatabase(b *testing.B) (*gorm.DB, *overviewBenchmarkQueryLogger) {
+	b.Helper()
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		b.Fatalf("resolve working directory: %v", err)
+	}
+	projectDataDirectory := filepath.Join(workingDirectory, "..", "..", "..", "data")
+	if err := os.MkdirAll(projectDataDirectory, 0o755); err != nil {
+		b.Fatalf("create project data directory: %v", err)
+	}
+	benchmarkDirectory, err := os.MkdirTemp(projectDataDirectory, "overview-custom-benchmark-")
+	if err != nil {
+		b.Fatalf("create benchmark directory: %v", err)
+	}
+	b.Cleanup(func() { _ = os.RemoveAll(benchmarkDirectory) })
+	db, err := repository.OpenDatabase(config.Config{SQLitePath: filepath.Join(benchmarkDirectory, "overview.db")})
+	if err != nil {
+		b.Fatalf("open benchmark database: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		b.Fatalf("resolve benchmark sql database: %v", err)
+	}
+	b.Cleanup(func() { _ = sqlDB.Close() })
+
+	start := time.Date(2025, 7, 2, 0, 0, 0, 0, time.Local)
+	rows := make([]entities.UsageOverviewDailyStat, 0, 365*4*4*3)
+	for dayIndex := 0; dayIndex < 365; dayIndex++ {
+		bucket := start.AddDate(0, 0, dayIndex)
+		for apiIndex := 0; apiIndex < 4; apiIndex++ {
+			for modelIndex := 0; modelIndex < 4; modelIndex++ {
+				for authIndex := 0; authIndex < 3; authIndex++ {
+					requests := int64(20 + (dayIndex+apiIndex+modelIndex+authIndex)%17)
+					inputTokens := requests * int64(80+modelIndex*10)
+					cacheReadTokens := requests * int64((dayIndex+authIndex)%20)
+					outputTokens := requests * int64(30+modelIndex*5)
+					rows = append(rows, entities.UsageOverviewDailyStat{
+						BucketStart: bucket, APIGroupKey: fmt.Sprintf("api-%d", apiIndex), Model: fmt.Sprintf("model-%d", modelIndex),
+						AuthIndex: fmt.Sprintf("auth-%d", authIndex), RequestCount: requests, SuccessCount: requests - 1, FailureCount: 1,
+						InputTokens: inputTokens, OutputTokens: outputTokens, CacheReadTokens: cacheReadTokens,
+						TotalTokens: inputTokens + outputTokens + cacheReadTokens,
+					})
+				}
+			}
+		}
+	}
+	if err := db.CreateInBatches(rows, 500).Error; err != nil {
+		b.Fatalf("seed daily rollups: %v", err)
+	}
+	queryLogger := &overviewBenchmarkQueryLogger{Interface: logger.Default.LogMode(logger.Silent)}
+	db.Logger = queryLogger
+	return db, queryLogger
+}

--- a/internal/repository/query_projection_test.go
+++ b/internal/repository/query_projection_test.go
@@ -16,8 +16,9 @@ func TestRepositoryQueriesAvoidKnownFullEntityReads(t *testing.T) {
 	)
 	assertFileContains(t, "usage.go",
 		"Select(usageEventProjectionColumns).Order(\"timestamp DESC, id DESC\")",
-		"Select(usageOverviewRawEventProjectionColumns).\n\t\tOrder(\"timestamp asc\")",
-		"usageOverviewRawEventProjectionColumns = \"api_group_key, provider, auth_type, model, model_alias, timestamp, source, auth_index, failed, generate, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cache_read_tokens, cache_creation_tokens, total_tokens\"",
+		"Select(projection).\n\t\tOrder(\"timestamp asc\")",
+		"usageOverviewBoundaryEventProjectionColumns = \"api_group_key, model, model_alias, timestamp, failed, input_tokens, output_tokens, reasoning_tokens, cache_read_tokens, cache_creation_tokens, total_tokens\"",
+		"usageOverviewRealtimeEventProjectionColumns = \"api_group_key, provider, auth_type, model, model_alias, timestamp, source, auth_index, failed, generate, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cache_read_tokens, cache_creation_tokens, total_tokens\"",
 	)
 	assertFileContains(t, "usage_recent_event_cache.go",
 		"Select(\"api_group_key, provider, auth_type, model, model_alias, timestamp, source, auth_index, failed, generate, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens\")",

--- a/internal/repository/test/usage_overview_custom_rollup_test.go
+++ b/internal/repository/test/usage_overview_custom_rollup_test.go
@@ -1,0 +1,216 @@
+package test
+
+import (
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+	repositorydto "cpa-usage-keeper/internal/repository/dto"
+	"cpa-usage-keeper/internal/timeutil"
+	"gorm.io/gorm"
+)
+
+func TestCustomHourOverviewReadsCompleteHourlyBucketsWithoutUsageEvents(t *testing.T) {
+	db := openTestDatabase(t)
+	queryNow := time.Date(2026, 7, 22, 10, 30, 0, 0, time.Local)
+	start := time.Date(2026, 7, 22, 6, 0, 0, 0, time.Local)
+	end := time.Date(2026, 7, 22, 11, 0, 0, 0, time.Local)
+	rows := make([]entities.UsageOverviewHourlyStat, 0, 5)
+	for bucket := start; bucket.Before(end); bucket = bucket.Add(time.Hour) {
+		rows = append(rows, entities.UsageOverviewHourlyStat{
+			BucketStart: bucket, APIGroupKey: "provider-a", Model: "model-a",
+			RequestCount: 1, SuccessCount: 1, InputTokens: 10, TotalTokens: 10,
+		})
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("seed hourly rollups: %v", err)
+	}
+
+	queries := captureOverviewDataQueries(t, db, "custom_hour")
+	overview, err := repository.BuildUsageOverviewWithFilter(db, repositorydto.UsageQueryFilter{
+		Range: "custom", CustomUnit: "hour", StartTime: &start, EndTime: &end, EndExclusive: true, QueryNow: &queryNow,
+	})
+	if err != nil {
+		t.Fatalf("BuildUsageOverviewWithFilter returned error: %v", err)
+	}
+
+	if overview.Usage.TotalRequests != 5 || overview.Usage.TotalTokens != 50 {
+		t.Fatalf("expected all five complete hourly buckets, got %+v", overview.Usage)
+	}
+	assertOverviewQueryTables(t, *queries, true, false)
+}
+
+func TestCustomOverviewRollupQueryProjectsAndGroupsOnlyCardDimensions(t *testing.T) {
+	db := openTestDatabase(t)
+	start := time.Date(2026, 7, 22, 6, 0, 0, 0, time.Local)
+	end := start.Add(5 * time.Hour)
+	if err := db.Create(&entities.UsageOverviewHourlyStat{
+		BucketStart: start, APIGroupKey: "provider-a", Model: "model-a", AuthIndex: "auth-a",
+		RequestCount: 1, SuccessCount: 1, InputTokens: 10, TotalTokens: 10,
+	}).Error; err != nil {
+		t.Fatalf("seed hourly rollup: %v", err)
+	}
+
+	queries := captureOverviewDataQueries(t, db, "projection")
+	if _, err := repository.BuildUsageOverviewWithFilter(db, repositorydto.UsageQueryFilter{
+		Range: "custom", CustomUnit: "hour", StartTime: &start, EndTime: &end, EndExclusive: true, QueryNow: &end,
+	}); err != nil {
+		t.Fatalf("BuildUsageOverviewWithFilter returned error: %v", err)
+	}
+
+	query := findOverviewRollupQuery(t, *queries, "usage_overview_hourly_stats")
+	for _, unwanted := range []string{"`id`", "auth_index", "cached_tokens", "created_at", "updated_at", "select *"} {
+		if strings.Contains(query, unwanted) {
+			t.Fatalf("rollup projection should exclude %q:\n%s", unwanted, query)
+		}
+	}
+	if !strings.Contains(query, "group by") || !strings.Contains(query, "bucket_start") || !strings.Contains(query, "model_alias") {
+		t.Fatalf("expected rollup query to group by bucket and pricing dimensions:\n%s", query)
+	}
+}
+
+func TestCustomOverviewGroupedProjectionPreservesPerRowCostNormalization(t *testing.T) {
+	db := openTestDatabase(t)
+	if _, err := repository.UpsertModelPriceSetting(db, repositorydto.ModelPriceSettingInput{
+		Model: "model-a", PromptPricePer1M: 1, CompletionPricePer1M: 0, CacheReadPricePer1M: 0,
+	}); err != nil {
+		t.Fatalf("seed model price: %v", err)
+	}
+	start := time.Date(2026, 7, 22, 6, 0, 0, 0, time.Local)
+	end := start.Add(5 * time.Hour)
+	rows := []entities.UsageOverviewHourlyStat{
+		{
+			BucketStart: start, APIGroupKey: "provider-a", Model: "model-a", AuthIndex: "auth-a",
+			RequestCount: 1, SuccessCount: 1, InputTokens: 10, CacheReadTokens: 20, TotalTokens: 30,
+		},
+		{
+			BucketStart: start, APIGroupKey: "provider-a", Model: "model-a", AuthIndex: "auth-b",
+			RequestCount: 1, SuccessCount: 1, InputTokens: 20, TotalTokens: 20,
+		},
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("seed adversarial hourly rollups: %v", err)
+	}
+
+	overview, err := repository.BuildUsageOverviewWithFilter(db, repositorydto.UsageQueryFilter{
+		Range: "custom", CustomUnit: "hour", StartTime: &start, EndTime: &end, EndExclusive: true, QueryNow: &end,
+	})
+	if err != nil {
+		t.Fatalf("BuildUsageOverviewWithFilter returned error: %v", err)
+	}
+
+	wantCost := 20.0 / 1_000_000.0
+	if math.Abs(overview.Summary.TotalCost-wantCost) > 0.000000001 {
+		t.Fatalf("expected per-row normalized cost %.12f, got %.12f", wantCost, overview.Summary.TotalCost)
+	}
+	if overview.Usage.TotalRequests != 2 || overview.Summary.InputTokens != 30 || overview.Summary.CacheReadTokens != 20 {
+		t.Fatalf("expected grouped display totals to preserve raw sums, usage=%+v summary=%+v", overview.Usage, overview.Summary)
+	}
+	bucket := timeutil.FormatStorageTime(start)
+	if overview.Series.Requests[bucket] != 2 || overview.Series.CacheReadRate[bucket] == nil || math.Abs(*overview.Series.CacheReadRate[bucket]-200.0/3.0) > 0.000000001 {
+		t.Fatalf("expected grouped series parity for %s, got %+v", bucket, overview.Series)
+	}
+}
+
+func TestPresetOverviewRawBoundaryUsesCardOnlyProjection(t *testing.T) {
+	db := openTestDatabase(t)
+	end := time.Date(2026, 7, 22, 10, 30, 0, 0, time.Local)
+	start := end.Add(-4 * time.Hour)
+	queries := captureOverviewDataQueries(t, db, "raw_projection")
+
+	if _, err := repository.BuildUsageOverviewWithFilter(db, repositorydto.UsageQueryFilter{
+		Range: "4h", StartTime: &start, EndTime: &end, QueryNow: &end,
+	}); err != nil {
+		t.Fatalf("BuildUsageOverviewWithFilter returned error: %v", err)
+	}
+
+	query := findOverviewRollupQuery(t, *queries, "usage_events")
+	for _, unwanted := range []string{"provider", "auth_type", "source", "auth_index", "generate", "latency_ms", "ttft_ms"} {
+		if strings.Contains(query, unwanted) {
+			t.Fatalf("Overview boundary projection should exclude %q:\n%s", unwanted, query)
+		}
+	}
+	for _, required := range []string{"api_group_key", "model", "model_alias", "timestamp", "failed", "input_tokens", "total_tokens"} {
+		if !strings.Contains(query, required) {
+			t.Fatalf("Overview boundary projection should include %q:\n%s", required, query)
+		}
+	}
+}
+
+func TestCustomDayOverviewReadsCompleteDailyBucketsWithoutUsageEvents(t *testing.T) {
+	db := openTestDatabase(t)
+	queryNow := time.Date(2026, 7, 22, 10, 30, 0, 0, time.Local)
+	start := time.Date(2026, 7, 20, 0, 0, 0, 0, time.Local)
+	end := time.Date(2026, 7, 23, 0, 0, 0, 0, time.Local)
+	rows := make([]entities.UsageOverviewDailyStat, 0, 3)
+	for bucket := start; bucket.Before(end); bucket = bucket.AddDate(0, 0, 1) {
+		rows = append(rows, entities.UsageOverviewDailyStat{
+			BucketStart: bucket, APIGroupKey: "provider-a", Model: "model-a",
+			RequestCount: 1, SuccessCount: 1, InputTokens: 10, TotalTokens: 10,
+		})
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("seed daily rollups: %v", err)
+	}
+
+	queries := captureOverviewDataQueries(t, db, "custom_day")
+	overview, err := repository.BuildUsageOverviewWithFilter(db, repositorydto.UsageQueryFilter{
+		Range: "custom", CustomUnit: "day", StartTime: &start, EndTime: &end, EndExclusive: true, QueryNow: &queryNow,
+	})
+	if err != nil {
+		t.Fatalf("BuildUsageOverviewWithFilter returned error: %v", err)
+	}
+
+	if overview.Usage.TotalRequests != 3 || overview.Usage.TotalTokens != 30 {
+		t.Fatalf("expected all three complete daily buckets, got %+v", overview.Usage)
+	}
+	assertOverviewQueryTables(t, *queries, false, true)
+}
+
+func captureOverviewDataQueries(t *testing.T, db *gorm.DB, suffix string) *[]string {
+	t.Helper()
+	queries := make([]string, 0, 3)
+	callbackName := "test:capture_overview_data_queries_" + suffix
+	capture := func(tx *gorm.DB) {
+		queries = append(queries, strings.ToLower(tx.Statement.SQL.String()))
+	}
+	if err := db.Callback().Query().After("gorm:query").Register(callbackName, capture); err != nil {
+		t.Fatalf("register query callback: %v", err)
+	}
+	if err := db.Callback().Row().After("gorm:row").Register(callbackName, capture); err != nil {
+		t.Fatalf("register row callback: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Callback().Query().Remove(callbackName)
+		_ = db.Callback().Row().Remove(callbackName)
+	})
+	return &queries
+}
+
+func assertOverviewQueryTables(t *testing.T, queries []string, wantHourly, wantDaily bool) {
+	t.Helper()
+	joined := strings.Join(queries, "\n")
+	if strings.Contains(joined, "usage_events") {
+		t.Fatalf("Custom Overview must not query usage_events:\n%s", joined)
+	}
+	if got := strings.Contains(joined, "usage_overview_hourly_stats"); got != wantHourly {
+		t.Fatalf("hourly rollup query presence=%t, want %t:\n%s", got, wantHourly, joined)
+	}
+	if got := strings.Contains(joined, "usage_overview_daily_stats"); got != wantDaily {
+		t.Fatalf("daily rollup query presence=%t, want %t:\n%s", got, wantDaily, joined)
+	}
+}
+
+func findOverviewRollupQuery(t *testing.T, queries []string, table string) string {
+	t.Helper()
+	for _, query := range queries {
+		if strings.Contains(query, table) {
+			return query
+		}
+	}
+	t.Fatalf("expected query for %s, got:\n%s", table, strings.Join(queries, "\n"))
+	return ""
+}

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -20,8 +20,11 @@ import (
 const usageEventProjectionColumns = "id, api_group_key, provider, auth_type, request_id, model, model_alias, reasoning_effort, service_tier, response_service_tier, executor_type, endpoint, timestamp, source, auth_index, failed, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cache_read_tokens, cache_creation_tokens, total_tokens"
 const analysisLatencyMaxDisplayPoints = 2500
 
-// usageOverviewRawEventProjectionColumns 是 Overview 边界补偿和 realtime DB 兜底的最小事件投影。
-const usageOverviewRawEventProjectionColumns = "api_group_key, provider, auth_type, model, model_alias, timestamp, source, auth_index, failed, generate, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cache_read_tokens, cache_creation_tokens, total_tokens"
+// usageOverviewBoundaryEventProjectionColumns 只包含非 Custom Overview 边界卡片计算需要的字段。
+const usageOverviewBoundaryEventProjectionColumns = "api_group_key, model, model_alias, timestamp, failed, input_tokens, output_tokens, reasoning_tokens, cache_read_tokens, cache_creation_tokens, total_tokens"
+
+// usageOverviewRealtimeEventProjectionColumns 保持 Realtime 的响应分布与身份字段完整。
+const usageOverviewRealtimeEventProjectionColumns = "api_group_key, provider, auth_type, model, model_alias, timestamp, source, auth_index, failed, generate, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cache_read_tokens, cache_creation_tokens, total_tokens"
 
 // usageEventProjection 是 usage_events 轻量投影，专门承接 select columns 的查询结果。
 type usageEventProjection struct {
@@ -957,6 +960,32 @@ func buildUsageOverviewFromStats(db *gorm.DB, filter dto.UsageQueryFilter, costR
 	windowMinutes := computeWindowMinutes(effectiveFilter)
 	bucketByDay := shouldBucketUsageOverviewByDay(effectiveFilter, windowMinutes)
 	overview := newUsageOverviewRecord(windowMinutes)
+	if strings.TrimSpace(filter.Range) == "custom" {
+		switch strings.TrimSpace(filter.CustomUnit) {
+		case "hour":
+			// Custom 小时的边界已由 API 对齐，包含当前小时也只读取增量 hourly 桶。
+			hourlyRows, err := loadUsageOverviewHourlyStatsWithFilter(db, filter, *filter.StartTime, *filter.EndTime)
+			if err != nil {
+				return nil, err
+			}
+			for _, row := range hourlyRows {
+				applyUsageOverviewStatToOverview(overview, row, false, costResolver)
+			}
+			finalizeUsageOverview(overview)
+			return overview, nil
+		case "day":
+			// Custom 天始终读取完整 daily 桶，当前日由后台增量汇总持续刷新。
+			dailyRows, err := loadUsageOverviewDailyStatsWithFilter(db, filter, *filter.StartTime, *filter.EndTime)
+			if err != nil {
+				return nil, err
+			}
+			for _, row := range dailyRows {
+				applyUsageOverviewStatToOverview(overview, row, true, costResolver)
+			}
+			finalizeUsageOverview(overview)
+			return overview, nil
+		}
+	}
 
 	// fullStart/fullEnd 是能被 hourly stats 完整覆盖的半开区间。
 	fullStart, fullEnd := usageOverviewFullHourWindow(*effectiveFilter.StartTime, *effectiveFilter.EndTime)
@@ -985,7 +1014,7 @@ func buildUsageOverviewFromStats(db *gorm.DB, filter dto.UsageQueryFilter, costR
 				return nil, err
 			}
 			for _, row := range hourlyRows {
-				applyUsageOverviewHourlyStatToOverview(overview, row, bucketByDay, costResolver)
+				applyUsageOverviewStatToOverview(overview, row, bucketByDay, costResolver)
 			}
 		} else {
 			// 长窗口中间的完整本地天用 daily stats，减少大量小时 row 累加。
@@ -994,7 +1023,7 @@ func buildUsageOverviewFromStats(db *gorm.DB, filter dto.UsageQueryFilter, costR
 				return nil, err
 			}
 			for _, row := range dailyRows {
-				applyUsageOverviewDailyStatToOverview(overview, row, bucketByDay, costResolver)
+				applyUsageOverviewStatToOverview(overview, row, bucketByDay, costResolver)
 			}
 
 			// 完整天两侧剩余的完整小时仍走 hourly stats，避免回退到大范围事件扫描。
@@ -1007,7 +1036,7 @@ func buildUsageOverviewFromStats(db *gorm.DB, filter dto.UsageQueryFilter, costR
 					return nil, err
 				}
 				for _, row := range hourlyRows {
-					applyUsageOverviewHourlyStatToOverview(overview, row, bucketByDay, costResolver)
+					applyUsageOverviewStatToOverview(overview, row, bucketByDay, costResolver)
 				}
 			}
 		}
@@ -1218,9 +1247,54 @@ func usageOverviewEventInsideWindow(event entities.UsageEvent, start, end time.T
 	return !timestamp.Before(start) && timestamp.Before(end)
 }
 
-// loadUsageOverviewHourlyStatsWithFilter 读取完整小时 stats，并复用 Overview 的 API key 过滤条件。
-func loadUsageOverviewHourlyStatsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time) ([]entities.UsageOverviewHourlyStat, error) {
-	return loadUsageOverviewHourlyStats(db, filter, start, end, false)
+type usageOverviewStatProjection struct {
+	BucketStart             time.Time
+	Model                   string
+	ModelAlias              string
+	RequestCount            int64
+	SuccessCount            int64
+	FailureCount            int64
+	InputTokens             int64
+	ReasoningTokens         int64
+	CacheReadTokens         int64
+	CacheCreationTokens     int64
+	TotalTokens             int64
+	CostUncachedInputTokens int64
+	CostOutputTokens        int64
+	CostCacheReadTokens     int64
+	CostCacheCreationTokens int64
+}
+
+// 标准 SQL CASE 先逐行完成计费 Token 的非负与普通输入归一化，再按卡片所需维度合并。
+const usageOverviewStatProjectionColumns = `
+	bucket_start,
+	model,
+	model_alias,
+	SUM(request_count) AS request_count,
+	SUM(success_count) AS success_count,
+	SUM(failure_count) AS failure_count,
+	SUM(input_tokens) AS input_tokens,
+	SUM(reasoning_tokens) AS reasoning_tokens,
+	SUM(cache_read_tokens) AS cache_read_tokens,
+	SUM(cache_creation_tokens) AS cache_creation_tokens,
+	SUM(total_tokens) AS total_tokens,
+	SUM(CASE
+		WHEN (CASE WHEN input_tokens > 0 THEN input_tokens ELSE 0 END) -
+			(CASE WHEN cache_read_tokens > 0 THEN cache_read_tokens ELSE 0 END) -
+			(CASE WHEN cache_creation_tokens > 0 THEN cache_creation_tokens ELSE 0 END) > 0
+		THEN (CASE WHEN input_tokens > 0 THEN input_tokens ELSE 0 END) -
+			(CASE WHEN cache_read_tokens > 0 THEN cache_read_tokens ELSE 0 END) -
+			(CASE WHEN cache_creation_tokens > 0 THEN cache_creation_tokens ELSE 0 END)
+		ELSE 0
+	END) AS cost_uncached_input_tokens,
+	SUM(CASE WHEN output_tokens > 0 THEN output_tokens ELSE 0 END) AS cost_output_tokens,
+	SUM(CASE WHEN cache_read_tokens > 0 THEN cache_read_tokens ELSE 0 END) AS cost_cache_read_tokens,
+	SUM(CASE WHEN cache_creation_tokens > 0 THEN cache_creation_tokens ELSE 0 END) AS cost_cache_creation_tokens`
+
+// loadUsageOverviewHourlyStatsWithFilter 只读取 Overview 卡片字段，并在 SQL 侧消除身份维度。
+func loadUsageOverviewHourlyStatsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time) ([]usageOverviewStatProjection, error) {
+	query := db.Model(&entities.UsageOverviewHourlyStat{})
+	return loadUsageOverviewStatProjection(query, filter, start, end, "hourly")
 }
 
 func loadAnalysisOverviewHourlyStatsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time) ([]entities.UsageOverviewHourlyStat, error) {
@@ -1276,9 +1350,24 @@ func loadUsageOverviewHourlyStats(db *gorm.DB, filter dto.UsageQueryFilter, star
 	return rows, nil
 }
 
-// loadUsageOverviewDailyStatsWithFilter 读取完整本地天 stats，并复用 Overview 的 API key 过滤条件。
-func loadUsageOverviewDailyStatsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time) ([]entities.UsageOverviewDailyStat, error) {
-	return loadUsageOverviewDailyStats(db, filter, start, end, false)
+// loadUsageOverviewDailyStatsWithFilter 只读取 Overview 卡片字段，并在 SQL 侧消除身份维度。
+func loadUsageOverviewDailyStatsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time) ([]usageOverviewStatProjection, error) {
+	query := db.Model(&entities.UsageOverviewDailyStat{})
+	return loadUsageOverviewStatProjection(query, filter, start, end, "daily")
+}
+
+func loadUsageOverviewStatProjection(query *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time, grain string) ([]usageOverviewStatProjection, error) {
+	rows := make([]usageOverviewStatProjection, 0)
+	query = query.
+		Select(usageOverviewStatProjectionColumns).
+		Where("bucket_start >= ? AND bucket_start < ?", timeutil.FormatStorageTime(start), timeutil.FormatStorageTime(end))
+	if apiGroupKey := strings.TrimSpace(filter.APIGroupKey); apiGroupKey != "" {
+		query = query.Where("api_group_key = ?", apiGroupKey)
+	}
+	if err := query.Group("bucket_start, model, model_alias").Order("bucket_start asc").Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("load usage overview %s projection: %w", grain, err)
+	}
+	return rows, nil
 }
 
 func loadAnalysisOverviewDailyStatsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time) ([]entities.UsageOverviewDailyStat, error) {
@@ -1330,7 +1419,7 @@ func loadUsageOverviewRawEventWindowsWithFilter(db *gorm.DB, filter dto.UsageQue
 			}
 		}
 		// 缓存不存在或窗口早于 70 分钟覆盖范围时，回到原来的窄边界 DB 查询。
-		windowEvents, err := loadUsageOverviewEventRangeWithFilter(db, filter, window.start, window.end, window.includeEnd)
+		windowEvents, err := loadUsageOverviewBoundaryEventRangeWithFilter(db, filter, window.start, window.end, window.includeEnd)
 		if err != nil {
 			return nil, err
 		}
@@ -1356,15 +1445,23 @@ func usageOverviewRecentCacheCoversWindow(recentCache *UsageRecentEventCache, wi
 	return !timeutil.NormalizeStorageTime(window.start).Before(coveredStart)
 }
 
-// loadUsageOverviewEventRangeWithFilter 使用单段 timestamp 范围查询，避免 OR 影响 usage_events 时间索引。
-func loadUsageOverviewEventRangeWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time, includeEnd bool) ([]entities.UsageEvent, error) {
+func loadUsageOverviewBoundaryEventRangeWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time, includeEnd bool) ([]entities.UsageEvent, error) {
+	return loadUsageOverviewEventRangeWithProjection(db, filter, start, end, includeEnd, usageOverviewBoundaryEventProjectionColumns)
+}
+
+func loadUsageOverviewRealtimeEventRangeWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time, includeEnd bool) ([]entities.UsageEvent, error) {
+	return loadUsageOverviewEventRangeWithProjection(db, filter, start, end, includeEnd, usageOverviewRealtimeEventProjectionColumns)
+}
+
+// loadUsageOverviewEventRangeWithProjection 使用单段 timestamp 范围查询，避免 OR 影响 usage_events 时间索引。
+func loadUsageOverviewEventRangeWithProjection(db *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time, includeEnd bool, projection string) ([]entities.UsageEvent, error) {
 	if end.Before(start) || (!includeEnd && end.Equal(start)) {
 		return nil, nil
 	}
 	// 单段范围让 SQLite 可以稳定使用 timestamp 索引，不把左右边界拼成 OR 查询。
 	query := db.Model(&entities.UsageEvent{}).
 		Where("timestamp >= ?", timeutil.FormatStorageTime(start)).
-		Select(usageOverviewRawEventProjectionColumns).
+		Select(projection).
 		Order("timestamp asc")
 	if includeEnd {
 		query = query.Where("timestamp <= ?", timeutil.FormatStorageTime(end))
@@ -1385,73 +1482,43 @@ func loadUsageOverviewEventRangeWithFilter(db *gorm.DB, filter dto.UsageQueryFil
 	return events, nil
 }
 
-// applyUsageOverviewHourlyStatToOverview 把小时 stats 同步写入 summary、snapshot 和主序列。
-func applyUsageOverviewHourlyStatToOverview(overview *dto.UsageOverviewRecord, row entities.UsageOverviewHourlyStat, bucketByDay bool, costResolver *UsageCostResolver) {
-	// 小时 stats 是完整小时事实，可直接累计到 snapshot totals。
-	applyUsageOverviewHourlyStatToSnapshot(overview.Usage, row)
+// applyUsageOverviewStatToOverview 把已确认完整的 hourly/daily stats 写入 summary、snapshot 和主序列。
+func applyUsageOverviewStatToOverview(overview *dto.UsageOverviewRecord, row usageOverviewStatProjection, bucketByDay bool, costResolver *UsageCostResolver) {
+	applyUsageOverviewStatToSnapshotTotals(overview.Usage, row.RequestCount, row.SuccessCount, row.FailureCount, row.TotalTokens)
 	// cost 不入 stats 表，必须在读取时按当前价格表重新计算。
-	result := costResolver.Calculate(UsageCostSubject{
-		Model:      row.Model,
-		ModelAlias: row.ModelAlias,
-		Tokens: helper.UsageTokenCostInput{
-			InputTokens:         row.InputTokens,
-			OutputTokens:        row.OutputTokens,
-			CacheReadTokens:     row.CacheReadTokens,
-			CacheCreationTokens: row.CacheCreationTokens,
-		},
-	})
+	result := calculateUsageOverviewProjectionCost(costResolver, row)
 	if !result.Available {
 		overview.Summary.CostAvailable = false
 	}
 	rowCost := result.Cost.TotalCostUSD
-	applyUsageOverviewStatToSummary(overview, row.RequestCount, row.InputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, rowCost)
+	applyUsageOverviewStatToSummary(overview, row.InputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, rowCost)
 
 	// 主序列按当前窗口选择小时或天粒度。
 	bucketKey, bucketMinutes := usageOverviewBucket(timeutil.NormalizeStorageTime(row.BucketStart), bucketByDay)
 	applyUsageOverviewStatToSeries(&overview.Series, row.RequestCount, row.InputTokens, row.CacheReadTokens, row.TotalTokens, rowCost, bucketKey, bucketMinutes)
 }
 
-// applyUsageOverviewDailyStatToOverview 把完整天 stats 写入长窗口 summary、snapshot 和主序列。
-func applyUsageOverviewDailyStatToOverview(overview *dto.UsageOverviewRecord, row entities.UsageOverviewDailyStat, bucketByDay bool, costResolver *UsageCostResolver) {
-	// 天 stats 只覆盖完整本地天，不能用于非整天边界。
-	applyUsageOverviewDailyStatToSnapshot(overview.Usage, row)
-	result := costResolver.Calculate(UsageCostSubject{
+func calculateUsageOverviewProjectionCost(costResolver *UsageCostResolver, row usageOverviewStatProjection) UsageCostResult {
+	return costResolver.Calculate(UsageCostSubject{
 		Model:      row.Model,
 		ModelAlias: row.ModelAlias,
 		Tokens: helper.UsageTokenCostInput{
-			InputTokens:         row.InputTokens,
-			OutputTokens:        row.OutputTokens,
-			CacheReadTokens:     row.CacheReadTokens,
-			CacheCreationTokens: row.CacheCreationTokens,
+			// SQL 已逐行归一化；重新拼成 resolver 输入后不会跨身份行改变 max(..., 0) 结果。
+			InputTokens:         row.CostUncachedInputTokens + row.CostCacheReadTokens + row.CostCacheCreationTokens,
+			OutputTokens:        row.CostOutputTokens,
+			CacheReadTokens:     row.CostCacheReadTokens,
+			CacheCreationTokens: row.CostCacheCreationTokens,
 		},
 	})
-	if !result.Available {
-		overview.Summary.CostAvailable = false
-	}
-	rowCost := result.Cost.TotalCostUSD
-	applyUsageOverviewStatToSummary(overview, row.RequestCount, row.InputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, rowCost)
-
-	bucketKey, bucketMinutes := usageOverviewBucket(timeutil.NormalizeStorageTime(row.BucketStart), bucketByDay)
-	applyUsageOverviewStatToSeries(&overview.Series, row.RequestCount, row.InputTokens, row.CacheReadTokens, row.TotalTokens, rowCost, bucketKey, bucketMinutes)
 }
 
 // applyUsageOverviewStatToSummary 写入 summary 中不在 StatisticsSnapshot 里的 token/cost 字段。
-func applyUsageOverviewStatToSummary(overview *dto.UsageOverviewRecord, requestCount, inputTokens, cacheReadTokens, cacheCreationTokens, reasoningTokens int64, cost float64) {
+func applyUsageOverviewStatToSummary(overview *dto.UsageOverviewRecord, inputTokens, cacheReadTokens, cacheCreationTokens, reasoningTokens int64, cost float64) {
 	overview.Summary.InputTokens += inputTokens
 	overview.Summary.CacheReadTokens += cacheReadTokens
 	overview.Summary.CacheCreationTokens += cacheCreationTokens
 	overview.Summary.ReasoningTokens += reasoningTokens
 	overview.Summary.TotalCost += cost
-}
-
-// applyUsageOverviewHourlyStatToSnapshot 把小时 stats 合入 Overview 基础 usage 统计。
-func applyUsageOverviewHourlyStatToSnapshot(snapshot *dto.StatisticsSnapshot, row entities.UsageOverviewHourlyStat) {
-	applyUsageOverviewStatToSnapshotTotals(snapshot, row.RequestCount, row.SuccessCount, row.FailureCount, row.TotalTokens)
-}
-
-// applyUsageOverviewDailyStatToSnapshot 把天 stats 合入 Overview 基础 usage 统计。
-func applyUsageOverviewDailyStatToSnapshot(snapshot *dto.StatisticsSnapshot, row entities.UsageOverviewDailyStat) {
-	applyUsageOverviewStatToSnapshotTotals(snapshot, row.RequestCount, row.SuccessCount, row.FailureCount, row.TotalTokens)
 }
 
 // applyUsageOverviewStatToSnapshotTotals 复用 hourly/daily stats 的基础 totals 累计逻辑。
@@ -1462,13 +1529,11 @@ func applyUsageOverviewStatToSnapshotTotals(snapshot *dto.StatisticsSnapshot, re
 	snapshot.FailureCount += failureCount
 }
 
-// applyUsageOverviewStatToSeries 维护主序列，并即时刷新 RPM/TPM/cache rate。
-func applyUsageOverviewStatToSeries(series *dto.UsageOverviewSeriesRecord, requestCount, inputTokens, cacheReadTokens, totalTokens int64, cost float64, bucketKey string, bucketMinutes int64) {
+// applyUsageOverviewStatToSeries 只累计主序列分子，派生指标在整个 bucket 完成后统一计算。
+func applyUsageOverviewStatToSeries(series *dto.UsageOverviewSeriesRecord, requestCount, inputTokens, cacheReadTokens, totalTokens int64, cost float64, bucketKey string, _ int64) {
 	series.Requests[bucketKey] += requestCount
 	series.Tokens[bucketKey] += totalTokens
 	series.Cost[bucketKey] += cost
-	series.RPM[bucketKey] = float64(series.Requests[bucketKey]) / float64(bucketMinutes)
-	series.TPM[bucketKey] = float64(series.Tokens[bucketKey]) / float64(bucketMinutes)
 	updateUsageOverviewSeriesCacheReadRate(series, bucketKey, inputTokens, cacheReadTokens)
 }
 
@@ -1692,7 +1757,7 @@ func loadUsageOverviewRealtimeEventsFromRecentCache(recentCache *UsageRecentEven
 // loadUsageOverviewRealtimeEventsFromDB 在最近事件缓存完全不可用时，使用 usage_events 窄窗兜底。
 func loadUsageOverviewRealtimeEventsFromDB(db *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time) ([]usageOverviewRealtimeEvent, error) {
 	// 兜底查询仍然只读实时窗口，不扩大成 Overview 的大范围扫描。
-	rows, err := loadUsageOverviewEventRangeWithFilter(db, filter, start, end, false)
+	rows, err := loadUsageOverviewRealtimeEventRangeWithFilter(db, filter, start, end, false)
 	if err != nil {
 		return nil, err
 	}
@@ -2182,13 +2247,11 @@ func newUsageOverviewSeriesRecord() dto.UsageOverviewSeriesRecord {
 }
 
 // applyUsageEventToOverviewSeries 把单条事件写入主序列。
-func applyUsageEventToOverviewSeries(series *dto.UsageOverviewSeriesRecord, event entities.UsageEvent, cost float64, bucketKey string, bucketMinutes int64) {
-	// 主序列按 bucket 累计请求、token、成本，并同步刷新 RPM/TPM/cache rate。
+func applyUsageEventToOverviewSeries(series *dto.UsageOverviewSeriesRecord, event entities.UsageEvent, cost float64, bucketKey string, _ int64) {
+	// 主序列按 bucket 累计请求、token、成本，派生值在 finalize 阶段一次生成。
 	series.Requests[bucketKey]++
 	series.Tokens[bucketKey] += event.TotalTokens
 	series.Cost[bucketKey] += cost
-	series.RPM[bucketKey] = float64(series.Requests[bucketKey]) / float64(bucketMinutes)
-	series.TPM[bucketKey] = float64(series.Tokens[bucketKey]) / float64(bucketMinutes)
 	updateUsageOverviewSeriesCacheReadRate(series, bucketKey, event.InputTokens, event.CacheReadTokens)
 }
 
@@ -2214,17 +2277,11 @@ func applyUsageEventToOverview(overview *dto.UsageOverviewRecord, event entities
 func updateUsageOverviewSeriesCacheReadRate(series *dto.UsageOverviewSeriesRecord, bucketKey string, inputTokens, cacheReadTokens int64) {
 	series.CacheReadRateInputTokens[bucketKey] += inputTokens
 	series.CacheReadRateReadTokens[bucketKey] += cacheReadTokens
-	input := series.CacheReadRateInputTokens[bucketKey]
-	if input <= 0 {
-		series.CacheReadRate[bucketKey] = nil
-		return
-	}
-	value := (float64(series.CacheReadRateReadTokens[bucketKey]) / float64(input)) * 100
-	series.CacheReadRate[bucketKey] = &value
 }
 
 // finalizeUsageOverview 从累计后的 usage 数据反推顶部 summary 派生指标。
 func finalizeUsageOverview(overview *dto.UsageOverviewRecord) {
+	finalizeUsageOverviewSeries(&overview.Series)
 	overview.Summary.RequestCount = overview.Usage.TotalRequests
 	overview.Summary.TokenCount = overview.Usage.TotalTokens
 	if overview.Summary.WindowMinutes > 0 {
@@ -2238,6 +2295,28 @@ func finalizeUsageOverview(overview *dto.UsageOverviewRecord) {
 		overview.Summary.DailyAverageCost = usageOverviewFloat64Ptr(overview.Summary.TotalCost / days)
 		overview.Summary.DailyAverageRangeDays = usageOverviewFloat64Ptr(days)
 	}
+}
+
+func finalizeUsageOverviewSeries(series *dto.UsageOverviewSeriesRecord) {
+	for bucketKey, requests := range series.Requests {
+		bucketMinutes := usageOverviewSeriesBucketMinutes(bucketKey)
+		series.RPM[bucketKey] = float64(requests) / float64(bucketMinutes)
+		series.TPM[bucketKey] = float64(series.Tokens[bucketKey]) / float64(bucketMinutes)
+		inputTokens := series.CacheReadRateInputTokens[bucketKey]
+		if inputTokens <= 0 {
+			series.CacheReadRate[bucketKey] = nil
+			continue
+		}
+		value := float64(series.CacheReadRateReadTokens[bucketKey]) / float64(inputTokens) * 100
+		series.CacheReadRate[bucketKey] = &value
+	}
+}
+
+func usageOverviewSeriesBucketMinutes(bucketKey string) int64 {
+	if len(bucketKey) == len(time.DateOnly) {
+		return usageOverviewDailyAverageDayMinutes
+	}
+	return int64(time.Hour / time.Minute)
 }
 
 func usageOverviewFloat64Ptr(value float64) *float64 {

--- a/internal/service/dto/usage.go
+++ b/internal/service/dto/usage.go
@@ -83,9 +83,6 @@ type UsageEventRecord struct {
 
 // UsageOverviewSummary 是 overview summary 的服务层结果。
 type UsageOverviewSummary struct {
-	RequestCount          int64
-	TokenCount            int64
-	WindowMinutes         int64
 	RPM                   float64
 	TPM                   float64
 	TotalCost             float64
@@ -102,12 +99,13 @@ type UsageOverviewSummary struct {
 
 // UsageOverviewSeries 是 overview series 的服务层结果。
 type UsageOverviewSeries struct {
-	Requests      map[string]int64
-	Tokens        map[string]int64
-	RPM           map[string]float64
-	TPM           map[string]float64
-	Cost          map[string]float64
-	CacheReadRate map[string]*float64
+	Buckets       []string
+	Requests      []int64
+	Tokens        []int64
+	RPM           []float64
+	TPM           []float64
+	Cost          []float64
+	CacheReadRate []*float64
 }
 
 // RealtimeTokenVelocityPoint 是 Overview token 速度图的单个短窗口桶。

--- a/internal/service/test/usage_overview_series_test.go
+++ b/internal/service/test/usage_overview_series_test.go
@@ -1,0 +1,30 @@
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/service"
+	servicedto "cpa-usage-keeper/internal/service/dto"
+)
+
+func TestLongCustomOverviewWithoutFactsReturnsEmptySeries(t *testing.T) {
+	db := openUsageServiceTestDatabase(t)
+	provider := service.NewUsageService(db)
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.Local)
+	end := start.AddDate(0, 0, 31)
+
+	overview, err := provider.GetUsageOverview(context.Background(), servicedto.UsageFilter{
+		Range: "custom", CustomUnit: "day", RangeCount: 31,
+		StartTime: &start, EndTime: &end, EndExclusive: true,
+	})
+	if err != nil {
+		t.Fatalf("GetUsageOverview returned error: %v", err)
+	}
+	if len(overview.Series.Buckets) != 0 || len(overview.Series.Requests) != 0 || len(overview.Series.Tokens) != 0 ||
+		len(overview.Series.RPM) != 0 || len(overview.Series.TPM) != 0 || len(overview.Series.Cost) != 0 ||
+		len(overview.Series.CacheReadRate) != 0 {
+		t.Fatalf("expected an empty series for an empty range, got %+v", overview.Series)
+	}
+}

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -73,9 +74,6 @@ func (s *usageService) GetUsageOverview(ctx context.Context, filter servicedto.U
 	return &servicedto.UsageOverviewSnapshot{
 		Usage: overview.Usage,
 		Summary: servicedto.UsageOverviewSummary{
-			RequestCount:          overview.Summary.RequestCount,
-			TokenCount:            overview.Summary.TokenCount,
-			WindowMinutes:         overview.Summary.WindowMinutes,
 			RPM:                   overview.Summary.RPM,
 			TPM:                   overview.Summary.TPM,
 			TotalCost:             overview.Summary.TotalCost,
@@ -89,7 +87,7 @@ func (s *usageService) GetUsageOverview(ctx context.Context, filter servicedto.U
 			DailyAverageCost:      overview.Summary.DailyAverageCost,
 			DailyAverageRangeDays: overview.Summary.DailyAverageRangeDays,
 		},
-		Series: mapUsageOverviewSeries(overview.Series),
+		Series: mapUsageOverviewSeries(overview.Series, filter),
 	}, nil
 }
 
@@ -237,15 +235,90 @@ func (s *usageService) GetUsageOverviewRealtime(ctx context.Context, filter serv
 	return &result, nil
 }
 
-func mapUsageOverviewSeries(series repodto.UsageOverviewSeriesRecord) servicedto.UsageOverviewSeries {
-	return servicedto.UsageOverviewSeries{
-		Requests:      series.Requests,
-		Tokens:        series.Tokens,
-		RPM:           series.RPM,
-		TPM:           series.TPM,
-		Cost:          series.Cost,
-		CacheReadRate: series.CacheReadRate,
+const usageOverviewSeriesMaxPoints = 90
+
+func mapUsageOverviewSeries(series repodto.UsageOverviewSeriesRecord, filter servicedto.UsageFilter) servicedto.UsageOverviewSeries {
+	if len(series.Requests) == 0 {
+		return emptyUsageOverviewServiceSeries(0)
 	}
+	labels := usageOverviewSeriesLabels(series, filter)
+	if len(labels) <= usageOverviewSeriesMaxPoints {
+		return mapUsageOverviewSeriesLabels(series, labels)
+	}
+
+	result := emptyUsageOverviewServiceSeries(usageOverviewSeriesMaxPoints)
+	for index := 0; index < usageOverviewSeriesMaxPoints; index++ {
+		start := index * len(labels) / usageOverviewSeriesMaxPoints
+		end := (index + 1) * len(labels) / usageOverviewSeriesMaxPoints
+		group := labels[start:end]
+		bucket := group[0]
+		var requests, tokens, inputTokens, cacheReadTokens int64
+		var cost float64
+		for _, label := range group {
+			requests += series.Requests[label]
+			tokens += series.Tokens[label]
+			cost += series.Cost[label]
+			inputTokens += series.CacheReadRateInputTokens[label]
+			cacheReadTokens += series.CacheReadRateReadTokens[label]
+		}
+		minutes := float64(len(group) * 24 * 60)
+		result.Buckets = append(result.Buckets, bucket)
+		result.Requests = append(result.Requests, requests)
+		result.Tokens = append(result.Tokens, tokens)
+		result.RPM = append(result.RPM, float64(requests)/minutes)
+		result.TPM = append(result.TPM, float64(tokens)/minutes)
+		result.Cost = append(result.Cost, cost)
+		result.CacheReadRate = append(result.CacheReadRate, usageOverviewSeriesCacheRate(inputTokens, cacheReadTokens))
+	}
+	return result
+}
+
+func usageOverviewSeriesLabels(series repodto.UsageOverviewSeriesRecord, filter servicedto.UsageFilter) []string {
+	if filter.Range == "custom" && filter.CustomUnit == "day" && filter.RangeCount > 30 && filter.StartTime != nil && filter.EndTime != nil {
+		start := time.Date(filter.StartTime.Year(), filter.StartTime.Month(), filter.StartTime.Day(), 0, 0, 0, 0, time.Local)
+		end := time.Date(filter.EndTime.Year(), filter.EndTime.Month(), filter.EndTime.Day(), 0, 0, 0, 0, time.Local)
+		labels := make([]string, 0, filter.RangeCount)
+		for day := start; day.Before(end); day = day.AddDate(0, 0, 1) {
+			labels = append(labels, day.Format(time.DateOnly))
+		}
+		return labels
+	}
+	labels := make([]string, 0, len(series.Requests))
+	for label := range series.Requests {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	return labels
+}
+
+func mapUsageOverviewSeriesLabels(series repodto.UsageOverviewSeriesRecord, labels []string) servicedto.UsageOverviewSeries {
+	result := emptyUsageOverviewServiceSeries(len(labels))
+	for _, label := range labels {
+		result.Buckets = append(result.Buckets, label)
+		result.Requests = append(result.Requests, series.Requests[label])
+		result.Tokens = append(result.Tokens, series.Tokens[label])
+		result.RPM = append(result.RPM, series.RPM[label])
+		result.TPM = append(result.TPM, series.TPM[label])
+		result.Cost = append(result.Cost, series.Cost[label])
+		result.CacheReadRate = append(result.CacheReadRate, series.CacheReadRate[label])
+	}
+	return result
+}
+
+func emptyUsageOverviewServiceSeries(capacity int) servicedto.UsageOverviewSeries {
+	return servicedto.UsageOverviewSeries{
+		Buckets: make([]string, 0, capacity), Requests: make([]int64, 0, capacity), Tokens: make([]int64, 0, capacity),
+		RPM: make([]float64, 0, capacity), TPM: make([]float64, 0, capacity), Cost: make([]float64, 0, capacity),
+		CacheReadRate: make([]*float64, 0, capacity),
+	}
+}
+
+func usageOverviewSeriesCacheRate(inputTokens, cacheReadTokens int64) *float64 {
+	if inputTokens <= 0 {
+		return nil
+	}
+	value := float64(cacheReadTokens) / float64(inputTokens) * 100
+	return &value
 }
 
 func mapUsageOverviewRealtime(realtime repodto.UsageOverviewRealtimeRecord) servicedto.UsageOverviewRealtime {

--- a/internal/service/usage_filter_test.go
+++ b/internal/service/usage_filter_test.go
@@ -56,16 +56,17 @@ func TestUsageServiceGetUsageOverviewDelegatesToFilteredOverview(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetUsageOverview returned error: %v", err)
 	}
-	if overview.Summary.RequestCount != 2 || overview.Summary.TokenCount != 2425 {
-		t.Fatalf("expected overview summary counts, got %+v", overview.Summary)
+	if overview.Usage == nil || overview.Usage.TotalRequests != 2 || overview.Usage.TotalTokens != 2425 {
+		t.Fatalf("expected overview usage counts, got %+v", overview.Usage)
 	}
-	if overview.Summary.WindowMinutes != 1440 {
-		t.Fatalf("expected 24h overview to use exact 1440 minute window, got %+v", overview.Summary)
+	if math.Abs(overview.Summary.RPM-2.0/1440.0) > 0.000000001 || math.Abs(overview.Summary.TPM-2425.0/1440.0) > 0.000000001 {
+		t.Fatalf("expected 24h overview rates to use exact 1440 minute window, got %+v", overview.Summary)
 	}
-	if overview.Series.Requests["2026-04-16T17:00:00+08:00"] != 1 || overview.Series.Requests["2026-04-16T18:00:00+08:00"] != 1 {
+	if len(overview.Series.Buckets) != 2 || overview.Series.Buckets[0] != "2026-04-16T17:00:00+08:00" || overview.Series.Buckets[1] != "2026-04-16T18:00:00+08:00" ||
+		overview.Series.Requests[0] != 1 || overview.Series.Requests[1] != 1 {
 		t.Fatalf("expected hourly request series values, got %+v", overview.Series)
 	}
-	if math.Abs(overview.Series.Cost["2026-04-16T17:00:00+08:00"]-0.01023) > 0.000000001 || math.Abs(overview.Series.Cost["2026-04-16T18:00:00+08:00"]-0.00525) > 0.000000001 {
+	if math.Abs(overview.Series.Cost[0]-0.01023) > 0.000000001 || math.Abs(overview.Series.Cost[1]-0.00525) > 0.000000001 {
 		t.Fatalf("expected hourly cost series values, got %+v", overview.Series)
 	}
 }
@@ -106,8 +107,8 @@ func TestUsageServiceGetUsageOverviewUsesRecentCacheForBoundaries(t *testing.T) 
 	if err != nil {
 		t.Fatalf("GetUsageOverview returned error: %v", err)
 	}
-	if overview.Summary.RequestCount != 1 || overview.Summary.TokenCount != 100 {
-		t.Fatalf("expected overview service to use recent cache boundary event, got %+v", overview.Summary)
+	if overview.Usage == nil || overview.Usage.TotalRequests != 1 || overview.Usage.TotalTokens != 100 {
+		t.Fatalf("expected overview service to use recent cache boundary event, got %+v", overview.Usage)
 	}
 }
 
@@ -234,8 +235,8 @@ func TestUsageServiceResolvesAPIKeyIDForUsageQueries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetUsageOverview returned error: %v", err)
 	}
-	if overview.Summary.RequestCount != 2 || overview.Summary.TokenCount != 30 {
-		t.Fatalf("expected overview to use resolved API key, got %+v", overview.Summary)
+	if overview.Usage == nil || overview.Usage.TotalRequests != 2 || overview.Usage.TotalTokens != 30 {
+		t.Fatalf("expected overview to use resolved API key, got %+v", overview.Usage)
 	}
 	analysis, err := provider.GetAnalysis(context.Background(), servicedto.UsageFilter{APIKeyID: targetID, Range: "custom", StartTime: &start, EndTime: &end})
 	if err != nil {

--- a/internal/timeutil/usage_query_range.go
+++ b/internal/timeutil/usage_query_range.go
@@ -24,8 +24,18 @@ type UsageQueryRange struct {
 	EndExclusive bool
 }
 
+// UsageQueryRangeOptions 允许调用方只放开自身明确支持的范围能力。
+type UsageQueryRangeOptions struct {
+	AllowLongCustomDayRange bool
+}
+
 // ParseUsageQueryRange 统一解析 Overview、Analysis、Events 与 Activity 共用的时间参数。
 func ParseUsageQueryRange(rangeValue, unitValue, startValue, endValue string, anchor time.Time) (UsageQueryRange, error) {
+	return ParseUsageQueryRangeWithOptions(rangeValue, unitValue, startValue, endValue, anchor, UsageQueryRangeOptions{})
+}
+
+// ParseUsageQueryRangeWithOptions 在保留公共默认限制的基础上应用调用方显式策略。
+func ParseUsageQueryRangeWithOptions(rangeValue, unitValue, startValue, endValue string, anchor time.Time, options UsageQueryRangeOptions) (UsageQueryRange, error) {
 	rangeValue = strings.TrimSpace(rangeValue)
 	if rangeValue == "" {
 		return UsageQueryRange{}, fmt.Errorf("usage range is required")
@@ -46,7 +56,7 @@ func ParseUsageQueryRange(rangeValue, unitValue, startValue, endValue string, an
 			EndTime:   NormalizeStorageTime(localStart.AddDate(0, 0, 1).Add(-time.Nanosecond)),
 		}, nil
 	case "custom":
-		return parseCustomUsageQueryRange(unitValue, startValue, endValue, anchor)
+		return parseCustomUsageQueryRange(unitValue, startValue, endValue, anchor, options)
 	default:
 		rollingRange, ok := ParseUsageRollingRange(rangeValue)
 		if !ok {
@@ -67,7 +77,7 @@ func ParseUsageQueryRange(rangeValue, unitValue, startValue, endValue string, an
 	}
 }
 
-func parseCustomUsageQueryRange(unitValue, startValue, endValue string, anchor time.Time) (UsageQueryRange, error) {
+func parseCustomUsageQueryRange(unitValue, startValue, endValue string, anchor time.Time, options UsageQueryRangeOptions) (UsageQueryRange, error) {
 	startValue = strings.TrimSpace(startValue)
 	endValue = strings.TrimSpace(endValue)
 	if startValue == "" || endValue == "" {
@@ -78,7 +88,7 @@ func parseCustomUsageQueryRange(unitValue, startValue, endValue string, anchor t
 		return UsageQueryRange{}, err
 	}
 	if unit == UsageQueryUnitDay {
-		return parseCustomUsageDayRange(startValue, endValue, anchor)
+		return parseCustomUsageDayRange(startValue, endValue, anchor, options.AllowLongCustomDayRange)
 	}
 	return parseCustomUsageHourRange(startValue, endValue, anchor)
 }
@@ -99,7 +109,7 @@ func resolveUsageQueryUnit(unitValue, startValue, endValue string) (UsageQueryUn
 	return unit, nil
 }
 
-func parseCustomUsageDayRange(startValue, endValue string, anchor time.Time) (UsageQueryRange, error) {
+func parseCustomUsageDayRange(startValue, endValue string, anchor time.Time, allowLongRange bool) (UsageQueryRange, error) {
 	startTime, err := time.ParseInLocation(time.DateOnly, startValue, time.Local)
 	if err != nil {
 		return UsageQueryRange{}, fmt.Errorf("invalid start: %w", err)
@@ -114,7 +124,7 @@ func parseCustomUsageDayRange(startValue, endValue string, anchor time.Time) (Us
 	if !anchor.IsZero() {
 		localAnchor := NormalizeStorageTime(anchor)
 		today := time.Date(localAnchor.Year(), localAnchor.Month(), localAnchor.Day(), 0, 0, 0, 0, time.Local)
-		if startTime.Before(today.AddDate(0, 0, -29)) {
+		if !allowLongRange && startTime.Before(today.AddDate(0, 0, -29)) {
 			return UsageQueryRange{}, fmt.Errorf("custom day range cannot start more than 30 calendar days ago")
 		}
 		if endDay.After(today) {

--- a/web/src/components/usage/CustomRangePanel.tsx
+++ b/web/src/components/usage/CustomRangePanel.tsx
@@ -15,6 +15,7 @@ import styles from './TimeRangeControl.module.scss';
 
 type CustomPickerView = 'summary' | 'day' | 'hour';
 type CustomEndpoint = 'start' | 'end';
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 interface CustomRangePanelProps {
   value: UsageCustomRange;
@@ -55,6 +56,12 @@ const formatCalendarDay = (value: string, locale?: string): string => new Intl.D
 }).format(parseDayKey(value));
 
 const monthKey = (value: string): string => value.slice(0, 7);
+
+const shiftMonth = (value: string, amount: number): string => {
+  const date = parseDayKey(`${value}-01`);
+  date.setUTCMonth(date.getUTCMonth() + amount);
+  return date.toISOString().slice(0, 7);
+};
 
 interface CalendarCell {
   value: string;
@@ -152,12 +159,13 @@ export function CustomRangePanel({ value, timeZone, locale, anchorMs, onChange, 
   const daySlots = useMemo(() => buildCustomDaySlots({ nowMs: anchorMs, timeZone, locale }), [anchorMs, locale, timeZone]);
   const hourSlots = useMemo(() => buildCustomHourSlots({ nowMs: anchorMs, timeZone, locale }), [anchorMs, locale, timeZone]);
   const weekdayLabels = useMemo(() => buildCustomWeekdayLabels(locale), [locale]);
-  const slots = value.unit === 'hour' ? hourSlots : daySlots;
-  const startIndex = slots.findIndex((slot) => slot.value === value.start);
-  const endIndex = slots.findIndex((slot) => slot.value === value.end);
-  const slotCount = Math.max(endIndex - startIndex + 1, 0);
-  const allowedMonths = useMemo(() => [...new Set(daySlots.map((slot) => monthKey(slot.value)))], [daySlots]);
-  const allowedDayValues = useMemo(() => new Set(daySlots.map((slot) => slot.value)), [daySlots]);
+  const startIndex = hourSlots.findIndex((slot) => slot.value === value.start);
+  const endIndex = hourSlots.findIndex((slot) => slot.value === value.end);
+  const slotCount = value.unit === 'hour'
+    ? Math.max(endIndex - startIndex + 1, 0)
+    : Math.max(Math.floor((parseDayKey(value.end).getTime() - parseDayKey(value.start).getTime()) / DAY_MS) + 1, 0);
+  const today = daySlots[daySlots.length - 1].value;
+  const currentMonth = monthKey(today);
   const activeDay = value[activeEndpoint].slice(0, 10);
   const [visibleMonth, setVisibleMonth] = useState(monthKey(activeDay));
   const [pickerSnapshot, setPickerSnapshot] = useState<UsageCustomRange | null>(null);
@@ -283,16 +291,15 @@ export function CustomRangePanel({ value, timeZone, locale, anchorMs, onChange, 
           <div className={styles.customCalendarHeader}>
             <button
               type="button"
-              disabled={allowedMonths.indexOf(visibleMonth) <= 0}
-              onClick={() => setVisibleMonth(allowedMonths[allowedMonths.indexOf(visibleMonth) - 1])}
+              onClick={() => setVisibleMonth((month) => shiftMonth(month, -1))}
               aria-label={t('usage_stats.range_custom_previous_month')}
             ><IconChevronLeft size={14} /></button>
             <strong>{new Intl.DateTimeFormat(locale, { year: 'numeric', month: 'long', timeZone: 'UTC' }).format(parseDayKey(`${visibleMonth}-01`))}</strong>
             <button
               type="button"
-              disabled={allowedMonths.indexOf(visibleMonth) >= allowedMonths.length - 1}
+              disabled={visibleMonth >= currentMonth}
               className={styles.customNextMonthButton}
-              onClick={() => setVisibleMonth(allowedMonths[allowedMonths.indexOf(visibleMonth) + 1])}
+              onClick={() => setVisibleMonth((month) => shiftMonth(month, 1))}
               aria-label={t('usage_stats.range_custom_next_month')}
             ><IconChevronLeft size={14} /></button>
           </div>
@@ -301,17 +308,17 @@ export function CustomRangePanel({ value, timeZone, locale, anchorMs, onChange, 
           </div>
           <div className={styles.customCalendarGrid}>
             {calendarCells.map(({ value: day, outsideMonth }, index) => {
-              const allowed = allowedDayValues.has(day);
+              const allowed = day <= today;
               const selected = day === value.start || day === value.end;
               const inRange = allowed && day >= value.start && day <= value.end;
               const previousDay = calendarCells[index - 1]?.value;
               const nextDay = calendarCells[index + 1]?.value;
               const previousInRange = previousDay !== undefined
-                && allowedDayValues.has(previousDay)
+                && previousDay <= today
                 && previousDay >= value.start
                 && previousDay <= value.end;
               const nextInRange = nextDay !== undefined
-                && allowedDayValues.has(nextDay)
+                && nextDay <= today
                 && nextDay >= value.start
                 && nextDay <= value.end;
               // 色带只在真实区间端点或每周换行处收口，不在月份边界人为断开。

--- a/web/src/components/usage/DailyAveragePanel.test.tsx
+++ b/web/src/components/usage/DailyAveragePanel.test.tsx
@@ -12,9 +12,6 @@ const usageWithDailyAverages: UsageOverviewPayload = {
     total_tokens: 52590000,
   },
   summary: {
-    request_count: 461,
-    token_count: 52590000,
-    window_minutes: 10080,
     rpm: 0.0457,
     tpm: 5217.26,
     total_cost: 56.47,
@@ -29,12 +26,13 @@ const usageWithDailyAverages: UsageOverviewPayload = {
     daily_average_range_days: 7,
   },
   series: {
-    requests: {},
-    tokens: {},
-    rpm: {},
-    tpm: {},
-    cost: {},
-    cache_read_rate: {},
+    buckets: [],
+    requests: [],
+    tokens: [],
+    rpm: [],
+    tpm: [],
+    cost: [],
+    cache_read_rate: [],
   },
 };
 

--- a/web/src/components/usage/StatCards.test.ts
+++ b/web/src/components/usage/StatCards.test.ts
@@ -10,9 +10,6 @@ const usageWithBackendSummary: UsageOverviewPayload = {
     total_tokens: 900,
   },
   summary: {
-    request_count: 3,
-    token_count: 777,
-    window_minutes: 120,
     rpm: 0.025,
     tpm: 6.475,
     total_cost: 1.234,
@@ -23,12 +20,13 @@ const usageWithBackendSummary: UsageOverviewPayload = {
     reasoning_tokens: 33,
   },
   series: {
-    requests: {},
-    tokens: {},
-    rpm: {},
-    tpm: {},
-    cost: {},
-    cache_read_rate: {},
+    buckets: [],
+    requests: [],
+    tokens: [],
+    rpm: [],
+    tpm: [],
+    cost: [],
+    cache_read_rate: [],
   },
 };
 
@@ -38,9 +36,8 @@ describe('buildStatCardMetrics', () => {
       usage: usageWithBackendSummary,
     });
 
-    expect(metrics.rateStats.requestCount).toBe(3);
-    expect(metrics.rateStats.tokenCount).toBe(777);
-    expect(metrics.rateStats.windowMinutes).toBe(120);
+    expect(metrics.rateStats.requestCount).toBe(9);
+    expect(metrics.rateStats.tokenCount).toBe(900);
     expect(metrics.rateStats.rpm).toBe(0.025);
     expect(metrics.rateStats.tpm).toBe(6.475);
     expect(metrics.requestStats.successRate).toBeCloseTo(88.8888888889);

--- a/web/src/components/usage/StatCards.tsx
+++ b/web/src/components/usage/StatCards.tsx
@@ -49,7 +49,7 @@ export interface StatCardsProps {
 interface StatCardMetrics {
   requestStats: { successRate: number | null };
   tokenBreakdown: { cacheReadTokens: number; cacheCreationTokens: number; reasoningTokens: number };
-  rateStats: { rpm: number; tpm: number; windowMinutes: number; requestCount: number; tokenCount: number };
+  rateStats: { rpm: number; tpm: number; requestCount: number; tokenCount: number };
   cacheReadRateStats: { cacheReadRate: number | null; cacheReadTokens: number; inputTokens: number };
   totalCost: number;
   costAvailable: boolean;
@@ -77,7 +77,7 @@ export function buildStatCardMetrics({ usage }: { usage: UsageOverviewPayload | 
     return {
       requestStats,
       tokenBreakdown: { cacheReadTokens: 0, cacheCreationTokens: 0, reasoningTokens: 0 },
-      rateStats: { rpm: 0, tpm: 0, windowMinutes: 1, requestCount: 0, tokenCount: 0 },
+      rateStats: { rpm: 0, tpm: 0, requestCount: 0, tokenCount: 0 },
       cacheReadRateStats: { cacheReadRate: null, cacheReadTokens: 0, inputTokens: 0 },
       totalCost: 0,
       costAvailable: false,
@@ -98,9 +98,8 @@ export function buildStatCardMetrics({ usage }: { usage: UsageOverviewPayload | 
     rateStats: {
       rpm: usage.summary.rpm ?? 0,
       tpm: usage.summary.tpm ?? 0,
-      windowMinutes: usage.summary.window_minutes ?? 1,
-      requestCount: usage.summary.request_count ?? 0,
-      tokenCount: usage.summary.token_count ?? 0,
+      requestCount: Math.max(safeNumber(usageSnapshot?.total_requests), 0),
+      tokenCount: Math.max(safeNumber(usageSnapshot?.total_tokens), 0),
     },
     cacheReadRateStats: {
       cacheReadRate: calculateCacheReadRate({ inputTokens, cacheReadTokens }),

--- a/web/src/components/usage/hooks/useSparklines.test.ts
+++ b/web/src/components/usage/hooks/useSparklines.test.ts
@@ -10,9 +10,6 @@ const usageWithBackendSeries: UsageOverviewPayload = {
     total_tokens: 900,
   },
   summary: {
-    request_count: 9,
-    token_count: 900,
-    window_minutes: 120,
     rpm: 0.075,
     tpm: 7.5,
     total_cost: 1,
@@ -23,30 +20,13 @@ const usageWithBackendSeries: UsageOverviewPayload = {
     reasoning_tokens: 0,
   },
   series: {
-    requests: {
-      '2026-04-23T10:00:00Z': 2,
-      '2026-04-23T11:00:00Z': 4,
-    },
-    tokens: {
-      '2026-04-23T10:00:00Z': 200,
-      '2026-04-23T11:00:00Z': 800,
-    },
-    rpm: {
-      '2026-04-23T10:00:00Z': 2 / 60,
-      '2026-04-23T11:00:00Z': 4 / 60,
-    },
-    tpm: {
-      '2026-04-23T10:00:00Z': 200 / 60,
-      '2026-04-23T11:00:00Z': 800 / 60,
-    },
-    cost: {
-      '2026-04-23T10:00:00Z': 0.2,
-      '2026-04-23T11:00:00Z': 0.8,
-    },
-    cache_read_rate: {
-      '2026-04-23T10:00:00Z': 25,
-      '2026-04-23T11:00:00Z': null,
-    },
+    buckets: ['2026-04-23T10:00:00Z', '2026-04-23T11:00:00Z'],
+    requests: [2, 4],
+    tokens: [200, 800],
+    rpm: [2 / 60, 4 / 60],
+    tpm: [200 / 60, 800 / 60],
+    cost: [0.2, 0.8],
+    cache_read_rate: [25, null],
   },
 };
 
@@ -71,10 +51,9 @@ describe('buildUsageSparklineSeries', () => {
         ...usageWithBackendSeries,
         series: {
           ...usageWithBackendSeries.series!,
-          requests: {
-            '2026-04-23T10:00:00Z': 1,
-          },
-          cache_read_rate: {},
+          buckets: ['2026-04-23T10:00:00Z'],
+          requests: [1],
+          cache_read_rate: [],
         },
       },
     });
@@ -89,24 +68,13 @@ describe('buildUsageSparklineSeries', () => {
         ...usageWithBackendSeries,
         series: {
           ...usageWithBackendSeries.series!,
-          requests: {
-            '2026-04-23T10:00:00Z': invalidNumber,
-          },
-          tokens: {
-            '2026-04-23T10:00:00Z': -4,
-          },
-          rpm: {
-            '2026-04-23T10:00:00Z': Number.POSITIVE_INFINITY,
-          },
-          tpm: {
-            '2026-04-23T10:00:00Z': Number.NaN,
-          },
-          cost: {
-            '2026-04-23T10:00:00Z': invalidNumber,
-          },
-          cache_read_rate: {
-            '2026-04-23T10:00:00Z': invalidNumber,
-          },
+          buckets: ['2026-04-23T10:00:00Z'],
+          requests: [invalidNumber],
+          tokens: [-4],
+          rpm: [Number.POSITIVE_INFINITY],
+          tpm: [Number.NaN],
+          cost: [invalidNumber],
+          cache_read_rate: [invalidNumber],
         },
       },
     });

--- a/web/src/components/usage/hooks/useSparklines.ts
+++ b/web/src/components/usage/hooks/useSparklines.ts
@@ -70,19 +70,19 @@ export function buildUsageSparklineSeries({ usage }: Omit<UseSparklinesOptions, 
     return { labels: [], requests: [], tokens: [], rpm: [], tpm: [], cacheReadRate: [], cost: [] };
   }
 
-  const labels = Object.keys(usage.series.requests ?? {}).sort((a, b) => a.localeCompare(b));
+  const labels = usage.series.buckets ?? [];
   if (!labels.length) {
     return { labels: [], requests: [], tokens: [], rpm: [], tpm: [], cacheReadRate: [], cost: [] };
   }
 
   return {
     labels,
-    requests: labels.map((label) => normalizeSparklineNumber(usage.series?.requests?.[label])),
-    tokens: labels.map((label) => normalizeSparklineNumber(usage.series?.tokens?.[label])),
-    rpm: labels.map((label) => normalizeSparklineNumber(usage.series?.rpm?.[label])),
-    tpm: labels.map((label) => normalizeSparklineNumber(usage.series?.tpm?.[label])),
-    cacheReadRate: labels.map((label) => normalizeNullableSparklineNumber(usage.series?.cache_read_rate?.[label])),
-    cost: labels.map((label) => normalizeSparklineNumber(usage.series?.cost?.[label])),
+    requests: labels.map((_, index) => normalizeSparklineNumber(usage.series?.requests?.[index])),
+    tokens: labels.map((_, index) => normalizeSparklineNumber(usage.series?.tokens?.[index])),
+    rpm: labels.map((_, index) => normalizeSparklineNumber(usage.series?.rpm?.[index])),
+    tpm: labels.map((_, index) => normalizeSparklineNumber(usage.series?.tpm?.[index])),
+    cacheReadRate: labels.map((_, index) => normalizeNullableSparklineNumber(usage.series?.cache_read_rate?.[index])),
+    cost: labels.map((_, index) => normalizeSparklineNumber(usage.series?.cost?.[index])),
   };
 }
 

--- a/web/src/components/usage/test/TimeRangeControl.test.tsx
+++ b/web/src/components/usage/test/TimeRangeControl.test.tsx
@@ -379,6 +379,23 @@ describe('TimeRangeControl', () => {
     expect(document.querySelector('[data-custom-calendar-month]')?.getAttribute('data-custom-calendar-month')).toBe('2026-07');
   });
 
+  it('navigates to historical calendar months beyond the former thirty-day window', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-17T07:36:42.000Z'));
+    await renderControl('custom', vi.fn(), {
+      unit: 'day',
+      start: '2026-06-18',
+      end: '2026-07-17',
+    });
+    const trigger = document.querySelector<HTMLButtonElement>('[data-time-range-trigger="desktop"]');
+    await act(async () => trigger?.click());
+    await act(async () => document.querySelector<HTMLButtonElement>('[data-custom-endpoint="start"]')?.click());
+    await act(async () => document.querySelector<HTMLButtonElement>('[aria-label="usage_stats.range_custom_previous_month"]')?.click());
+
+    expect(document.querySelector('[data-custom-calendar-month]')?.getAttribute('data-custom-calendar-month')).toBe('2026-05');
+    expect(document.querySelector<HTMLButtonElement>('[data-custom-calendar-cell="2026-05-01"]')?.disabled).toBe(false);
+  });
+
   it('keeps crossed-month ranges continuous inside a fixed six-week calendar', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-07-17T07:36:42.000Z'));

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -75,9 +75,6 @@ export interface UsageOverviewUsageSnapshot {
 }
 
 export interface UsageOverviewSummary {
-  request_count: number
-  token_count: number
-  window_minutes: number
   rpm: number
   tpm: number
   total_cost: number
@@ -93,12 +90,13 @@ export interface UsageOverviewSummary {
 }
 
 export interface UsageOverviewSeries {
-  requests: Record<string, number>
-  tokens: Record<string, number>
-  rpm: Record<string, number>
-  tpm: Record<string, number>
-  cost: Record<string, number>
-	cache_read_rate: Record<string, number | null>
+  buckets: string[]
+  requests: number[]
+  tokens: number[]
+  rpm: number[]
+  tpm: number[]
+  cost: number[]
+	cache_read_rate: Array<number | null>
 }
 
 export type UsageActivityWindow = '24h' | '7d' | '30d' | '1y'
@@ -229,8 +227,6 @@ export interface UsageOverviewResponse {
   summary?: UsageOverviewSummary
   series?: UsageOverviewSeries
   timezone?: string
-  range_start?: string
-  range_end?: string
 }
 
 export interface UsageEventTokens {

--- a/web/src/pages/test/UsagePage.logic.test.ts
+++ b/web/src/pages/test/UsagePage.logic.test.ts
@@ -150,7 +150,7 @@ describe('UsagePage legacy Custom range migration', () => {
     });
   });
 
-  it('clamps aged legacy dates while preserving the selected end', async () => {
+  it('preserves historical legacy dates and their selected end', async () => {
     const usagePageModule = await import('../UsagePage') as Record<string, unknown>;
     const migrateLegacyUsageRangeState = usagePageModule.migrateLegacyUsageRangeState as ((
       range: { unit: 'day'; start: string; end: string },
@@ -168,7 +168,7 @@ describe('UsagePage legacy Custom range migration', () => {
       range: 'custom',
       customRange: {
         unit: 'day',
-        start: '2026-06-18',
+        start: '2026-06-17',
         end: '2026-07-16',
       },
       timeZone: 'Asia/Shanghai',

--- a/web/src/utils/usage/customRange.ts
+++ b/web/src/utils/usage/customRange.ts
@@ -141,7 +141,14 @@ export const normalizeCustomRange = (
   options: CustomRangeClockOptions,
 ): UsageCustomRange => {
   const unit = range?.unit ?? 'day';
-  const slots = unit === 'hour' ? buildCustomHourSlots(options) : buildCustomDaySlots(options);
+  if (unit === 'day') {
+    const today = formatDateKey(getZonedParts(options.nowMs, options.timeZone));
+    if (isValidDateKey(range?.start) && isValidDateKey(range?.end) && range.start <= range.end && range.end <= today) {
+      return { unit, start: range.start, end: range.end };
+    }
+    return buildDefaultCustomRange({ unit, ...options });
+  }
+  const slots = buildCustomHourSlots(options);
   const startIndex = slots.findIndex((slot) => slot.value === range?.start);
   const endIndex = slots.findIndex((slot) => slot.value === range?.end);
   const selectedSlots = endIndex - startIndex + 1;
@@ -162,7 +169,14 @@ export const clampCustomRangeToCurrentBounds = (
   range: UsageCustomRange,
   options: CustomRangeClockOptions,
 ): UsageCustomRange => {
-  const slots = range.unit === 'hour' ? buildCustomHourSlots(options) : buildCustomDaySlots(options);
+  if (range.unit === 'day') {
+    const today = formatDateKey(getZonedParts(options.nowMs, options.timeZone));
+    if (!isValidDateKey(range.start) || !isValidDateKey(range.end) || range.start > range.end || range.start > today) {
+      return buildDefaultCustomRange({ unit: range.unit, ...options });
+    }
+    return { unit: range.unit, start: range.start, end: range.end > today ? today : range.end };
+  }
+  const slots = buildCustomHourSlots(options);
   const firstSlot = slots[0];
   const lastSlot = slots[slots.length - 1];
   const firstTimestamp = customRangeSlotTimestamp(firstSlot.value, range.unit);

--- a/web/src/utils/usage/test/customRange.test.ts
+++ b/web/src/utils/usage/test/customRange.test.ts
@@ -61,14 +61,14 @@ describe('custom usage range slots', () => {
     });
   });
 
-  it('replaces stale or too-short persisted ranges with a valid default', () => {
+  it('preserves historical day ranges and replaces too-short hour ranges with a valid default', () => {
     expect(normalizeCustomRange({
       unit: 'day',
       start: '2026-05-01',
       end: '2026-07-17',
     }, { nowMs: SHANGHAI_NOW, timeZone: 'Asia/Shanghai' })).toEqual({
       unit: 'day',
-      start: '2026-07-11',
+      start: '2026-05-01',
       end: '2026-07-17',
     });
     expect(normalizeCustomRange({
@@ -120,7 +120,7 @@ describe('custom usage range slots', () => {
       unit: 'day' as const,
       storedStart: '2026-06-17',
       storedEnd: '2026-07-16',
-      expectedStart: '2026-06-18',
+      expectedStart: '2026-06-17',
       expectedEnd: '2026-07-16',
     },
   ])('clamps an aged persisted $unit range while preserving its end', ({ unit, storedStart, storedEnd, expectedStart, expectedEnd }) => {
@@ -173,7 +173,7 @@ describe('custom usage range slots', () => {
       end: '2026-07-16',
     }, { nowMs: SHANGHAI_NOW, timeZone: 'Asia/Shanghai' })).toEqual({
       unit: 'day',
-      start: '2026-06-18',
+      start: '2026-06-17',
       end: '2026-07-16',
     });
   });


### PR DESCRIPTION
## Summary

- allow unrestricted Custom day ranges while keeping Custom hour ranges capped at 24 hours
- query only hourly or daily Overview rollups for Custom ranges and avoid raw usage_events access
- reduce aggregation projections and response payloads, with aligned sparklines capped at 90 points
- preserve existing Hours, Days, Today, Yesterday, Activity, and Realtime behavior

Relate to #317

## Validation

- `TZ=Asia/Shanghai GOCACHE=/tmp/cpa-usage-keeper-go-build GOFLAGS=-count=1 go test ./internal/api ./internal/api/test ./internal/service ./internal/service/test ./internal/repository ./internal/repository/test ./internal/timeutil ./internal/timeutil/test`
- `TZ=UTC GOCACHE=/tmp/cpa-usage-keeper-go-build GOFLAGS=-count=1 make verify`
- real HTTP Overview benchmark smoke run for 30, 90, and 365 day Custom ranges