### PR TITLE
perf(usage): batch redis inbox processed updates

### DIFF
--- a/internal/benchmark/redis_process_benchmark_test.go
+++ b/internal/benchmark/redis_process_benchmark_test.go
@@ -81,8 +81,11 @@ func benchmarkRedisUsageInboxProcessing(b *testing.B, rowCount, identityCount in
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
 		db := openRedisProcessBenchmarkDB(b, rowCount, identityCount, i)
+		// 使用生产 notifier 的同步内存路径，但不启动后台聚合 goroutine，隔离 ingestion 自身成本。
+		aggregationRunner := poller.NewUsageAggregationRunner(db, nil)
 		syncService := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{
-			Now: func() time.Time { return time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC) },
+			Now:                      func() time.Time { return time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC) },
+			UsageAggregationNotifier: aggregationRunner,
 		})
 		b.StartTimer()
 
@@ -187,7 +190,7 @@ func redisProcessBenchmarkMessage(i, identityCount int, base time.Time) string {
 	authIndex := redisProcessBenchmarkAuthIndex(i % identityCount)
 	timestamp := base.Add(time.Duration(i) * time.Millisecond).Format(time.RFC3339Nano)
 	return fmt.Sprintf(
-		`{"timestamp":%q,"latency_ms":120,"source":"redis","auth_index":%q,"tokens":{"input_tokens":120,"output_tokens":48,"reasoning_tokens":8,"cached_tokens":16,"cache_read_tokens":4,"cache_creation_tokens":2,"total_tokens":176},"provider":"codex","model":"gpt-5","auth_type":"oauth","api_key":"bench-group","request_id":%q}`,
+		`{"timestamp":%q,"latency_ms":120,"source":"redis","auth_index":%q,"tokens":{"input_tokens":120,"output_tokens":48,"reasoning_tokens":8,"cached_tokens":16,"cache_read_tokens":4,"cache_creation_tokens":2,"total_tokens":168},"provider":"codex","model":"gpt-5","auth_type":"oauth","api_key":"bench-group","request_id":%q}`,
 		timestamp,
 		authIndex,
 		fmt.Sprintf("bench-%08d", i),

--- a/internal/repository/redis_usage_inbox.go
+++ b/internal/repository/redis_usage_inbox.go
@@ -50,7 +50,15 @@ const (
 
 	redisUsageInboxMaxErrorLength     = 1024
 	redisUsageInboxMaxProcessAttempts = 5
+	// 每行 CASE 映射占 2 个变量，WHERE IN 再占 1 个；300 行连同固定字段仍低于 SQLite 999 变量限制。
+	redisUsageInboxProcessedBatchSize = 300
 )
+
+// RedisUsageInboxProcessedUpdate 保存单条 inbox 与最终 usage event 的稳定映射。
+type RedisUsageInboxProcessedUpdate struct {
+	ID       int64
+	EventKey string
+}
 
 func InsertRedisUsageInboxRawMessages(db *gorm.DB, source string, messages []string, poppedAt time.Time) ([]entities.RedisUsageInbox, error) {
 	// inputs 统一走结构化 DTO，避免 raw message 快捷入口和测试入口出现两套入库逻辑。
@@ -109,6 +117,35 @@ func MarkRedisUsageInboxProcessed(db *gorm.DB, id int64, eventKey string, proces
 		"processed_at":    timeutil.FormatStorageTime(processedAt),
 		"last_error":      "",
 	}).Error
+}
+
+// MarkRedisUsageInboxProcessedBatch 分批更新 processed 状态，同时保持每个 inbox ID 对应自己的 event key。
+func MarkRedisUsageInboxProcessedBatch(db *gorm.DB, updates []RedisUsageInboxProcessedUpdate, processedAt time.Time) error {
+	for start := 0; start < len(updates); start += redisUsageInboxProcessedBatchSize {
+		end := min(start+redisUsageInboxProcessedBatchSize, len(updates))
+		batch := updates[start:end]
+		ids := make([]int64, 0, len(batch))
+		caseArgs := make([]any, 0, len(batch)*2)
+		var eventKeyCase strings.Builder
+		eventKeyCase.WriteString("CASE id")
+		for _, update := range batch {
+			eventKeyCase.WriteString(" WHEN ? THEN ?")
+			caseArgs = append(caseArgs, update.ID, update.EventKey)
+			ids = append(ids, update.ID)
+		}
+		eventKeyCase.WriteString(" ELSE usage_event_key END")
+
+		result := db.Model(&entities.RedisUsageInbox{}).Where("id IN ?", ids).Updates(map[string]any{
+			"status":          RedisUsageInboxStatusProcessed,
+			"usage_event_key": gorm.Expr(eventKeyCase.String(), caseArgs...),
+			"processed_at":    timeutil.FormatStorageTime(processedAt),
+			"last_error":      "",
+		})
+		if result.Error != nil {
+			return fmt.Errorf("mark redis usage inbox processed batch [%d:%d]: %w", start, end, result.Error)
+		}
+	}
+	return nil
 }
 
 func MarkRedisUsageInboxDecodeFailed(db *gorm.DB, id int64, decodeErr error) error {

--- a/internal/repository/test/redis_usage_inbox_batch_test.go
+++ b/internal/repository/test/redis_usage_inbox_batch_test.go
@@ -1,0 +1,87 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+	repositorydto "cpa-usage-keeper/internal/repository/dto"
+	"cpa-usage-keeper/internal/timeutil"
+)
+
+func TestMarkRedisUsageInboxProcessedBatchMapsKeysAcrossChunks(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load Asia/Shanghai: %v", err)
+	}
+	time.Local = location
+	t.Cleanup(func() { time.Local = previousLocal })
+	db := openTestDatabase(t)
+	const rowCount = 601
+	processedAt := time.Date(2026, 7, 23, 9, 30, 0, 123456789, location)
+	inputs := make([]repositorydto.RedisInboxInsert, 0, rowCount)
+	for i := 0; i < rowCount; i++ {
+		inputs = append(inputs, repositorydto.RedisInboxInsert{
+			Source:     "redis_subscribe:usage",
+			RawMessage: fmt.Sprintf(`{"request_id":"batch-map-%d"}`, i),
+			PoppedAt:   processedAt.Add(-time.Minute),
+		})
+	}
+	rows, err := repository.InsertRedisUsageInboxMessages(db, inputs)
+	if err != nil {
+		t.Fatalf("seed redis usage inbox rows: %v", err)
+	}
+	if err := db.Model(&entities.RedisUsageInbox{}).Where("id > 0").Update("last_error", "stale error").Error; err != nil {
+		t.Fatalf("seed stale inbox errors: %v", err)
+	}
+	oldUpdatedAt := processedAt.Add(-24 * time.Hour)
+	if err := db.Model(&entities.RedisUsageInbox{}).Where("id = ?", rows[0].ID).UpdateColumn("updated_at", timeutil.FormatStorageTime(oldUpdatedAt)).Error; err != nil {
+		t.Fatalf("seed old updated_at: %v", err)
+	}
+
+	updates := make([]repository.RedisUsageInboxProcessedUpdate, 0, len(rows))
+	for i, row := range rows {
+		updates = append(updates, repository.RedisUsageInboxProcessedUpdate{
+			ID:       row.ID,
+			EventKey: fmt.Sprintf("event-key-%d", i),
+		})
+	}
+	if err := repository.MarkRedisUsageInboxProcessedBatch(db, updates, processedAt); err != nil {
+		t.Fatalf("MarkRedisUsageInboxProcessedBatch returned error: %v", err)
+	}
+
+	var stored []entities.RedisUsageInbox
+	if err := db.Order("id ASC").Find(&stored).Error; err != nil {
+		t.Fatalf("load processed inbox rows: %v", err)
+	}
+	if len(stored) != rowCount {
+		t.Fatalf("expected %d inbox rows, got %d", rowCount, len(stored))
+	}
+	for i, row := range stored {
+		if row.Status != repository.RedisUsageInboxStatusProcessed || row.UsageEventKey != fmt.Sprintf("event-key-%d", i) {
+			t.Fatalf("unexpected processed mapping at index %d: %+v", i, row)
+		}
+		if row.ProcessedAt == nil || !row.ProcessedAt.Equal(processedAt) {
+			t.Fatalf("unexpected processed_at at index %d: %+v", i, row.ProcessedAt)
+		}
+		if row.LastError != "" {
+			t.Fatalf("expected last_error cleared at index %d, got %q", i, row.LastError)
+		}
+		if row.UpdatedAt.IsZero() {
+			t.Fatalf("expected updated_at at index %d", i)
+		}
+	}
+	if stored[0].UpdatedAt.Equal(oldUpdatedAt) {
+		t.Fatalf("expected batch update to advance updated_at, still %s", stored[0].UpdatedAt)
+	}
+	for _, field := range []string{"processed_at", "updated_at"} {
+		rawValue := rawSQLiteTimeValue(t, db, "redis_usage_inboxes", field, fmt.Sprintf("id = %d", rows[0].ID))
+		assertProjectTimezoneStorageValue(t, rawValue, "redis_usage_inboxes."+field)
+		if field == "processed_at" && rawValue != timeutil.FormatStorageTime(processedAt) {
+			t.Fatalf("expected processed_at %q, got %q", timeutil.FormatStorageTime(processedAt), rawValue)
+		}
+	}
+}

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -288,11 +288,14 @@ func (s *SyncService) processRedisInboxRows(ctx context.Context, writeDB *gorm.D
 		if persistErr != nil {
 			return persistErr
 		}
-		// validRows 和 events 按同一循环 append，索引一一对应。
+		// validRows 和 events 按同一循环 append，先固定一一对应关系，再由仓储层按 SQLite 变量上限分批标记。
+		processedUpdates := make([]repository.RedisUsageInboxProcessedUpdate, 0, len(validRows))
 		for i, row := range validRows {
-			if markErr := repository.MarkRedisUsageInboxProcessed(tx, row.ID, events[i].EventKey, fetchedAt); markErr != nil {
-				return fmt.Errorf("mark redis usage inbox processed: %w", markErr)
-			}
+			processedUpdates = append(processedUpdates, repository.RedisUsageInboxProcessedUpdate{ID: row.ID, EventKey: events[i].EventKey})
+		}
+		// 所有子批次仍在当前外层事务内；任意标记失败都会连同 usage_events 和前序标记一起回滚。
+		if markErr := repository.MarkRedisUsageInboxProcessedBatch(tx, processedUpdates, fetchedAt); markErr != nil {
+			return fmt.Errorf("mark redis usage inbox processed: %w", markErr)
 		}
 		return nil
 	})

