### PR TITLE
feat(overview): integrate daily averages into stat cards

### DIFF
--- a/web/src/components/usage/DailyAverageCard.tsx
+++ b/web/src/components/usage/DailyAverageCard.tsx
@@ -1,11 +1,9 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react';
+import { useMemo, type CSSProperties, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IconDiamond, IconDollarSign, IconSatellite } from '@/components/ui/icons';
 import { formatCompactNumber, formatUsd } from '@/utils/usage';
 import type { UsageOverviewPayload } from './hooks/useUsageData';
 import styles from '@/pages/UsagePage.module.scss';
-
-const DAILY_AVERAGE_TRANSITION_MS = 220;
 
 interface DailyAverageMetrics {
   requests: number;
@@ -15,10 +13,9 @@ interface DailyAverageMetrics {
   costAvailable: boolean;
 }
 
-interface DailyAveragePanelProps {
+interface DailyAverageCardProps {
   usage: UsageOverviewPayload | null;
   loading: boolean;
-  reserveVisible?: boolean;
 }
 
 interface DailyAverageMetricItem {
@@ -27,7 +24,7 @@ interface DailyAverageMetricItem {
   value: string;
   icon: ReactNode;
   accent: string;
-  className?: string;
+  hint?: string;
 }
 
 const isFiniteMetric = (value: unknown): value is number => (
@@ -58,6 +55,7 @@ export function buildDailyAverageMetrics(usage: UsageOverviewPayload | null): Da
   if (!isFiniteMetric(requests) || !isFiniteMetric(tokens) || !isFiniteMetric(cost) || !isFiniteMetric(rangeDays)) {
     return null;
   }
+
   return {
     requests,
     tokens,
@@ -67,83 +65,37 @@ export function buildDailyAverageMetrics(usage: UsageOverviewPayload | null): Da
   };
 }
 
-export function DailyAveragePanel({ usage, loading, reserveVisible = false }: DailyAveragePanelProps) {
+export function DailyAverageCard({ usage, loading }: DailyAverageCardProps) {
   const { t } = useTranslation();
   const metrics = useMemo(() => buildDailyAverageMetrics(usage), [usage]);
-  const shouldRenderPanel = Boolean(metrics) || reserveVisible;
-  const [renderPanel, setRenderPanel] = useState(shouldRenderPanel);
-  const [visible, setVisible] = useState(false);
-  const renderPanelRef = useRef(renderPanel);
-
-  useEffect(() => {
-    renderPanelRef.current = renderPanel;
-  }, [renderPanel]);
-
-  useEffect(() => {
-    let frame: number | null = null;
-    let enterFrame: number | null = null;
-    let timer: number | null = null;
-
-    if (shouldRenderPanel) {
-      frame = window.requestAnimationFrame(() => {
-        const hadPanel = renderPanelRef.current;
-        setRenderPanel(true);
-        if (hadPanel) {
-          setVisible(true);
-          return;
-        }
-        setVisible(false);
-        enterFrame = window.requestAnimationFrame(() => setVisible(true));
-      });
-      return () => {
-        if (frame !== null) window.cancelAnimationFrame(frame);
-        if (enterFrame !== null) window.cancelAnimationFrame(enterFrame);
-      };
-    }
-
-    frame = window.requestAnimationFrame(() => setVisible(false));
-    timer = window.setTimeout(() => setRenderPanel(false), DAILY_AVERAGE_TRANSITION_MS);
-    return () => {
-      if (frame !== null) window.cancelAnimationFrame(frame);
-      if (timer !== null) window.clearTimeout(timer);
-    };
-  }, [shouldRenderPanel]);
-
-  if (!renderPanel) {
-    return null;
-  }
-
   const metricItems: DailyAverageMetricItem[] = [
     {
       key: 'requests',
       label: t('usage_stats.avg_requests'),
       value: loading || !metrics ? '-' : formatAverageCount(metrics.requests),
-      icon: <IconSatellite size={15} />,
+      icon: <IconSatellite size={14} />,
       accent: '#3b82f6',
     },
     {
       key: 'tokens',
       label: t('usage_stats.avg_tokens'),
       value: loading || !metrics ? '-' : formatCompactNumber(metrics.tokens),
-      icon: <IconDiamond size={15} />,
+      icon: <IconDiamond size={14} />,
       accent: '#8b5cf6',
     },
     {
       key: 'cost',
       label: t('usage_stats.avg_cost'),
       value: loading || !metrics ? '-' : formatUsd(metrics.cost),
-      icon: <IconDollarSign size={15} />,
+      icon: <IconDollarSign size={14} />,
       accent: '#f59e0b',
-      className: styles.dailyAverageMetricCost,
+      hint: metrics && !metrics.costAvailable ? t('usage_stats.cost_need_price') : undefined,
     },
   ];
 
   return (
-    <section
-      className={`${styles.dailyAveragePanel} ${visible ? styles.dailyAveragePanelVisible : styles.dailyAveragePanelEntering}`.trim()}
-      aria-label={t('usage_stats.daily_average')}
-    >
-      <div className={styles.dailyAverageIdentity}>
+    <section className={`${styles.statCard} ${styles.dailyAverageCard}`} aria-label={t('usage_stats.daily_average')}>
+      <div className={styles.dailyAverageCardHeader}>
         <span className={styles.dailyAverageTitle}>{t('usage_stats.daily_average')}</span>
         {metrics && (
           <span className={styles.dailyAverageRangePill}>
@@ -155,20 +107,18 @@ export function DailyAveragePanel({ usage, loading, reserveVisible = false }: Da
         {metricItems.map((item) => (
           <div
             key={item.key}
-            className={`${styles.dailyAverageMetric} ${item.className ?? ''}`.trim()}
+            className={styles.dailyAverageMetric}
             style={{ '--metric-accent': item.accent } as CSSProperties}
           >
             <span className={styles.dailyAverageMetricIcon}>{item.icon}</span>
-            <span className={styles.dailyAverageMetricText}>
+            <span className={styles.dailyAverageMetricCopy}>
               <span className={styles.dailyAverageMetricLabel}>{item.label}</span>
-              <strong className={styles.dailyAverageMetricValue}>{item.value}</strong>
+              {item.hint && <span className={styles.dailyAverageCostHint}>{item.hint}</span>}
             </span>
+            <strong className={styles.dailyAverageMetricValue}>{item.value}</strong>
           </div>
         ))}
       </div>
-      {metrics && !metrics.costAvailable && (
-        <span className={styles.dailyAverageCostHint}>{t('usage_stats.cost_need_price')}</span>
-      )}
     </section>
   );
 }

--- a/web/src/components/usage/StatCards.tsx
+++ b/web/src/components/usage/StatCards.tsx
@@ -131,7 +131,7 @@ export function StatCards({
   );
 
   useEffect(() => {
-    // 等浏览器完成当前布局后再切换展开态，让首次出现和范围切换都能触发横向动画。
+    // 等浏览器完成当前布局后再切换展开态，让首次出现和范围切换都能触发卡片布局动画。
     const frame = window.requestAnimationFrame(() => setDailyAverageExpanded(shouldExpandDailyAverage));
     return () => window.cancelAnimationFrame(frame);
   }, [shouldExpandDailyAverage]);

--- a/web/src/components/usage/StatCards.tsx
+++ b/web/src/components/usage/StatCards.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type CSSProperties, type ReactNode } from 'react';
+import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Line } from 'react-chartjs-2';
 import {
@@ -19,6 +19,7 @@ import {
 import { sparklineOptions } from '@/utils/usage/chartConfig';
 import type { UsageOverviewPayload, UsagePayload } from './hooks/useUsageData';
 import type { SparklineBundle } from './hooks/useSparklines';
+import { buildDailyAverageMetrics, DailyAverageCard } from './DailyAverageCard';
 import styles from '@/pages/UsagePage.module.scss';
 
 interface StatCardData {
@@ -36,6 +37,8 @@ interface StatCardData {
 export interface StatCardsProps {
   usage: UsageOverviewPayload | null;
   loading: boolean;
+  dailyAverageUsage: UsageOverviewPayload | null;
+  reserveDailyAverage: boolean;
   sparklines: {
     requests: SparklineBundle | null;
     tokens: SparklineBundle | null;
@@ -111,13 +114,27 @@ export function buildStatCardMetrics({ usage }: { usage: UsageOverviewPayload | 
   };
 }
 
-export function StatCards({ usage, loading, sparklines }: StatCardsProps) {
+export function StatCards({
+  usage,
+  loading,
+  dailyAverageUsage,
+  reserveDailyAverage,
+  sparklines,
+}: StatCardsProps) {
   const { t } = useTranslation();
   const usageSnapshot = usage?.usage ?? null;
+  const shouldExpandDailyAverage = Boolean(buildDailyAverageMetrics(dailyAverageUsage)) || reserveDailyAverage;
+  const [dailyAverageExpanded, setDailyAverageExpanded] = useState(false);
   const { requestStats, tokenBreakdown, rateStats, cacheReadRateStats, totalCost, costAvailable } = useMemo(
     () => buildStatCardMetrics({ usage }),
     [usage]
   );
+
+  useEffect(() => {
+    // 等浏览器完成当前布局后再切换展开态，让首次出现和范围切换都能触发横向动画。
+    const frame = window.requestAnimationFrame(() => setDailyAverageExpanded(shouldExpandDailyAverage));
+    return () => window.cancelAnimationFrame(frame);
+  }, [shouldExpandDailyAverage]);
 
   const statsCards: StatCardData[] = [
     {
@@ -251,41 +268,59 @@ export function StatCards({ usage, loading, sparklines }: StatCardsProps) {
     },
   ];
 
-  return (
-    <div className={styles.statsGrid}>
-      {statsCards.map((card) => (
-        <div
-          key={card.key}
-          className={styles.statCard}
-          style={
-            {
-              '--accent': card.accent,
-              '--accent-soft': card.accentSoft,
-              '--accent-border': card.accentBorder,
-            } as CSSProperties
-          }
-        >
-          <div className={styles.statCardHeader}>
-            <div className={styles.statLabelGroup}>
-              <span className={styles.statLabel}>{card.label}</span>
-            </div>
-            <span className={styles.statIconBadge}>{card.icon}</span>
-          </div>
-          <div className={styles.statValue}>{card.value}</div>
-          {card.meta && <div className={styles.statMetaRow}>{card.meta}</div>}
-          <div className={styles.statTrend}>
-            {card.trend ? (
-              <Line
-                className={styles.sparkline}
-                data={card.trend.data}
-                options={sparklineOptions}
-              />
-            ) : (
-              <div className={styles.statTrendPlaceholder}></div>
-            )}
-          </div>
+  const primaryCards = statsCards.slice(0, 2);
+  const secondaryCards = statsCards.slice(2);
+  const renderStatCard = (card: StatCardData) => (
+    <div
+      key={card.key}
+      className={styles.statCard}
+      style={
+        {
+          '--accent': card.accent,
+          '--accent-soft': card.accentSoft,
+          '--accent-border': card.accentBorder,
+        } as CSSProperties
+      }
+    >
+      <div className={styles.statCardHeader}>
+        <div className={styles.statLabelGroup}>
+          <span className={styles.statLabel}>{card.label}</span>
         </div>
-      ))}
+        <span className={styles.statIconBadge}>{card.icon}</span>
+      </div>
+      <div className={styles.statValue}>{card.value}</div>
+      {card.meta && <div className={styles.statMetaRow}>{card.meta}</div>}
+      <div className={styles.statTrend}>
+        {card.trend ? (
+          <Line
+            className={styles.sparkline}
+            data={card.trend.data}
+            options={sparklineOptions}
+          />
+        ) : (
+          <div className={styles.statTrendPlaceholder}></div>
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className={styles.statsSection}>
+      <div
+        className={`${styles.primaryStatsRow} ${dailyAverageExpanded ? styles.primaryStatsRowExpanded : ''}`.trim()}
+      >
+        <div className={styles.dailyAverageSlot} aria-hidden={!dailyAverageExpanded}>
+          <DailyAverageCard usage={dailyAverageUsage} loading={loading} />
+        </div>
+        {primaryCards.map((card) => (
+          <div key={card.key} className={styles.primaryStatSlot}>
+            {renderStatCard(card)}
+          </div>
+        ))}
+      </div>
+      <div className={styles.secondaryStatsGrid}>
+        {secondaryCards.map(renderStatCard)}
+      </div>
     </div>
   );
 }

--- a/web/src/components/usage/index.ts
+++ b/web/src/components/usage/index.ts
@@ -1,5 +1,5 @@
 export { StatCards } from './StatCards';
-export { DailyAveragePanel } from './DailyAveragePanel';
+export { DailyAverageCard } from './DailyAverageCard';
 export { OverviewRealtimePanel } from './OverviewRealtimePanel';
 export { AnalysisPanel } from './analysis';
 export { ApiKeySettingsCard } from './ApiKeySettingsCard';

--- a/web/src/components/usage/test/DailyAverageCard.test.tsx
+++ b/web/src/components/usage/test/DailyAverageCard.test.tsx
@@ -1,8 +1,8 @@
 import '@/i18n';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
-import { DailyAveragePanel, buildDailyAverageMetrics } from './DailyAveragePanel';
-import type { UsageOverviewPayload } from './hooks/useUsageData';
+import { DailyAverageCard, buildDailyAverageMetrics } from '../DailyAverageCard';
+import type { UsageOverviewPayload } from '../hooks/useUsageData';
 
 const usageWithDailyAverages: UsageOverviewPayload = {
   usage: {
@@ -38,9 +38,7 @@ const usageWithDailyAverages: UsageOverviewPayload = {
 
 describe('buildDailyAverageMetrics', () => {
   it('uses backend daily average fields without deriving averages in the frontend', () => {
-    const metrics = buildDailyAverageMetrics(usageWithDailyAverages);
-
-    expect(metrics).toEqual({
+    expect(buildDailyAverageMetrics(usageWithDailyAverages)).toEqual({
       requests: 65.9,
       tokens: 7512857,
       cost: 8.067,
@@ -50,7 +48,7 @@ describe('buildDailyAverageMetrics', () => {
   });
 
   it('returns null when backend daily average fields are absent', () => {
-    const metrics = buildDailyAverageMetrics({
+    expect(buildDailyAverageMetrics({
       ...usageWithDailyAverages,
       summary: {
         ...usageWithDailyAverages.summary!,
@@ -59,16 +57,13 @@ describe('buildDailyAverageMetrics', () => {
         daily_average_cost: undefined,
         daily_average_range_days: undefined,
       },
-    });
-
-    expect(metrics).toBeNull();
+    })).toBeNull();
   });
-
 });
 
-describe('DailyAveragePanel', () => {
-  it('renders a top summary panel without a left identity icon or per-day suffixes', () => {
-    const html = renderToStaticMarkup(<DailyAveragePanel usage={usageWithDailyAverages} loading={false} />);
+describe('DailyAverageCard', () => {
+  it('renders the three backend averages in one compact summary card', () => {
+    const html = renderToStaticMarkup(<DailyAverageCard usage={usageWithDailyAverages} loading={false} />);
 
     expect(html).toContain('Daily Average');
     expect(html).toContain('Range 7 days');
@@ -81,16 +76,12 @@ describe('DailyAveragePanel', () => {
     expect(html).toContain('Set pricing to calculate cost');
     expect(html).not.toContain('/day');
     expect(html.match(/<svg/g)).toHaveLength(3);
+    expect(html.indexOf('Set pricing to calculate cost')).toBeGreaterThan(html.indexOf('Avg Cost'));
+    expect(html.indexOf('Set pricing to calculate cost')).toBeLessThan(html.indexOf('$8.07'));
   });
 
-  it('renders nothing before the backend exposes daily average fields', () => {
-    const html = renderToStaticMarkup(<DailyAveragePanel usage={null} loading={false} />);
-
-    expect(html).toBe('');
-  });
-
-  it('keeps the panel shell visible while another daily-average range is loading', () => {
-    const html = renderToStaticMarkup(<DailyAveragePanel usage={null} loading={true} reserveVisible />);
+  it('renders a loading shell before an eligible range returns its averages', () => {
+    const html = renderToStaticMarkup(<DailyAverageCard usage={null} loading />);
 
     expect(html).toContain('Daily Average');
     expect(html).toContain('Avg Requests');

--- a/web/src/pages/KeyOverviewPage.tsx
+++ b/web/src/pages/KeyOverviewPage.tsx
@@ -8,7 +8,6 @@ import { IconRefreshCw } from '@/components/ui/icons';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { buildUsageStatsQueryKey, useThemeStore } from '@/stores';
 import {
-  DailyAveragePanel,
   OverviewRealtimePanel,
   RecentActivityPanel,
   StatCards,
@@ -19,7 +18,7 @@ import {
 } from '@/components/usage';
 import type { UsageOverviewPayload } from '@/components/usage/hooks/useUsageData';
 import { BrandLink } from '@/components/BrandLink';
-import { getCurrentOverviewUsage, getDailyAveragePanelUsage, getOverviewDisplayLoading, isDailyAverageRange } from '@/utils/usage/overview';
+import { getCurrentOverviewUsage, getDailyAverageCardUsage, getOverviewDisplayLoading, isDailyAverageRange } from '@/utils/usage/overview';
 import { clampStoredUsageRangeStateToCurrentBounds, parseStoredUsageRangeState, scheduleCustomRangeBoundsRefresh, serializeUsageRangeState, type StoredUsageRangeState } from '@/utils/usage/customRange';
 import { buildUsageRangeQuery } from '@/utils/usage/rangeQuery';
 import type { Theme } from '@/types';
@@ -358,13 +357,13 @@ export function KeyOverviewPage({ apiKey, onAuthRequired }: KeyOverviewPageProps
 
   const overviewDisplayLoading = getOverviewDisplayLoading({ loading, hasUsage: Boolean(usage) });
   const currentOverviewUsage = getCurrentOverviewUsage(usage, usageRangeQueryKey, loadedUsageRange);
-  const reserveDailyAveragePanel = isDailyAverageRange({
+  const reserveDailyAverageCard = isDailyAverageRange({
     range: timeRange,
     customUnit: customRange?.unit,
     customStart: customRange?.start,
     customEnd: customRange?.end,
   });
-  const dailyAveragePanelUsage = getDailyAveragePanelUsage(currentOverviewUsage, usage, reserveDailyAveragePanel, loading);
+  const dailyAverageCardUsage = getDailyAverageCardUsage(currentOverviewUsage, usage, reserveDailyAverageCard, loading);
   const {
     requestsSparkline,
     tokensSparkline,
@@ -516,11 +515,11 @@ export function KeyOverviewPage({ apiKey, onAuthRequired }: KeyOverviewPageProps
 
             {displayError && <div className={styles.errorBox}>{displayError}</div>}
 
-            <DailyAveragePanel usage={dailyAveragePanelUsage} loading={overviewDisplayLoading} reserveVisible={reserveDailyAveragePanel} />
-
             <StatCards
               usage={usage}
               loading={overviewDisplayLoading}
+              dailyAverageUsage={dailyAverageCardUsage}
+              reserveDailyAverage={reserveDailyAverageCard}
               sparklines={{
                 requests: requestsSparkline,
                 tokens: tokensSparkline,

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -732,7 +732,7 @@
 @media (prefers-reduced-motion: reduce) {
   .usageFilterTransition,
   .usageFilterBar,
-  .dailyAveragePanel {
+  .dailyAverageSlot {
     transition: none;
   }
 
@@ -740,8 +740,7 @@
     transform: none;
   }
 
-  .dailyAveragePanelEntering,
-  .dailyAveragePanelVisible {
+  .dailyAverageSlot {
     transform: none;
   }
 }
@@ -925,113 +924,230 @@
 }
 
 // Stats Grid
-.dailyAveragePanel {
-  display: grid;
-  grid-template-columns: minmax(176px, 0.72fr) minmax(0, 2.28fr);
+.statsSection {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.primaryStatsRow {
+  display: flex;
   align-items: stretch;
-  gap: 12px;
-  max-height: 0;
-  padding: 0 14px;
-  opacity: 0;
-  overflow: hidden;
-  transform: translateY(-6px);
-  border: 1px solid transparent;
-  border-radius: $radius-md;
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--bg-primary) 92%, transparent), color-mix(in srgb, var(--bg-secondary) 90%, transparent)),
-    var(--bg-primary);
-  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.07);
-  transition:
-    opacity 220ms ease,
-    transform 220ms ease,
-    max-height 220ms ease,
-    padding 220ms ease,
-    border-color 220ms ease;
+  gap: 14px;
+  width: 100%;
+  min-height: 176px;
+
+  @include tablet {
+    overflow-x: auto;
+    scroll-snap-type: x proximity;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
 
   @include mobile {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 10px;
+    flex-direction: column;
+    min-height: 168px;
+    overflow: visible;
+    scroll-snap-type: none;
   }
 }
 
-.dailyAveragePanelEntering {
-  transform: translateY(-6px);
-}
-
-.dailyAveragePanelVisible {
-  max-height: 320px;
-  padding: 14px;
-  opacity: 1;
-  transform: translateY(0);
-  border-color: color-mix(in srgb, var(--border-color) 82%, transparent);
-}
-
-.dailyAverageIdentity {
+.dailyAverageSlot {
   display: flex;
+  flex: 0 1 0;
   min-width: 0;
-  flex-direction: column;
-  justify-content: center;
-  gap: 8px;
-  padding: 4px 2px;
+  margin-right: -14px;
+  opacity: 0;
+  overflow: hidden;
+  pointer-events: none;
+  transform: translateX(-12px) scale(0.98);
+  transform-origin: left center;
+  transition:
+    flex-grow 220ms ease,
+    flex-basis 220ms ease,
+    max-height 220ms ease,
+    margin-right 220ms ease,
+    margin-bottom 220ms ease,
+    opacity 160ms ease,
+    transform 220ms ease;
+
+  > .dailyAverageCard {
+    flex: 1;
+    width: 100%;
+  }
+
+  @include tablet {
+    flex: 0 0 0;
+    scroll-snap-align: start;
+  }
+
+  @include mobile {
+    flex: 0 0 auto;
+    width: 100%;
+    max-height: 0;
+    margin-right: 0;
+    margin-bottom: -14px;
+    scroll-snap-align: none;
+    transform: translateY(-6px) scale(0.98);
+  }
+}
+
+.primaryStatsRowExpanded {
+  .dailyAverageSlot {
+    flex-grow: 0.72;
+    margin-right: 0;
+    overflow: visible;
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateX(0) scale(1);
+  }
+
+  @include tablet {
+    .dailyAverageSlot {
+      flex-basis: calc(50% - 7px);
+      flex-grow: 0;
+    }
+  }
+
+  @include mobile {
+    .dailyAverageSlot {
+      flex-basis: auto;
+      flex-grow: 0;
+      max-height: 220px;
+      margin-bottom: 0;
+      transform: translateY(0) scale(1);
+    }
+  }
+}
+
+.primaryStatSlot {
+  display: flex;
+  flex: 1 1 0;
+  min-width: 0;
+
+  > .statCard {
+    flex: 1;
+    width: 100%;
+  }
+
+  @include tablet {
+    flex: 0 0 calc(50% - 7px);
+    scroll-snap-align: start;
+  }
+
+  @include mobile {
+    flex: 0 0 auto;
+    width: 100%;
+    scroll-snap-align: none;
+  }
+}
+
+.secondaryStatsGrid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+
+  @include tablet {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @include mobile {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.statCard.dailyAverageCard {
+  --accent-border: rgba(139, 92, 246, 0.36);
+
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  padding-inline: 22px;
+  background:
+    radial-gradient(90% 120% at 0% 0%, rgba(59, 130, 246, 0.14), transparent 58%),
+    linear-gradient(180deg, rgba(139, 92, 246, 0.07), rgba(255, 255, 255, 0)),
+    var(--bg-primary);
+
+  &::before {
+    background: linear-gradient(90deg, #3b82f6 0%, #8b5cf6 52%, #f59e0b 100%);
+  }
+
+  @include tablet {
+    padding-inline: 18px;
+  }
+}
+
+.dailyAverageCardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
 }
 
 .dailyAverageTitle {
   color: var(--text-primary);
-  font-size: 16px;
+  font-size: 13px;
   font-weight: 800;
-  line-height: 1.15;
+  line-height: 1.2;
   letter-spacing: 0;
+  white-space: nowrap;
 }
 
 .dailyAverageRangePill {
-  width: fit-content;
+  flex: 0 1 auto;
   max-width: 100%;
-  padding: 4px 9px;
+  padding: 4px 8px;
+  overflow: hidden;
   border-radius: $radius-full;
   border: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
   background: color-mix(in srgb, var(--bg-secondary) 86%, transparent);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 700;
   line-height: 1.2;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .dailyAverageMetrics {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 10px;
+  flex: 1;
+  grid-template-rows: repeat(3, minmax(0, 1fr));
   min-width: 0;
 }
 
 .dailyAverageMetric {
   --metric-accent: var(--primary-color);
 
-  display: flex;
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
   align-items: center;
   gap: 10px;
   min-width: 0;
-  min-height: 64px;
-  padding: 11px 12px;
-  border-radius: $radius-md;
-  border: 1px solid color-mix(in srgb, var(--metric-accent) 22%, var(--border-color));
-  background:
-    radial-gradient(120% 120% at 10% 0%, color-mix(in srgb, var(--metric-accent) 12%, transparent), transparent 62%),
-    color-mix(in srgb, var(--bg-primary) 78%, var(--bg-secondary));
+  min-height: 0;
+  padding: 7px 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
+
+  &:last-child {
+    border-bottom: 0;
+  }
 }
 
 .dailyAverageMetricIcon {
   display: grid;
-  width: 30px;
-  height: 30px;
-  flex: 0 0 30px;
+  width: 28px;
+  height: 28px;
   place-items: center;
   border-radius: $radius-md;
   background: color-mix(in srgb, var(--metric-accent) 12%, var(--bg-primary));
   color: var(--metric-accent);
 }
 
-.dailyAverageMetricText {
+.dailyAverageMetricCopy {
   display: flex;
   min-width: 0;
   flex-direction: column;
@@ -1042,8 +1158,11 @@
   color: var(--text-tertiary);
   font-size: 11px;
   font-weight: 700;
-  line-height: 1.25;
+  line-height: 1.15;
   letter-spacing: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .dailyAverageMetricValue {
@@ -1053,42 +1172,15 @@
   line-height: 1.15;
   font-variant-numeric: tabular-nums;
   letter-spacing: 0;
-  overflow-wrap: anywhere;
-}
-
-@include mobile {
-  .dailyAverageMetrics {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-.dailyAverageMetricCost {
-  @include mobile {
-    grid-column: 1 / -1;
-  }
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .dailyAverageCostHint {
-  grid-column: 2;
-  margin-top: -4px;
   color: var(--text-tertiary);
-  font-size: 11px;
-  line-height: 1.3;
-
-  @include mobile {
-    grid-column: 1;
-    margin-top: 0;
-  }
-}
-
-.statsGrid {
-  display: grid;
-  gap: 14px;
-  grid-template-columns: repeat(12, minmax(0, 1fr));
-
-  @include mobile {
-    grid-template-columns: 1fr;
-  }
+  font-size: 9px;
+  line-height: 1.2;
 }
 
 .statCard {
@@ -1096,7 +1188,6 @@
   --accent-soft: rgba($primary-color, 0.18);
   --accent-border: rgba($primary-color, 0.35);
 
-  grid-column: span 3;
   position: relative;
   padding: 18px;
   background:
@@ -1132,28 +1223,19 @@
     box-shadow: 0 16px 40px rgba(0, 0, 0, 0.22);
   }
 
-  @include tablet {
-    grid-column: span 6;
-  }
-
   @include mobile {
-    grid-column: auto;
     min-height: 168px;
   }
 }
 
-.statCard:nth-child(-n + 2) {
-  grid-column: span 6;
-
+.primaryStatSlot {
   .statValue {
     font-size: 32px;
   }
 }
 
 @include mobile {
-  .statCard:nth-child(-n + 2) {
-    grid-column: auto;
-
+  .primaryStatSlot {
     .statValue {
       font-size: 28px;
     }

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -731,16 +731,11 @@
 
 @media (prefers-reduced-motion: reduce) {
   .usageFilterTransition,
-  .usageFilterBar,
-  .dailyAverageSlot {
+  .usageFilterBar {
     transition: none;
   }
 
   .usageFilterTransition {
-    transform: none;
-  }
-
-  .dailyAverageSlot {
     transform: none;
   }
 }
@@ -923,7 +918,7 @@
   }
 }
 
-// Stats Grid
+// Stats Layout
 .statsSection {
   display: flex;
   flex-direction: column;
@@ -1023,6 +1018,17 @@
   }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .dailyAverageSlot {
+    transition: none;
+    transform: none;
+  }
+
+  .primaryStatsRowExpanded .dailyAverageSlot {
+    transform: none;
+  }
+}
+
 .primaryStatSlot {
   display: flex;
   flex: 1 1 0;
@@ -1065,7 +1071,7 @@
   height: 100%;
   min-width: 0;
   min-height: 0;
-  padding-inline: 22px;
+  padding-inline: 18px;
   background:
     radial-gradient(90% 120% at 0% 0%, rgba(59, 130, 246, 0.14), transparent 58%),
     linear-gradient(180deg, rgba(139, 92, 246, 0.07), rgba(255, 255, 255, 0)),
@@ -1075,8 +1081,8 @@
     background: linear-gradient(90deg, #3b82f6 0%, #8b5cf6 52%, #f59e0b 100%);
   }
 
-  @include tablet {
-    padding-inline: 18px;
+  @include desktop {
+    padding-inline: 22px;
   }
 }
 

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -13,7 +13,6 @@ import { useHeaderRefresh } from '@/hooks/useHeaderRefresh';
 import { useThemeStore } from '@/stores';
 import {
   StatCards,
-  DailyAveragePanel,
   RecentActivityPanel,
   OverviewRealtimePanel,
   AnalysisPanel,
@@ -39,7 +38,7 @@ import {
 } from '@/components/usage/RequestEventsDetailsCard';
 import { clampStoredUsageRangeStateToCurrentBounds, parseLegacyCustomRange, parseStoredUsageRangeState, scheduleCustomRangeBoundsRefresh, serializeUsageRangeState, type StoredUsageRangeState } from '@/utils/usage/customRange';
 import { buildUsageRangeQuery } from '@/utils/usage/rangeQuery';
-import { getDailyAveragePanelUsage, isDailyAverageRange } from '@/utils/usage/overview';
+import { getDailyAverageCardUsage, isDailyAverageRange } from '@/utils/usage/overview';
 import type { Theme } from '@/types';
 import { BrandLink } from '@/components/BrandLink';
 import { isCPAMCEmbed } from '@/embed/cpamcEmbed';
@@ -1715,13 +1714,13 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   } = useSparklines({ usage, loading });
 
   const overviewDisplayLoading = getOverviewDisplayLoading({ loading, hasUsage: Boolean(usage) });
-  const reserveDailyAveragePanel = isDailyAverageRange({
+  const reserveDailyAverageCard = isDailyAverageRange({
     range: timeRange,
     customUnit: customRange?.unit,
     customStart: customRange?.start,
     customEnd: customRange?.end,
   });
-  const dailyAveragePanelUsage = getDailyAveragePanelUsage(currentOverviewUsage, usage, reserveDailyAveragePanel, loading);
+  const dailyAverageCardUsage = getDailyAverageCardUsage(currentOverviewUsage, usage, reserveDailyAverageCard, loading);
 
   return (
     <div className={styles.pageShell} data-keeper-page="usage">
@@ -1929,11 +1928,11 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
 
             {activeTab === 'overview' && (
               <>
-                <DailyAveragePanel usage={dailyAveragePanelUsage} loading={overviewDisplayLoading} reserveVisible={reserveDailyAveragePanel} />
-
                 <StatCards
                   usage={usage}
                   loading={overviewDisplayLoading}
+                  dailyAverageUsage={dailyAverageCardUsage}
+                  reserveDailyAverage={reserveDailyAverageCard}
                   sparklines={{
                     requests: requestsSparkline,
                     tokens: tokensSparkline,

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -379,7 +379,16 @@ describe('UsagePage toolbar styles', () => {
   })
 
   it('adds a small desktop-only side inset to Daily Average content', () => {
-    expect(usagePageStyles).toMatch(/\.statCard\.dailyAverageCard\s*\{[\s\S]*?padding-inline:\s*22px;[\s\S]*?@include tablet\s*\{[\s\S]*?padding-inline:\s*18px;/)
+    expect(usagePageStyles).toMatch(/\.statCard\.dailyAverageCard\s*\{[\s\S]*?padding-inline:\s*18px;[\s\S]*?@include desktop\s*\{[\s\S]*?padding-inline:\s*22px;/)
+  })
+
+  it('places the Daily Average reduced-motion override after its animation rules', () => {
+    const slotStylesIndex = usagePageStyles.indexOf('.dailyAverageSlot {', usagePageStyles.indexOf('// Stats Layout'))
+    const reducedMotionIndex = usagePageStyles.lastIndexOf('@media (prefers-reduced-motion: reduce)')
+    const reducedMotionStyles = usagePageStyles.slice(reducedMotionIndex)
+
+    expect(reducedMotionIndex).toBeGreaterThan(slotStylesIndex)
+    expect(reducedMotionStyles).toMatch(/\.dailyAverageSlot\s*\{[\s\S]*?transition:\s*none;[\s\S]*?transform:\s*none;/)
   })
 
   it('keeps the shared stat-card shadow visible after Daily Average expands', () => {

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -27,7 +27,7 @@ const overviewActivityCardsSource = readSource(new URL('../../components/usage/O
 const activityHeatmapGridSource = readSource(new URL('../../components/usage/ActivityHeatmapGrid.tsx', import.meta.url))
 const serviceHealthCardSource = readSource(new URL('../../components/usage/ServiceHealthCard.tsx', import.meta.url))
 const statCardsSource = readSource(new URL('../../components/usage/StatCards.tsx', import.meta.url))
-const dailyAveragePanelSource = readSource(new URL('../../components/usage/DailyAveragePanel.tsx', import.meta.url))
+const dailyAverageCardSource = readSource(new URL('../../components/usage/DailyAverageCard.tsx', import.meta.url))
 const timeRangeControlSource = readSource(new URL('../../components/usage/TimeRangeControl.tsx', import.meta.url))
 const timeRangeControlStyles = readSource(new URL('../../components/usage/TimeRangeControl.module.scss', import.meta.url))
 
@@ -339,10 +339,12 @@ describe('UsagePage toolbar styles', () => {
     expect(timeRangeControlStyles).toMatch(/@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.liquidParticle\s*\{[\s\S]*?opacity:\s*0\.72;/)
   })
 
-  it('keeps overview stat cards in a two-plus-four desktop grid with a distinct cache-rate color', () => {
-    expect(usagePageStyles).toMatch(/\.statCard\s*\{[\s\S]*?grid-column:\s*span 3;/)
-    expect(usagePageStyles).toMatch(/\.statCard:nth-child\(-n \+ 2\)\s*\{[\s\S]*?grid-column:\s*span 6;/)
+  it('keeps overview stat cards in a primary row plus a four-card desktop grid', () => {
+    expect(usagePageStyles).toMatch(/\.primaryStatsRow\s*\{[\s\S]*?display:\s*flex;/)
+    expect(usagePageStyles).toMatch(/\.secondaryStatsGrid\s*\{[\s\S]*?grid-template-columns:\s*repeat\(4, minmax\(0, 1fr\)\);/)
     expect(usagePageStyles).toMatch(/\.statLabel\s*\{[\s\S]*?letter-spacing:\s*0;/)
+    expect(statCardsSource).toContain('const primaryCards = statsCards.slice(0, 2)')
+    expect(statCardsSource).toContain('const secondaryCards = statsCards.slice(2)')
     expect(statCardsSource).toContain("key: 'requests'")
     expect(statCardsSource).toContain("accent: '#3b82f6'")
     expect(statCardsSource).toContain("key: 'cache-read-rate'")
@@ -350,22 +352,55 @@ describe('UsagePage toolbar styles', () => {
     expect(statCardsSource.match(/accent:\s*'#[0-9a-f]{6}'/g)).toHaveLength(new Set(statCardsSource.match(/accent:\s*'#[0-9a-f]{6}'/g)).size)
   })
 
-  it('places the Daily Average panel above stat cards with animated responsive styling', () => {
-    const usageDailyAverageIndex = usagePageSource.indexOf('<DailyAveragePanel usage={dailyAveragePanelUsage} loading={overviewDisplayLoading} reserveVisible={reserveDailyAveragePanel} />')
-    const keyDailyAverageIndex = keyOverviewPageSource.indexOf('<DailyAveragePanel usage={dailyAveragePanelUsage} loading={overviewDisplayLoading} reserveVisible={reserveDailyAveragePanel} />')
-    expect(usageDailyAverageIndex).toBeGreaterThanOrEqual(0)
-    expect(keyDailyAverageIndex).toBeGreaterThanOrEqual(0)
-    expect(usageDailyAverageIndex).toBeLessThan(usagePageSource.indexOf('<StatCards'))
-    expect(keyDailyAverageIndex).toBeLessThan(keyOverviewPageSource.indexOf('<StatCards'))
-    expect(dailyAveragePanelSource).toContain('buildDailyAverageMetrics')
-    expect(dailyAveragePanelSource).not.toContain('dailyAverageIdentityIcon')
-    expect(usagePageStyles).toMatch(/\.dailyAveragePanel\s*\{[\s\S]*?transition:[\s\S]*?opacity/)
-    expect(usagePageStyles).toMatch(/\.dailyAveragePanelEntering\s*\{[\s\S]*?transform:\s*translateY\(-6px\);/)
-    expect(usagePageStyles).toMatch(/\.dailyAveragePanelVisible\s*\{[\s\S]*?opacity:\s*1;/)
-    expect(usagePageStyles).toMatch(/\.dailyAverageMetrics\s*\{[\s\S]*?grid-template-columns:\s*repeat\(3, minmax\(0, 1fr\)\);/)
-    expect(usagePageStyles).toMatch(/@include mobile\s*\{[\s\S]*?\.dailyAverageMetrics\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2, minmax\(0, 1fr\)\);/)
-    expect(usagePageStyles).toMatch(/\.dailyAverageMetricCost\s*\{[\s\S]*?grid-column:\s*1 \/ -1;/)
+  it('expands Daily Average as the first compact primary card without changing row height', () => {
+    const primaryStatsRowStyles = styleRuleBlock(usagePageStyles, '.primaryStatsRow')
+
+    expect(usagePageSource).not.toContain('<DailyAveragePanel')
+    expect(keyOverviewPageSource).not.toContain('<DailyAveragePanel')
+    expect(usagePageSource).toContain('dailyAverageUsage={dailyAverageCardUsage}')
+    expect(usagePageSource).toContain('reserveDailyAverage={reserveDailyAverageCard}')
+    expect(keyOverviewPageSource).toContain('dailyAverageUsage={dailyAverageCardUsage}')
+    expect(keyOverviewPageSource).toContain('reserveDailyAverage={reserveDailyAverageCard}')
+    expect(statCardsSource).toContain('<DailyAverageCard')
+    expect(statCardsSource).toContain('styles.primaryStatsRowExpanded')
+    expect(dailyAverageCardSource).toContain('buildDailyAverageMetrics')
+    expect(usagePageStyles).toMatch(/\.primaryStatsRow\s*\{[\s\S]*?min-height:\s*176px;/)
+    expect(primaryStatsRowStyles).not.toMatch(/(?:^|\n)\s*height:\s*176px;/)
+    expect(usagePageStyles).toMatch(/\.dailyAverageSlot\s*\{[\s\S]*?flex:\s*0 1 0;[\s\S]*?margin-right:\s*-14px;/)
+    expect(usagePageStyles).toMatch(/\.dailyAverageSlot\s*\{[\s\S]*?display:\s*flex;/)
+    expect(usagePageStyles).toMatch(/\.primaryStatsRowExpanded\s*\{[\s\S]*?\.dailyAverageSlot\s*\{[\s\S]*?flex-grow:\s*0\.72;[\s\S]*?margin-right:\s*0;/)
+    expect(usagePageStyles).toMatch(/\.primaryStatSlot\s*\{[\s\S]*?display:\s*flex;/)
+    expect(usagePageStyles).toMatch(/\.dailyAverageCard\s*\{[\s\S]*?height:\s*100%;/)
+    expect(dailyAverageCardSource).toContain('styles.dailyAverageMetricCopy')
+    expect(usagePageStyles).toMatch(/\.dailyAverageMetrics\s*\{[\s\S]*?grid-template-rows:\s*repeat\(3, minmax\(0, 1fr\)\);/)
+    expect(usagePageStyles).toMatch(/\.dailyAverageMetric\s*\{[\s\S]*?grid-template-columns:\s*28px minmax\(0, 1fr\) auto;/)
+    expect(usagePageStyles).toMatch(/\.dailyAverageMetric\s*\{[\s\S]*?border-bottom:\s*1px solid/)
     expect(usagePageStyles).toContain('@media (prefers-reduced-motion: reduce)')
+  })
+
+  it('adds a small desktop-only side inset to Daily Average content', () => {
+    expect(usagePageStyles).toMatch(/\.statCard\.dailyAverageCard\s*\{[\s\S]*?padding-inline:\s*22px;[\s\S]*?@include tablet\s*\{[\s\S]*?padding-inline:\s*18px;/)
+  })
+
+  it('keeps the shared stat-card shadow visible after Daily Average expands', () => {
+    expect(dailyAverageCardSource).toContain('className={`${styles.statCard} ${styles.dailyAverageCard}`}')
+    expect(usagePageStyles).toMatch(/\.primaryStatsRowExpanded\s*\{\s*\.dailyAverageSlot\s*\{\s*flex-grow:\s*0\.72;\s*margin-right:\s*0;\s*overflow:\s*visible;/)
+  })
+
+  it('lets the Daily Average background fade out instead of repainting the lower-right corner', () => {
+    const start = usagePageStyles.indexOf('.statCard.dailyAverageCard')
+    const end = usagePageStyles.indexOf('\n.dailyAverageCardHeader', start)
+    const dailyAverageCardStyles = usagePageStyles.slice(start, end)
+
+    expect(dailyAverageCardStyles).toContain('radial-gradient(90% 120% at 0% 0%')
+    expect(dailyAverageCardStyles).not.toContain('radial-gradient(88% 110% at 100% 100%, rgba(245, 158, 11, 0.12)')
+  })
+
+  it('keeps primary overview cards stacked in one column on mobile', () => {
+    expect(usagePageStyles).toMatch(/\.primaryStatsRow\s*\{[\s\S]*?@include mobile\s*\{[\s\S]*?flex-direction:\s*column;[\s\S]*?overflow:\s*visible;/)
+    expect(usagePageStyles).toMatch(/\.dailyAverageSlot\s*\{[\s\S]*?@include mobile\s*\{[\s\S]*?flex:\s*0 0 auto;[\s\S]*?width:\s*100%;[\s\S]*?max-height:\s*0;[\s\S]*?margin-right:\s*0;[\s\S]*?margin-bottom:\s*-14px;/)
+    expect(usagePageStyles).toMatch(/\.primaryStatsRowExpanded\s*\{[\s\S]*?@include mobile\s*\{[\s\S]*?\.dailyAverageSlot\s*\{[\s\S]*?max-height:\s*220px;[\s\S]*?margin-bottom:\s*0;/)
+    expect(usagePageStyles).toMatch(/\.primaryStatSlot\s*\{[\s\S]*?@include mobile\s*\{[\s\S]*?flex:\s*0 0 auto;[\s\S]*?width:\s*100%;/)
   })
 
   it('renders Recent Activity between the stat cards and realtime metrics', () => {

--- a/web/src/utils/usage/overview.test.ts
+++ b/web/src/utils/usage/overview.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getCurrentOverviewUsage, getDailyAveragePanelUsage, getOverviewDisplayLoading, isDailyAverageRange } from './overview';
+import { getCurrentOverviewUsage, getDailyAverageCardUsage, getOverviewDisplayLoading, isDailyAverageRange } from './overview';
 
 describe('shared usage overview helpers', () => {
   it('keeps loading visible only while the overview has no usage payload', () => {
@@ -34,9 +34,9 @@ describe('shared usage overview helpers', () => {
     const currentUsage = { summary: { daily_average_requests: 30 } };
     const fallbackUsage = { summary: { daily_average_requests: 7 } };
 
-    expect(getDailyAveragePanelUsage(currentUsage, fallbackUsage, true)).toBe(currentUsage);
-    expect(getDailyAveragePanelUsage(null, fallbackUsage, true, true)).toBe(fallbackUsage);
-    expect(getDailyAveragePanelUsage(null, fallbackUsage, true, false)).toBeNull();
-    expect(getDailyAveragePanelUsage(null, fallbackUsage, false, true)).toBeNull();
+    expect(getDailyAverageCardUsage(currentUsage, fallbackUsage, true)).toBe(currentUsage);
+    expect(getDailyAverageCardUsage(null, fallbackUsage, true, true)).toBe(fallbackUsage);
+    expect(getDailyAverageCardUsage(null, fallbackUsage, true, false)).toBeNull();
+    expect(getDailyAverageCardUsage(null, fallbackUsage, false, true)).toBeNull();
   });
 });

--- a/web/src/utils/usage/overview.test.ts
+++ b/web/src/utils/usage/overview.test.ts
@@ -30,7 +30,7 @@ describe('shared usage overview helpers', () => {
     expect(isDailyAverageRange({ range: 'yesterday' })).toBe(false);
   });
 
-  it('keeps the previous usage for the daily average panel while another daily-average range loads', () => {
+  it('keeps the previous usage for the daily average card while another daily-average range loads', () => {
     const currentUsage = { summary: { daily_average_requests: 30 } };
     const fallbackUsage = { summary: { daily_average_requests: 7 } };
 

--- a/web/src/utils/usage/overview.ts
+++ b/web/src/utils/usage/overview.ts
@@ -14,7 +14,7 @@ export const getCurrentOverviewUsage = <T>(
   return usage;
 };
 
-export const getDailyAveragePanelUsage = <T>(
+export const getDailyAverageCardUsage = <T>(
   currentUsage: T | null,
   fallbackUsage: T | null,
   reserveVisible: boolean,


### PR DESCRIPTION
## Summary

- integrate Daily Average into the shared Overview and Key Overview stat-card row for eligible ranges
- animate card insertion without adding a separate desktop panel while preserving mobile stacking
- align shared card elevation, responsive spacing, gradients, and reduced-motion behavior

## Validation

- rtk env TZ=UTC GOCACHE=/tmp/cpa-usage-keeper-go-build GOFLAGS=-count=1 make verify