### PR TITLE
fix(ui): align logout confirmation buttons

### DIFF
--- a/web/src/components/usage/SessionSettingsCard.tsx
+++ b/web/src/components/usage/SessionSettingsCard.tsx
@@ -126,10 +126,10 @@ export function SessionSettingsCard({ sessions, loading = false, revokingId = nu
           closeDisabled={confirmingRevoking}
           footer={
             <>
-              <Button type="button" variant="secondary" onClick={() => setConfirmingSession(null)} disabled={confirmingRevoking}>
+              <Button type="button" variant="secondary" className={styles.usagePillAction} onClick={() => setConfirmingSession(null)} disabled={confirmingRevoking}>
                 {t('common.cancel')}
               </Button>
-              <Button type="button" variant="danger" onClick={() => void handleConfirmLogout()} loading={confirmingRevoking}>
+              <Button type="button" variant="danger" className={`${styles.usagePillAction} ${styles.usagePillActionDanger}`} onClick={() => void handleConfirmLogout()} loading={confirmingRevoking}>
                 {confirmingRevoking ? t('usage_stats.session_settings_logging_out') : t(confirmationKeys.confirmKey)}
               </Button>
             </>

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -2123,10 +2123,10 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
         closeDisabled={loggingOut}
         footer={
           <>
-            <Button type="button" variant="secondary" onClick={() => setLogoutConfirmOpen(false)} disabled={loggingOut}>
+            <Button type="button" variant="secondary" className={styles.usagePillAction} onClick={() => setLogoutConfirmOpen(false)} disabled={loggingOut}>
               {t('common.cancel')}
             </Button>
-            <Button type="button" variant="danger" onClick={() => void handleConfirmLogout()} loading={loggingOut}>
+            <Button type="button" variant="danger" className={`${styles.usagePillAction} ${styles.usagePillActionDanger}`} onClick={() => void handleConfirmLogout()} loading={loggingOut}>
               {loggingOut ? t('common.loading') : t('usage_stats.logout_confirm_action')}
             </Button>
           </>

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -679,6 +679,24 @@ describe('UsagePage toolbar styles', () => {
     expect(usagePageStyles).toMatch(/\.sessionSettingsLogoutButton\s*\{[\s\S]*?min-width:\s*92px;/)
   })
 
+  it('keeps both logout confirmation button pairs aligned with Usage dialog actions', () => {
+    const sessionLogoutModalStart = sessionSettingsSource.indexOf('<Modal\n          open={Boolean(confirmingSession)}')
+    const pageLogoutModalStart = usagePageSource.indexOf('<Modal\n        open={logoutConfirmOpen}')
+    const sessionLogoutModal = sessionSettingsSource.slice(
+      sessionLogoutModalStart,
+      sessionSettingsSource.indexOf('</Modal>', sessionLogoutModalStart),
+    )
+    const pageLogoutModal = usagePageSource.slice(
+      pageLogoutModalStart,
+      usagePageSource.indexOf('</Modal>', pageLogoutModalStart),
+    )
+
+    for (const modalSource of [sessionLogoutModal, pageLogoutModal]) {
+      expect(modalSource).toMatch(/variant="secondary"\s+className=\{styles\.usagePillAction\}/)
+      expect(modalSource).toContain('className={`${styles.usagePillAction} ${styles.usagePillActionDanger}`}')
+    }
+  })
+
   it('keeps Session and API Key Settings row actions compact like Model Pricing actions', () => {
     const apiKeyButtonsBlock = usagePageStyles.slice(
       usagePageStyles.indexOf('.apiKeySettingsCopyButton,'),


### PR DESCRIPTION
## Summary

- align Session Management logout confirmation actions with the existing Usage pill styles
- align the top-right sign-out confirmation actions with the same secondary and danger styling
- add regression coverage for both dialog footers

## Validation

- TZ=UTC GOCACHE=/tmp/cpa-usage-keeper-go-build GOFLAGS=-count=1 make verify
