### PR TITLE
feat(overview): add five rollup dimensions

### DIFF
--- a/internal/entities/test/entities_test.go
+++ b/internal/entities/test/entities_test.go
@@ -97,3 +97,45 @@ func TestCacheTokenSchemaUsesExplicitReadAndWriteNames(t *testing.T) {
 		t.Fatal("expected model_price_settings.cache_creation_price_per1_m to remain")
 	}
 }
+
+func TestUsageOverviewSchemaIncludesFiveAggregationDimensions(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite memory database: %v", err)
+	}
+	if err := db.AutoMigrate(&UsageOverviewHourlyStat{}, &UsageOverviewDailyStat{}); err != nil {
+		t.Fatalf("AutoMigrate usage overview schema returned error: %v", err)
+	}
+
+	dimensions := []string{"service_tier", "response_service_tier", "reasoning_effort", "endpoint", "executor_type"}
+	for _, table := range []string{"usage_overview_hourly_stats", "usage_overview_daily_stats"} {
+		for _, dimension := range dimensions {
+			if !db.Migrator().HasColumn(table, dimension) {
+				t.Fatalf("expected %s.%s", table, dimension)
+			}
+		}
+	}
+
+	assertUsageOverviewDimensionIndex(t, db, "uniq_usage_overview_hourly_stats_dimensions")
+	assertUsageOverviewDimensionIndex(t, db, "uniq_usage_overview_daily_stats_dimensions")
+}
+
+func assertUsageOverviewDimensionIndex(t *testing.T, db *gorm.DB, name string) {
+	t.Helper()
+	type indexColumn struct {
+		Seqno int
+		Name  string
+	}
+	var rows []indexColumn
+	if err := db.Raw("PRAGMA index_info(" + name + ")").Scan(&rows).Error; err != nil {
+		t.Fatalf("load index %s columns: %v", name, err)
+	}
+	want := []string{"bucket_start", "api_group_key", "model", "auth_index", "model_alias", "service_tier", "response_service_tier", "reasoning_effort", "endpoint", "executor_type"}
+	got := make([]string, len(rows))
+	for index, row := range rows {
+		got[index] = row.Name
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected %s columns: got %v want %v", name, got, want)
+	}
+}

--- a/internal/entities/test/entities_test.go
+++ b/internal/entities/test/entities_test.go
@@ -5,6 +5,7 @@ import (
 	_ "cpa-usage-keeper/internal/timeutil"
 	"reflect"
 	"testing"
+	"time"
 
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -116,12 +117,31 @@ func TestUsageOverviewSchemaIncludesFiveAggregationDimensions(t *testing.T) {
 		}
 	}
 
-	assertUsageOverviewDimensionIndex(t, db, "uniq_usage_overview_hourly_stats_dimensions")
-	assertUsageOverviewDimensionIndex(t, db, "uniq_usage_overview_daily_stats_dimensions")
+	assertUsageOverviewDimensionIndex(t, db, "usage_overview_hourly_stats", "uniq_usage_overview_hourly_stats_dimensions")
+	assertUsageOverviewDimensionIndex(t, db, "usage_overview_daily_stats", "uniq_usage_overview_daily_stats_dimensions")
+	assertUsageOverviewDuplicateDimensionKeyRejected(t, db)
 }
 
