### PR TITLE
perf(analysis): narrow rollup query projections

### DIFF
--- a/internal/repository/test/usage_analysis_projection_test.go
+++ b/internal/repository/test/usage_analysis_projection_test.go
@@ -1,0 +1,434 @@
+package test
+
+import (
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/pricing"
+	"cpa-usage-keeper/internal/repository"
+	repodto "cpa-usage-keeper/internal/repository/dto"
+
+	"gorm.io/gorm"
+)
+
+var analysisProjectionFixedColumns = []string{
+	"bucket_start",
+	"api_group_key",
+	"model",
+	"auth_index",
+	"model_alias",
+	"request_count",
+	"input_tokens",
+	"output_tokens",
+	"reasoning_tokens",
+	"cache_read_tokens",
+	"cache_creation_tokens",
+	"total_tokens",
+}
+
+func TestAnalysisProjectionSelectsOnlyFixedColumnsWithoutPricingRules(t *testing.T) {
+	tests := []struct {
+		name      string
+		start     time.Time
+		end       time.Time
+		wantTable string
+	}{
+		{
+			name:      "hourly",
+			start:     time.Date(2026, 1, 1, 0, 0, 0, 0, time.Local),
+			end:       time.Date(2026, 1, 1, 1, 0, 0, 0, time.Local),
+			wantTable: "usage_overview_hourly_stats",
+		},
+		{
+			name:      "daily",
+			start:     time.Date(2026, 1, 1, 0, 0, 0, 0, time.Local),
+			end:       time.Date(2026, 1, 4, 0, 0, 0, 0, time.Local),
+			wantTable: "usage_overview_daily_stats",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := openTestDatabase(t)
+			queries := captureAnalysisRollupQueries(t, db)
+			if _, err := repository.BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{
+				Range: "custom", StartTime: &tt.start, EndTime: &tt.end, EndExclusive: true,
+			}, emptyPricingResolverForTest()); err != nil {
+				t.Fatalf("BuildAnalysisWithFilter: %v", err)
+			}
+
+			query := requireSingleAnalysisRollupQuery(t, *queries, tt.wantTable)
+			if got := analysisProjectionSelectColumns(t, query); !reflect.DeepEqual(got, analysisProjectionFixedColumns) {
+				t.Fatalf("selected columns = %#v, want %#v\nSQL: %s", got, analysisProjectionFixedColumns, query)
+			}
+			if strings.Contains(query, " group by ") {
+				t.Fatalf("Analysis projection must not use GROUP BY: %s", query)
+			}
+		})
+	}
+}
+
+func TestAnalysisProjectionAddsOnlyActivePricingDimensions(t *testing.T) {
+	tests := []struct {
+		name         string
+		rules        []pricing.RuleConfig
+		wantOptional []string
+	}{
+		{
+			name: "service tier and endpoint",
+			rules: []pricing.RuleConfig{
+				{Key: "service_tier", Value: "priority", Multiplier: 2},
+				{Key: "endpoint", Value: "/responses", Multiplier: 3},
+			},
+			wantOptional: []string{"service_tier", "endpoint"},
+		},
+		{
+			name:         "response service tier",
+			rules:        []pricing.RuleConfig{{Key: "response_service_tier", Value: "batch", Multiplier: 2}},
+			wantOptional: []string{"response_service_tier"},
+		},
+		{
+			name:         "reasoning effort",
+			rules:        []pricing.RuleConfig{{Key: "reasoning_effort", Value: "xhigh", Multiplier: 2}},
+			wantOptional: []string{"reasoning_effort"},
+		},
+		{
+			name:         "executor type",
+			rules:        []pricing.RuleConfig{{Key: "executor_type", Value: "cli", Multiplier: 2}},
+			wantOptional: []string{"executor_type"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := openTestDatabase(t)
+			queries := captureAnalysisRollupQueries(t, db)
+			start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.Local)
+			end := start.Add(time.Hour)
+			if _, err := repository.BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{
+				Range: "custom", StartTime: &start, EndTime: &end, EndExclusive: true,
+			}, repositoryPricingResolver(t, tt.rules)); err != nil {
+				t.Fatalf("BuildAnalysisWithFilter: %v", err)
+			}
+
+			query := requireSingleAnalysisRollupQuery(t, *queries, "usage_overview_hourly_stats")
+			want := append(append([]string{}, analysisProjectionFixedColumns...), tt.wantOptional...)
+			if got := analysisProjectionSelectColumns(t, query); !reflect.DeepEqual(got, want) {
+				t.Fatalf("selected columns = %#v, want %#v\nSQL: %s", got, want, query)
+			}
+		})
+	}
+}
+
+func TestAnalysisProjectionPreservesHourlyResultsAndAPIKeyFiltering(t *testing.T) {
+	db := openTestDatabase(t)
+	bucket := time.Date(2026, 2, 1, 6, 0, 0, 0, time.Local)
+	end := bucket.Add(time.Hour)
+	if err := db.Create(&[]entities.CPAAPIKey{
+		{APIKey: "group-a", DisplayKey: "sk-***a"},
+		{APIKey: "group-deleted", DisplayKey: "sk-***deleted", IsDeleted: true},
+	}).Error; err != nil {
+		t.Fatalf("seed API keys: %v", err)
+	}
+	seedAnalysisProjectionIdentities(t, db, "identity-a")
+	if err := db.Create(&[]entities.UsageOverviewHourlyStat{
+		{
+			BucketStart: bucket, APIGroupKey: "group-a", Model: "model-a", AuthIndex: "identity-a", ModelAlias: "alias-a",
+			ServiceTier: "priority", Endpoint: "/responses", RequestCount: 2, InputTokens: 1_000_000, OutputTokens: 300_000,
+			ReasoningTokens: 100_000, CacheReadTokens: 200_000, CacheCreationTokens: 100_000, TotalTokens: 1_300_000,
+		},
+		{
+			BucketStart: bucket, APIGroupKey: "group-deleted", Model: "model-a", RequestCount: 99,
+			InputTokens: 99_000_000, TotalTokens: 99_000_000,
+		},
+	}).Error; err != nil {
+		t.Fatalf("seed hourly stats: %v", err)
+	}
+	resolver := analysisProjectionPricingResolver(t, []pricing.RuleConfig{
+		{Key: "service_tier", Value: "priority", Multiplier: 2},
+		{Key: "endpoint", Value: "/responses", Multiplier: 3},
+	})
+	analysis, err := repository.BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{
+		Range: "custom", StartTime: &bucket, EndTime: &end, EndExclusive: true,
+	}, resolver)
+	if err != nil {
+		t.Fatalf("BuildAnalysisWithFilter: %v", err)
+	}
+
+	if analysis.Granularity != repodto.AnalysisGranularityHourly || len(analysis.TokenUsage) != 1 {
+		t.Fatalf("unexpected hourly result: %+v", analysis)
+	}
+	usage := analysis.TokenUsage[0]
+	if !usage.Bucket.Equal(bucket) || usage.Requests != 2 || usage.InputTokens != 1_000_000 || usage.OutputTokens != 300_000 ||
+		usage.ReasoningTokens != 100_000 || usage.CacheReadTokens != 200_000 || usage.CacheCreationTokens != 100_000 || usage.TotalTokens != 1_300_000 || !usage.CostAvailable {
+		t.Fatalf("unexpected hourly token usage: %+v", usage)
+	}
+	assertFloatClose(t, usage.CostUSD, 9.3)
+	assertAnalysisProjectionComposition(t, analysis.APIKeyComposition, "group-a", "", 2, 1_300_000, 9.3)
+	assertAnalysisProjectionComposition(t, analysis.ModelComposition, "model-a", "", 2, 1_300_000, 9.3)
+	assertAnalysisProjectionComposition(t, analysis.AuthFilesComposition, "identity-a", "Auth Account", 2, 1_300_000, 9.3)
+	assertAnalysisProjectionComposition(t, analysis.AIProviderComposition, "identity-a", "Provider Account", 2, 1_300_000, 9.3)
+	if len(analysis.Heatmap) != 1 || analysis.Heatmap[0].APIKey != "group-a" || analysis.Heatmap[0].Model != "model-a" ||
+		analysis.Heatmap[0].Requests != 2 || analysis.Heatmap[0].TotalTokens != 1_300_000 || !analysis.Heatmap[0].CostAvailable {
+		t.Fatalf("unexpected heatmap: %+v", analysis.Heatmap)
+	}
+	assertFloatClose(t, analysis.Heatmap[0].CostUSD, 9.3)
+	if len(analysis.ModelEfficiency) != 1 {
+		t.Fatalf("unexpected model efficiency: %+v", analysis.ModelEfficiency)
+	}
+	efficiency := analysis.ModelEfficiency[0]
+	if efficiency.Model != "model-a" || efficiency.Requests != 2 || efficiency.TotalTokens != 1_300_000 || !efficiency.CostAvailable {
+		t.Fatalf("unexpected model efficiency: %+v", efficiency)
+	}
+	assertFloatClose(t, efficiency.CostUSD, 9.3)
+	assertFloatClose(t, efficiency.CostPerRequestUSD, 4.65)
+	assertFloatClose(t, efficiency.OutputTokensPerRequest, 150_000)
+	assertFloatClose(t, efficiency.CacheReadRate, 0.2)
+	assertFloatClose(t, analysis.CostBreakdown.UncachedInputCostUSD, 4.2)
+	assertFloatClose(t, analysis.CostBreakdown.CacheReadCostUSD, 0.6)
+	assertFloatClose(t, analysis.CostBreakdown.CacheWriteCostUSD, 0.9)
+	assertFloatClose(t, analysis.CostBreakdown.OutputCostUSD, 3.6)
+	assertFloatClose(t, analysis.CostBreakdown.TotalCostUSD, 9.3)
+	if !analysis.CostBreakdown.CostAvailable {
+		t.Fatalf("expected available cost breakdown: %+v", analysis.CostBreakdown)
+	}
+
+	if err := db.Create(&entities.CPAAPIKey{APIKey: "group-b", DisplayKey: "sk-***b"}).Error; err != nil {
+		t.Fatalf("seed second active API key: %v", err)
+	}
+	if err := db.Create(&entities.UsageOverviewHourlyStat{
+		BucketStart: bucket, APIGroupKey: "group-b", Model: "model-a", RequestCount: 7, InputTokens: 7_000, TotalTokens: 7_000,
+	}).Error; err != nil {
+		t.Fatalf("seed filtered hourly stat: %v", err)
+	}
+	filtered, err := repository.BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{
+		Range: "custom", APIGroupKey: "group-a", StartTime: &bucket, EndTime: &end, EndExclusive: true,
+	}, resolver)
+	if err != nil {
+		t.Fatalf("BuildAnalysisWithFilter with API key: %v", err)
+	}
+	assertAnalysisProjectionComposition(t, filtered.APIKeyComposition, "group-a", "", 2, 1_300_000, 9.3)
+}
+
+func TestAnalysisProjectionPreservesDailyAndBoundaryHourlyResults(t *testing.T) {
+	db := openTestDatabase(t)
+	start := time.Date(2026, 2, 1, 5, 0, 0, 0, time.Local)
+	end := time.Date(2026, 2, 4, 8, 0, 0, 0, time.Local)
+	if err := db.Create(&entities.CPAAPIKey{APIKey: "group-a", DisplayKey: "sk-***a"}).Error; err != nil {
+		t.Fatalf("seed API key: %v", err)
+	}
+	seedAnalysisProjectionIdentities(t, db, "identity-a")
+	sharedHourly := func(bucket time.Time, requests, input, output, reasoning, cacheRead, cacheCreation, total int64) entities.UsageOverviewHourlyStat {
+		return entities.UsageOverviewHourlyStat{
+			BucketStart: bucket, APIGroupKey: "group-a", Model: "model-a", AuthIndex: "identity-a", ModelAlias: "alias-a",
+			ResponseServiceTier: "batch", ReasoningEffort: "xhigh", ExecutorType: "cli", RequestCount: requests,
+			InputTokens: input, OutputTokens: output, ReasoningTokens: reasoning, CacheReadTokens: cacheRead,
+			CacheCreationTokens: cacheCreation, TotalTokens: total,
+		}
+	}
+	if err := db.Create(&[]entities.UsageOverviewHourlyStat{
+		sharedHourly(time.Date(2026, 2, 1, 6, 0, 0, 0, time.Local), 1, 100, 10, 2, 20, 10, 110),
+		sharedHourly(time.Date(2026, 2, 4, 2, 0, 0, 0, time.Local), 3, 300, 30, 6, 60, 30, 330),
+	}).Error; err != nil {
+		t.Fatalf("seed boundary hourly stats: %v", err)
+	}
+	if err := db.Create(&entities.UsageOverviewDailyStat{
+		BucketStart: time.Date(2026, 2, 2, 0, 0, 0, 0, time.Local), APIGroupKey: "group-a", Model: "model-a",
+		AuthIndex: "identity-a", ModelAlias: "alias-a", ResponseServiceTier: "batch", ReasoningEffort: "xhigh", ExecutorType: "cli",
+		RequestCount: 2, InputTokens: 200, OutputTokens: 20, ReasoningTokens: 4, CacheReadTokens: 40,
+		CacheCreationTokens: 20, TotalTokens: 220,
+	}).Error; err != nil {
+		t.Fatalf("seed daily stat: %v", err)
+	}
+	resolver := analysisProjectionPricingResolver(t, []pricing.RuleConfig{
+		{Key: "response_service_tier", Value: "batch", Multiplier: 2},
+		{Key: "reasoning_effort", Value: "xhigh", Multiplier: 3},
+		{Key: "executor_type", Value: "cli", Multiplier: 4},
+	})
+	analysis, err := repository.BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{
+		Range: "custom", StartTime: &start, EndTime: &end, EndExclusive: true,
+	}, resolver)
+	if err != nil {
+		t.Fatalf("BuildAnalysisWithFilter: %v", err)
+	}
+
+	if analysis.Granularity != repodto.AnalysisGranularityDaily || len(analysis.TokenUsage) != 3 {
+		t.Fatalf("unexpected daily result: %+v", analysis)
+	}
+	wantBuckets := []struct {
+		bucket   time.Time
+		requests int64
+		tokens   int64
+	}{
+		{time.Date(2026, 2, 1, 0, 0, 0, 0, time.Local), 1, 110},
+		{time.Date(2026, 2, 2, 0, 0, 0, 0, time.Local), 2, 220},
+		{time.Date(2026, 2, 4, 0, 0, 0, 0, time.Local), 3, 330},
+	}
+	for i, want := range wantBuckets {
+		got := analysis.TokenUsage[i]
+		if !got.Bucket.Equal(want.bucket) || got.Requests != want.requests || got.TotalTokens != want.tokens || !got.CostAvailable {
+			t.Fatalf("token usage[%d] = %+v, want bucket=%v requests=%d total=%d", i, got, want.bucket, want.requests, want.tokens)
+		}
+	}
+	assertAnalysisProjectionComposition(t, analysis.APIKeyComposition, "group-a", "", 6, 660, 0.01656)
+	assertAnalysisProjectionComposition(t, analysis.ModelComposition, "model-a", "", 6, 660, 0.01656)
+	assertAnalysisProjectionComposition(t, analysis.AuthFilesComposition, "identity-a", "Auth Account", 6, 660, 0.01656)
+	assertAnalysisProjectionComposition(t, analysis.AIProviderComposition, "identity-a", "Provider Account", 6, 660, 0.01656)
+	if len(analysis.Heatmap) != 1 || analysis.Heatmap[0].Requests != 6 || analysis.Heatmap[0].TotalTokens != 660 {
+		t.Fatalf("unexpected daily heatmap: %+v", analysis.Heatmap)
+	}
+	assertFloatClose(t, analysis.Heatmap[0].CostUSD, 0.01656)
+	if len(analysis.ModelEfficiency) != 1 || analysis.ModelEfficiency[0].Requests != 6 || analysis.ModelEfficiency[0].TotalTokens != 660 {
+		t.Fatalf("unexpected daily model efficiency: %+v", analysis.ModelEfficiency)
+	}
+	assertFloatClose(t, analysis.ModelEfficiency[0].CostUSD, 0.01656)
+	assertFloatClose(t, analysis.CostBreakdown.UncachedInputCostUSD, 0.01008)
+	assertFloatClose(t, analysis.CostBreakdown.CacheReadCostUSD, 0.00144)
+	assertFloatClose(t, analysis.CostBreakdown.CacheWriteCostUSD, 0.00216)
+	assertFloatClose(t, analysis.CostBreakdown.OutputCostUSD, 0.00288)
+	assertFloatClose(t, analysis.CostBreakdown.TotalCostUSD, 0.01656)
+}
+
+func TestBuildAnalysisWithoutUsageEventsUsesOnlyRollupTables(t *testing.T) {
+	db := openTestDatabase(t)
+	bucket := time.Date(2026, 3, 1, 8, 0, 0, 0, time.Local)
+	end := bucket.Add(time.Hour)
+	if err := db.Create(&entities.CPAAPIKey{APIKey: "group-a", DisplayKey: "sk-***a"}).Error; err != nil {
+		t.Fatalf("seed API key: %v", err)
+	}
+	if err := db.Create(&entities.UsageOverviewHourlyStat{
+		BucketStart: bucket, APIGroupKey: "group-a", Model: "model-a", RequestCount: 1, InputTokens: 10, TotalTokens: 10,
+	}).Error; err != nil {
+		t.Fatalf("seed hourly stat: %v", err)
+	}
+	if err := db.Migrator().DropTable(&entities.UsageEvent{}); err != nil {
+		t.Fatalf("drop usage_events: %v", err)
+	}
+	queries := captureAllAnalysisQueries(t, db)
+	analysis, err := repository.BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{
+		Range: "custom", StartTime: &bucket, EndTime: &end, EndExclusive: true,
+	}, emptyPricingResolverForTest())
+	if err != nil {
+		t.Fatalf("BuildAnalysisWithFilter without usage_events: %v", err)
+	}
+	if len(analysis.TokenUsage) != 1 || analysis.TokenUsage[0].TotalTokens != 10 {
+		t.Fatalf("unexpected Analysis result without usage_events: %+v", analysis)
+	}
+	foundRollup := false
+	for _, query := range *queries {
+		if strings.Contains(query, "usage_events") {
+			t.Fatalf("Analysis queried usage_events: %s", query)
+		}
+		if strings.Contains(query, "usage_overview_hourly_stats") {
+			foundRollup = true
+		}
+	}
+	if !foundRollup {
+		t.Fatalf("expected Analysis to query hourly rollup, got %#v", *queries)
+	}
+}
+
+func captureAnalysisRollupQueries(t *testing.T, db *gorm.DB) *[]string {
+	t.Helper()
+	rollupQueries := make([]string, 0, 3)
+	callbackName := "test:capture-analysis-rollup-only:" + strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+	if err := db.Callback().Query().After("gorm:query").Register(callbackName, func(tx *gorm.DB) {
+		query := strings.ToLower(strings.Join(strings.Fields(tx.Statement.SQL.String()), " "))
+		if strings.Contains(query, "usage_overview_hourly_stats") || strings.Contains(query, "usage_overview_daily_stats") {
+			rollupQueries = append(rollupQueries, query)
+		}
+	}); err != nil {
+		t.Fatalf("register rollup query callback: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Callback().Query().Remove(callbackName) })
+	return &rollupQueries
+}
+
+func captureAllAnalysisQueries(t *testing.T, db *gorm.DB) *[]string {
+	t.Helper()
+	queries := make([]string, 0, 4)
+	callbackName := "test:capture-analysis-all:" + strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+	if err := db.Callback().Query().After("gorm:query").Register(callbackName, func(tx *gorm.DB) {
+		queries = append(queries, strings.ToLower(strings.Join(strings.Fields(tx.Statement.SQL.String()), " ")))
+	}); err != nil {
+		t.Fatalf("register query callback: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Callback().Query().Remove(callbackName) })
+	return &queries
+}
+
+func requireSingleAnalysisRollupQuery(t *testing.T, queries []string, table string) string {
+	t.Helper()
+	matching := make([]string, 0, 1)
+	for _, query := range queries {
+		if strings.Contains(query, table) {
+			matching = append(matching, query)
+		}
+	}
+	if len(matching) != 1 {
+		t.Fatalf("queries for %s = %#v, want exactly one", table, matching)
+	}
+	return matching[0]
+}
+
+func analysisProjectionSelectColumns(t *testing.T, query string) []string {
+	t.Helper()
+	selectStart := strings.Index(query, "select ")
+	fromStart := strings.Index(query, " from ")
+	if selectStart < 0 || fromStart < 0 || fromStart <= selectStart {
+		t.Fatalf("cannot parse SELECT columns from %q", query)
+	}
+	parts := strings.Split(query[selectStart+len("select "):fromStart], ",")
+	columns := make([]string, 0, len(parts))
+	for _, part := range parts {
+		column := strings.TrimSpace(strings.ReplaceAll(part, "`", ""))
+		if dot := strings.LastIndex(column, "."); dot >= 0 {
+			column = column[dot+1:]
+		}
+		columns = append(columns, column)
+	}
+	return columns
+}
+
+func seedAnalysisProjectionIdentities(t *testing.T, db *gorm.DB, identity string) {
+	t.Helper()
+	if err := db.Create(&[]entities.UsageIdentity{
+		{AuthType: entities.UsageIdentityAuthTypeAuthFile, AuthTypeName: "authfile", Identity: identity, Name: "Auth Account"},
+		{AuthType: entities.UsageIdentityAuthTypeAIProvider, AuthTypeName: "apikey", Identity: identity, Name: "Provider Account"},
+	}).Error; err != nil {
+		t.Fatalf("seed usage identities: %v", err)
+	}
+}
+
+func analysisProjectionPricingResolver(t *testing.T, rules []pricing.RuleConfig) pricing.Resolver {
+	t.Helper()
+	multiplier := 1.0
+	snapshot, err := pricing.CompileSnapshot([]pricing.ModelConfig{{
+		Pricing: entities.ModelPriceSetting{
+			Model: "model-a", PricingStyle: entities.ModelPricingStyleOpenAI, PromptPricePer1M: 1,
+			CompletionPricePer1M: 2, CacheReadPricePer1M: 0.5, CacheWritePricePer1M: 1.5, PriceMultiplier: &multiplier,
+		},
+		Rules: rules,
+	}})
+	if err != nil {
+		t.Fatalf("CompileSnapshot: %v", err)
+	}
+	return pricing.NewCatalog(snapshot).NewResolver()
+}
+
+func assertAnalysisProjectionComposition(t *testing.T, got []repodto.AnalysisCompositionRecord, key, label string, requests, totalTokens int64, cost float64) {
+	t.Helper()
+	if len(got) != 1 || got[0].Key != key || got[0].Label != label || got[0].Requests != requests || got[0].TotalTokens != totalTokens || !got[0].CostAvailable {
+		t.Fatalf("composition = %+v, want key=%q label=%q requests=%d total=%d", got, key, label, requests, totalTokens)
+	}
+	assertFloatClose(t, got[0].CostUSD, cost)
+}
+
+func assertFloatClose(t *testing.T, got, want float64) {
+	t.Helper()
+	if math.Abs(got-want) > 1e-12 {
+		t.Fatalf("got %.15f, want %.15f", got, want)
+	}
+}

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -359,6 +359,8 @@ func BuildAnalysisWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, costResol
 	if filter.StartTime == nil || filter.EndTime == nil {
 		return nil, fmt.Errorf("analysis requires start_time and end_time")
 	}
+	// 同一请求内固定一次价格字段快照，确保 daily 与两侧 hourly 边界使用完全相同的查询维度。
+	activeFields := costResolver.ActiveFields()
 	windowMinutes := computeWindowMinutes(filter)
 	bucketByDay := windowMinutes > 24*60
 	record := &dto.AnalysisRecord{
@@ -382,34 +384,34 @@ func BuildAnalysisWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, costResol
 	}
 	if bucketByDay {
 		fullDayStart, fullDayEnd := usageOverviewFullDayWindow(fullStart, fullEnd)
-		var dailyRows []entities.UsageOverviewDailyStat
+		var dailyRows []analysisOverviewStatProjection
 		if fullDayEnd.After(fullDayStart) {
 			var err error
-			dailyRows, err = loadAnalysisOverviewDailyStatsWithFilter(db, filter, fullDayStart, fullDayEnd)
+			dailyRows, err = loadAnalysisOverviewDailyStatsWithFilter(db, filter, fullDayStart, fullDayEnd, activeFields)
 			if err != nil {
 				return nil, err
 			}
 		}
-		hourlyRows, err := loadAnalysisDailyBoundaryHourlyStatsWithFilter(db, filter, fullStart, fullDayStart, fullDayEnd, fullEnd)
+		hourlyRows, err := loadAnalysisDailyBoundaryHourlyStatsWithFilter(db, filter, fullStart, fullDayStart, fullDayEnd, fullEnd, activeFields)
 		if err != nil {
 			return nil, err
 		}
-		dailyIdentityLookup, err := loadAnalysisDailyIdentityLookup(db, dailyRows)
+		dailyIdentityLookup, err := loadAnalysisProjectionIdentityLookup(db, dailyRows)
 		if err != nil {
 			return nil, err
 		}
-		hourlyIdentityLookup, err := loadAnalysisHourlyIdentityLookup(db, hourlyRows)
+		hourlyIdentityLookup, err := loadAnalysisProjectionIdentityLookup(db, hourlyRows)
 		if err != nil {
 			return nil, err
 		}
 		applyAnalysisDailyAndBoundaryHourlyRows(record, dailyRows, dailyIdentityLookup, hourlyRows, hourlyIdentityLookup, costResolver)
 		return record, nil
 	}
-	rows, err := loadAnalysisOverviewHourlyStatsWithFilter(db, filter, fullStart, fullEnd)
+	rows, err := loadAnalysisOverviewHourlyStatsWithFilter(db, filter, fullStart, fullEnd, activeFields)
 	if err != nil {
 		return nil, err
 	}
-	identityLookup, err := loadAnalysisHourlyIdentityLookup(db, rows)
+	identityLookup, err := loadAnalysisProjectionIdentityLookup(db, rows)
 	if err != nil {
 		return nil, err
 	}
@@ -560,23 +562,11 @@ func sampleAnalysisLatencyPoints(ttftValues, latencyValues []int64) ([]dto.Analy
 	return points, true
 }
 
-func loadAnalysisHourlyIdentityLookup(db *gorm.DB, rows []entities.UsageOverviewHourlyStat) (analysisIdentityLookup, error) {
-	return loadAnalysisIdentityLookup(db, collectAnalysisAuthIndexes(len(rows), func(i int) string {
-		return rows[i].AuthIndex
-	}))
-}
-
-func loadAnalysisDailyIdentityLookup(db *gorm.DB, rows []entities.UsageOverviewDailyStat) (analysisIdentityLookup, error) {
-	return loadAnalysisIdentityLookup(db, collectAnalysisAuthIndexes(len(rows), func(i int) string {
-		return rows[i].AuthIndex
-	}))
-}
-
-func collectAnalysisAuthIndexes(count int, authIndexAt func(int) string) []string {
-	authIndexes := make([]string, 0, count)
+func loadAnalysisProjectionIdentityLookup(db *gorm.DB, rows []analysisOverviewStatProjection) (analysisIdentityLookup, error) {
+	authIndexes := make([]string, 0, len(rows))
 	seen := map[string]struct{}{}
-	for i := range count {
-		authIndex := strings.TrimSpace(authIndexAt(i))
+	for _, row := range rows {
+		authIndex := strings.TrimSpace(row.AuthIndex)
 		if authIndex == "" {
 			continue
 		}
@@ -586,7 +576,7 @@ func collectAnalysisAuthIndexes(count int, authIndexAt func(int) string) []strin
 		seen[authIndex] = struct{}{}
 		authIndexes = append(authIndexes, authIndex)
 	}
-	return authIndexes
+	return loadAnalysisIdentityLookup(db, authIndexes)
 }
 
 func loadAnalysisIdentityLookup(db *gorm.DB, authIndexes []string) (analysisIdentityLookup, error) {
@@ -611,7 +601,7 @@ func loadAnalysisIdentityLookup(db *gorm.DB, authIndexes []string) (analysisIden
 	return lookup, nil
 }
 
-func applyAnalysisHourlyRows(record *dto.AnalysisRecord, rows []entities.UsageOverviewHourlyStat, identityLookup analysisIdentityLookup, costResolver pricing.Resolver) {
+func applyAnalysisHourlyRows(record *dto.AnalysisRecord, rows []analysisOverviewStatProjection, identityLookup analysisIdentityLookup, costResolver pricing.Resolver) {
 	bucketTotals := map[time.Time]*dto.AnalysisTokenUsageBucketRecord{}
 	apiTotals := map[string]*dto.AnalysisCompositionRecord{}
 	modelTotals := map[string]*dto.AnalysisCompositionRecord{}
@@ -620,7 +610,7 @@ func applyAnalysisHourlyRows(record *dto.AnalysisRecord, rows []entities.UsageOv
 	heatmapTotals := map[analysisHeatmapKey]*dto.AnalysisHeatmapRecord{}
 	for _, row := range rows {
 		bucket := timeutil.NormalizeStorageTime(row.BucketStart).Truncate(time.Hour)
-		costResult := costResolver.Calculate(UsageOverviewHourlyCostSubject(row))
+		costResult := calculateAnalysisOverviewProjectionCost(costResolver, row)
 		cost, costAvailable := costResult.Cost, costResult.Available
 		applyAnalysisRow(record, bucketTotals, apiTotals, modelTotals, heatmapTotals, bucket, row.APIGroupKey, row.Model, row.RequestCount, row.InputTokens, row.OutputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, row.TotalTokens, cost, costAvailable)
 		applyAnalysisIdentityComposition(identityLookup, authFileTotals, aiProviderTotals, row.AuthIndex, row.RequestCount, row.InputTokens, row.OutputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, row.TotalTokens, cost, costAvailable)
@@ -628,7 +618,7 @@ func applyAnalysisHourlyRows(record *dto.AnalysisRecord, rows []entities.UsageOv
 	finalizeAnalysisRecord(record, bucketTotals, apiTotals, modelTotals, authFileTotals, aiProviderTotals, heatmapTotals)
 }
 
-func applyAnalysisDailyAndBoundaryHourlyRows(record *dto.AnalysisRecord, dailyRows []entities.UsageOverviewDailyStat, dailyIdentityLookup analysisIdentityLookup, hourlyRows []entities.UsageOverviewHourlyStat, hourlyIdentityLookup analysisIdentityLookup, costResolver pricing.Resolver) {
+func applyAnalysisDailyAndBoundaryHourlyRows(record *dto.AnalysisRecord, dailyRows []analysisOverviewStatProjection, dailyIdentityLookup analysisIdentityLookup, hourlyRows []analysisOverviewStatProjection, hourlyIdentityLookup analysisIdentityLookup, costResolver pricing.Resolver) {
 	bucketTotals := map[time.Time]*dto.AnalysisTokenUsageBucketRecord{}
 	apiTotals := map[string]*dto.AnalysisCompositionRecord{}
 	modelTotals := map[string]*dto.AnalysisCompositionRecord{}
@@ -637,7 +627,7 @@ func applyAnalysisDailyAndBoundaryHourlyRows(record *dto.AnalysisRecord, dailyRo
 	heatmapTotals := map[analysisHeatmapKey]*dto.AnalysisHeatmapRecord{}
 	for _, row := range dailyRows {
 		bucket := timeutil.NormalizeStorageTime(row.BucketStart)
-		costResult := costResolver.Calculate(UsageOverviewDailyCostSubject(row))
+		costResult := calculateAnalysisOverviewProjectionCost(costResolver, row)
 		cost, costAvailable := costResult.Cost, costResult.Available
 		applyAnalysisRow(record, bucketTotals, apiTotals, modelTotals, heatmapTotals, bucket, row.APIGroupKey, row.Model, row.RequestCount, row.InputTokens, row.OutputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, row.TotalTokens, cost, costAvailable)
 		applyAnalysisIdentityComposition(dailyIdentityLookup, authFileTotals, aiProviderTotals, row.AuthIndex, row.RequestCount, row.InputTokens, row.OutputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, row.TotalTokens, cost, costAvailable)
@@ -645,7 +635,7 @@ func applyAnalysisDailyAndBoundaryHourlyRows(record *dto.AnalysisRecord, dailyRo
 	for _, row := range hourlyRows {
 		bucketStart := timeutil.NormalizeStorageTime(row.BucketStart)
 		bucket := time.Date(bucketStart.Year(), bucketStart.Month(), bucketStart.Day(), 0, 0, 0, 0, bucketStart.Location())
-		costResult := costResolver.Calculate(UsageOverviewHourlyCostSubject(row))
+		costResult := calculateAnalysisOverviewProjectionCost(costResolver, row)
 		cost, costAvailable := costResult.Cost, costResult.Available
 		applyAnalysisRow(record, bucketTotals, apiTotals, modelTotals, heatmapTotals, bucket, row.APIGroupKey, row.Model, row.RequestCount, row.InputTokens, row.OutputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, row.TotalTokens, cost, costAvailable)
 		applyAnalysisIdentityComposition(hourlyIdentityLookup, authFileTotals, aiProviderTotals, row.AuthIndex, row.RequestCount, row.InputTokens, row.OutputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, row.TotalTokens, cost, costAvailable)
@@ -1204,23 +1194,6 @@ func usageOverviewEventInsideWindow(event entities.UsageEvent, start, end time.T
 	return !timestamp.Before(start) && timestamp.Before(end)
 }
 
-func loadAnalysisOverviewHourlyStatsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time) ([]entities.UsageOverviewHourlyStat, error) {
-	return loadUsageOverviewHourlyStats(db, filter, start, end, true)
-}
-
-func loadAnalysisDailyBoundaryHourlyStatsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, fullStart, fullDayStart, fullDayEnd, fullEnd time.Time) ([]entities.UsageOverviewHourlyStat, error) {
-	windows := analysisDailyBoundaryHourlyWindows(fullStart, fullDayStart, fullDayEnd, fullEnd)
-	rows := make([]entities.UsageOverviewHourlyStat, 0)
-	for _, window := range windows {
-		windowRows, err := loadAnalysisOverviewHourlyStatsWithFilter(db, filter, window.start, window.end)
-		if err != nil {
-			return nil, err
-		}
-		rows = append(rows, windowRows...)
-	}
-	return rows, nil
-}
-
 func analysisDailyBoundaryHourlyWindows(fullStart, fullDayStart, fullDayEnd, fullEnd time.Time) []usageOverviewRawEventWindow {
 	windows := make([]usageOverviewRawEventWindow, 0, 2)
 	leftEnd := fullDayStart
@@ -1238,44 +1211,6 @@ func analysisDailyBoundaryHourlyWindows(fullStart, fullDayStart, fullDayEnd, ful
 		windows = append(windows, usageOverviewRawEventWindow{start: rightStart, end: fullEnd})
 	}
 	return mergeUsageOverviewRawEventWindows(windows)
-}
-
-func loadUsageOverviewHourlyStats(db *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time, activeCPAAPIKeysOnly bool) ([]entities.UsageOverviewHourlyStat, error) {
-	var rows []entities.UsageOverviewHourlyStat
-	query := db.Model(&entities.UsageOverviewHourlyStat{}).
-		Where("bucket_start >= ? AND bucket_start < ?", timeutil.FormatStorageTime(start), timeutil.FormatStorageTime(end)).
-		Order("bucket_start asc")
-	if activeCPAAPIKeysOnly {
-		query = query.Joins("INNER JOIN cpa_api_keys ON cpa_api_keys.api_key = usage_overview_hourly_stats.api_group_key AND cpa_api_keys.is_deleted = ?", false)
-	}
-	if apiGroupKey := strings.TrimSpace(filter.APIGroupKey); apiGroupKey != "" {
-		query = query.Where("api_group_key = ?", apiGroupKey)
-	}
-	if err := query.Find(&rows).Error; err != nil {
-		return nil, fmt.Errorf("load usage overview hourly stats: %w", err)
-	}
-	return rows, nil
-}
-
-func loadAnalysisOverviewDailyStatsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time) ([]entities.UsageOverviewDailyStat, error) {
-	return loadUsageOverviewDailyStats(db, filter, start, end, true)
-}
-
-func loadUsageOverviewDailyStats(db *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time, activeCPAAPIKeysOnly bool) ([]entities.UsageOverviewDailyStat, error) {
-	var rows []entities.UsageOverviewDailyStat
-	query := db.Model(&entities.UsageOverviewDailyStat{}).
-		Where("bucket_start >= ? AND bucket_start < ?", timeutil.FormatStorageTime(start), timeutil.FormatStorageTime(end)).
-		Order("bucket_start asc")
-	if activeCPAAPIKeysOnly {
-		query = query.Joins("INNER JOIN cpa_api_keys ON cpa_api_keys.api_key = usage_overview_daily_stats.api_group_key AND cpa_api_keys.is_deleted = ?", false)
-	}
-	if apiGroupKey := strings.TrimSpace(filter.APIGroupKey); apiGroupKey != "" {
-		query = query.Where("api_group_key = ?", apiGroupKey)
-	}
-	if err := query.Find(&rows).Error; err != nil {
-		return nil, fmt.Errorf("load usage overview daily stats: %w", err)
-	}
-	return rows, nil
 }
 
 func loadUsageOverviewRawEventWindowsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, windows []usageOverviewRawEventWindow, recentCache *UsageRecentEventCache, activeFields pricing.ActiveFields) ([]entities.UsageEvent, error) {

--- a/internal/repository/usage_analysis_projection.go
+++ b/internal/repository/usage_analysis_projection.go
@@ -1,0 +1,126 @@
+package repository
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/pricing"
+	"cpa-usage-keeper/internal/repository/dto"
+	"cpa-usage-keeper/internal/timeutil"
+
+	"gorm.io/gorm"
+)
+
+// analysisOverviewStatProjection 同时承接 hourly 与 daily 聚合表的 Analysis 窄投影。
+type analysisOverviewStatProjection struct {
+	BucketStart         time.Time
+	APIGroupKey         string
+	Model               string
+	AuthIndex           string
+	ModelAlias          string
+	ServiceTier         string
+	ResponseServiceTier string
+	ReasoningEffort     string
+	Endpoint            string
+	ExecutorType        string
+	RequestCount        int64
+	InputTokens         int64
+	OutputTokens        int64
+	ReasoningTokens     int64
+	CacheReadTokens     int64
+	CacheCreationTokens int64
+	TotalTokens         int64
+}
+
+var analysisOverviewProjectionFixedColumns = [...]string{
+	"bucket_start",
+	"api_group_key",
+	"model",
+	"auth_index",
+	"model_alias",
+	"request_count",
+	"input_tokens",
+	"output_tokens",
+	"reasoning_tokens",
+	"cache_read_tokens",
+	"cache_creation_tokens",
+	"total_tokens",
+}
+
+func analysisOverviewProjectionColumns(activeFields pricing.ActiveFields) string {
+	columns := make([]string, 0, len(analysisOverviewProjectionFixedColumns)+activeFields.Len())
+	seen := make(map[string]struct{}, len(analysisOverviewProjectionFixedColumns)+activeFields.Len())
+	for _, column := range analysisOverviewProjectionFixedColumns {
+		columns = append(columns, column)
+		seen[column] = struct{}{}
+	}
+	// 价格维度只能来自编译后的固定枚举；展示必需列已固定读取，这里只追加实际启用且未重复的条件列。
+	for _, column := range UsagePricingDimensionColumns(activeFields) {
+		if _, ok := seen[column]; ok {
+			continue
+		}
+		columns = append(columns, column)
+		seen[column] = struct{}{}
+	}
+	return strings.Join(columns, ", ")
+}
+
+func loadAnalysisOverviewHourlyStatsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time, activeFields pricing.ActiveFields) ([]analysisOverviewStatProjection, error) {
+	query := db.Model(&entities.UsageOverviewHourlyStat{}).
+		Joins("INNER JOIN cpa_api_keys ON cpa_api_keys.api_key = usage_overview_hourly_stats.api_group_key AND cpa_api_keys.is_deleted = ?", false)
+	return loadAnalysisOverviewStatProjection(query, filter, start, end, "hourly", activeFields)
+}
+
+func loadAnalysisOverviewDailyStatsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time, activeFields pricing.ActiveFields) ([]analysisOverviewStatProjection, error) {
+	query := db.Model(&entities.UsageOverviewDailyStat{}).
+		Joins("INNER JOIN cpa_api_keys ON cpa_api_keys.api_key = usage_overview_daily_stats.api_group_key AND cpa_api_keys.is_deleted = ?", false)
+	return loadAnalysisOverviewStatProjection(query, filter, start, end, "daily", activeFields)
+}
+
+func loadAnalysisOverviewStatProjection(query *gorm.DB, filter dto.UsageQueryFilter, start, end time.Time, grain string, activeFields pricing.ActiveFields) ([]analysisOverviewStatProjection, error) {
+	rows := make([]analysisOverviewStatProjection, 0)
+	query = query.
+		Select(analysisOverviewProjectionColumns(activeFields)).
+		Where("bucket_start >= ? AND bucket_start < ?", timeutil.FormatStorageTime(start), timeutil.FormatStorageTime(end)).
+		Order("bucket_start asc")
+	if apiGroupKey := strings.TrimSpace(filter.APIGroupKey); apiGroupKey != "" {
+		query = query.Where("api_group_key = ?", apiGroupKey)
+	}
+	if err := query.Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("load usage overview %s stats: %w", grain, err)
+	}
+	return rows, nil
+}
+
+func loadAnalysisDailyBoundaryHourlyStatsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, fullStart, fullDayStart, fullDayEnd, fullEnd time.Time, activeFields pricing.ActiveFields) ([]analysisOverviewStatProjection, error) {
+	windows := analysisDailyBoundaryHourlyWindows(fullStart, fullDayStart, fullDayEnd, fullEnd)
+	rows := make([]analysisOverviewStatProjection, 0)
+	for _, window := range windows {
+		windowRows, err := loadAnalysisOverviewHourlyStatsWithFilter(db, filter, window.start, window.end, activeFields)
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, windowRows...)
+	}
+	return rows, nil
+}
+
+func calculateAnalysisOverviewProjectionCost(costResolver pricing.Resolver, row analysisOverviewStatProjection) pricing.CostResult {
+	return costResolver.Calculate(newUsagePricingCostSubject(
+		row.APIGroupKey,
+		row.Model,
+		row.AuthIndex,
+		row.ModelAlias,
+		row.ServiceTier,
+		row.ResponseServiceTier,
+		row.ReasoningEffort,
+		row.Endpoint,
+		row.ExecutorType,
+		row.InputTokens,
+		row.OutputTokens,
+		row.CacheReadTokens,
+		row.CacheCreationTokens,
+	))
+}


### PR DESCRIPTION
## Summary

- replace full hourly and daily Analysis rollup entity loads with a fixed narrow projection
- append only pricing dimensions active in the request-level resolver snapshot
- preserve active API key filtering, identity composition, token and cost aggregation, and response ordering without querying `usage_events` or using SQL `GROUP BY`

## Validation

- `TZ=UTC GOCACHE=/tmp/cpa-usage-keeper-go-build go test ./internal/repository/... -run "Test.*Analysis" -count=1`
- `TZ=Asia/Shanghai GOCACHE=/tmp/cpa-usage-keeper-go-build go test ./internal/repository/... -run "Test.*Analysis" -count=1`
- `TZ=UTC GOCACHE=/tmp/cpa-usage-keeper-go-build GOFLAGS=-count=1 make verify`