### PR TITLE
feat(logging): add dedicated error log files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,8 +108,8 @@ LOG_LEVEL=info
 # Whether to write persistent log files. Required: no. Default: true.
 LOG_FILE_ENABLED=true
 
-# 日志文件保留天数；0 表示不自动清理。必填：否。默认值：7。
-# Number of days to retain log files; 0 disables cleanup. Required: no. Default: 7.
+# 综合日志文件保留历史天数，并额外保留当天；0 表示不自动清理；仅错误日志固定保留历史 30 天及当天。必填：否。默认值：7。
+# Number of historical days to retain combined logs, plus the current day; 0 disables cleanup; error-only logs keep 30 history days plus the current day. Required: no. Default: 7.
 LOG_RETENTION_DAYS=7
 
 # 是否在每日维护中删除过期 usage_events 原始事件；默认不清理，设为 true 后会删除早于 90 个本地自然日前 00:00 的数据。必填：否。默认值：false。

--- a/README.md
+++ b/README.md
@@ -322,11 +322,13 @@ Scheduled Auth Files quota refresh is configured from the gear button in the Aut
 | `WORK_DIR` | No | `./data` | Application work directory; database, logs, and backups default to `app.db`, `logs/`, and `backups/` under it |
 | `LOG_LEVEL` | No | `info` | Log level |
 | `LOG_FILE_ENABLED` | No | `true` | Write persistent log files |
-| `LOG_RETENTION_DAYS` | No | `7` | Log retention days; `0` disables cleanup |
+| `LOG_RETENTION_DAYS` | No | `7` | Combined-log history days, plus the current day; `0` disables cleanup. Error-only logs keep 30 history days plus the current day |
 | `CLEANUP_USAGE_EVENTS_ENABLED` | No | `false` | Delete expired raw `usage_events` during daily maintenance; when enabled, rows earlier than local midnight 90 calendar days ago are deleted |
 | `BACKUP_ENABLED` | No | `true` | Enable SQLite database backups |
 | `BACKUP_INTERVAL` | No | `24h` | Database backup interval |
 | `BACKUP_RETENTION_DAYS` | No | `7` | Backup retention days |
+
+When file logging is enabled, `cpa-usage-keeper-YYYY-MM-DD.log` contains all emitted levels. Error, fatal, and panic entries are also copied to `cpa-usage-keeper-error-YYYY-MM-DD.log`, which keeps the previous 30 local calendar dates plus the current date.
 
 ### Built-In HTTPS
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -322,11 +322,13 @@ Auth Files 定时限额刷新在 Auth Files 巡检弹窗的小齿轮中配置。
 | `WORK_DIR` | 否 | `./data` | 应用工作目录；数据库、日志和备份默认分别写入 `app.db`、`logs/`、`backups/` |
 | `LOG_LEVEL` | 否 | `info` | 日志级别 |
 | `LOG_FILE_ENABLED` | 否 | `true` | 是否写入持久化日志文件 |
-| `LOG_RETENTION_DAYS` | 否 | `7` | 日志保留天数；`0` 表示不自动清理 |
+| `LOG_RETENTION_DAYS` | 否 | `7` | 综合日志保留历史天数，并额外保留当天；`0` 表示不自动清理。仅错误日志固定保留历史 30 天及当天 |
 | `CLEANUP_USAGE_EVENTS_ENABLED` | 否 | `false` | 是否在每日维护中删除过期 `usage_events` 原始事件；启用后会删除早于 90 个本地自然日前 00:00 的数据 |
 | `BACKUP_ENABLED` | 否 | `true` | 是否启用 SQLite 数据库备份 |
 | `BACKUP_INTERVAL` | 否 | `24h` | 数据库备份间隔 |
 | `BACKUP_RETENTION_DAYS` | 否 | `7` | 备份保留天数 |