-func assertUsageOverviewDimensionIndex(t *testing.T, db *gorm.DB, name string) {
+func assertUsageOverviewDimensionIndex(t *testing.T, db *gorm.DB, table string, name string) {
 	t.Helper()
+	type indexListRow struct {
+		Name   string `gorm:"column:name"`
+		Unique int    `gorm:"column:unique"`
+	}
+	var indexes []indexListRow
+	if err := db.Raw("PRAGMA index_list(" + table + ")").Scan(&indexes).Error; err != nil {
+		t.Fatalf("list %s indexes: %v", table, err)
+	}
+	foundUnique := false
+	for _, index := range indexes {
+		if index.Name == name && index.Unique == 1 {
+			foundUnique = true
+		}
+	}
+	if !foundUnique {
+		t.Fatalf("expected %s to be a unique index on %s", name, table)
+	}
+
 	type indexColumn struct {
 		Seqno int
 		Name  string
@@ -137,5 +157,27 @@ func assertUsageOverviewDimensionIndex(t *testing.T, db *gorm.DB, name string) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected %s columns: got %v want %v", name, got, want)
+	}
+}
+
+func assertUsageOverviewDuplicateDimensionKeyRejected(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	now := time.Now()
+	hourly := UsageOverviewHourlyStat{BucketStart: now, APIGroupKey: "api-a", Model: "gpt-a", AuthIndex: "auth-a", ModelAlias: "alias-a", ServiceTier: "default", ResponseServiceTier: "default", ReasoningEffort: "high", Endpoint: "/v1/responses", ExecutorType: "CodexExecutor", CreatedAt: now, UpdatedAt: now}
+	if err := db.Create(&hourly).Error; err != nil {
+		t.Fatalf("insert first hourly dimension key: %v", err)
+	}
+	hourly.ID = 0
+	if err := db.Create(&hourly).Error; err == nil {
+		t.Fatal("expected duplicate hourly dimension key to fail")
+	}
+
+	daily := UsageOverviewDailyStat{BucketStart: now, APIGroupKey: "api-a", Model: "gpt-a", AuthIndex: "auth-a", ModelAlias: "alias-a", ServiceTier: "default", ResponseServiceTier: "default", ReasoningEffort: "high", Endpoint: "/v1/responses", ExecutorType: "CodexExecutor", CreatedAt: now, UpdatedAt: now}
+	if err := db.Create(&daily).Error; err != nil {
+		t.Fatalf("insert first daily dimension key: %v", err)
+	}
+	daily.ID = 0
+	if err := db.Create(&daily).Error; err == nil {
+		t.Fatal("expected duplicate daily dimension key to fail")
 	}
 }

--- a/internal/entities/usage_overview_daily_stat.go
+++ b/internal/entities/usage_overview_daily_stat.go
@@ -5,11 +5,16 @@ import "time"
 // UsageOverviewDailyStat 是 Overview 页面按天预聚合的 usage 统计。
 type UsageOverviewDailyStat struct {
 	ID                  int64     `gorm:"primaryKey"`
-	BucketStart         time.Time `gorm:"serializer:storageTime;not null;uniqueIndex:uniq_usage_overview_daily_stats_bucket_api_model_auth_alias,priority:1;index:idx_usage_overview_daily_stats_bucket_start;index:idx_usage_overview_daily_stats_api_bucket,priority:2;index:idx_usage_overview_daily_stats_api_model_bucket,priority:3;index:idx_usage_overview_daily_stats_auth_bucket,priority:2;index:idx_usage_overview_daily_stats_model_alias_bucket,priority:2"`
-	APIGroupKey         string    `gorm:"not null;uniqueIndex:uniq_usage_overview_daily_stats_bucket_api_model_auth_alias,priority:2;index:idx_usage_overview_daily_stats_api_bucket,priority:1;index:idx_usage_overview_daily_stats_api_model_bucket,priority:1"`
-	Model               string    `gorm:"not null;uniqueIndex:uniq_usage_overview_daily_stats_bucket_api_model_auth_alias,priority:3;index:idx_usage_overview_daily_stats_api_model_bucket,priority:2"`
-	AuthIndex           string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_daily_stats_bucket_api_model_auth_alias,priority:4;index:idx_usage_overview_daily_stats_auth_bucket,priority:1"`
-	ModelAlias          string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_daily_stats_bucket_api_model_auth_alias,priority:5;index:idx_usage_overview_daily_stats_model_alias_bucket,priority:1"`
+	BucketStart         time.Time `gorm:"serializer:storageTime;not null;uniqueIndex:uniq_usage_overview_daily_stats_dimensions,priority:1;index:idx_usage_overview_daily_stats_bucket_start;index:idx_usage_overview_daily_stats_api_bucket,priority:2;index:idx_usage_overview_daily_stats_api_model_bucket,priority:3;index:idx_usage_overview_daily_stats_auth_bucket,priority:2;index:idx_usage_overview_daily_stats_model_alias_bucket,priority:2"`
+	APIGroupKey         string    `gorm:"not null;uniqueIndex:uniq_usage_overview_daily_stats_dimensions,priority:2;index:idx_usage_overview_daily_stats_api_bucket,priority:1;index:idx_usage_overview_daily_stats_api_model_bucket,priority:1"`
+	Model               string    `gorm:"not null;uniqueIndex:uniq_usage_overview_daily_stats_dimensions,priority:3;index:idx_usage_overview_daily_stats_api_model_bucket,priority:2"`
+	AuthIndex           string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_daily_stats_dimensions,priority:4;index:idx_usage_overview_daily_stats_auth_bucket,priority:1"`
+	ModelAlias          string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_daily_stats_dimensions,priority:5;index:idx_usage_overview_daily_stats_model_alias_bucket,priority:1"`
+	ServiceTier         string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_daily_stats_dimensions,priority:6"`
+	ResponseServiceTier string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_daily_stats_dimensions,priority:7"`
+	ReasoningEffort     string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_daily_stats_dimensions,priority:8"`
+	Endpoint            string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_daily_stats_dimensions,priority:9"`
+	ExecutorType        string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_daily_stats_dimensions,priority:10"`
 	RequestCount        int64     `gorm:"not null;default:0"`
 	SuccessCount        int64     `gorm:"not null;default:0"`
 	FailureCount        int64     `gorm:"not null;default:0"`

--- a/internal/entities/usage_overview_hourly_stat.go
+++ b/internal/entities/usage_overview_hourly_stat.go
@@ -5,11 +5,16 @@ import "time"
 // UsageOverviewHourlyStat 是 Overview 页面按小时预聚合的 usage 统计。
 type UsageOverviewHourlyStat struct {
 	ID                  int64     `gorm:"primaryKey"`
-	BucketStart         time.Time `gorm:"serializer:storageTime;not null;uniqueIndex:uniq_usage_overview_hourly_stats_bucket_api_model_auth_alias,priority:1;index:idx_usage_overview_hourly_stats_bucket_start;index:idx_usage_overview_hourly_stats_api_bucket,priority:2;index:idx_usage_overview_hourly_stats_api_model_bucket,priority:3;index:idx_usage_overview_hourly_stats_auth_bucket,priority:2;index:idx_usage_overview_hourly_stats_model_alias_bucket,priority:2"`
-	APIGroupKey         string    `gorm:"not null;uniqueIndex:uniq_usage_overview_hourly_stats_bucket_api_model_auth_alias,priority:2;index:idx_usage_overview_hourly_stats_api_bucket,priority:1;index:idx_usage_overview_hourly_stats_api_model_bucket,priority:1"`
-	Model               string    `gorm:"not null;uniqueIndex:uniq_usage_overview_hourly_stats_bucket_api_model_auth_alias,priority:3;index:idx_usage_overview_hourly_stats_api_model_bucket,priority:2"`
-	AuthIndex           string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_hourly_stats_bucket_api_model_auth_alias,priority:4;index:idx_usage_overview_hourly_stats_auth_bucket,priority:1"`
-	ModelAlias          string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_hourly_stats_bucket_api_model_auth_alias,priority:5;index:idx_usage_overview_hourly_stats_model_alias_bucket,priority:1"`
+	BucketStart         time.Time `gorm:"serializer:storageTime;not null;uniqueIndex:uniq_usage_overview_hourly_stats_dimensions,priority:1;index:idx_usage_overview_hourly_stats_bucket_start;index:idx_usage_overview_hourly_stats_api_bucket,priority:2;index:idx_usage_overview_hourly_stats_api_model_bucket,priority:3;index:idx_usage_overview_hourly_stats_auth_bucket,priority:2;index:idx_usage_overview_hourly_stats_model_alias_bucket,priority:2"`
+	APIGroupKey         string    `gorm:"not null;uniqueIndex:uniq_usage_overview_hourly_stats_dimensions,priority:2;index:idx_usage_overview_hourly_stats_api_bucket,priority:1;index:idx_usage_overview_hourly_stats_api_model_bucket,priority:1"`
+	Model               string    `gorm:"not null;uniqueIndex:uniq_usage_overview_hourly_stats_dimensions,priority:3;index:idx_usage_overview_hourly_stats_api_model_bucket,priority:2"`
+	AuthIndex           string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_hourly_stats_dimensions,priority:4;index:idx_usage_overview_hourly_stats_auth_bucket,priority:1"`
+	ModelAlias          string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_hourly_stats_dimensions,priority:5;index:idx_usage_overview_hourly_stats_model_alias_bucket,priority:1"`
+	ServiceTier         string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_hourly_stats_dimensions,priority:6"`
+	ResponseServiceTier string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_hourly_stats_dimensions,priority:7"`
+	ReasoningEffort     string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_hourly_stats_dimensions,priority:8"`
+	Endpoint            string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_hourly_stats_dimensions,priority:9"`
+	ExecutorType        string    `gorm:"not null;default:'';uniqueIndex:uniq_usage_overview_hourly_stats_dimensions,priority:10"`
 	RequestCount        int64     `gorm:"not null;default:0"`
 	SuccessCount        int64     `gorm:"not null;default:0"`
 	FailureCount        int64     `gorm:"not null;default:0"`

--- a/internal/overview/aggregate.go
+++ b/internal/overview/aggregate.go
@@ -1,0 +1,169 @@
+package overview
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/timeutil"
+)
+
+type aggregateKey struct {
+	BucketStart         time.Time
+	APIGroupKey         string
+	Model               string
+	AuthIndex           string
+	ModelAlias          string
+	ServiceTier         string
+	ResponseServiceTier string
+	ReasoningEffort     string
+	Endpoint            string
+	ExecutorType        string
+}
+
+// BuildRows 使用最终唯一键把一批 usage events 同时聚合成 hourly 和 daily rows。
+func BuildRows(events []entities.UsageEvent) ([]entities.UsageOverviewHourlyStat, []entities.UsageOverviewDailyStat, int64) {
+	// 两个 map 都直接使用数据库最终唯一键，迁移与运行时不会产生不同分组。
+	hourly := make(map[aggregateKey]*entities.UsageOverviewHourlyStat)
+	daily := make(map[aggregateKey]*entities.UsageOverviewDailyStat)
+	maxEventID := int64(0)
+
+	for _, event := range events {
+		// checkpoint 只推进到当前 batch 实际构建完成的最大事件 ID。
+		if event.ID > maxEventID {
+			maxEventID = event.ID
+		}
+		// 所有字符串维度在进入唯一键前统一清理首尾空白。
+		dimensions := aggregateKey{
+			APIGroupKey:         normalizeRequiredDimension(event.APIGroupKey),
+			Model:               normalizeRequiredDimension(event.Model),
+			AuthIndex:           normalizeOptionalDimension(event.AuthIndex),
+			ServiceTier:         normalizeOptionalDimension(event.ServiceTier),
+			ResponseServiceTier: normalizeOptionalDimension(event.ResponseServiceTier),
+			ReasoningEffort:     normalizeOptionalDimension(event.ReasoningEffort),
+			Endpoint:            normalizeOptionalDimension(event.Endpoint),
+			ExecutorType:        normalizeOptionalDimension(event.ExecutorType),
+		}
+		// nullable model_alias 与 nullable endpoint 一样归一为空字符串。
+		if event.ModelAlias != nil {
+			dimensions.ModelAlias = normalizeOptionalDimension(*event.ModelAlias)
+		}
+
+		// 时间先归一到项目存储时区，再沿用现有整点和本地自然日边界。
+		timestamp := timeutil.NormalizeStorageTime(event.Timestamp)
+		hourKey := dimensions
+		hourKey.BucketStart = timestamp.Truncate(time.Hour)
+		dayKey := dimensions
+		dayKey.BucketStart = time.Date(timestamp.Year(), timestamp.Month(), timestamp.Day(), 0, 0, 0, 0, timestamp.Location())
+
+		// 第一次遇到最终唯一键时创建维度完整的稀疏行。
+		if hourly[hourKey] == nil {
+			hourly[hourKey] = &entities.UsageOverviewHourlyStat{
+				BucketStart: hourKey.BucketStart, APIGroupKey: hourKey.APIGroupKey, Model: hourKey.Model,
+				AuthIndex: hourKey.AuthIndex, ModelAlias: hourKey.ModelAlias, ServiceTier: hourKey.ServiceTier,
+				ResponseServiceTier: hourKey.ResponseServiceTier, ReasoningEffort: hourKey.ReasoningEffort,
+				Endpoint: hourKey.Endpoint, ExecutorType: hourKey.ExecutorType,
+			}
+		}
+		if daily[dayKey] == nil {
+			daily[dayKey] = &entities.UsageOverviewDailyStat{
+				BucketStart: dayKey.BucketStart, APIGroupKey: dayKey.APIGroupKey, Model: dayKey.Model,
+				AuthIndex: dayKey.AuthIndex, ModelAlias: dayKey.ModelAlias, ServiceTier: dayKey.ServiceTier,
+				ResponseServiceTier: dayKey.ResponseServiceTier, ReasoningEffort: dayKey.ReasoningEffort,
+				Endpoint: dayKey.Endpoint, ExecutorType: dayKey.ExecutorType,
+			}
+		}
+		addEventToHourlyRow(hourly[hourKey], event)
+		addEventToDailyRow(daily[dayKey], event)
+	}
+
+	// map 转切片后固定写入顺序，让迁移重跑和故障定位保持稳定。
+	hourlyRows := make([]entities.UsageOverviewHourlyStat, 0, len(hourly))
+	for _, row := range hourly {
+		hourlyRows = append(hourlyRows, *row)
+	}
+	dailyRows := make([]entities.UsageOverviewDailyStat, 0, len(daily))
+	for _, row := range daily {
+		dailyRows = append(dailyRows, *row)
+	}
+	sort.Slice(hourlyRows, func(left, right int) bool {
+		return hourlyRowLess(hourlyRows[left], hourlyRows[right])
+	})
+	sort.Slice(dailyRows, func(left, right int) bool {
+		return dailyRowLess(dailyRows[left], dailyRows[right])
+	})
+	return hourlyRows, dailyRows, maxEventID
+}
+
+func normalizeRequiredDimension(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "unknown"
+	}
+	return trimmed
+}
+
+func normalizeOptionalDimension(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func addEventToHourlyRow(row *entities.UsageOverviewHourlyStat, event entities.UsageEvent) {
+	row.RequestCount++
+	if event.Failed {
+		row.FailureCount++
+	} else {
+		row.SuccessCount++
+	}
+	row.InputTokens += event.InputTokens
+	row.OutputTokens += event.OutputTokens
+	row.ReasoningTokens += event.ReasoningTokens
+	row.CachedTokens += event.CachedTokens
+	row.CacheReadTokens += event.CacheReadTokens
+	row.CacheCreationTokens += event.CacheCreationTokens
+	row.TotalTokens += event.TotalTokens
+}
+
+func addEventToDailyRow(row *entities.UsageOverviewDailyStat, event entities.UsageEvent) {
+	row.RequestCount++
+	if event.Failed {
+		row.FailureCount++
+	} else {
+		row.SuccessCount++
+	}
+	row.InputTokens += event.InputTokens
+	row.OutputTokens += event.OutputTokens
+	row.ReasoningTokens += event.ReasoningTokens
+	row.CachedTokens += event.CachedTokens
+	row.CacheReadTokens += event.CacheReadTokens
+	row.CacheCreationTokens += event.CacheCreationTokens
+	row.TotalTokens += event.TotalTokens
+}
+
+func hourlyRowLess(left, right entities.UsageOverviewHourlyStat) bool {
+	return dimensionsLess(
+		aggregateKey{left.BucketStart, left.APIGroupKey, left.Model, left.AuthIndex, left.ModelAlias, left.ServiceTier, left.ResponseServiceTier, left.ReasoningEffort, left.Endpoint, left.ExecutorType},
+		aggregateKey{right.BucketStart, right.APIGroupKey, right.Model, right.AuthIndex, right.ModelAlias, right.ServiceTier, right.ResponseServiceTier, right.ReasoningEffort, right.Endpoint, right.ExecutorType},
+	)
+}
+
+func dailyRowLess(left, right entities.UsageOverviewDailyStat) bool {
+	return dimensionsLess(
+		aggregateKey{left.BucketStart, left.APIGroupKey, left.Model, left.AuthIndex, left.ModelAlias, left.ServiceTier, left.ResponseServiceTier, left.ReasoningEffort, left.Endpoint, left.ExecutorType},
+		aggregateKey{right.BucketStart, right.APIGroupKey, right.Model, right.AuthIndex, right.ModelAlias, right.ServiceTier, right.ResponseServiceTier, right.ReasoningEffort, right.Endpoint, right.ExecutorType},
+	)
+}
+
+func dimensionsLess(left, right aggregateKey) bool {
+	if !left.BucketStart.Equal(right.BucketStart) {
+		return left.BucketStart.Before(right.BucketStart)
+	}
+	leftValues := [...]string{left.APIGroupKey, left.Model, left.AuthIndex, left.ModelAlias, left.ServiceTier, left.ResponseServiceTier, left.ReasoningEffort, left.Endpoint, left.ExecutorType}
+	rightValues := [...]string{right.APIGroupKey, right.Model, right.AuthIndex, right.ModelAlias, right.ServiceTier, right.ResponseServiceTier, right.ReasoningEffort, right.Endpoint, right.ExecutorType}
+	for index := range leftValues {
+		if leftValues[index] != rightValues[index] {
+			return leftValues[index] < rightValues[index]
+		}
+	}
+	return false
+}

--- a/internal/repository/migration/20260723_usage_overview_five_dimensions.go
+++ b/internal/repository/migration/20260723_usage_overview_five_dimensions.go
@@ -1,0 +1,158 @@
+package migration
+
+import (
+	"fmt"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/overview"
+	"cpa-usage-keeper/internal/repository/overviewstore"
+	"cpa-usage-keeper/internal/timeutil"
+
+	"gorm.io/gorm"
+)
+
+const (
+	// usageOverviewFiveDimensionsBatchSize 用短事务重放 raw events，避免长期占用 SQLite writer。
+	usageOverviewFiveDimensionsBatchSize = 1000
+	// usageOverviewMigrationCheckpointName 与运行时继续共享既有 Overview cursor。
+	usageOverviewMigrationCheckpointName = "overview"
+)
+
+// usageOverviewFiveDimensionsMigration 从当前仍保留的 usage_events 重建五维 hourly/daily rollup。
+func usageOverviewFiveDimensionsMigration(db *gorm.DB) error {
+	now := timeutil.NormalizeStorageTime(time.Now())
+
+	// 固定 migration 启动时可见的最大 ID；之后新增事件留给正常增量聚合追赶。
+	var targetEventID int64
+	if db.Migrator().HasTable(&entities.UsageEvent{}) {
+		if err := db.Model(&entities.UsageEvent{}).Select("COALESCE(MAX(id), 0)").Scan(&targetEventID).Error; err != nil {
+			return fmt.Errorf("load usage overview five-dimension target: %w", err)
+		}
+	}
+
+	// schema、旧数据清空和 checkpoint 归零必须一起提交，失败时保留可用旧表。
+	if err := prepareUsageOverviewFiveDimensions(db); err != nil {
+		return err
+	}
+
+	// 每批同时写入 hourly、daily 并推进同一个 checkpoint；中断后重启会从零安全重建。
+	for {
+		processed, err := migrateUsageOverviewFiveDimensionsBatch(db, now, targetEventID)
+		if err != nil {
+			return err
+		}
+		if processed == 0 {
+			break
+		}
+	}
+
+	// 只有已提交 cursor 到达固定 target 后，外层 runner 才能记录 migration version。
+	return verifyUsageOverviewFiveDimensionsTarget(db, targetEventID)
+}
+
+func prepareUsageOverviewFiveDimensions(db *gorm.DB) error {
+	return db.Transaction(func(tx *gorm.DB) error {
+		// AutoMigrate 为两个 rollup 增加五列并创建最终十列唯一索引。
+		if err := tx.AutoMigrate(&entities.UsageOverviewHourlyStat{}, &entities.UsageOverviewDailyStat{}); err != nil {
+			return fmt.Errorf("create usage overview five-dimension schema: %w", err)
+		}
+		// checkpoint schema 本次没有变化；只为异常缺表的旧库补建，避免无关表重建。
+		if !tx.Migrator().HasTable(&entities.UsageOverviewAggregationCheckpoint{}) {
+			if err := tx.AutoMigrate(&entities.UsageOverviewAggregationCheckpoint{}); err != nil {
+				return fmt.Errorf("create usage overview aggregation checkpoint schema: %w", err)
+			}
+		}
+
+		// 最终索引建立后删除旧五列唯一索引，避免继续维护无效重复结构。
+		for _, oldIndex := range []struct {
+			table string
+			name  string
+		}{
+			{table: "usage_overview_hourly_stats", name: "uniq_usage_overview_hourly_stats_bucket_api_model_auth_alias"},
+			{table: "usage_overview_daily_stats", name: "uniq_usage_overview_daily_stats_bucket_api_model_auth_alias"},
+		} {
+			if tx.Migrator().HasIndex(oldIndex.table, oldIndex.name) {
+				if err := tx.Migrator().DropIndex(oldIndex.table, oldIndex.name); err != nil {
+					return fmt.Errorf("drop legacy usage overview index %s: %w", oldIndex.name, err)
+				}
+			}
+		}
+
+		// 已有 rollup 不含五维信息，不能保留或与重建结果混合。
+		if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&entities.UsageOverviewHourlyStat{}).Error; err != nil {
+			return fmt.Errorf("clear usage overview hourly stats: %w", err)
+		}
+		if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&entities.UsageOverviewDailyStat{}).Error; err != nil {
+			return fmt.Errorf("clear usage overview daily stats: %w", err)
+		}
+
+		// checkpoint 与空 rollup 同事务归零，禁止页面看到新 schema 配旧 cursor。
+		checkpoint := entities.UsageOverviewAggregationCheckpoint{Name: usageOverviewMigrationCheckpointName}
+		if err := tx.Where("name = ?", usageOverviewMigrationCheckpointName).FirstOrCreate(&checkpoint).Error; err != nil {
+			return fmt.Errorf("get usage overview migration checkpoint: %w", err)
+		}
+		if err := tx.Model(&entities.UsageOverviewAggregationCheckpoint{}).
+			Where("id = ?", checkpoint.ID).
+			Updates(map[string]any{
+				"last_aggregated_usage_event_id": 0,
+				"stats_updated_at":               nil,
+			}).Error; err != nil {
+			return fmt.Errorf("reset usage overview migration checkpoint: %w", err)
+		}
+		return nil
+	})
+}
+
+func migrateUsageOverviewFiveDimensionsBatch(db *gorm.DB, now time.Time, targetEventID int64) (int, error) {
+	processed := 0
+	err := db.Transaction(func(tx *gorm.DB) error {
+		var checkpoint entities.UsageOverviewAggregationCheckpoint
+		if err := tx.Where("name = ?", usageOverviewMigrationCheckpointName).Take(&checkpoint).Error; err != nil {
+			return fmt.Errorf("load usage overview migration checkpoint: %w", err)
+		}
+		if checkpoint.LastAggregatedUsageEventID >= targetEventID {
+			return nil
+		}
+
+		// 迁移与运行时读取完全相同的旧计数列和五个新增维度。
+		var events []entities.UsageEvent
+		if err := tx.Select("id, api_group_key, model, model_alias, auth_index, service_tier, response_service_tier, reasoning_effort, endpoint, executor_type, timestamp, failed, input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens").
+			Where("id > ? AND id <= ?", checkpoint.LastAggregatedUsageEventID, targetEventID).
+			Order("id asc").
+			Limit(usageOverviewFiveDimensionsBatchSize).
+			Find(&events).Error; err != nil {
+			return fmt.Errorf("load usage overview five-dimension events: %w", err)
+		}
+		if len(events) == 0 {
+			return nil
+		}
+
+		hourlyRows, dailyRows, maxEventID := overview.BuildRows(events)
+		if err := overviewstore.ApplyRows(tx, hourlyRows, dailyRows, now); err != nil {
+			return err
+		}
+		if err := tx.Model(&entities.UsageOverviewAggregationCheckpoint{}).
+			Where("id = ?", checkpoint.ID).
+			Updates(map[string]any{
+				"last_aggregated_usage_event_id": maxEventID,
+				"stats_updated_at":               timeutil.FormatStorageTime(now),
+			}).Error; err != nil {
+			return fmt.Errorf("update usage overview five-dimension checkpoint: %w", err)
+		}
+		processed = len(events)
+		return nil
+	})
+	return processed, err
+}
+
+func verifyUsageOverviewFiveDimensionsTarget(db *gorm.DB, targetEventID int64) error {
+	var checkpoint entities.UsageOverviewAggregationCheckpoint
+	if err := db.Where("name = ?", usageOverviewMigrationCheckpointName).Take(&checkpoint).Error; err != nil {
+		return fmt.Errorf("verify usage overview five-dimension checkpoint: %w", err)
+	}
+	if checkpoint.LastAggregatedUsageEventID < targetEventID {
+		return fmt.Errorf("usage overview five-dimension checkpoint %d did not reach target %d", checkpoint.LastAggregatedUsageEventID, targetEventID)
+	}
+	return nil
+}

