### PR TITLE
feat(ui): refresh login page branding

### DIFF
--- a/web/src/i18n/index.test.ts
+++ b/web/src/i18n/index.test.ts
@@ -306,9 +306,12 @@ describe('i18n resources', () => {
     expect(i18n.getResource('zh-TW', 'translation', 'usage_stats.credentials_quota_reset_failed')).toBe('重置限額失敗，請稍後重試。')
   })
 
-  it('keeps the login product title aligned across languages', () => {
-    expect(i18n.getResourceBundle('en', 'translation').auth.login_title).toBe('CPA Usage Statistics Dashboard');
-    expect(i18n.getResourceBundle('zh', 'translation').auth.login_title).toBe('CPA 用量统计\n仪表盘');
-    expect(i18n.getResourceBundle('zh-TW', 'translation').auth.login_title).toBe('CPA 用量統計\n儀表板');
+  it('keeps the login product identity aligned across languages', () => {
+    expect(i18n.getResourceBundle('en', 'translation').auth.login_title).toBe('CPA USAGE KEEPER');
+    expect(i18n.getResourceBundle('en', 'translation').auth.login_subtitle).toBe('Every flow leaves a trace.');
+    expect(i18n.getResourceBundle('zh', 'translation').auth.login_title).toBe('CPA USAGE KEEPER');
+    expect(i18n.getResourceBundle('zh', 'translation').auth.login_subtitle).toBe('万千流转，皆有迹可循。');
+    expect(i18n.getResourceBundle('zh-TW', 'translation').auth.login_title).toBe('CPA USAGE KEEPER');
+    expect(i18n.getResourceBundle('zh-TW', 'translation').auth.login_subtitle).toBe('萬千流轉，皆有跡可循。');
   });
 });

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -43,8 +43,8 @@ const resources = {
         no_requests: 'No requests'
       },
       auth: {
-        login_title: 'CPA Usage Statistics Dashboard',
-        login_subtitle: 'Preserve CPA request history, aggregate usage analytics, and inspect request health, model activity, and API statistics from a protected console.',
+        login_title: 'CPA USAGE KEEPER',
+        login_subtitle: 'Every flow leaves a trace.',
         console_kicker: 'Access control',
         console_title: 'Choose your console',
         console_hint: 'Administrators manage the full dashboard. API Key viewers see analytics scoped to their own key.',
@@ -749,8 +749,8 @@ const resources = {
         no_requests: '暂无请求'
       },
       auth: {
-        login_title: 'CPA 用量统计\n仪表盘',
-        login_subtitle: '持续保存 CPA 请求记录，聚合用量分析，并在受保护的控制台中查看请求健康、模型活动与 API 统计。',
+        login_title: 'CPA USAGE KEEPER',
+        login_subtitle: '万千流转，皆有迹可循。',
         console_kicker: '访问控制',
         console_title: '选择访问方式',
         console_hint: '管理员可进入完整控制台；API Key 查看者只能查看该 API Key 对应的只读概览。',
@@ -1455,8 +1455,8 @@ const resources = {
         no_requests: '尚無請求'
       },
       auth: {
-        login_title: 'CPA 用量統計\n儀表板',
-        login_subtitle: '持續保存 CPA 請求記錄，彙整用量分析，並在受保護的控制台中查看請求健康、模型活動與 API 統計。',
+        login_title: 'CPA USAGE KEEPER',
+        login_subtitle: '萬千流轉，皆有跡可循。',
         console_kicker: '存取控制',
         console_title: '選擇存取方式',
         console_hint: '管理員可進入完整控制台；API Key 檢視者只能查看該 API Key 對應的唯讀總覽。',

--- a/web/src/pages/LoginPage.module.scss
+++ b/web/src/pages/LoginPage.module.scss
@@ -77,10 +77,15 @@
 }
 
 .brandBlock {
+  transform: translateY(-50px);
   display: flex;
   flex-direction: column;
   gap: 16px;
   min-width: 0;
+
+  @include mobile {
+    transform: none;
+  }
 }
 
 .eyebrow {
@@ -88,12 +93,12 @@
   align-items: center;
   width: fit-content;
   min-height: 40px;
-  padding: 0 18px;
-  border-radius: 999px;
-  border: 1px solid rgba($primary-color, 0.24);
-  background: color-mix(in srgb, var(--bg-primary) 82%, transparent);
+  padding: 0;
+  border-radius: 0;
+  border: 0;
+  background: transparent;
   color: var(--text-primary);
-  font-size: 15px;
+  font-size: 20px;
   font-weight: 900;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -101,18 +106,22 @@
 
 .title {
   margin: 0;
-  font-size: clamp(38px, 5.6vw, 68px);
+  font-size: 60px;
   line-height: 0.92;
   letter-spacing: -0.055em;
   white-space: pre-line;
   color: var(--text-primary);
+
+  @include mobile {
+    font-size: 38px;
+  }
 }
 
 .subtitle {
   margin: 0;
   max-width: 560px;
   color: var(--text-secondary);
-  font-size: 15px;
+  font-size: 16px;
   line-height: 1.75;
 }
 

--- a/web/src/pages/test/LoginPage.styles.test.ts
+++ b/web/src/pages/test/LoginPage.styles.test.ts
@@ -6,6 +6,7 @@ const themeStyles = readFileSync(new URL('../../styles/themes.scss', import.meta
 const pageShellRules = loginPageStyles.match(/\.pageShell\s*\{[\s\S]*?\n\}/g) ?? []
 const pageShellStyles = pageShellRules[0] ?? ''
 const pageShellBackground = pageShellStyles.match(/background:\s*([\s\S]*?);/)?.[1] ?? ''
+const eyebrowStyles = loginPageStyles.match(/\.eyebrow\s*\{([\s\S]*?)\n\}/)?.[1] ?? ''
 
 describe('LoginPage layout styles', () => {
   it('ends the login surface on the base theme background without an edge glow', () => {
@@ -22,12 +23,31 @@ describe('LoginPage layout styles', () => {
     expect(loginPageStyles).toMatch(/\.frame\s*\{[\s\S]*?gap:\s*64px;/)
   })
 
+  it('nudges the desktop brand block upward without shifting the mobile layout', () => {
+    expect(loginPageStyles).toMatch(/\.brandBlock\s*\{[\s\S]*?transform:\s*translateY\(-50px\);/)
+    expect(loginPageStyles).toMatch(/\.brandBlock\s*\{[\s\S]*?@include mobile\s*\{[\s\S]*?transform:\s*none;/)
+  })
+
   it('keeps the compact single-column layout on mobile', () => {
     expect(loginPageStyles).toMatch(/@include mobile\s*\{[\s\S]*?grid-template-columns:\s*1fr;[\s\S]*?gap:\s*18px;/)
   })
 
   it('preserves intentional line breaks in localized login titles', () => {
     expect(loginPageStyles).toMatch(/\.title\s*\{[\s\S]*?white-space:\s*pre-line;/)
+  })
+
+  it('uses tuned desktop brand typography without enlarging the mobile title', () => {
+    expect(loginPageStyles).toMatch(/\.title\s*\{[\s\S]*?font-size:\s*60px;/)
+    expect(loginPageStyles).toMatch(/\.title\s*\{[\s\S]*?@include mobile\s*\{[\s\S]*?font-size:\s*38px;/)
+    expect(loginPageStyles).toMatch(/\.subtitle\s*\{[\s\S]*?font-size:\s*16px;/)
+  })
+
+  it('renders a larger standalone brand mark without pill chrome', () => {
+    expect(eyebrowStyles).toMatch(/border:\s*0;/)
+    expect(eyebrowStyles).toMatch(/border-radius:\s*0;/)
+    expect(eyebrowStyles).toMatch(/background:\s*transparent;/)
+    expect(eyebrowStyles).toMatch(/padding:\s*0;/)
+    expect(eyebrowStyles).toMatch(/font-size:\s*20px;/)
   })
 
   it('keeps the login card width stable when localized copy changes', () => {


### PR DESCRIPTION
## Summary

- rename the login hero to `CPA USAGE KEEPER` across English and Chinese locales
- replace the legacy functional description with concise localized taglines
- refine hero positioning, typography, and the standalone Keeper mark

## Testing

- `rtk env TZ=UTC GOCACHE=/tmp/cpa-usage-keeper-go-build GOFLAGS=-count=1 make verify`