+
+启用文件日志后，`cpa-usage-keeper-YYYY-MM-DD.log` 会记录所有已输出级别；error、fatal 和 panic 级别还会同时写入 `cpa-usage-keeper-error-YYYY-MM-DD.log`，该文件固定保留历史 30 个本地自然日及当天。
 
 ### 内置 HTTPS
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,9 @@ func main() {
 
 	application, err := app.NewWithOptions(app.Options{EnvFile: *envFile})
 	if err != nil {
+		if app.IsInitializationErrorLogged(err) {
+			os.Exit(1)
+		}
 		logrus.WithError(err).Fatal("initialize app")
 	}
 	defer application.Close()

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -76,6 +76,35 @@ type App struct {
 // newUsageRecentEventCache 是最近事件缓存构造入口，测试可替换它来覆盖缓存初始化失败路径。
 var newUsageRecentEventCache = repository.NewUsageRecentEventCache
 
+type loggedInitializationError struct {
+	err error
+}
+
+func (e *loggedInitializationError) Error() string {
+	return e.err.Error()
+}
+
+func (e *loggedInitializationError) Unwrap() error {
+	return e.err
+}
+
+// IsInitializationErrorLogged 判断构造阶段是否已在释放日志资源前写入终止错误。
+func IsInitializationErrorLogged(err error) bool {
+	var logged *loggedInitializationError
+	return errors.As(err, &logged)
+}
+
+func failInitialization(logCloser io.Closer, err error) error {
+	logging.LogTerminalFatal("initialize app", err)
+	if closeErr := logCloser.Close(); closeErr != nil {
+		wrappedCloseErr := fmt.Errorf("close logging: %w", closeErr)
+		err = errors.Join(err, wrappedCloseErr)
+		// 文件日志已经进入关闭流程，额外将关闭失败写到恢复后的控制台输出，避免错误只留在返回值里。
+		logging.LogTerminalError("close logging after initialization failure", wrappedCloseErr)
+	}
+	return &loggedInitializationError{err: err}
+}
+
 func New() (*App, error) {
 	return NewWithOptions(Options{})
 }
@@ -99,8 +128,7 @@ func NewWithConfig(cfg config.Config) (*App, error) {
 	db, readDB, err := repository.OpenDatabasePools(cfg)
 	// 任一数据库池构造失败时 repository 已回收局部资源，App 只需要释放日志句柄。
 	if err != nil {
-		_ = logCloser.Close()
-		return nil, err
+		return nil, failInitialization(logCloser, err)
 	}
 	// 最近事件缓存继续使用统一 DB；其 Query 会由 dbresolver 自动路由到 reader。
 	recentUsageCache, err := newUsageRecentEventCache(db, repository.UsageRecentEventCacheOptions{})
@@ -118,8 +146,7 @@ func NewWithConfig(cfg config.Config) (*App, error) {
 			_ = closeGormDB(readDB)
 		}
 		_ = closeGormDB(db)
-		_ = logCloser.Close()
-		return nil, fmt.Errorf("load pricing snapshot: %w", err)
+		return nil, failInitialization(logCloser, fmt.Errorf("load pricing snapshot: %w", err))
 	}
 	pricingCatalog := pricing.NewCatalog(pricingSnapshot)
 
@@ -198,8 +225,7 @@ func NewWithConfig(cfg config.Config) (*App, error) {
 			// 最后关闭唯一 writer，确保任何已开始的写操作先于日志资源结束。
 			_ = closeGormDB(db)
 			// 数据库资源全部回收后再关闭日志文件。
-			_ = logCloser.Close()
-			return nil, err
+			return nil, failInitialization(logCloser, err)
 		}
 		// 备份期间其它写入继续在 writer 池外排队；页面查询仍可使用独立 reader，不恢复旧版的全局读阻塞。
 		backupStore := newDatabaseBackupStore(sqlDB, cfg.BackupDir)

--- a/internal/app/test/pricing_catalog_startup_test.go
+++ b/internal/app/test/pricing_catalog_startup_test.go
@@ -1,6 +1,8 @@
 package test
 
 import (
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -39,13 +41,58 @@ func TestPricingCatalogStartupFailsWhenPersistedSnapshotIsInvalid(t *testing.T) 
 		t.Fatalf("close seed database: %v", err)
 	}
 
-	application, err := keeperapp.NewWithConfig(pricingCatalogStartupConfig(databasePath))
+	logDir := t.TempDir()
+	cfg := pricingCatalogStartupConfig(databasePath)
+	cfg.LogFileEnabled = true
+	cfg.LogDir = logDir
+	previousStderr := os.Stderr
+	stderrReader, stderrWriter, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatalf("create stderr pipe: %v", pipeErr)
+	}
+	os.Stderr = stderrWriter
+	t.Cleanup(func() {
+		os.Stderr = previousStderr
+		_ = stderrReader.Close()
+		_ = stderrWriter.Close()
+	})
+	application, err := keeperapp.NewWithConfig(cfg)
+	if closeErr := stderrWriter.Close(); closeErr != nil {
+		t.Fatalf("close stderr writer: %v", closeErr)
+	}
+	os.Stderr = previousStderr
+	console, consoleErr := io.ReadAll(stderrReader)
+	if consoleErr != nil {
+		t.Fatalf("read startup stderr: %v", consoleErr)
+	}
 	if application != nil {
 		_ = application.Close()
 		t.Fatal("expected invalid pricing snapshot to prevent App construction")
 	}
 	if err == nil || !strings.Contains(err.Error(), "pricing snapshot") {
 		t.Fatalf("expected pricing snapshot startup error, got %v", err)
+	}
+	if !keeperapp.IsInitializationErrorLogged(err) {
+		t.Fatalf("expected initialization error to record that it was already logged, got %T", err)
+	}
+	errorLogPath := filepath.Join(logDir, "cpa-usage-keeper-error-"+time.Now().Format("2006-01-02")+".log")
+	errorLog, readErr := os.ReadFile(errorLogPath)
+	if readErr != nil {
+		t.Fatalf("read startup error log: %v", readErr)
+	}
+	if !strings.Contains(string(errorLog), "| fatal | initialize app") || !strings.Contains(string(errorLog), "pricing snapshot") {
+		t.Fatalf("expected initialization failure before log close, got %q", errorLog)
+	}
+	combinedLogPath := filepath.Join(logDir, "cpa-usage-keeper-"+time.Now().Format("2006-01-02")+".log")
+	combinedLog, readErr := os.ReadFile(combinedLogPath)
+	if readErr != nil {
+		t.Fatalf("read startup combined log: %v", readErr)
+	}
+	if !strings.Contains(string(combinedLog), "| fatal | initialize app") || !strings.Contains(string(combinedLog), "pricing snapshot") {
+		t.Fatalf("expected initialization failure in combined log, got %q", combinedLog)
+	}
+	if count := strings.Count(string(console), "initialize app"); count != 1 {
+		t.Fatalf("expected one initialization failure on stderr, got %d in %q", count, console)
 	}
 
 	// 构造失败必须释放 reader/writer，随后应能立即重新打开同一个数据库。

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	stdlog "log"
@@ -15,17 +16,33 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const logFilePrefix = "cpa-usage-keeper-"
+const (
+	logFilePrefix         = "cpa-usage-keeper-"
+	errorLogFilePrefix    = "cpa-usage-keeper-error-"
+	errorLogRetentionDays = 30
+)
 
 type noopCloser struct{}
 
 func (noopCloser) Close() error { return nil }
+
+type multiCloser []io.Closer
+
+func (closers multiCloser) Close() error {
+	var closeErr error
+	for _, closer := range closers {
+		closeErr = errors.Join(closeErr, closer.Close())
+	}
+	return closeErr
+}
 
 type restoreCloser struct {
 	closer                     io.Closer
 	previousLogrusOutput       io.Writer
 	previousLogrusLevel        logrus.Level
 	previousLogrusFormatter    logrus.Formatter
+	previousLogrusHooks        logrus.LevelHooks
+	restoreLogrusHooks         bool
 	previousStdlogOutput       io.Writer
 	previousStdlogFlags        int
 	previousStdlogPrefix       string
@@ -33,20 +50,28 @@ type restoreCloser struct {
 	previousGinErrorWriter     io.Writer
 	previousGinDebugPrint      func(string, ...interface{})
 	previousGinDebugPrintRoute func(string, string, string, int)
+	closeOnce                  sync.Once
+	closeErr                   error
 }
 
 func (c *restoreCloser) Close() error {
-	logrus.SetOutput(c.previousLogrusOutput)
-	logrus.SetLevel(c.previousLogrusLevel)
-	logrus.SetFormatter(c.previousLogrusFormatter)
-	stdlog.SetOutput(c.previousStdlogOutput)
-	stdlog.SetFlags(c.previousStdlogFlags)
-	stdlog.SetPrefix(c.previousStdlogPrefix)
-	gin.DefaultWriter = c.previousGinDefaultWriter
-	gin.DefaultErrorWriter = c.previousGinErrorWriter
-	gin.DebugPrintFunc = c.previousGinDebugPrint
-	gin.DebugPrintRouteFunc = c.previousGinDebugPrintRoute
-	return c.closer.Close()
+	c.closeOnce.Do(func() {
+		if c.restoreLogrusHooks {
+			logrus.StandardLogger().ReplaceHooks(c.previousLogrusHooks)
+		}
+		logrus.SetOutput(c.previousLogrusOutput)
+		logrus.SetLevel(c.previousLogrusLevel)
+		logrus.SetFormatter(c.previousLogrusFormatter)
+		stdlog.SetOutput(c.previousStdlogOutput)
+		stdlog.SetFlags(c.previousStdlogFlags)
+		stdlog.SetPrefix(c.previousStdlogPrefix)
+		gin.DefaultWriter = c.previousGinDefaultWriter
+		gin.DefaultErrorWriter = c.previousGinErrorWriter
+		gin.DebugPrintFunc = c.previousGinDebugPrint
+		gin.DebugPrintRouteFunc = c.previousGinDebugPrintRoute
+		c.closeErr = c.closer.Close()
+	})
+	return c.closeErr
 }
 
 func resolveLogDir(cfg config.Config) string {
@@ -80,14 +105,45 @@ func Configure(cfg config.Config) (io.Closer, error) {
 
 	writer := io.Writer(os.Stderr)
 	var closer io.Closer = noopCloser{}
+	var errorHook *errorFileHook
 	if cfg.LogFileEnabled {
 		logDir := resolveLogDir(cfg)
 		dailyWriter, err := newDailyFileWriter(logDir, cfg.LogRetentionDays, time.Now)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("initialize combined log writer: %w", err)
+		}
+		errorWriter, err := newDailyFileWriterWithPrefix(logDir, errorLogFilePrefix, errorLogRetentionDays, time.Now)
+		if err != nil {
+			initializationErr := fmt.Errorf("initialize dedicated error log writer: %w", err)
+			if closeErr := dailyWriter.Close(); closeErr != nil {
+				initializationErr = errors.Join(initializationErr, fmt.Errorf("close combined log writer: %w", closeErr))
+			}
+			return nil, initializationErr
+		}
+		dailyWriter.maintenanceReporter = func(err error) {
+			reportInternalError("combined log maintenance failed", err)
+		}
+		errorWriter.maintenanceReporter = func(err error) {
+			reportInternalError("dedicated error log maintenance failed", err)
 		}
 		writer = io.MultiWriter(os.Stderr, NewPlainWriter(dailyWriter))
-		closer = dailyWriter
+		closer = multiCloser{dailyWriter, errorWriter}
+		errorHook = &errorFileHook{
+			writer: errorWriter,
+		}
+	}
+
+	logger := logrus.StandardLogger()
+	var previousLogrusHooks logrus.LevelHooks
+	restoreLogrusHooks := errorHook != nil
+	if restoreLogrusHooks {
+		previousLogrusHooks = logger.ReplaceHooks(make(logrus.LevelHooks))
+		configuredHooks := cloneLevelHooks(previousLogrusHooks)
+		// 专用 hook 必须先落盘且永远返回 nil，避免它自身的故障阻断已有 hook。
+		for _, hookLevel := range errorHook.Levels() {
+			configuredHooks[hookLevel] = append([]logrus.Hook{errorHook}, configuredHooks[hookLevel]...)
+		}
+		logger.ReplaceHooks(configuredHooks)
 	}
 
 	logrus.SetLevel(level)
@@ -102,6 +158,8 @@ func Configure(cfg config.Config) (io.Closer, error) {
 		previousLogrusOutput:       previousLogrusOutput,
 		previousLogrusLevel:        previousLogrusLevel,
 		previousLogrusFormatter:    previousLogrusFormatter,
+		previousLogrusHooks:        previousLogrusHooks,
+		restoreLogrusHooks:         restoreLogrusHooks,
 		previousStdlogOutput:       previousStdlogOutput,
 		previousStdlogFlags:        previousStdlogFlags,
 		previousStdlogPrefix:       previousStdlogPrefix,
@@ -110,6 +168,56 @@ func Configure(cfg config.Config) (io.Closer, error) {
 		previousGinDebugPrint:      previousGinDebugPrint,
 		previousGinDebugPrintRoute: previousGinDebugPrintRoute,
 	}, nil
+}
+
+type errorFileHook struct {
+	writer *dailyFileWriter
+}
+
+func (*errorFileHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (h *errorFileHook) Fire(entry *logrus.Entry) error {
+	if entry.Level > logrus.ErrorLevel {
+		reportInternalError("dedicated error log maintenance failed", h.writer.Maintain())
+		return nil
+	}
+	content, err := (keeperFormatter{}).Format(entry)
+	if err != nil {
+		reportInternalError("dedicated error log format failed", err)
+		return nil
+	}
+	_, err = NewPlainWriter(h.writer).Write(content)
+	reportInternalError("dedicated error log write failed", err)
+	return nil
+}
+
+func reportInternalError(message string, err error) {
+	if err == nil {
+		return
+	}
+	entry := &logrus.Entry{
+		Logger:  logrus.StandardLogger(),
+		Data:    logrus.Fields{"error": err.Error()},
+		Time:    time.Now(),
+		Level:   logrus.ErrorLevel,
+		Message: message,
+	}
+	content, formatErr := (keeperFormatter{}).Format(entry)
+	if formatErr != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "%s: %v: %v\n", message, err, formatErr)
+		return
+	}
+	_, _ = os.Stderr.Write(content)
+}
+
+func cloneLevelHooks(hooks logrus.LevelHooks) logrus.LevelHooks {
+	cloned := make(logrus.LevelHooks, len(hooks))
+	for level, levelHooks := range hooks {
+		cloned[level] = append([]logrus.Hook(nil), levelHooks...)
+	}
+	return cloned
 }
 
 // ConfigureBootstrap 让配置加载阶段的致命错误也沿用 Keeper 控制台格式。
@@ -126,13 +234,22 @@ func NewStandardLogger(level logrus.Level) *stdlog.Logger {
 
 // LogTerminalError 保证进程即将失败退出时的原因不被 fatal/panic 阈值过滤。
 func LogTerminalError(message string, err error) {
+	logTerminal(logrus.ErrorLevel, message, err)
+}
+
+// LogTerminalFatal 同步写入 fatal 日志但不退出，让调用方先释放日志文件再结束进程。
+func LogTerminalFatal(message string, err error) {
+	logTerminal(logrus.FatalLevel, message, err)
+}
+
+func logTerminal(level logrus.Level, message string, err error) {
 	logger := logrus.StandardLogger()
 	previousLevel := logger.GetLevel()
-	if !logger.IsLevelEnabled(logrus.ErrorLevel) {
-		logger.SetLevel(logrus.ErrorLevel)
+	if !logger.IsLevelEnabled(level) {
+		logger.SetLevel(level)
 		defer logger.SetLevel(previousLevel)
 	}
-	logger.WithError(err).Error(message)
+	logger.WithError(err).Log(level, message)
 }
 
 type logrusWriter struct {
@@ -159,31 +276,36 @@ func configureGinLogging() {
 }
 
 type dailyFileWriter struct {
-	mu            sync.Mutex
-	dir           string
-	retentionDays int
-	now           func() time.Time
-	currentDate   string
-	file          *os.File
+	mu                  sync.Mutex
+	dir                 string
+	prefix              string
+	retentionDays       int
+	now                 func() time.Time
+	currentDate         string
+	lastMaintenanceDate string
+	file                *os.File
+	closed              bool
+	maintenanceReporter func(error)
 }
 
 func newDailyFileWriter(dir string, retentionDays int, now func() time.Time) (*dailyFileWriter, error) {
+	return newDailyFileWriterWithPrefix(dir, logFilePrefix, retentionDays, now)
+}
+
+func newDailyFileWriterWithPrefix(dir, prefix string, retentionDays int, now func() time.Time) (*dailyFileWriter, error) {
 	if now == nil {
 		now = time.Now
 	}
 	writer := &dailyFileWriter{
 		dir:           dir,
+		prefix:        prefix,
 		retentionDays: retentionDays,
 		now:           now,
 	}
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return nil, fmt.Errorf("create log dir: %w", err)
 	}
-	if err := writer.rotateLocked(); err != nil {
-		return nil, err
-	}
-	if err := writer.cleanupLocked(); err != nil {
-		_ = writer.Close()
+	if err := writer.rotateLocked(now()); err != nil {
 		return nil, err
 	}
 	return writer, nil
@@ -191,23 +313,48 @@ func newDailyFileWriter(dir string, retentionDays int, now func() time.Time) (*d
 
 func (w *dailyFileWriter) Write(p []byte) (int, error) {
 	w.mu.Lock()
-	defer w.mu.Unlock()
+	if w.closed {
+		w.mu.Unlock()
+		return 0, os.ErrClosed
+	}
 
-	date := w.now().Format("2006-01-02")
+	// 一次写入只采样一次时间，避免跨日瞬间的轮转、写入和维护观察到不同日期。
+	now := w.now()
+	maintenanceErr := w.maintainLocked(now)
+	reporter := w.maintenanceReporter
+
+	date := now.Format("2006-01-02")
+	var written int
+	var writeErr error
 	if w.file == nil || w.currentDate != date {
-		if err := w.rotateLocked(); err != nil {
-			return 0, err
-		}
-		if err := w.cleanupLocked(); err != nil {
-			return 0, err
+		writeErr = w.rotateLocked(now)
+	}
+	if writeErr == nil {
+		written, writeErr = w.file.Write(p)
+		if writeErr == nil && written != len(p) {
+			writeErr = io.ErrShortWrite
 		}
 	}
-	return w.file.Write(p)
+	w.mu.Unlock()
+	if maintenanceErr != nil && reporter != nil {
+		reporter(maintenanceErr)
+	}
+	return written, writeErr
+}
+
+func (w *dailyFileWriter) Maintain() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.maintainLocked(w.now())
 }
 
 func (w *dailyFileWriter) Close() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if w.closed {
+		return nil
+	}
+	w.closed = true
 	if w.file == nil {
 		return nil
 	}
@@ -216,17 +363,32 @@ func (w *dailyFileWriter) Close() error {
 	return err
 }
 
-func (w *dailyFileWriter) rotateLocked() error {
-	date := w.now().Format("2006-01-02")
+func (w *dailyFileWriter) closeCurrentFileLocked() error {
+	if w.file == nil {
+		w.currentDate = ""
+		return nil
+	}
+	file := w.file
+	w.file = nil
+	w.currentDate = ""
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close log file: %w", err)
+	}
+	return nil
+}
+
+func (w *dailyFileWriter) rotateLocked(now time.Time) error {
+	if w.closed {
+		return os.ErrClosed
+	}
+	date := now.Format("2006-01-02")
 	if w.file != nil && w.currentDate == date {
 		return nil
 	}
-	if w.file != nil {
-		if err := w.file.Close(); err != nil {
-			return fmt.Errorf("close log file: %w", err)
-		}
+	if err := w.closeCurrentFileLocked(); err != nil {
+		return err
 	}
-	filePath := filepath.Join(w.dir, logFilePrefix+date+".log")
+	filePath := filepath.Join(w.dir, w.prefix+date+".log")
 	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("open log file: %w", err)
@@ -236,35 +398,60 @@ func (w *dailyFileWriter) rotateLocked() error {
 	return nil
 }
 
-func (w *dailyFileWriter) cleanupLocked() error {
+func (w *dailyFileWriter) maintainLocked(now time.Time) error {
+	if w.closed {
+		return os.ErrClosed
+	}
+	date := now.Format("2006-01-02")
+	var maintenanceErr error
+	// 当天尚未触发文件写入时只关闭跨日旧句柄，不为新日期创建空文件。
+	if w.file != nil && w.currentDate != date {
+		if err := w.closeCurrentFileLocked(); err != nil {
+			maintenanceErr = errors.Join(maintenanceErr, err)
+		}
+	}
+	if w.lastMaintenanceDate == date {
+		return maintenanceErr
+	}
+	// 即使清理失败，同一日期也不反复扫描和刷屏；下一自然日再尝试。
+	w.lastMaintenanceDate = date
+	return errors.Join(maintenanceErr, w.cleanupLocked(now))
+}
+
+func (w *dailyFileWriter) cleanupLocked(now time.Time) error {
+	if w.closed {
+		return os.ErrClosed
+	}
 	if w.retentionDays <= 0 {
 		return nil
 	}
-	cutoff := w.now().AddDate(0, 0, -w.retentionDays)
+	// 保留配置指定的历史自然日，再加上当天；例如 30 表示历史 30 天加今天。
+	cutoff := dateOnly(now.AddDate(0, 0, -w.retentionDays))
 	entries, err := os.ReadDir(w.dir)
 	if err != nil {
 		return fmt.Errorf("read log dir: %w", err)
 	}
+	var cleanupErr error
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
 		name := entry.Name()
-		if !strings.HasPrefix(name, logFilePrefix) || !strings.HasSuffix(name, ".log") {
+		if !strings.HasPrefix(name, w.prefix) || !strings.HasSuffix(name, ".log") {
 			continue
 		}
-		datePart := strings.TrimSuffix(strings.TrimPrefix(name, logFilePrefix), ".log")
-		logDate, err := time.ParseInLocation("2006-01-02", datePart, time.Local)
+		datePart := strings.TrimSuffix(strings.TrimPrefix(name, w.prefix), ".log")
+		logDate, err := time.ParseInLocation("2006-01-02", datePart, now.Location())
 		if err != nil {
 			continue
 		}
-		if logDate.Before(dateOnly(cutoff)) {
+		if logDate.Before(cutoff) {
 			if err := os.Remove(filepath.Join(w.dir, name)); err != nil {
-				return fmt.Errorf("remove old log file: %w", err)
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("remove old log file %s: %w", name, err))
 			}
 		}
 	}
-	return nil
+	return cleanupErr
 }
 
 func dateOnly(value time.Time) time.Time {

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -126,6 +126,8 @@ func Configure(cfg config.Config) (io.Closer, error) {
 		errorWriter.maintenanceReporter = func(err error) {
 			reportInternalError("dedicated error log maintenance failed", err)
 		}
+		reportInternalError("combined log maintenance failed", dailyWriter.Maintain())
+		reportInternalError("dedicated error log maintenance failed", errorWriter.Maintain())
 		writer = io.MultiWriter(os.Stderr, NewPlainWriter(dailyWriter))
 		closer = multiCloser{dailyWriter, errorWriter}
 		errorHook = &errorFileHook{

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -322,6 +322,9 @@ func TestRetentionDeletesOnlyOldAppLogs(t *testing.T) {
 		t.Fatalf("newDailyFileWriter returned error: %v", err)
 	}
 	defer writer.Close()
+	if err := writer.Maintain(); err != nil {
+		t.Fatalf("maintain daily log files: %v", err)
+	}
 
 	if _, err := os.Stat(oldAppLog); !os.IsNotExist(err) {
 		t.Fatalf("expected old app log to be removed, stat err=%v", err)

--- a/internal/logging/test/error_file_test.go
+++ b/internal/logging/test/error_file_test.go
@@ -1,0 +1,484 @@
+package logging_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/config"
+	"cpa-usage-keeper/internal/logging"
+	"github.com/sirupsen/logrus"
+)
+
+const errorLogFilePrefix = "cpa-usage-keeper-error-"
+
+func TestConfigureDuplicatesOnlyErrorLevelsToDedicatedDailyFile(t *testing.T) {
+	logDir := t.TempDir()
+	cfg := config.Config{
+		LogLevel:         "info",
+		LogFileEnabled:   true,
+		LogDir:           logDir,
+		LogRetentionDays: 7,
+	}
+
+	_ = captureConsole(t, cfg, func() {
+		logger := logrus.StandardLogger()
+		logger.Log(logrus.InfoLevel, "info stays in combined log")
+		logger.Log(logrus.WarnLevel, "warn stays in combined log")
+		logger.Log(logrus.ErrorLevel, "error is duplicated")
+		logger.Log(logrus.FatalLevel, "fatal is duplicated")
+		func() {
+			defer func() { _ = recover() }()
+			logger.Log(logrus.PanicLevel, "panic is duplicated")
+		}()
+	})
+
+	combined := readLogFile(t, filepath.Join(logDir, "cpa-usage-keeper-"+today()+".log"))
+	for _, message := range []string{
+		"info stays in combined log",
+		"warn stays in combined log",
+		"error is duplicated",
+		"fatal is duplicated",
+		"panic is duplicated",
+	} {
+		if !strings.Contains(combined, message) {
+			t.Fatalf("expected combined log to contain %q, got %q", message, combined)
+		}
+	}
+
+	errorOnly := readLogFile(t, filepath.Join(logDir, errorLogFilePrefix+today()+".log"))
+	for _, message := range []string{"error is duplicated", "fatal is duplicated", "panic is duplicated"} {
+		if !strings.Contains(errorOnly, message) {
+			t.Fatalf("expected error log to contain %q, got %q", message, errorOnly)
+		}
+	}
+	for _, message := range []string{"info stays in combined log", "warn stays in combined log"} {
+		if strings.Contains(errorOnly, message) {
+			t.Fatalf("expected error log to exclude %q, got %q", message, errorOnly)
+		}
+	}
+	if ansiPattern.MatchString(errorOnly) {
+		t.Fatalf("expected error log without ANSI sequences, got %q", errorOnly)
+	}
+	if lines := strings.Count(errorOnly, "\n"); lines != 3 {
+		t.Fatalf("expected three error-level log lines, got %d in %q", lines, errorOnly)
+	}
+}
+
+func TestConfigureKeepsCombinedAndErrorRetentionBoundaries(t *testing.T) {
+	logDir := t.TempDir()
+	now := time.Now()
+	expiredCombined := filepath.Join(logDir, "cpa-usage-keeper-"+now.AddDate(0, 0, -8).Format("2006-01-02")+".log")
+	oldestRetainedCombined := filepath.Join(logDir, "cpa-usage-keeper-"+now.AddDate(0, 0, -7).Format("2006-01-02")+".log")
+	expiredError := filepath.Join(logDir, errorLogFilePrefix+now.AddDate(0, 0, -31).Format("2006-01-02")+".log")
+	oldestRetainedError := filepath.Join(logDir, errorLogFilePrefix+now.AddDate(0, 0, -30).Format("2006-01-02")+".log")
+	otherLog := filepath.Join(logDir, "other.log")
+	for _, path := range []string{expiredCombined, oldestRetainedCombined, expiredError, oldestRetainedError, otherLog} {
+		if err := os.WriteFile(path, []byte("fixture"), 0644); err != nil {
+			t.Fatalf("write fixture %s: %v", path, err)
+		}
+	}
+
+	_ = captureConsole(t, config.Config{
+		LogLevel:         "info",
+		LogFileEnabled:   true,
+		LogDir:           logDir,
+		LogRetentionDays: 7,
+	}, func() {
+		logrus.Info("trigger retention maintenance")
+	})
+
+	for _, path := range []string{expiredCombined, expiredError} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected expired log %s to be removed, stat err=%v", path, err)
+		}
+	}
+	for _, path := range []string{oldestRetainedCombined, oldestRetainedError, otherLog} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected retained file %s to remain: %v", path, err)
+		}
+	}
+}
+
+func TestConfigureCloseRestoresExistingLogrusHooks(t *testing.T) {
+	logger := logrus.StandardLogger()
+	previousHooks := logger.ReplaceHooks(make(logrus.LevelHooks))
+	t.Cleanup(func() { logger.ReplaceHooks(previousHooks) })
+	existing := &sentinelHook{}
+	logger.AddHook(existing)
+
+	closer, err := logging.Configure(config.Config{
+		LogLevel:         "info",
+		LogFileEnabled:   true,
+		LogDir:           t.TempDir(),
+		LogRetentionDays: 7,
+	})
+	if err != nil {
+		t.Fatalf("configure logging: %v", err)
+	}
+	if hooks := logger.Hooks[logrus.ErrorLevel]; len(hooks) != 2 {
+		_ = closer.Close()
+		t.Fatalf("expected existing hook plus dedicated error hook, got %d", len(hooks))
+	}
+	if err := closer.Close(); err != nil {
+		t.Fatalf("close logging: %v", err)
+	}
+
+	hooks := logger.Hooks[logrus.ErrorLevel]
+	if len(hooks) != 1 || hooks[0] != existing {
+		t.Fatalf("expected only the original hook after close, got %#v", hooks)
+	}
+}
+
+func TestConfigureReportsDedicatedErrorFileInitializationFailure(t *testing.T) {
+	logDir := t.TempDir()
+	errorLogPath := filepath.Join(logDir, errorLogFilePrefix+today()+".log")
+	if err := os.Mkdir(errorLogPath, 0755); err != nil {
+		t.Fatalf("create error-log failure fixture: %v", err)
+	}
+
+	_, err := logging.Configure(config.Config{
+		LogLevel:         "info",
+		LogFileEnabled:   true,
+		LogDir:           logDir,
+		LogRetentionDays: 7,
+	})
+	if err == nil {
+		t.Fatal("expected error log initialization failure")
+	}
+	if !strings.Contains(err.Error(), "initialize dedicated error log writer") {
+		t.Fatalf("expected dedicated writer context, got %v", err)
+	}
+}
+
+func TestConfigureMaintainsErrorRetentionWhenOnlyInfoLogsContinue(t *testing.T) {
+	earlier, later := consecutiveDateLocations(t)
+	previousLocal := time.Local
+	time.Local = earlier
+	t.Cleanup(func() { time.Local = previousLocal })
+
+	logDir := t.TempDir()
+	closer, err := logging.Configure(config.Config{
+		LogLevel:         "info",
+		LogFileEnabled:   true,
+		LogDir:           logDir,
+		LogRetentionDays: 7,
+	})
+	if err != nil {
+		t.Fatalf("configure logging: %v", err)
+	}
+	t.Cleanup(func() { _ = closer.Close() })
+
+	expiredDate := time.Now().In(later).AddDate(0, 0, -40).Format("2006-01-02")
+	expiredPath := filepath.Join(logDir, errorLogFilePrefix+expiredDate+".log")
+	if err := os.WriteFile(expiredPath, []byte("expired"), 0644); err != nil {
+		t.Fatalf("write expired error log: %v", err)
+	}
+
+	time.Local = later
+	logrus.Info("ordinary traffic triggers daily maintenance")
+
+	if _, err := os.Stat(expiredPath); !os.IsNotExist(err) {
+		t.Fatalf("expected ordinary logs to clean expired error log, stat err=%v", err)
+	}
+}
+
+func TestDedicatedErrorHookRunsFirstAndFailureDoesNotStopFollowingHooks(t *testing.T) {
+	earlier, later := consecutiveDateLocations(t)
+	previousLocal := time.Local
+	time.Local = earlier
+	t.Cleanup(func() { time.Local = previousLocal })
+
+	logger := logrus.StandardLogger()
+	previousHooks := logger.ReplaceHooks(make(logrus.LevelHooks))
+	t.Cleanup(func() { logger.ReplaceHooks(previousHooks) })
+	existing := &sentinelHook{}
+	logger.AddHook(existing)
+
+	logDir := t.TempDir()
+	closer, err := logging.Configure(config.Config{
+		LogLevel:         "info",
+		LogFileEnabled:   true,
+		LogDir:           logDir,
+		LogRetentionDays: 7,
+	})
+	if err != nil {
+		t.Fatalf("configure logging: %v", err)
+	}
+	t.Cleanup(func() { _ = closer.Close() })
+	configuredHooks := logger.Hooks[logrus.ErrorLevel]
+	if len(configuredHooks) != 2 || configuredHooks[0] == existing || configuredHooks[1] != existing {
+		t.Fatalf("expected dedicated error hook before existing hook, got %#v", configuredHooks)
+	}
+	expiredPath := filepath.Join(logDir, errorLogFilePrefix+time.Now().In(later).AddDate(0, 0, -40).Format("2006-01-02")+".log")
+	if err := os.WriteFile(expiredPath, []byte("expired"), 0644); err != nil {
+		t.Fatalf("write expired error log: %v", err)
+	}
+	errorLogPath := filepath.Join(logDir, errorLogFilePrefix+time.Now().In(later).Format("2006-01-02")+".log")
+	if err := os.Mkdir(errorLogPath, 0755); err != nil {
+		t.Fatalf("create write failure fixture: %v", err)
+	}
+	time.Local = later
+
+	output := captureStderr(t, func() {
+		logrus.Error("dedicated writer fails")
+	})
+	if !strings.Contains(output, "dedicated error log write failed") {
+		t.Fatalf("expected active dedicated hook failure to be exercised, got %q", output)
+	}
+	if existing.fireCount != 1 {
+		t.Fatalf("expected following hook to fire once, got %d", existing.fireCount)
+	}
+	if _, err := os.Stat(expiredPath); !os.IsNotExist(err) {
+		t.Fatalf("expected maintenance before failed error write to remove %s, stat err=%v", expiredPath, err)
+	}
+}
+
+func TestClosedDedicatedErrorHookCannotReopenItsFile(t *testing.T) {
+	logger := logrus.StandardLogger()
+	previousHooks := logger.ReplaceHooks(make(logrus.LevelHooks))
+	t.Cleanup(func() { logger.ReplaceHooks(previousHooks) })
+
+	logDir := t.TempDir()
+	closer, err := logging.Configure(config.Config{
+		LogLevel:         "info",
+		LogFileEnabled:   true,
+		LogDir:           logDir,
+		LogRetentionDays: 7,
+	})
+	if err != nil {
+		t.Fatalf("configure logging: %v", err)
+	}
+	dedicated := logger.Hooks[logrus.ErrorLevel][0]
+	if err := closer.Close(); err != nil {
+		t.Fatalf("close logging: %v", err)
+	}
+
+	errorLogPath := filepath.Join(logDir, errorLogFilePrefix+today()+".log")
+	if err := os.Remove(errorLogPath); err != nil {
+		t.Fatalf("remove closed error log: %v", err)
+	}
+	entry := logrus.NewEntry(logger)
+	entry.Level = logrus.ErrorLevel
+	entry.Message = "late error"
+	_ = captureStderr(t, func() {
+		if err := dedicated.Fire(entry); err != nil {
+			t.Fatalf("expected closed hook failure to stay isolated, got %v", err)
+		}
+	})
+	if _, err := os.Stat(errorLogPath); !os.IsNotExist(err) {
+		t.Fatalf("expected closed hook not to recreate error log, stat err=%v", err)
+	}
+}
+
+func TestConfigureRecoversAfterDailyFileOpenFailure(t *testing.T) {
+	earlier, later := consecutiveDateLocations(t)
+	previousLocal := time.Local
+	time.Local = earlier
+	t.Cleanup(func() { time.Local = previousLocal })
+
+	logDir := t.TempDir()
+	closer, err := logging.Configure(config.Config{
+		LogLevel:         "info",
+		LogFileEnabled:   true,
+		LogDir:           logDir,
+		LogRetentionDays: 7,
+	})
+	if err != nil {
+		t.Fatalf("configure logging: %v", err)
+	}
+	t.Cleanup(func() { _ = closer.Close() })
+
+	laterDate := time.Now().In(later).Format("2006-01-02")
+	laterPath := filepath.Join(logDir, "cpa-usage-keeper-"+laterDate+".log")
+	if err := os.Mkdir(laterPath, 0755); err != nil {
+		t.Fatalf("create rollover failure fixture: %v", err)
+	}
+	time.Local = later
+	logrus.Info("first rollover attempt fails")
+	if err := os.Remove(laterPath); err != nil {
+		t.Fatalf("remove rollover failure fixture: %v", err)
+	}
+
+	logrus.Info("rollover recovers")
+	content, err := os.ReadFile(laterPath)
+	if err != nil {
+		t.Fatalf("read recovered daily log: %v", err)
+	}
+	if !strings.Contains(string(content), "rollover recovers") {
+		t.Fatalf("expected recovered writer to persist later log, got %q", content)
+	}
+}
+
+func TestDedicatedErrorMaintenanceFailureIsReportedOnceForSameDate(t *testing.T) {
+	earlier, later := consecutiveDateLocations(t)
+	previousLocal := time.Local
+	time.Local = earlier
+	t.Cleanup(func() { time.Local = previousLocal })
+
+	baseDir := t.TempDir()
+	logDir := filepath.Join(baseDir, "logs")
+	closer, err := logging.Configure(config.Config{
+		LogLevel:         "info",
+		LogFileEnabled:   true,
+		LogDir:           logDir,
+		LogRetentionDays: 7,
+	})
+	if err != nil {
+		t.Fatalf("configure logging: %v", err)
+	}
+	t.Cleanup(func() { _ = closer.Close() })
+	dedicated := logrus.StandardLogger().Hooks[logrus.InfoLevel][0]
+	entry := logrus.NewEntry(logrus.StandardLogger())
+	entry.Level = logrus.InfoLevel
+	entry.Message = "ordinary maintenance"
+	if err := dedicated.Fire(entry); err != nil {
+		t.Fatalf("initial maintenance hook: %v", err)
+	}
+
+	movedLogDir := filepath.Join(baseDir, "moved-logs")
+	if err := os.Rename(logDir, movedLogDir); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("moving a directory with open files is unavailable on Windows: %v", err)
+		}
+		t.Fatalf("move log directory: %v", err)
+	}
+	time.Local = later
+
+	output := captureStderr(t, func() {
+		if err := dedicated.Fire(entry); err != nil {
+			t.Fatalf("later-date maintenance hook: %v", err)
+		}
+		if err := dedicated.Fire(entry); err != nil {
+			t.Fatalf("repeated same-date maintenance hook: %v", err)
+		}
+	})
+	if count := strings.Count(output, "dedicated error log maintenance failed"); count != 1 {
+		t.Fatalf("expected one maintenance failure report per day, got %d in %q", count, output)
+	}
+	if strings.Contains(output, "dedicated error log write failed") {
+		t.Fatalf("expected maintenance failure not to be reported as write failure, got %q", output)
+	}
+}
+
+func TestConfigureCloseIsIdempotent(t *testing.T) {
+	first, err := logging.Configure(config.Config{
+		LogLevel:         "info",
+		LogFileEnabled:   true,
+		LogDir:           t.TempDir(),
+		LogRetentionDays: 7,
+	})
+	if err != nil {
+		t.Fatalf("configure first logger: %v", err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first logger: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first logger twice: %v", err)
+	}
+}
+
+func TestDedicatedErrorMaintenanceClosesStaleDailyFile(t *testing.T) {
+	earlier, later := consecutiveDateLocations(t)
+	previousLocal := time.Local
+	time.Local = earlier
+	t.Cleanup(func() { time.Local = previousLocal })
+
+	logDir := t.TempDir()
+	closer, err := logging.Configure(config.Config{
+		LogLevel:         "info",
+		LogFileEnabled:   true,
+		LogDir:           logDir,
+		LogRetentionDays: 7,
+	})
+	if err != nil {
+		t.Fatalf("configure logging: %v", err)
+	}
+	t.Cleanup(func() { _ = closer.Close() })
+	dedicated := logrus.StandardLogger().Hooks[logrus.InfoLevel][0]
+	stalePath := filepath.Join(logDir, errorLogFilePrefix+time.Now().Format("2006-01-02")+".log")
+	if count := openFileDescriptorCount(t, stalePath); count == 0 {
+		t.Fatalf("expected dedicated writer to hold %s before maintenance", stalePath)
+	}
+
+	time.Local = later
+	entry := logrus.NewEntry(logrus.StandardLogger())
+	entry.Level = logrus.InfoLevel
+	entry.Message = "advance daily maintenance"
+	if err := dedicated.Fire(entry); err != nil {
+		t.Fatalf("maintenance hook: %v", err)
+	}
+
+	if count := openFileDescriptorCount(t, stalePath); count != 0 {
+		t.Fatalf("expected stale dedicated error file to be closed, found %d descriptors", count)
+	}
+}
+
+func readLogFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log file %s: %v", path, err)
+	}
+	return string(content)
+}
+
+func today() string {
+	return time.Now().Format("2006-01-02")
+}
+
+func consecutiveDateLocations(t *testing.T) (*time.Location, *time.Location) {
+	t.Helper()
+	earlier, err := time.LoadLocation("Pacific/Honolulu")
+	if err != nil {
+		t.Fatalf("load earlier timezone: %v", err)
+	}
+	later, err := time.LoadLocation("Pacific/Kiritimati")
+	if err != nil {
+		t.Fatalf("load later timezone: %v", err)
+	}
+	if time.Now().In(earlier).Format("2006-01-02") == time.Now().In(later).Format("2006-01-02") {
+		t.Fatal("expected test timezones to produce consecutive dates")
+	}
+	return earlier, later
+}
+
+func openFileDescriptorCount(t *testing.T, targetPath string) int {
+	t.Helper()
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		t.Skipf("file descriptor inspection unavailable: %v", err)
+	}
+	targetPath, err = filepath.Abs(targetPath)
+	if err != nil {
+		t.Fatalf("resolve target path: %v", err)
+	}
+	count := 0
+	for _, entry := range entries {
+		link, err := os.Readlink(filepath.Join("/proc/self/fd", entry.Name()))
+		if err != nil {
+			continue
+		}
+		link = strings.TrimSuffix(link, " (deleted)")
+		if link == targetPath {
+			count++
+		}
+	}
+	return count
+}
+
+type sentinelHook struct {
+	fireCount int
+}
+
+func (*sentinelHook) Levels() []logrus.Level { return logrus.AllLevels }
+func (h *sentinelHook) Fire(*logrus.Entry) error {
+	h.fireCount++
+	return nil
+}

--- a/internal/logging/test/error_file_test.go
+++ b/internal/logging/test/error_file_test.go
@@ -68,7 +68,7 @@ func TestConfigureDuplicatesOnlyErrorLevelsToDedicatedDailyFile(t *testing.T) {
 	}
 }
 
-func TestConfigureKeepsCombinedAndErrorRetentionBoundaries(t *testing.T) {
+func TestConfigureCleansCombinedAndErrorRetentionOnInitialization(t *testing.T) {
 	logDir := t.TempDir()
 	now := time.Now()
 	expiredCombined := filepath.Join(logDir, "cpa-usage-keeper-"+now.AddDate(0, 0, -8).Format("2006-01-02")+".log")
@@ -83,13 +83,11 @@ func TestConfigureKeepsCombinedAndErrorRetentionBoundaries(t *testing.T) {
 	}
 
 	_ = captureConsole(t, config.Config{
-		LogLevel:         "info",
+		LogLevel:         "error",
 		LogFileEnabled:   true,
 		LogDir:           logDir,
 		LogRetentionDays: 7,
-	}, func() {
-		logrus.Info("trigger retention maintenance")
-	})
+	}, func() {})
 
 	for _, path := range []string{expiredCombined, expiredError} {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {


### PR DESCRIPTION
## Summary

- duplicate error, fatal, and panic entries into dedicated daily plain-text log files
- retain error logs for the previous 30 local calendar days plus the current day while preserving configurable combined-log retention
- keep retention maintenance best-effort and persist fatal initialization failures before logging shuts down
- document both log files and their retention behavior

## Validation

- `TZ=Asia/Shanghai go test -count=1 ./internal/logging/... ./internal/app/test`
- `TZ=UTC GOFLAGS=-count=1 make verify`
- `go test -race -count=1 ./internal/logging/...`
- Windows amd64 logging test cross-compile