--- a/internal/repository/migration/20260723_usage_overview_five_dimensions.go
+++ b/internal/repository/migration/20260723_usage_overview_five_dimensions.go
@@ -53,29 +53,31 @@ func usageOverviewFiveDimensionsMigration(db *gorm.DB) error {
 
 func prepareUsageOverviewFiveDimensions(db *gorm.DB) error {
 	return db.Transaction(func(tx *gorm.DB) error {
-		// AutoMigrate 为两个 rollup 增加五列并创建最终十列唯一索引。
-		if err := tx.AutoMigrate(&entities.UsageOverviewHourlyStat{}, &entities.UsageOverviewDailyStat{}); err != nil {
-			return fmt.Errorf("create usage overview five-dimension schema: %w", err)
+		rollups := usageOverviewFiveDimensionRollups()
+		// 已有大表只补五列并先移除索引；缺表才直接创建完整空表。
+		for _, rollup := range rollups {
+			if !tx.Migrator().HasTable(rollup.model) {
+				if err := tx.AutoMigrate(rollup.model); err != nil {
+					return fmt.Errorf("create %s five-dimension schema: %w", rollup.table, err)
+				}
+				continue
+			}
+			if err := addUsageOverviewFiveDimensionColumns(tx, rollup); err != nil {
+				return err
+			}
+			// 批次失败后 version 尚未记录，重跑时也要先移除可能残留的最终索引。
+			for _, index := range []string{rollup.legacyIndex, rollup.finalIndex} {
+				if tx.Migrator().HasIndex(rollup.table, index) {
+					if err := tx.Migrator().DropIndex(rollup.table, index); err != nil {
+						return fmt.Errorf("drop usage overview index %s: %w", index, err)
+					}
+				}
+			}
 		}
 		// checkpoint schema 本次没有变化；只为异常缺表的旧库补建，避免无关表重建。
 		if !tx.Migrator().HasTable(&entities.UsageOverviewAggregationCheckpoint{}) {
 			if err := tx.AutoMigrate(&entities.UsageOverviewAggregationCheckpoint{}); err != nil {
 				return fmt.Errorf("create usage overview aggregation checkpoint schema: %w", err)
-			}
-		}
-
-		// 最终索引建立后删除旧五列唯一索引，避免继续维护无效重复结构。
-		for _, oldIndex := range []struct {
-			table string
-			name  string
-		}{
-			{table: "usage_overview_hourly_stats", name: "uniq_usage_overview_hourly_stats_bucket_api_model_auth_alias"},
-			{table: "usage_overview_daily_stats", name: "uniq_usage_overview_daily_stats_bucket_api_model_auth_alias"},
-		} {
-			if tx.Migrator().HasIndex(oldIndex.table, oldIndex.name) {
-				if err := tx.Migrator().DropIndex(oldIndex.table, oldIndex.name); err != nil {
-					return fmt.Errorf("drop legacy usage overview index %s: %w", oldIndex.name, err)
-				}
 			}
 		}
 
@@ -100,8 +102,63 @@ func prepareUsageOverviewFiveDimensions(db *gorm.DB) error {
 			}).Error; err != nil {
 			return fmt.Errorf("reset usage overview migration checkpoint: %w", err)
 		}
+
+		// 只在空 rollup 上创建最终十列唯一索引，避免无用的旧数据全表建索引。
+		for _, rollup := range rollups {
+			if tx.Migrator().HasIndex(rollup.table, rollup.finalIndex) {
+				continue
+			}
+			if err := tx.Migrator().CreateIndex(rollup.model, rollup.finalIndex); err != nil {
+				return fmt.Errorf("create usage overview index %s: %w", rollup.finalIndex, err)
+			}
+		}
 		return nil
 	})
+}
+
+type usageOverviewFiveDimensionRollup struct {
+	model       any
+	table       string
+	legacyIndex string
+	finalIndex  string
+}
+
+func usageOverviewFiveDimensionRollups() []usageOverviewFiveDimensionRollup {
+	return []usageOverviewFiveDimensionRollup{
+		{
+			model:       &entities.UsageOverviewHourlyStat{},
+			table:       "usage_overview_hourly_stats",
+			legacyIndex: "uniq_usage_overview_hourly_stats_bucket_api_model_auth_alias",
+			finalIndex:  "uniq_usage_overview_hourly_stats_dimensions",
+		},
+		{
+			model:       &entities.UsageOverviewDailyStat{},
+			table:       "usage_overview_daily_stats",
+			legacyIndex: "uniq_usage_overview_daily_stats_bucket_api_model_auth_alias",
+			finalIndex:  "uniq_usage_overview_daily_stats_dimensions",
+		},
+	}
+}
+
+func addUsageOverviewFiveDimensionColumns(tx *gorm.DB, rollup usageOverviewFiveDimensionRollup) error {
+	for _, column := range []struct {
+		name  string
+		field string
+	}{
+		{name: "service_tier", field: "ServiceTier"},
+		{name: "response_service_tier", field: "ResponseServiceTier"},
+		{name: "reasoning_effort", field: "ReasoningEffort"},
+		{name: "endpoint", field: "Endpoint"},
+		{name: "executor_type", field: "ExecutorType"},
+	} {
+		if tx.Migrator().HasColumn(rollup.model, column.name) {
+			continue
+		}
+		if err := tx.Migrator().AddColumn(rollup.model, column.field); err != nil {
+			return fmt.Errorf("add %s.%s: %w", rollup.table, column.name, err)
+		}
+	}
+	return nil
 }
 
 func migrateUsageOverviewFiveDimensionsBatch(db *gorm.DB, now time.Time, targetEventID int64) (int, error) {

--- a/internal/repository/migration/migration.go
+++ b/internal/repository/migration/migration.go
@@ -61,6 +61,8 @@ const (
 	migrationUsageActivityStats = "20260719_usage_activity_stats"
 	// migrationAlignUsageActivityShort 把已部署 short 行切换到本地自然日边界。
 	migrationAlignUsageActivityShort = "20260722_align_usage_activity_short"
+	// migrationUsageOverviewFiveDimensions 从现存 raw events 重建五维 hourly/daily rollup。
+	migrationUsageOverviewFiveDimensions = "20260723_usage_overview_five_dimensions"
 )
 
 type schemaMigration struct {
@@ -166,6 +168,8 @@ func orderedMigrations() []databaseMigration {
 		{version: migrationUsageActivityStats, run: usageActivityStatsMigration, disableTransaction: true},
 		// short 重建在默认事务内原子完成，失败时旧行和版本标记一起回滚。
 		{version: migrationAlignUsageActivityShort, run: alignUsageActivityShortMigration},
+		// 五维重建自己管理 schema/setup 与 1000-event 小事务，外层不能再包长事务。
+		{version: migrationUsageOverviewFiveDimensions, run: usageOverviewFiveDimensionsMigration, disableTransaction: true},
 	}
 }
 

--- a/internal/repository/migration/migration_test.go
+++ b/internal/repository/migration/migration_test.go
@@ -70,6 +70,7 @@ func TestOrderedMigrationsPreservesExecutionOrder(t *testing.T) {
 		// Activity 必须在所有 usage_events 字段规范化 migration 之后回填。
 		"20260719_usage_activity_stats",
 		"20260722_align_usage_activity_short",
+		"20260723_usage_overview_five_dimensions",
 	}
 	assertStringSlicesEqual(t, want, got)
 }

--- a/internal/repository/migration/test/usage_overview_five_dimensions_test.go
+++ b/internal/repository/migration/test/usage_overview_five_dimensions_test.go
@@ -1,8 +1,10 @@
 package test
 
 import (
+	"context"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
 )
 
 const usageOverviewFiveDimensionsMigrationVersion = "20260723_usage_overview_five_dimensions"
@@ -22,7 +25,36 @@ type usageOverviewFiveDimensionRow struct {
 	Endpoint            string
 	ExecutorType        string
 	RequestCount        int64
+	SuccessCount        int64
+	FailureCount        int64
+	InputTokens         int64
+	OutputTokens        int64
+	ReasoningTokens     int64
+	CachedTokens        int64
+	CacheReadTokens     int64
+	CacheCreationTokens int64
 	TotalTokens         int64
+}
+
+type usageOverviewMigrationSQLRecorder struct {
+	recording  bool
+	statements []string
+}
+
+func (recorder *usageOverviewMigrationSQLRecorder) LogMode(gormlogger.LogLevel) gormlogger.Interface {
+	return recorder
+}
+
+func (*usageOverviewMigrationSQLRecorder) Info(context.Context, string, ...interface{})  {}
+func (*usageOverviewMigrationSQLRecorder) Warn(context.Context, string, ...interface{})  {}
+func (*usageOverviewMigrationSQLRecorder) Error(context.Context, string, ...interface{}) {}
+
+func (recorder *usageOverviewMigrationSQLRecorder) Trace(_ context.Context, _ time.Time, statement func() (string, int64), _ error) {
+	if !recorder.recording {
+		return
+	}
+	sql, _ := statement()
+	recorder.statements = append(recorder.statements, sql)
 }
 
 func TestUsageOverviewFiveDimensionsMigrationRebuildsFromCurrentUsageEvents(t *testing.T) {
@@ -30,9 +62,10 @@ func TestUsageOverviewFiveDimensionsMigrationRebuildsFromCurrentUsageEvents(t *t
 	time.Local = time.UTC
 	t.Cleanup(func() { time.Local = previousLocal })
 
+	recorder := &usageOverviewMigrationSQLRecorder{}
 	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "five-dimensions.db")), &gorm.Config{NowFunc: func() time.Time {
 		return timeutil.NormalizeStorageTime(time.Now())
-	}})
+	}, Logger: recorder})
 	if err != nil {
 		t.Fatalf("open five-dimension migration database: %v", err)
 	}