--- a/internal/service/test/redis_usage_inbox_batch_test.go
+++ b/internal/service/test/redis_usage_inbox_batch_test.go
@@ -1,0 +1,168 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+	repositorydto "cpa-usage-keeper/internal/repository/dto"
+	"cpa-usage-keeper/internal/service"
+
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+type redisInboxUpdateCounter struct {
+	updateCount int
+}
+
+func (c *redisInboxUpdateCounter) LogMode(gormlogger.LogLevel) gormlogger.Interface {
+	return c
+}
+
+func (c *redisInboxUpdateCounter) Info(context.Context, string, ...any) {}
+
+func (c *redisInboxUpdateCounter) Warn(context.Context, string, ...any) {}
+
+func (c *redisInboxUpdateCounter) Error(context.Context, string, ...any) {}
+
+func (c *redisInboxUpdateCounter) Trace(_ context.Context, _ time.Time, sql func() (string, int64), _ error) {
+	statement, _ := sql()
+	normalized := strings.ToLower(strings.TrimSpace(statement))
+	if strings.HasPrefix(normalized, "update ") && strings.Contains(normalized, "redis_usage_inboxes") {
+		c.updateCount++
+	}
+}
+
+func TestProcessRedisUsageInboxBatchesProcessedMarks(t *testing.T) {
+	db := openOpenAITokenNormalizationTestDatabase(t)
+	const rowCount = 301
+	now := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	rows, err := repository.InsertRedisUsageInboxMessages(db, redisInboxBatchInputs("batch-mark", rowCount, now))
+	if err != nil {
+		t.Fatalf("seed redis usage inbox rows: %v", err)
+	}
+
+	counter := &redisInboxUpdateCounter{}
+	loggedDB := db.Session(&gorm.Session{Logger: counter})
+	notifier := &recordingUsageAggregationNotifier{}
+	syncService := service.NewSyncServiceWithOptions(loggedDB, service.SyncServiceOptions{
+		BaseURL:                  "https://cpa.example.com",
+		Now:                      func() time.Time { return now },
+		UsageAggregationNotifier: notifier,
+	})
+	result, err := syncService.ProcessRedisUsageInbox(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessRedisUsageInbox returned error: %v", err)
+	}
+	if result == nil || result.InsertedEvents != rowCount {
+		t.Fatalf("expected %d inserted events, got %+v", rowCount, result)
+	}
+	if counter.updateCount != 2 {
+		t.Fatalf("expected 2 batched inbox UPDATE statements, got %d", counter.updateCount)
+	}
+	var processedCount int64
+	if err := db.Model(&entities.RedisUsageInbox{}).Where("status = ?", repository.RedisUsageInboxStatusProcessed).Count(&processedCount).Error; err != nil {
+		t.Fatalf("count processed inbox rows: %v", err)
+	}
+	if processedCount != rowCount {
+		t.Fatalf("expected %d processed inbox rows, got %d", rowCount, processedCount)
+	}
+	var storedInbox []entities.RedisUsageInbox
+	if err := db.Order("id ASC").Find(&storedInbox).Error; err != nil {
+		t.Fatalf("load processed inbox rows: %v", err)
+	}
+	var storedEvents []entities.UsageEvent
+	if err := db.Order("id ASC").Find(&storedEvents).Error; err != nil {
+		t.Fatalf("load inserted usage events: %v", err)
+	}
+	if len(storedInbox) != rowCount || len(storedEvents) != rowCount {
+		t.Fatalf("expected %d inbox rows and events, got inbox=%d events=%d", rowCount, len(storedInbox), len(storedEvents))
+	}
+	eventKeyByRequestID := make(map[string]string, len(storedEvents))
+	for _, event := range storedEvents {
+		eventKeyByRequestID[event.RequestID] = event.EventKey
+	}
+	for i, inbox := range storedInbox {
+		expectedRequestID := fmt.Sprintf("batch-mark-%d", i)
+		expectedEventKey, exists := eventKeyByRequestID[expectedRequestID]
+		if !exists || expectedEventKey == "" {
+			t.Fatalf("missing persisted event mapping for request_id %q", expectedRequestID)
+		}
+		if inbox.ID != rows[i].ID || inbox.UsageEventKey != expectedEventKey {
+			t.Fatalf("unexpected inbox/event mapping at index %d: inbox=%+v expected_event_key=%q", i, inbox, expectedEventKey)
+		}
+	}
+}
+
+func TestProcessRedisUsageInboxRollsBackAllChunksWhenLaterProcessedMarkFails(t *testing.T) {
+	db := openOpenAITokenNormalizationTestDatabase(t)
+	const rowCount = 301
+	now := time.Date(2026, 7, 23, 10, 30, 0, 0, time.UTC)
+	rows, err := repository.InsertRedisUsageInboxMessages(db, redisInboxBatchInputs("batch-rollback", rowCount, now))
+	if err != nil {
+		t.Fatalf("seed redis usage inbox rows: %v", err)
+	}
+	if err := db.Exec(fmt.Sprintf(
+		`CREATE TRIGGER fail_later_processed_mark BEFORE UPDATE OF status ON redis_usage_inboxes WHEN OLD.id = %d AND NEW.status = 'processed' BEGIN SELECT RAISE(ABORT, 'later processed mark failed'); END;`,
+		rows[300].ID,
+	)).Error; err != nil {
+		t.Fatalf("create later-batch failure trigger: %v", err)
+	}
+
+	notifier := &recordingUsageAggregationNotifier{}
+	syncService := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{
+		BaseURL:                  "https://cpa.example.com",
+		Now:                      func() time.Time { return now },
+		UsageAggregationNotifier: notifier,
+	})
+	result, err := syncService.ProcessRedisUsageInbox(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "later processed mark failed") {
+		t.Fatalf("expected later processed mark failure, got result=%+v err=%v", result, err)
+	}
+	if notifier.usageCalls != 0 {
+		t.Fatalf("expected no commit notification after rollback, got %d", notifier.usageCalls)
+	}
+	var eventCount int64
+	if err := db.Model(&entities.UsageEvent{}).Count(&eventCount).Error; err != nil {
+		t.Fatalf("count rolled-back usage events: %v", err)
+	}
+	if eventCount != 0 {
+		t.Fatalf("expected all usage events rolled back, got %d", eventCount)
+	}
+	var stored []entities.RedisUsageInbox
+	if err := db.Order("id ASC").Find(&stored).Error; err != nil {
+		t.Fatalf("load failed inbox rows: %v", err)
+	}
+	if len(stored) != rowCount {
+		t.Fatalf("expected %d inbox rows, got %d", rowCount, len(stored))
+	}
+	for i, row := range stored {
+		if row.Status != repository.RedisUsageInboxStatusProcessFailed || row.AttemptCount != 1 {
+			t.Fatalf("expected process_failed retry state at index %d, got %+v", i, row)
+		}
+		if row.UsageEventKey != "" || row.ProcessedAt != nil {
+			t.Fatalf("expected processed fields rolled back at index %d, got %+v", i, row)
+		}
+	}
+}
+
+func redisInboxBatchInputs(prefix string, rowCount int, poppedAt time.Time) []repositorydto.RedisInboxInsert {
+	inputs := make([]repositorydto.RedisInboxInsert, 0, rowCount)
+	for i := 0; i < rowCount; i++ {
+		inputs = append(inputs, repositorydto.RedisInboxInsert{
+			Source: "redis_subscribe:usage",
+			RawMessage: fmt.Sprintf(
+				`{"timestamp":"2026-07-23T09:59:00Z","provider":"OpenAI","auth_type":"api_key","auth_index":"batch-auth","model":"gpt-5.6","request_id":"%s-%d","executor_type":"CodexExecutor","tokens":{"input_tokens":10,"output_tokens":5,"total_tokens":15}}`,
+				prefix,
+				i,
+			),
+			PoppedAt: poppedAt,
+		})
+	}
+	return inputs
+}


### PR DESCRIPTION
## Summary
- batch Redis inbox processed-state updates into bounded 300-row CASE statements
- preserve the existing shared transaction rollback, retry, and discard semantics
- add cross-chunk mapping and rollback coverage and benchmark the production notifier path

## Performance
- 1,000 rows: 123.2 ms to 88.8 ms; throughput 8,120 to 11,267 events/s
- 10,000 rows: 1.087 s to 0.711 s; throughput 9,199 to 14,066 events/s
- allocation volume reduced by about 50% and allocation count by about 65%

## Validation
- targeted storage-time test under TZ=UTC and TZ=Asia/Shanghai
- full TZ=UTC make verify: backend, 84 frontend test files / 745 tests, lint, typecheck, and production build