@@ -46,9 +79,11 @@ func TestUsageOverviewFiveDimensionsMigrationRebuildsFromCurrentUsageEvents(t *t
 	if err := db.Exec("DELETE FROM schema_migrations WHERE version = ?", usageOverviewFiveDimensionsMigrationVersion).Error; err != nil {
 		t.Fatalf("enable five-dimension migration: %v", err)
 	}
+	recorder.recording = true
 	if err := migration.Run(db); err != nil {
 		t.Fatalf("run five-dimension migration: %v", err)
 	}
+	recorder.recording = false
 
 	for _, table := range []string{"usage_overview_hourly_stats", "usage_overview_daily_stats"} {
 		for _, column := range []string{"service_tier", "response_service_tier", "reasoning_effort", "endpoint", "executor_type"} {
@@ -67,8 +102,10 @@ func TestUsageOverviewFiveDimensionsMigrationRebuildsFromCurrentUsageEvents(t *t
 
 	assertUsageOverviewFiveDimensionMigrationRows(t, db, "usage_overview_hourly_stats")
 	assertUsageOverviewFiveDimensionMigrationRows(t, db, "usage_overview_daily_stats")
-	assertUsageOverviewFiveDimensionIndex(t, db, "uniq_usage_overview_hourly_stats_dimensions")
-	assertUsageOverviewFiveDimensionIndex(t, db, "uniq_usage_overview_daily_stats_dimensions")
+	assertUsageOverviewFiveDimensionIndex(t, db, "usage_overview_hourly_stats", "uniq_usage_overview_hourly_stats_dimensions")
+	assertUsageOverviewFiveDimensionIndex(t, db, "usage_overview_daily_stats", "uniq_usage_overview_daily_stats_dimensions")
+	assertUsageOverviewIndexCreatedAfterClear(t, recorder.statements, "usage_overview_hourly_stats", "uniq_usage_overview_hourly_stats_dimensions")
+	assertUsageOverviewIndexCreatedAfterClear(t, recorder.statements, "usage_overview_daily_stats", "uniq_usage_overview_daily_stats_dimensions")
 	for _, oldIndex := range []string{
 		"uniq_usage_overview_hourly_stats_bucket_api_model_auth_alias",
 		"uniq_usage_overview_daily_stats_bucket_api_model_auth_alias",
@@ -284,21 +321,22 @@ func seedUsageOverviewFiveDimensionMigrationData(t *testing.T, db *gorm.DB) {
 		timestamp                                                         time.Time
 		serviceTier, responseTier, effort, executor                       string
 		endpoint                                                          any
+		failed                                                            bool
 		input, output, reasoning, cached, cacheRead, cacheCreation, total int64
 	}
 	fixtures := []fixture{
-		{1, dayOne, "default", "default", "xhigh", "CodexWebsocketsExecutor", "GET /v1/responses", 10, 2, 1, 7, 3, 1, 12},
-		{2, dayOne.Add(10 * time.Minute), "priority", "priority", "max", "CodexExecutor", "POST /v1/responses", 20, 3, 2, 8, 4, 2, 23},
-		{3, dayOne.Add(20 * time.Minute), " default ", " default ", " xhigh ", " CodexWebsocketsExecutor ", " GET /v1/responses ", 30, 4, 3, 9, 5, 3, 34},
-		{4, dayTwo, "default", "default", "xhigh", "CodexWebsocketsExecutor", nil, 40, 5, 4, 10, 6, 4, 45},
+		{1, dayOne, "default", "default", "xhigh", "CodexWebsocketsExecutor", "GET /v1/responses", false, 10, 2, 1, 7, 3, 1, 12},
+		{2, dayOne.Add(10 * time.Minute), "priority", "priority", "max", "CodexExecutor", "POST /v1/responses", true, 20, 3, 2, 8, 4, 2, 23},
+		{3, dayOne.Add(20 * time.Minute), " default ", " default ", " xhigh ", " CodexWebsocketsExecutor ", " GET /v1/responses ", false, 30, 4, 3, 9, 5, 3, 34},
+		{4, dayTwo, "default", "default", "xhigh", "CodexWebsocketsExecutor", nil, false, 40, 5, 4, 10, 6, 4, 45},
 	}
 	for _, row := range fixtures {
 		if err := db.Exec(`INSERT INTO usage_events (
 			id, api_group_key, model, model_alias, auth_index, timestamp, failed,
 			input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens,
 			service_tier, response_service_tier, reasoning_effort, endpoint, executor_type
-		) VALUES (?, 'api-a', 'gpt-a', 'gpt-alias', 'auth-a', ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			row.id, timeutil.FormatStorageTime(row.timestamp), row.input, row.output, row.reasoning, row.cached, row.cacheRead, row.cacheCreation, row.total,
+		) VALUES (?, 'api-a', 'gpt-a', 'gpt-alias', 'auth-a', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			row.id, timeutil.FormatStorageTime(row.timestamp), row.failed, row.input, row.output, row.reasoning, row.cached, row.cacheRead, row.cacheCreation, row.total,
 			row.serviceTier, row.responseTier, row.effort, row.endpoint, row.executor).Error; err != nil {
 			t.Fatalf("seed usage event %d: %v", row.id, err)
 		}
@@ -320,7 +358,7 @@ func assertUsageOverviewFiveDimensionMigrationRows(t *testing.T, db *gorm.DB, ta
 	t.Helper()
 	var rows []usageOverviewFiveDimensionRow
 	if err := db.Table(table).
-		Select("service_tier, response_service_tier, reasoning_effort, endpoint, executor_type, request_count, total_tokens").
+		Select("service_tier, response_service_tier, reasoning_effort, endpoint, executor_type, request_count, success_count, failure_count, input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens").
 		Order("bucket_start ASC, service_tier ASC").
 		Find(&rows).Error; err != nil {
 		t.Fatalf("load rebuilt %s rows: %v", table, err)
@@ -328,19 +366,37 @@ func assertUsageOverviewFiveDimensionMigrationRows(t *testing.T, db *gorm.DB, ta
 	if len(rows) != 3 {
 		t.Fatalf("expected 3 rebuilt %s rows, got %d: %+v", table, len(rows), rows)
 	}
-	if got := rows[0]; got.ServiceTier != "default" || got.ResponseServiceTier != "default" || got.ReasoningEffort != "xhigh" || got.Endpoint != "GET /v1/responses" || got.ExecutorType != "CodexWebsocketsExecutor" || got.RequestCount != 2 || got.TotalTokens != 46 {
+	if got := rows[0]; got.ServiceTier != "default" || got.ResponseServiceTier != "default" || got.ReasoningEffort != "xhigh" || got.Endpoint != "GET /v1/responses" || got.ExecutorType != "CodexWebsocketsExecutor" || got.RequestCount != 2 || got.SuccessCount != 2 || got.FailureCount != 0 || got.InputTokens != 40 || got.OutputTokens != 6 || got.ReasoningTokens != 4 || got.CachedTokens != 16 || got.CacheReadTokens != 8 || got.CacheCreationTokens != 4 || got.TotalTokens != 46 {
 		t.Fatalf("unexpected first rebuilt %s row: %+v", table, got)
 	}
-	if got := rows[1]; got.ServiceTier != "priority" || got.ResponseServiceTier != "priority" || got.ReasoningEffort != "max" || got.Endpoint != "POST /v1/responses" || got.ExecutorType != "CodexExecutor" || got.RequestCount != 1 || got.TotalTokens != 23 {
+	if got := rows[1]; got.ServiceTier != "priority" || got.ResponseServiceTier != "priority" || got.ReasoningEffort != "max" || got.Endpoint != "POST /v1/responses" || got.ExecutorType != "CodexExecutor" || got.RequestCount != 1 || got.SuccessCount != 0 || got.FailureCount != 1 || got.InputTokens != 20 || got.OutputTokens != 3 || got.ReasoningTokens != 2 || got.CachedTokens != 8 || got.CacheReadTokens != 4 || got.CacheCreationTokens != 2 || got.TotalTokens != 23 {
 		t.Fatalf("unexpected second rebuilt %s row: %+v", table, got)
 	}
-	if got := rows[2]; got.ServiceTier != "default" || got.ResponseServiceTier != "default" || got.ReasoningEffort != "xhigh" || got.Endpoint != "" || got.ExecutorType != "CodexWebsocketsExecutor" || got.RequestCount != 1 || got.TotalTokens != 45 {
+	if got := rows[2]; got.ServiceTier != "default" || got.ResponseServiceTier != "default" || got.ReasoningEffort != "xhigh" || got.Endpoint != "" || got.ExecutorType != "CodexWebsocketsExecutor" || got.RequestCount != 1 || got.SuccessCount != 1 || got.FailureCount != 0 || got.InputTokens != 40 || got.OutputTokens != 5 || got.ReasoningTokens != 4 || got.CachedTokens != 10 || got.CacheReadTokens != 6 || got.CacheCreationTokens != 4 || got.TotalTokens != 45 {
 		t.Fatalf("unexpected third rebuilt %s row: %+v", table, got)
 	}
 }
 
-func assertUsageOverviewFiveDimensionIndex(t *testing.T, db *gorm.DB, name string) {
+func assertUsageOverviewFiveDimensionIndex(t *testing.T, db *gorm.DB, table string, name string) {
 	t.Helper()
+	type indexListRow struct {
+		Name   string `gorm:"column:name"`
+		Unique int    `gorm:"column:unique"`
+	}
+	var indexes []indexListRow
+	if err := db.Raw("PRAGMA index_list(" + table + ")").Scan(&indexes).Error; err != nil {
+		t.Fatalf("list %s indexes: %v", table, err)
+	}
+	foundUnique := false
+	for _, index := range indexes {
+		if index.Name == name && index.Unique == 1 {
+			foundUnique = true
+		}
+	}
+	if !foundUnique {
+		t.Fatalf("expected %s to be a unique index on %s", name, table)
+	}
+
 	type indexColumn struct {
 		Seqno int
 		Name  string
@@ -356,5 +412,19 @@ func assertUsageOverviewFiveDimensionIndex(t *testing.T, db *gorm.DB, name strin
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected %s columns: got %v want %v", name, got, want)
+	}
+}
+
+func assertUsageOverviewIndexCreatedAfterClear(t *testing.T, statements []string, table string, index string) {
+	t.Helper()
+	normalized := strings.ToLower(strings.Join(statements, "\n"))
+	normalized = strings.NewReplacer("`", "", "\"", "").Replace(normalized)
+	clearPosition := strings.Index(normalized, "delete from "+table)
+	indexPosition := strings.Index(normalized, "create unique index "+index)
+	if clearPosition < 0 || indexPosition < 0 {
+		t.Fatalf("expected migration SQL to clear %s and create %s, got:\n%s", table, index, normalized)
+	}
+	if indexPosition < clearPosition {
+		t.Fatalf("expected migration to clear %s before creating %s", table, index)
 	}
 }

--- a/internal/repository/migration/test/usage_overview_five_dimensions_test.go
+++ b/internal/repository/migration/test/usage_overview_five_dimensions_test.go
@@ -1,0 +1,360 @@
+package test
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/repository/migration"
+	"cpa-usage-keeper/internal/timeutil"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const usageOverviewFiveDimensionsMigrationVersion = "20260723_usage_overview_five_dimensions"
+
+type usageOverviewFiveDimensionRow struct {
+	ServiceTier         string
+	ResponseServiceTier string
+	ReasoningEffort     string
+	Endpoint            string
+	ExecutorType        string
+	RequestCount        int64
+	TotalTokens         int64
+}
+
+func TestUsageOverviewFiveDimensionsMigrationRebuildsFromCurrentUsageEvents(t *testing.T) {
+	previousLocal := time.Local
+	time.Local = time.UTC
+	t.Cleanup(func() { time.Local = previousLocal })
+
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "five-dimensions.db")), &gorm.Config{NowFunc: func() time.Time {
+		return timeutil.NormalizeStorageTime(time.Now())
+	}})
+	if err != nil {
+		t.Fatalf("open five-dimension migration database: %v", err)
+	}
+	closeMigrationTestDatabase(t, db)
+	createLegacyUsageOverviewFiveDimensionSchema(t, db)
+	seedUsageOverviewFiveDimensionMigrationData(t, db)
+
+	if err := migration.MarkAllAsApplied(db); err != nil {
+		t.Fatalf("mark historical migrations applied: %v", err)
+	}
+	if err := db.Exec("DELETE FROM schema_migrations WHERE version = ?", usageOverviewFiveDimensionsMigrationVersion).Error; err != nil {
+		t.Fatalf("enable five-dimension migration: %v", err)
+	}
+	if err := migration.Run(db); err != nil {
+		t.Fatalf("run five-dimension migration: %v", err)
+	}
+
+	for _, table := range []string{"usage_overview_hourly_stats", "usage_overview_daily_stats"} {
+		for _, column := range []string{"service_tier", "response_service_tier", "reasoning_effort", "endpoint", "executor_type"} {
+			if !db.Migrator().HasColumn(table, column) {
+				t.Fatalf("expected %s.%s after migration", table, column)
+			}
+		}
+		var staleCount int64
+		if err := db.Table(table).Where("api_group_key = ?", "stale-api").Count(&staleCount).Error; err != nil {
+			t.Fatalf("count stale %s rows: %v", table, err)
+		}
+		if staleCount != 0 {
+			t.Fatalf("expected stale %s rows to be removed, got %d", table, staleCount)
+		}
+	}
+
+	assertUsageOverviewFiveDimensionMigrationRows(t, db, "usage_overview_hourly_stats")
+	assertUsageOverviewFiveDimensionMigrationRows(t, db, "usage_overview_daily_stats")
+	assertUsageOverviewFiveDimensionIndex(t, db, "uniq_usage_overview_hourly_stats_dimensions")
+	assertUsageOverviewFiveDimensionIndex(t, db, "uniq_usage_overview_daily_stats_dimensions")
+	for _, oldIndex := range []string{
+		"uniq_usage_overview_hourly_stats_bucket_api_model_auth_alias",
+		"uniq_usage_overview_daily_stats_bucket_api_model_auth_alias",
+	} {
+		var count int64
+		if err := db.Raw("SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?", oldIndex).Scan(&count).Error; err != nil {
+			t.Fatalf("check old index %s: %v", oldIndex, err)
+		}
+		if count != 0 {
+			t.Fatalf("expected old index %s to be removed", oldIndex)
+		}
+	}
+
+	var checkpoint struct {
+		LastAggregatedUsageEventID int64
+	}
+	if err := db.Table("usage_overview_aggregation_checkpoints").Select("last_aggregated_usage_event_id").Where("name = ?", "overview").Take(&checkpoint).Error; err != nil {
+		t.Fatalf("load rebuilt overview checkpoint: %v", err)
+	}
+	if checkpoint.LastAggregatedUsageEventID != 4 {
+		t.Fatalf("expected rebuilt overview checkpoint 4, got %d", checkpoint.LastAggregatedUsageEventID)
+	}
+
+	var applied int64
+	if err := db.Table("schema_migrations").Where("version = ?", usageOverviewFiveDimensionsMigrationVersion).Count(&applied).Error; err != nil {
+		t.Fatalf("count five-dimension migration version: %v", err)
+	}
+	if applied != 1 {
+		t.Fatalf("expected five-dimension migration to be recorded once, got %d", applied)
+	}
+}
+
+func TestUsageOverviewFiveDimensionsMigrationRestartsCleanlyAfterBatchFailure(t *testing.T) {
+	previousLocal := time.Local
+	time.Local = time.UTC
+	t.Cleanup(func() { time.Local = previousLocal })
+
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "five-dimensions-retry.db")), &gorm.Config{NowFunc: func() time.Time {
+		return timeutil.NormalizeStorageTime(time.Now())
+	}})
+	if err != nil {
+		t.Fatalf("open five-dimension retry database: %v", err)
+	}
+	closeMigrationTestDatabase(t, db)
+	createLegacyUsageOverviewFiveDimensionSchema(t, db)
+	seedUsageOverviewFiveDimensionBatchEvents(t, db, 1001)
+
+	// 最后一条事件单独形成第二批 row，并由 trigger 强制让该事务失败。
+	if err := db.Exec(`CREATE TRIGGER fail_usage_overview_second_batch
+		BEFORE UPDATE ON usage_overview_aggregation_checkpoints
+		WHEN NEW.last_aggregated_usage_event_id > 1000
+		BEGIN
+			SELECT RAISE(FAIL, 'forced usage overview second batch failure');
+		END`).Error; err != nil {
+		t.Fatalf("create five-dimension failure trigger: %v", err)
+	}
+	if err := migration.MarkAllAsApplied(db); err != nil {
+		t.Fatalf("mark retry migrations applied: %v", err)
+	}
+	if err := db.Exec("DELETE FROM schema_migrations WHERE version = ?", usageOverviewFiveDimensionsMigrationVersion).Error; err != nil {
+		t.Fatalf("enable retry five-dimension migration: %v", err)
+	}
+
+	if err := migration.Run(db); err == nil {
+		t.Fatal("expected second five-dimension batch to fail")
+	}
+	assertUsageOverviewMigrationCheckpoint(t, db, 1000)
+	assertUsageOverviewMigrationVersionCount(t, db, 0)
+	assertUsageOverviewMigrationRequestCount(t, db, "usage_overview_hourly_stats", 1000)
+	assertUsageOverviewMigrationRequestCount(t, db, "usage_overview_daily_stats", 1000)
+
+	// version 缺失时重跑会再次执行 setup：清空首批结果、checkpoint 归零后完整重建。
+	if err := db.Exec("DROP TRIGGER fail_usage_overview_second_batch").Error; err != nil {
+		t.Fatalf("drop five-dimension failure trigger: %v", err)
+	}
+	if err := migration.Run(db); err != nil {
+		t.Fatalf("rerun five-dimension migration: %v", err)
+	}
+	assertUsageOverviewMigrationCheckpoint(t, db, 1001)
+	assertUsageOverviewMigrationVersionCount(t, db, 1)
+	assertUsageOverviewMigrationRequestCount(t, db, "usage_overview_hourly_stats", 1001)
+	assertUsageOverviewMigrationRequestCount(t, db, "usage_overview_daily_stats", 1001)
+}
+
+func seedUsageOverviewFiveDimensionBatchEvents(t *testing.T, db *gorm.DB, count int) {
+	t.Helper()
+	err := db.Transaction(func(tx *gorm.DB) error {
+		for id := 1; id <= count; id++ {
+			apiGroupKey := "api-a"
+			if id == count {
+				apiGroupKey = "fail-api"
+			}
+			if err := tx.Exec(`INSERT INTO usage_events (
+				id, api_group_key, model, model_alias, auth_index, timestamp, failed,
+				input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens,
+				service_tier, response_service_tier, reasoning_effort, endpoint, executor_type
+			) VALUES (?, ?, 'gpt-a', 'gpt-alias', 'auth-a', ?, 0, 1, 0, 0, 0, 0, 0, 1, 'default', 'default', 'xhigh', 'GET /v1/responses', 'CodexExecutor')`,
+				id, apiGroupKey, timeutil.FormatStorageTime(time.Date(2026, 7, 20, 10, 10, 0, 0, time.UTC))).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed five-dimension batch events: %v", err)
+	}
+}
+
+func assertUsageOverviewMigrationCheckpoint(t *testing.T, db *gorm.DB, want int64) {
+	t.Helper()
+	var checkpoint struct {
+		LastAggregatedUsageEventID int64
+	}
+	if err := db.Table("usage_overview_aggregation_checkpoints").Select("last_aggregated_usage_event_id").Where("name = ?", "overview").Take(&checkpoint).Error; err != nil {
+		t.Fatalf("load overview migration checkpoint: %v", err)
+	}
+	if checkpoint.LastAggregatedUsageEventID != want {
+		t.Fatalf("expected overview migration checkpoint %d, got %d", want, checkpoint.LastAggregatedUsageEventID)
+	}
+}
+
+func assertUsageOverviewMigrationVersionCount(t *testing.T, db *gorm.DB, want int64) {
+	t.Helper()
+	var count int64
+	if err := db.Table("schema_migrations").Where("version = ?", usageOverviewFiveDimensionsMigrationVersion).Count(&count).Error; err != nil {
+		t.Fatalf("count five-dimension migration version: %v", err)
+	}
+	if count != want {
+		t.Fatalf("expected five-dimension migration version count %d, got %d", want, count)
+	}
+}
+
+func assertUsageOverviewMigrationRequestCount(t *testing.T, db *gorm.DB, table string, want int64) {
+	t.Helper()
+	var total int64
+	if err := db.Table(table).Select("COALESCE(SUM(request_count), 0)").Scan(&total).Error; err != nil {
+		t.Fatalf("sum %s request count: %v", table, err)
+	}
+	if total != want {
+		t.Fatalf("expected %s request count %d, got %d", table, want, total)
+	}
+}
+
+func createLegacyUsageOverviewFiveDimensionSchema(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	statColumns := `
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		bucket_start DATETIME NOT NULL,
+		api_group_key TEXT NOT NULL,
+		model TEXT NOT NULL,
+		auth_index TEXT NOT NULL DEFAULT '',
+		model_alias TEXT NOT NULL DEFAULT '',
+		request_count INTEGER NOT NULL DEFAULT 0,
+		success_count INTEGER NOT NULL DEFAULT 0,
+		failure_count INTEGER NOT NULL DEFAULT 0,
+		input_tokens INTEGER NOT NULL DEFAULT 0,
+		output_tokens INTEGER NOT NULL DEFAULT 0,
+		reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+		cached_tokens INTEGER NOT NULL DEFAULT 0,
+		cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+		cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+		total_tokens INTEGER NOT NULL DEFAULT 0,
+		created_at DATETIME NOT NULL,
+		updated_at DATETIME NOT NULL`
+	statements := []string{
+		`CREATE TABLE usage_events (
+			id INTEGER PRIMARY KEY,
+			api_group_key TEXT,
+			model TEXT,
+			model_alias TEXT,
+			auth_index TEXT,
+			timestamp DATETIME,
+			failed NUMERIC,
+			input_tokens INTEGER,
+			output_tokens INTEGER,
+			reasoning_tokens INTEGER,
+			cached_tokens INTEGER,
+			cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+			cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+			total_tokens INTEGER,
+			service_tier TEXT NOT NULL DEFAULT '',
+			response_service_tier TEXT NOT NULL DEFAULT '',
+			reasoning_effort TEXT NOT NULL DEFAULT '',
+			endpoint TEXT,
+			executor_type TEXT NOT NULL DEFAULT ''
+		)`,
+		"CREATE TABLE usage_overview_hourly_stats (" + statColumns + ")",
+		"CREATE TABLE usage_overview_daily_stats (" + statColumns + ")",
+		`CREATE UNIQUE INDEX uniq_usage_overview_hourly_stats_bucket_api_model_auth_alias ON usage_overview_hourly_stats (bucket_start, api_group_key, model, auth_index, model_alias)`,
+		`CREATE UNIQUE INDEX uniq_usage_overview_daily_stats_bucket_api_model_auth_alias ON usage_overview_daily_stats (bucket_start, api_group_key, model, auth_index, model_alias)`,
+		`CREATE TABLE usage_overview_aggregation_checkpoints (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL UNIQUE,
+			last_aggregated_usage_event_id INTEGER NOT NULL DEFAULT 0,
+			stats_updated_at DATETIME,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		)`,
+	}
+	for _, statement := range statements {
+		if err := db.Exec(statement).Error; err != nil {
+			t.Fatalf("create legacy five-dimension schema: %v", err)
+		}
+	}
+}
+
+func seedUsageOverviewFiveDimensionMigrationData(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	dayOne := time.Date(2026, 7, 20, 10, 10, 0, 0, time.UTC)
+	dayTwo := time.Date(2026, 7, 21, 11, 10, 0, 0, time.UTC)
+	type fixture struct {
+		id                                                                int64
+		timestamp                                                         time.Time
+		serviceTier, responseTier, effort, executor                       string
+		endpoint                                                          any
+		input, output, reasoning, cached, cacheRead, cacheCreation, total int64
+	}
+	fixtures := []fixture{
+		{1, dayOne, "default", "default", "xhigh", "CodexWebsocketsExecutor", "GET /v1/responses", 10, 2, 1, 7, 3, 1, 12},
+		{2, dayOne.Add(10 * time.Minute), "priority", "priority", "max", "CodexExecutor", "POST /v1/responses", 20, 3, 2, 8, 4, 2, 23},
+		{3, dayOne.Add(20 * time.Minute), " default ", " default ", " xhigh ", " CodexWebsocketsExecutor ", " GET /v1/responses ", 30, 4, 3, 9, 5, 3, 34},
+		{4, dayTwo, "default", "default", "xhigh", "CodexWebsocketsExecutor", nil, 40, 5, 4, 10, 6, 4, 45},
+	}
+	for _, row := range fixtures {
+		if err := db.Exec(`INSERT INTO usage_events (
+			id, api_group_key, model, model_alias, auth_index, timestamp, failed,
+			input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens,
+			service_tier, response_service_tier, reasoning_effort, endpoint, executor_type
+		) VALUES (?, 'api-a', 'gpt-a', 'gpt-alias', 'auth-a', ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			row.id, timeutil.FormatStorageTime(row.timestamp), row.input, row.output, row.reasoning, row.cached, row.cacheRead, row.cacheCreation, row.total,
+			row.serviceTier, row.responseTier, row.effort, row.endpoint, row.executor).Error; err != nil {
+			t.Fatalf("seed usage event %d: %v", row.id, err)
+		}
+	}
+	now := timeutil.FormatStorageTime(dayTwo)
+	for _, table := range []string{"usage_overview_hourly_stats", "usage_overview_daily_stats"} {
+		if err := db.Exec("INSERT INTO "+table+" (bucket_start, api_group_key, model, request_count, created_at, updated_at) VALUES (?, 'stale-api', 'stale-model', 99, ?, ?)", now, now, now).Error; err != nil {
+			t.Fatalf("seed stale %s row: %v", table, err)
+		}
+	}
+	if err := db.Exec(`INSERT INTO usage_overview_aggregation_checkpoints
+		(name, last_aggregated_usage_event_id, stats_updated_at, created_at, updated_at)
+		VALUES ('overview', 999, ?, ?, ?)`, now, now, now).Error; err != nil {
+		t.Fatalf("seed stale overview checkpoint: %v", err)
+	}
+}
+
+func assertUsageOverviewFiveDimensionMigrationRows(t *testing.T, db *gorm.DB, table string) {
+	t.Helper()
+	var rows []usageOverviewFiveDimensionRow
+	if err := db.Table(table).
+		Select("service_tier, response_service_tier, reasoning_effort, endpoint, executor_type, request_count, total_tokens").
+		Order("bucket_start ASC, service_tier ASC").
+		Find(&rows).Error; err != nil {
+		t.Fatalf("load rebuilt %s rows: %v", table, err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rebuilt %s rows, got %d: %+v", table, len(rows), rows)
+	}
+	if got := rows[0]; got.ServiceTier != "default" || got.ResponseServiceTier != "default" || got.ReasoningEffort != "xhigh" || got.Endpoint != "GET /v1/responses" || got.ExecutorType != "CodexWebsocketsExecutor" || got.RequestCount != 2 || got.TotalTokens != 46 {
+		t.Fatalf("unexpected first rebuilt %s row: %+v", table, got)
+	}
+	if got := rows[1]; got.ServiceTier != "priority" || got.ResponseServiceTier != "priority" || got.ReasoningEffort != "max" || got.Endpoint != "POST /v1/responses" || got.ExecutorType != "CodexExecutor" || got.RequestCount != 1 || got.TotalTokens != 23 {
+		t.Fatalf("unexpected second rebuilt %s row: %+v", table, got)
+	}
+	if got := rows[2]; got.ServiceTier != "default" || got.ResponseServiceTier != "default" || got.ReasoningEffort != "xhigh" || got.Endpoint != "" || got.ExecutorType != "CodexWebsocketsExecutor" || got.RequestCount != 1 || got.TotalTokens != 45 {
+		t.Fatalf("unexpected third rebuilt %s row: %+v", table, got)
+	}
+}
+
+func assertUsageOverviewFiveDimensionIndex(t *testing.T, db *gorm.DB, name string) {
+	t.Helper()
+	type indexColumn struct {
+		Seqno int
+		Name  string
+	}
+	var rows []indexColumn
+	if err := db.Raw("PRAGMA index_info(" + name + ")").Scan(&rows).Error; err != nil {
+		t.Fatalf("load index %s columns: %v", name, err)
+	}
+	want := []string{"bucket_start", "api_group_key", "model", "auth_index", "model_alias", "service_tier", "response_service_tier", "reasoning_effort", "endpoint", "executor_type"}
+	got := make([]string, len(rows))
+	for index, row := range rows {
+		got[index] = row.Name
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected %s columns: got %v want %v", name, got, want)
+	}
+}

--- a/internal/repository/overviewstore/store.go
+++ b/internal/repository/overviewstore/store.go
@@ -1,0 +1,113 @@
+package overviewstore
+
+import (
+	"fmt"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/timeutil"
+
+	"gorm.io/gorm"
+)
+
+const overviewDimensionsPredicate = "bucket_start = ? AND api_group_key = ? AND model = ? AND auth_index = ? AND model_alias = ? AND service_tier = ? AND response_service_tier = ? AND reasoning_effort = ? AND endpoint = ? AND executor_type = ?"
+
+// ApplyRows 用同一套五维唯一键把 hourly 和 daily 增量写入当前事务。
+func ApplyRows(tx *gorm.DB, hourlyRows []entities.UsageOverviewHourlyStat, dailyRows []entities.UsageOverviewDailyStat, now time.Time) error {
+	// hourly 必须全部成功，调用方才会继续提交 daily 和 checkpoint。
+	for _, row := range hourlyRows {
+		if err := applyHourlyRow(tx, row, now); err != nil {
+			return err
+		}
+	}
+	// daily 与 hourly 共享同一事务和累计公式，禁止出现单表已推进状态。
+	for _, row := range dailyRows {
+		if err := applyDailyRow(tx, row, now); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyHourlyRow(tx *gorm.DB, row entities.UsageOverviewHourlyStat, now time.Time) error {
+	updates := tokenStatUpdates(row.RequestCount, row.SuccessCount, row.FailureCount, row.InputTokens, row.OutputTokens, row.ReasoningTokens, row.CachedTokens, row.CacheReadTokens, row.CacheCreationTokens, row.TotalTokens, now)
+	args := hourlyDimensionArgs(row)
+	// update-first 避免正常累计走唯一索引冲突路径并消耗自增 ID。
+	result := tx.Model(&entities.UsageOverviewHourlyStat{}).Where(overviewDimensionsPredicate, args...).Updates(updates)
+	if result.Error != nil {
+		return fmt.Errorf("update usage overview hourly stat: %w", result.Error)
+	}
+	if result.RowsAffected > 0 {
+		return nil
+	}
+
+	row.CreatedAt = timeutil.NormalizeStorageTime(now)
+	row.UpdatedAt = timeutil.NormalizeStorageTime(now)
+	if insertErr := tx.Create(&row).Error; insertErr != nil {
+		// 并发创建相同 key 时只重试一次完整五维 UPDATE。
+		retryResult := tx.Model(&entities.UsageOverviewHourlyStat{}).Where(overviewDimensionsPredicate, args...).Updates(updates)
+		if retryResult.Error != nil {
+			return fmt.Errorf("insert usage overview hourly stat: %w; retry update: %v", insertErr, retryResult.Error)
+		}
+		if retryResult.RowsAffected == 0 {
+			return fmt.Errorf("insert usage overview hourly stat: %w; retry update matched no existing row", insertErr)
+		}
+	}
+	return nil
+}
+
+func applyDailyRow(tx *gorm.DB, row entities.UsageOverviewDailyStat, now time.Time) error {
+	updates := tokenStatUpdates(row.RequestCount, row.SuccessCount, row.FailureCount, row.InputTokens, row.OutputTokens, row.ReasoningTokens, row.CachedTokens, row.CacheReadTokens, row.CacheCreationTokens, row.TotalTokens, now)
+	args := dailyDimensionArgs(row)
+	// daily 使用与 hourly 完全相同的最终唯一键和 update-first 语义。
+	result := tx.Model(&entities.UsageOverviewDailyStat{}).Where(overviewDimensionsPredicate, args...).Updates(updates)
+	if result.Error != nil {
+		return fmt.Errorf("update usage overview daily stat: %w", result.Error)
+	}
+	if result.RowsAffected > 0 {
+		return nil
+	}
+
+	row.CreatedAt = timeutil.NormalizeStorageTime(now)
+	row.UpdatedAt = timeutil.NormalizeStorageTime(now)
+	if insertErr := tx.Create(&row).Error; insertErr != nil {
+		retryResult := tx.Model(&entities.UsageOverviewDailyStat{}).Where(overviewDimensionsPredicate, args...).Updates(updates)
+		if retryResult.Error != nil {
+			return fmt.Errorf("insert usage overview daily stat: %w; retry update: %v", insertErr, retryResult.Error)
+		}
+		if retryResult.RowsAffected == 0 {
+			return fmt.Errorf("insert usage overview daily stat: %w; retry update matched no existing row", insertErr)
+		}
+	}
+	return nil
+}
+
+func hourlyDimensionArgs(row entities.UsageOverviewHourlyStat) []any {
+	return []any{
+		timeutil.FormatStorageTime(row.BucketStart), row.APIGroupKey, row.Model, row.AuthIndex, row.ModelAlias,
+		row.ServiceTier, row.ResponseServiceTier, row.ReasoningEffort, row.Endpoint, row.ExecutorType,
+	}
+}
+
+func dailyDimensionArgs(row entities.UsageOverviewDailyStat) []any {
+	return []any{
+		timeutil.FormatStorageTime(row.BucketStart), row.APIGroupKey, row.Model, row.AuthIndex, row.ModelAlias,
+		row.ServiceTier, row.ResponseServiceTier, row.ReasoningEffort, row.Endpoint, row.ExecutorType,
+	}
+}
+
+func tokenStatUpdates(requestCount, successCount, failureCount, inputTokens, outputTokens, reasoningTokens, cachedTokens, cacheReadTokens, cacheCreationTokens, totalTokens int64, now time.Time) map[string]any {
+	return map[string]any{
+		"request_count":         gorm.Expr("request_count + ?", requestCount),
+		"success_count":         gorm.Expr("success_count + ?", successCount),
+		"failure_count":         gorm.Expr("failure_count + ?", failureCount),
+		"input_tokens":          gorm.Expr("input_tokens + ?", inputTokens),
+		"output_tokens":         gorm.Expr("output_tokens + ?", outputTokens),
+		"reasoning_tokens":      gorm.Expr("reasoning_tokens + ?", reasoningTokens),
+		"cached_tokens":         gorm.Expr("cached_tokens + ?", cachedTokens),
+		"cache_read_tokens":     gorm.Expr("cache_read_tokens + ?", cacheReadTokens),
+		"cache_creation_tokens": gorm.Expr("cache_creation_tokens + ?", cacheCreationTokens),
+		"total_tokens":          gorm.Expr("total_tokens + ?", totalTokens),
+		"updated_at":            timeutil.FormatStorageTime(now),
+	}
+}

--- a/internal/repository/test/db_test.go
+++ b/internal/repository/test/db_test.go
@@ -62,7 +62,7 @@ func TestOpenDatabaseCreatesFreshDatabaseFromCurrentSchemaWithoutRunningMigratio
 	closeTestDatabase(t, db)
 
 	var latestMigrationCount int64
-	if err := db.Table("schema_migrations").Where("version = ?", "20260702_model_price_multiplier").Count(&latestMigrationCount).Error; err != nil {
+	if err := db.Table("schema_migrations").Where("version = ?", "20260723_usage_overview_five_dimensions").Count(&latestMigrationCount).Error; err != nil {
 		t.Fatalf("count latest schema migration: %v", err)
 	}
 	if latestMigrationCount != 1 {
@@ -108,18 +108,25 @@ func TestOpenDatabaseCreatesFreshDatabaseFromCurrentSchemaWithoutRunningMigratio
 	if db.Migrator().HasTable("usage_overview_health_stats") {
 		t.Fatal("expected fresh schema not to create legacy usage_overview_health_stats")
 	}
+	for _, table := range []string{"usage_overview_hourly_stats", "usage_overview_daily_stats"} {
+		for _, column := range []string{"service_tier", "response_service_tier", "reasoning_effort", "endpoint", "executor_type"} {
+			if !db.Migrator().HasColumn(table, column) {
+				t.Fatalf("expected fresh schema to create %s.%s", table, column)
+			}
+		}
+	}
 	for _, indexName := range []string{
 		"idx_usage_events_api_group_key",
 		"idx_usage_events_auth_index",
 		"idx_usage_events_model",
 		"idx_usage_events_auth_type_auth_index_id",
 		"idx_usage_events_auth_index_timestamp_id",
-		"uniq_usage_overview_hourly_stats_bucket_api_model_auth_alias",
+		"uniq_usage_overview_hourly_stats_dimensions",
 		"idx_usage_overview_hourly_stats_api_bucket",
 		"idx_usage_overview_hourly_stats_api_model_bucket",
 		"idx_usage_overview_hourly_stats_auth_bucket",
 		"idx_usage_overview_hourly_stats_model_alias_bucket",
-		"uniq_usage_overview_daily_stats_bucket_api_model_auth_alias",
+		"uniq_usage_overview_daily_stats_dimensions",
 		"idx_usage_overview_daily_stats_api_bucket",
 		"idx_usage_overview_daily_stats_api_model_bucket",
 		"idx_usage_overview_daily_stats_auth_bucket",

--- a/internal/repository/test/usage_overview_five_dimensions_test.go
+++ b/internal/repository/test/usage_overview_five_dimensions_test.go
@@ -1,0 +1,143 @@
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+	"gorm.io/gorm"
+)
+
+type usageOverviewFiveDimensionRow struct {
+	ServiceTier         string
+	ResponseServiceTier string
+	ReasoningEffort     string
+	Endpoint            string
+	ExecutorType        string
+	RequestCount        int64
+	TotalTokens         int64
+}
+
+type usageOverviewFiveDimensionKey struct {
+	ServiceTier         string
+	ResponseServiceTier string
+	ReasoningEffort     string
+	Endpoint            string
+	ExecutorType        string
+}
+
+func TestUsageOverviewAggregationSeparatesFiveDimensionCombinations(t *testing.T) {
+	previousLocal := time.Local
+	time.Local = time.UTC
+	t.Cleanup(func() { time.Local = previousLocal })
+
+	db := openTestDatabase(t)
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	alias := "gpt-alias"
+	events := []entities.UsageEvent{
+		{
+			EventKey: "five-dimensions-1", APIGroupKey: "api-a", Model: "gpt-a", ModelAlias: &alias, AuthIndex: "auth-a",
+			ServiceTier: "default", ResponseServiceTier: "default", ReasoningEffort: "xhigh", Endpoint: "GET /v1/responses", ExecutorType: "CodexWebsocketsExecutor",
+			Timestamp: now.Add(-50 * time.Minute), InputTokens: 10, OutputTokens: 2, TotalTokens: 12,
+		},
+		{
+			EventKey: "five-dimensions-2", APIGroupKey: "api-a", Model: "gpt-a", ModelAlias: &alias, AuthIndex: "auth-a",
+			ServiceTier: "priority", ResponseServiceTier: "default", ReasoningEffort: "xhigh", Endpoint: "GET /v1/responses", ExecutorType: "CodexWebsocketsExecutor",
+			Timestamp: now.Add(-40 * time.Minute), InputTokens: 20, OutputTokens: 3, TotalTokens: 23,
+		},
+		{
+			EventKey: "five-dimensions-3", APIGroupKey: "api-a", Model: "gpt-a", ModelAlias: &alias, AuthIndex: "auth-a",
+			ServiceTier: "default", ResponseServiceTier: "priority", ReasoningEffort: "xhigh", Endpoint: "GET /v1/responses", ExecutorType: "CodexWebsocketsExecutor",
+			Timestamp: now.Add(-30 * time.Minute), InputTokens: 30, OutputTokens: 4, TotalTokens: 34,
+		},
+		{
+			EventKey: "five-dimensions-4", APIGroupKey: "api-a", Model: "gpt-a", ModelAlias: &alias, AuthIndex: "auth-a",
+			ServiceTier: "default", ResponseServiceTier: "default", ReasoningEffort: "max", Endpoint: "GET /v1/responses", ExecutorType: "CodexWebsocketsExecutor",
+			Timestamp: now.Add(-20 * time.Minute), InputTokens: 40, OutputTokens: 5, TotalTokens: 45,
+		},
+		{
+			EventKey: "five-dimensions-5", APIGroupKey: "api-a", Model: "gpt-a", ModelAlias: &alias, AuthIndex: "auth-a",
+			ServiceTier: "default", ResponseServiceTier: "default", ReasoningEffort: "xhigh", Endpoint: "POST /v1/responses", ExecutorType: "CodexWebsocketsExecutor",
+			Timestamp: now.Add(-10 * time.Minute), InputTokens: 50, OutputTokens: 6, TotalTokens: 56,
+		},
+		{
+			EventKey: "five-dimensions-6", APIGroupKey: "api-a", Model: "gpt-a", ModelAlias: &alias, AuthIndex: "auth-a",
+			ServiceTier: "default", ResponseServiceTier: "default", ReasoningEffort: "xhigh", Endpoint: "GET /v1/responses", ExecutorType: "CodexExecutor",
+			Timestamp: now.Add(-5 * time.Minute), InputTokens: 60, OutputTokens: 7, TotalTokens: 67,
+		},
+		{
+			EventKey: "five-dimensions-7", APIGroupKey: "api-a", Model: "gpt-a", ModelAlias: &alias, AuthIndex: "auth-a",
+			ServiceTier: " default ", ResponseServiceTier: " default ", ReasoningEffort: " xhigh ", Endpoint: " GET /v1/responses ", ExecutorType: " CodexWebsocketsExecutor ",
+			Timestamp: now.Add(-time.Minute), InputTokens: 70, OutputTokens: 8, TotalTokens: 78,
+		},
+	}
+	if _, _, err := repository.InsertUsageEvents(db, events); err != nil {
+		t.Fatalf("insert five-dimension events: %v", err)
+	}
+	if err := repository.AggregateUsageOverviewStats(context.Background(), db, now); err != nil {
+		t.Fatalf("aggregate five-dimension events: %v", err)
+	}
+
+	assertUsageOverviewFiveDimensionRows(t, db, "usage_overview_hourly_stats")
+	assertUsageOverviewFiveDimensionRows(t, db, "usage_overview_daily_stats")
+
+	var checkpoint entities.UsageOverviewAggregationCheckpoint
+	if err := db.Where("name = ?", "overview").Take(&checkpoint).Error; err != nil {
+		t.Fatalf("load five-dimension checkpoint: %v", err)
+	}
+	if checkpoint.LastAggregatedUsageEventID != 7 {
+		t.Fatalf("expected checkpoint 7, got %d", checkpoint.LastAggregatedUsageEventID)
+	}
+}
+
+func assertUsageOverviewFiveDimensionRows(t *testing.T, db *gorm.DB, table string) {
+	t.Helper()
+	var count int64
+	if err := db.Table(table).Where("api_group_key = ? AND model = ? AND auth_index = ? AND model_alias = ?", "api-a", "gpt-a", "auth-a", "gpt-alias").Count(&count).Error; err != nil {
+		t.Fatalf("count %s five-dimension rows: %v", table, err)
+	}
+	if count != 6 {
+		t.Fatalf("expected %s to contain 6 five-dimension rows, got %d", table, count)
+	}
+
+	var rows []usageOverviewFiveDimensionRow
+	if err := db.Table(table).
+		Select("service_tier, response_service_tier, reasoning_effort, endpoint, executor_type, request_count, total_tokens").
+		Where("api_group_key = ? AND model = ? AND auth_index = ? AND model_alias = ?", "api-a", "gpt-a", "auth-a", "gpt-alias").
+		Find(&rows).Error; err != nil {
+		t.Fatalf("load %s five-dimension rows: %v", table, err)
+	}
+	if len(rows) != 6 {
+		t.Fatalf("expected 6 %s rows, got %d", table, len(rows))
+	}
+	want := map[usageOverviewFiveDimensionKey]struct {
+		requestCount int64
+		totalTokens  int64
+	}{
+		{ServiceTier: "default", ResponseServiceTier: "default", ReasoningEffort: "xhigh", Endpoint: "GET /v1/responses", ExecutorType: "CodexWebsocketsExecutor"}:  {requestCount: 2, totalTokens: 90},
+		{ServiceTier: "priority", ResponseServiceTier: "default", ReasoningEffort: "xhigh", Endpoint: "GET /v1/responses", ExecutorType: "CodexWebsocketsExecutor"}: {requestCount: 1, totalTokens: 23},
+		{ServiceTier: "default", ResponseServiceTier: "priority", ReasoningEffort: "xhigh", Endpoint: "GET /v1/responses", ExecutorType: "CodexWebsocketsExecutor"}: {requestCount: 1, totalTokens: 34},
+		{ServiceTier: "default", ResponseServiceTier: "default", ReasoningEffort: "max", Endpoint: "GET /v1/responses", ExecutorType: "CodexWebsocketsExecutor"}:    {requestCount: 1, totalTokens: 45},
+		{ServiceTier: "default", ResponseServiceTier: "default", ReasoningEffort: "xhigh", Endpoint: "POST /v1/responses", ExecutorType: "CodexWebsocketsExecutor"}: {requestCount: 1, totalTokens: 56},
+		{ServiceTier: "default", ResponseServiceTier: "default", ReasoningEffort: "xhigh", Endpoint: "GET /v1/responses", ExecutorType: "CodexExecutor"}:            {requestCount: 1, totalTokens: 67},
+	}
+	for _, row := range rows {
+		key := usageOverviewFiveDimensionKey{
+			ServiceTier: row.ServiceTier, ResponseServiceTier: row.ResponseServiceTier, ReasoningEffort: row.ReasoningEffort,
+			Endpoint: row.Endpoint, ExecutorType: row.ExecutorType,
+		}
+		expected, ok := want[key]
+		if !ok {
+			t.Fatalf("unexpected %s dimensions: %+v", table, row)
+		}
+		if row.RequestCount != expected.requestCount || row.TotalTokens != expected.totalTokens {
+			t.Fatalf("unexpected %s totals for %+v: got requests=%d tokens=%d want requests=%d tokens=%d", table, key, row.RequestCount, row.TotalTokens, expected.requestCount, expected.totalTokens)
+		}
+		delete(want, key)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing %s dimension rows: %+v", table, want)
+	}
+}

--- a/internal/repository/usage_overview_stats.go
+++ b/internal/repository/usage_overview_stats.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/overview"
+	"cpa-usage-keeper/internal/repository/overviewstore"
 	"cpa-usage-keeper/internal/timeutil"
 
 	"gorm.io/gorm"
@@ -124,7 +125,7 @@ func aggregateUsageOverviewStatsBatch(ctx context.Context, db *gorm.DB, now time
 
 		// SELECT 明确保留全部旧 hourly/daily 累计字段，包括 cached_tokens。
 		var events []entities.UsageEvent
-		if err := tx.Select("id, api_group_key, model, model_alias, auth_index, timestamp, failed, input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens").
+		if err := tx.Select("id, api_group_key, model, model_alias, auth_index, service_tier, response_service_tier, reasoning_effort, endpoint, executor_type, timestamp, failed, input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens").
 			Where("id > ?", checkpoint.LastAggregatedUsageEventID).
 			Order("id asc").
 			Limit(limit).
@@ -137,14 +138,10 @@ func aggregateUsageOverviewStatsBatch(ctx context.Context, db *gorm.DB, now time
 			return nil
 		}
 
-		// 只构建原有 hourly/daily rows；Activity 由独立事务和 checkpoint 处理。
-		hourlyRows, dailyRows, maxEventID := buildUsageOverviewStatsRows(events)
-		// hourly 写入函数和字段累计表达式保持原实现不变。
-		if err := applyUsageOverviewHourlyStats(tx, hourlyRows, now); err != nil {
-			return err
-		}
-		// daily 写入函数和字段累计表达式保持原实现不变。
-		if err := applyUsageOverviewDailyStats(tx, dailyRows, now); err != nil {
+		// migration 与运行时共用同一个五维分组实现，避免重建后增量语义漂移。
+		hourlyRows, dailyRows, maxEventID := overview.BuildRows(events)
+		// hourly、daily 必须通过同一写入层在当前事务内一起完成。
+		if err := overviewstore.ApplyRows(tx, hourlyRows, dailyRows, now); err != nil {
 			return err
 		}
 		// 只有两个旧表都成功后才推进原 Overview checkpoint。
@@ -176,292 +173,4 @@ func getOrCreateUsageOverviewAggregationCheckpoint(tx *gorm.DB) (entities.UsageO
 	}
 	// 返回当前旧 cursor 供本 batch 使用。
 	return checkpoint, nil
-}
-
-type usageOverviewStatsKey struct {
-	BucketStart time.Time
-	APIGroupKey string
-	Model       string
-	AuthIndex   string
-	ModelAlias  string
-}
-
-// buildUsageOverviewStatsRows 先在内存按聚合 key 合并一批事件，减少 SQLite 写入次数。
-func buildUsageOverviewStatsRows(events []entities.UsageEvent) ([]entities.UsageOverviewHourlyStat, []entities.UsageOverviewDailyStat, int64) {
-	// hourly map 的 key 和最终唯一索引维度保持不变。
-	hourly := make(map[usageOverviewStatsKey]*entities.UsageOverviewHourlyStat)
-	// daily map 的 key 和最终唯一索引维度保持不变。
-	daily := make(map[usageOverviewStatsKey]*entities.UsageOverviewDailyStat)
-	// maxEventID 继续决定同事务提交的 Overview checkpoint。
-	maxEventID := int64(0)
-	// 每条事件仍同时进入一个 hourly 和一个 daily row。
-	for _, event := range events {
-		// 记录本批最大 ID，保持原 cursor 推进语义。
-		if event.ID > maxEventID {
-			maxEventID = event.ID
-		}
-		// 时间先归一化到项目存储时区，保持旧 bucket 边界。
-		timestamp := timeutil.NormalizeStorageTime(event.Timestamp)
-		// API group 继续用原有 unknown 规范化逻辑。
-		apiGroupKey := normalizeUsageOverviewDimension(event.APIGroupKey)
-		// model 继续用原有 unknown 规范化逻辑。
-		model := normalizeUsageOverviewDimension(event.Model)
-		// auth index 继续只去除首尾空白。
-		authIndex := normalizeUsageOverviewOptionalDimension(event.AuthIndex)
-		// nil model alias 继续映射为空字符串。
-		modelAlias := ""
-		// 非 nil alias 继续只去除首尾空白。
-		if event.ModelAlias != nil {
-			modelAlias = normalizeUsageOverviewOptionalDimension(*event.ModelAlias)
-		}
-		// hourly bucket 继续使用项目时区 timestamp 的整点截断。
-		hourBucket := timestamp.Truncate(time.Hour)
-		// daily bucket 继续使用项目时区本地零点。
-		dayBucket := time.Date(timestamp.Year(), timestamp.Month(), timestamp.Day(), 0, 0, 0, 0, timestamp.Location())
-
-		// hourly key 维度和旧唯一索引完全一致。
-		hourKey := usageOverviewStatsKey{BucketStart: hourBucket, APIGroupKey: apiGroupKey, Model: model, AuthIndex: authIndex, ModelAlias: modelAlias}
-		// 第一次遇到 key 时创建空 hourly row。
-		if _, ok := hourly[hourKey]; !ok {
-			hourly[hourKey] = &entities.UsageOverviewHourlyStat{BucketStart: hourBucket, APIGroupKey: apiGroupKey, Model: model, AuthIndex: authIndex, ModelAlias: modelAlias}
-		}
-		// 原 helper 继续逐字段累计所有旧 hourly 字段。
-		addUsageOverviewEventToStats(hourly[hourKey], event)
-
-		// daily key 维度和旧唯一索引完全一致。
-		dayKey := usageOverviewStatsKey{BucketStart: dayBucket, APIGroupKey: apiGroupKey, Model: model, AuthIndex: authIndex, ModelAlias: modelAlias}
-		// 第一次遇到 key 时创建空 daily row。
-		if _, ok := daily[dayKey]; !ok {
-			daily[dayKey] = &entities.UsageOverviewDailyStat{BucketStart: dayBucket, APIGroupKey: apiGroupKey, Model: model, AuthIndex: authIndex, ModelAlias: modelAlias}
-		}
-		// 原 helper 继续逐字段累计所有旧 daily 字段。
-		addUsageOverviewEventToStats(daily[dayKey], event)
-	}
-
-	// 把 hourly map 复制为写入切片，保持原写入函数输入类型。
-	hourlyRows := make([]entities.UsageOverviewHourlyStat, 0, len(hourly))
-	// 每个 hourly 唯一 key 只生成一行。
-	for _, row := range hourly {
-		hourlyRows = append(hourlyRows, *row)
-	}
-	// 把 daily map 复制为写入切片，保持原写入函数输入类型。
-	dailyRows := make([]entities.UsageOverviewDailyStat, 0, len(daily))
-	// 每个 daily 唯一 key 只生成一行。
-	for _, row := range daily {
-		dailyRows = append(dailyRows, *row)
-	}
-	// 只返回两个既有 rollup 和原 checkpoint cursor；Health 已由 Activity 替代。
-	return hourlyRows, dailyRows, maxEventID
-}
-
-func normalizeUsageOverviewOptionalDimension(value string) string {
-	return strings.TrimSpace(value)
-}
-
-type usageOverviewTokenStat interface {
-	*entities.UsageOverviewHourlyStat | *entities.UsageOverviewDailyStat
-}
-
-// addUsageOverviewEventToStats 将单条事件累加到 hourly 或 daily token stats 行。
-func addUsageOverviewEventToStats[T usageOverviewTokenStat](row T, event entities.UsageEvent) {
-	// 只按具体旧实体类型分派，不改变 hourly/daily 各自的字段集合。
-	switch stat := any(row).(type) {
-	case *entities.UsageOverviewHourlyStat:
-		// hourly 继续调用原小时累计公式。
-		addUsageOverviewEventToHourlyStat(stat, event)
-	case *entities.UsageOverviewDailyStat:
-		// daily 继续调用原自然日累计公式。
-		addUsageOverviewEventToDailyStat(stat, event)
-	}
-}
-
-// addUsageOverviewEventToHourlyStat 累加请求数、成功失败数和各类 token 到小时行。
-func addUsageOverviewEventToHourlyStat(row *entities.UsageOverviewHourlyStat, event entities.UsageEvent) {
-	// 每条事件继续增加一个旧 request_count。
-	row.RequestCount++
-	// failed 继续决定旧成功失败二选一累计。
-	if event.Failed {
-		// 失败事件只增加 failure_count。
-		row.FailureCount++
-	} else {
-		// 成功事件只增加 success_count。
-		row.SuccessCount++
-	}
-	// 旧 input_tokens 继续原样累计。
-	row.InputTokens += event.InputTokens
-	// 旧 output_tokens 继续原样累计。
-	row.OutputTokens += event.OutputTokens
-	// 旧 reasoning_tokens 继续原样累计。
-	row.ReasoningTokens += event.ReasoningTokens
-	// 旧 cached_tokens 兼容字段必须继续累计。
-	row.CachedTokens += event.CachedTokens
-	// 旧 cache_read_tokens 继续原样累计。
-	row.CacheReadTokens += event.CacheReadTokens
-	// 旧 cache_creation_tokens 继续原样累计。
-	row.CacheCreationTokens += event.CacheCreationTokens
-	// 旧 total_tokens 继续原样累计。
-	row.TotalTokens += event.TotalTokens
-}
-
-// addUsageOverviewEventToDailyStat 累加请求数、成功失败数和各类 token 到天行。
-func addUsageOverviewEventToDailyStat(row *entities.UsageOverviewDailyStat, event entities.UsageEvent) {
-	// 每条事件继续增加一个旧 request_count。
-	row.RequestCount++
-	// failed 继续决定旧成功失败二选一累计。
-	if event.Failed {
-		// 失败事件只增加 failure_count。
-		row.FailureCount++
-	} else {
-		// 成功事件只增加 success_count。
-		row.SuccessCount++
-	}
-	// 旧 input_tokens 继续原样累计。
-	row.InputTokens += event.InputTokens
-	// 旧 output_tokens 继续原样累计。
-	row.OutputTokens += event.OutputTokens
-	// 旧 reasoning_tokens 继续原样累计。
-	row.ReasoningTokens += event.ReasoningTokens
-	// 旧 cached_tokens 兼容字段必须继续累计。
-	row.CachedTokens += event.CachedTokens
-	// 旧 cache_read_tokens 继续原样累计。
-	row.CacheReadTokens += event.CacheReadTokens
-	// 旧 cache_creation_tokens 继续原样累计。
-	row.CacheCreationTokens += event.CacheCreationTokens
-	// 旧 total_tokens 继续原样累计。
-	row.TotalTokens += event.TotalTokens
-}
-
-// applyUsageOverviewHourlyStats 分批写入小时聚合行，复用 SQLite 参数数量保护。
-func applyUsageOverviewHourlyStats(tx *gorm.DB, rows []entities.UsageOverviewHourlyStat, now time.Time) error {
-	// 外层按旧实体写入批次遍历，避免一次处理过多聚合 rows。
-	for start := 0; start < len(rows); start += insertBatchSize(entities.UsageOverviewHourlyStat{}) {
-		// 当前 end 不得越过 rows 尾部。
-		end := min(start+insertBatchSize(entities.UsageOverviewHourlyStat{}), len(rows))
-		// 当前分段仍逐行使用 update-first 语义。
-		for index := start; index < end; index++ {
-			// 任一 hourly 行失败都让上层 Overview 事务整体回滚。
-			if err := applyUsageOverviewHourlyStat(tx, rows[index], now); err != nil {
-				return err
-			}
-		}
-	}
-	// 全部 hourly rows 成功后才允许继续 daily。
-	return nil
-}
-
-// applyUsageOverviewDailyStats 分批写入天聚合行，复用 SQLite 参数数量保护。
-func applyUsageOverviewDailyStats(tx *gorm.DB, rows []entities.UsageOverviewDailyStat, now time.Time) error {
-	// 外层按旧实体写入批次遍历，避免一次处理过多聚合 rows。
-	for start := 0; start < len(rows); start += insertBatchSize(entities.UsageOverviewDailyStat{}) {
-		// 当前 end 不得越过 rows 尾部。
-		end := min(start+insertBatchSize(entities.UsageOverviewDailyStat{}), len(rows))
-		// 当前分段仍逐行使用 update-first 语义。
-		for index := start; index < end; index++ {
-			// 任一 daily 行失败都让上层 Overview 事务整体回滚。
-			if err := applyUsageOverviewDailyStat(tx, rows[index], now); err != nil {
-				return err
-			}
-		}
-	}
-	// 全部 daily rows 成功后，上层才能推进旧 checkpoint。
-	return nil
-}
-
-// applyUsageOverviewHourlyStat 使用 update-first 写入小时 stats，避免 upsert 冲突路径消耗自增 ID。
-func applyUsageOverviewHourlyStat(tx *gorm.DB, row entities.UsageOverviewHourlyStat, now time.Time) error {
-	// updates 继续包含旧 hourly 的全部请求与 Token 增量字段。
-	updates := usageOverviewTokenStatUpdates(row.RequestCount, row.SuccessCount, row.FailureCount, row.InputTokens, row.OutputTokens, row.ReasoningTokens, row.CachedTokens, row.CacheReadTokens, row.CacheCreationTokens, row.TotalTokens, now)
-	// 先按旧唯一维度 UPDATE，避免正常已有行走 INSERT 冲突路径。
-	result := tx.Model(&entities.UsageOverviewHourlyStat{}).Where("bucket_start = ? AND api_group_key = ? AND model = ? AND auth_index = ? AND model_alias = ?", timeutil.FormatStorageTime(row.BucketStart), row.APIGroupKey, row.Model, row.AuthIndex, row.ModelAlias).Updates(updates)
-	// UPDATE 数据库错误必须立即回滚当前 Overview 事务。
-	if result.Error != nil {
-		return fmt.Errorf("update usage overview hourly stat: %w", result.Error)
-	}
-	// 已有行命中后当前 hourly row 已完成累计。
-	if result.RowsAffected > 0 {
-		return nil
-	}
-	// 首次出现的 key 使用本批固定 now 作为创建时间。
-	row.CreatedAt = now
-	// 新行初始更新时间与创建时间保持一致。
-	row.UpdatedAt = now
-	// 首次 key INSERT 失败时只允许按唯一键重试一次 UPDATE，以兼容并发创建竞态。
-	if insertErr := tx.Create(&row).Error; insertErr != nil {
-		// retryResult 必须同时检查数据库错误和实际匹配行数。
-		retryResult := tx.Model(&entities.UsageOverviewHourlyStat{}).Where("bucket_start = ? AND api_group_key = ? AND model = ? AND auth_index = ? AND model_alias = ?", timeutil.FormatStorageTime(row.BucketStart), row.APIGroupKey, row.Model, row.AuthIndex, row.ModelAlias).Updates(updates)
-		// retry UPDATE 自身失败时保留 INSERT 与 UPDATE 两段错误上下文。
-		if retryResult.Error != nil {
-			return fmt.Errorf("insert usage overview hourly stat: %w; retry update: %v", insertErr, retryResult.Error)
-		}
-		// 没有并发创建出的同 key 行时，原 INSERT 错误不能被零行 UPDATE 静默吞掉。
-		if retryResult.RowsAffected == 0 {
-			return fmt.Errorf("insert usage overview hourly stat: %w; retry update matched no existing row", insertErr)
-		}
-	}
-	// INSERT 或可靠 retry UPDATE 成功后返回。
-	return nil
-}
-
-// applyUsageOverviewDailyStat 使用 update-first 写入天 stats，支撑长窗口完整天查询。
-func applyUsageOverviewDailyStat(tx *gorm.DB, row entities.UsageOverviewDailyStat, now time.Time) error {
-	// updates 继续包含旧 daily 的全部请求与 Token 增量字段。
-	updates := usageOverviewTokenStatUpdates(row.RequestCount, row.SuccessCount, row.FailureCount, row.InputTokens, row.OutputTokens, row.ReasoningTokens, row.CachedTokens, row.CacheReadTokens, row.CacheCreationTokens, row.TotalTokens, now)
-	// 先按旧唯一维度 UPDATE，避免正常已有行走 INSERT 冲突路径。
-	result := tx.Model(&entities.UsageOverviewDailyStat{}).Where("bucket_start = ? AND api_group_key = ? AND model = ? AND auth_index = ? AND model_alias = ?", timeutil.FormatStorageTime(row.BucketStart), row.APIGroupKey, row.Model, row.AuthIndex, row.ModelAlias).Updates(updates)
-	// UPDATE 数据库错误必须立即回滚当前 Overview 事务。
-	if result.Error != nil {
-		return fmt.Errorf("update usage overview daily stat: %w", result.Error)
-	}
-	// 已有行命中后当前 daily row 已完成累计。
-	if result.RowsAffected > 0 {
-		return nil
-	}
-	// 首次出现的 key 使用本批固定 now 作为创建时间。
-	row.CreatedAt = now
-	// 新行初始更新时间与创建时间保持一致。
-	row.UpdatedAt = now
-	// 首次 key INSERT 失败时只允许按唯一键重试一次 UPDATE，以兼容并发创建竞态。
-	if insertErr := tx.Create(&row).Error; insertErr != nil {
-		// retryResult 必须同时检查数据库错误和实际匹配行数。
-		retryResult := tx.Model(&entities.UsageOverviewDailyStat{}).Where("bucket_start = ? AND api_group_key = ? AND model = ? AND auth_index = ? AND model_alias = ?", timeutil.FormatStorageTime(row.BucketStart), row.APIGroupKey, row.Model, row.AuthIndex, row.ModelAlias).Updates(updates)
-		// retry UPDATE 自身失败时保留 INSERT 与 UPDATE 两段错误上下文。
-		if retryResult.Error != nil {
-			return fmt.Errorf("insert usage overview daily stat: %w; retry update: %v", insertErr, retryResult.Error)
-		}
-		// 没有并发创建出的同 key 行时，原 INSERT 错误不能被零行 UPDATE 静默吞掉。
-		if retryResult.RowsAffected == 0 {
-			return fmt.Errorf("insert usage overview daily stat: %w; retry update matched no existing row", insertErr)
-		}
-	}
-	// INSERT 或可靠 retry UPDATE 成功后返回。
-	return nil
-}
-
-// usageOverviewTokenStatUpdates 生成 hourly/daily 共用的累加更新表达式。
-func usageOverviewTokenStatUpdates(requestCount, successCount, failureCount, inputTokens, outputTokens, reasoningTokens, cachedTokens, cacheReadTokens, cacheCreationTokens, totalTokens int64, now time.Time) map[string]any {
-	// 每个表达式只做旧字段的原增量加法，不引入 Activity 语义。
-	return map[string]any{
-		// request_count 累加本批旧请求数。
-		"request_count": gorm.Expr("request_count + ?", requestCount),
-		// success_count 累加本批旧成功数。
-		"success_count": gorm.Expr("success_count + ?", successCount),
-		// failure_count 累加本批旧失败数。
-		"failure_count": gorm.Expr("failure_count + ?", failureCount),
-		// input_tokens 累加本批旧输入量。
-		"input_tokens": gorm.Expr("input_tokens + ?", inputTokens),
-		// output_tokens 累加本批旧输出量。
-		"output_tokens": gorm.Expr("output_tokens + ?", outputTokens),
-		// reasoning_tokens 累加本批旧推理量。
-		"reasoning_tokens": gorm.Expr("reasoning_tokens + ?", reasoningTokens),
-		// cached_tokens 必须继续按原公式累计。
-		"cached_tokens": gorm.Expr("cached_tokens + ?", cachedTokens),
-		// cache_read_tokens 累加本批旧读取缓存量。
-		"cache_read_tokens": gorm.Expr("cache_read_tokens + ?", cacheReadTokens),
-		// cache_creation_tokens 累加本批旧创建缓存量。
-		"cache_creation_tokens": gorm.Expr("cache_creation_tokens + ?", cacheCreationTokens),
-		// total_tokens 累加本批旧总量。
-		"total_tokens": gorm.Expr("total_tokens + ?", totalTokens),
-		// updated_at 继续使用本批固定时间。
-		"updated_at": timeutil.FormatStorageTime(now),
-	}
 }


### PR DESCRIPTION
## Summary

- add service_tier, response_service_tier, reasoning_effort, endpoint, and executor_type to hourly and daily Overview rollup dimensions
- rebuild both rollups from retained usage_events in bounded batches while resetting and re-advancing the Overview checkpoint
- share aggregation and write-key logic between migration and steady-state processing, and create the final unique indexes only after clearing old rollups

## Validation

- rtk env TZ=UTC GOCACHE=/tmp/cpa-usage-keeper-go-build GOFLAGS=-count=1 make verify
- targeted migration and aggregation tests under TZ=UTC and TZ=Asia/Shanghai
- copied test database migration: 144,876 raw events, 5,365 hourly rows, 1,705 daily rows, zero aggregate/dimension mismatches, and PRAGMA integrity_check = ok

## Notes

- the rebuild intentionally uses only usage_events still retained in the database; previously cleaned raw history is not reconstructed
- cost-calculation behavior across newly split rollup rows is intentionally deferred to a separate follow-up