### PR TITLE
feat(ui): standardize dashboard card styles

### DIFF
--- a/web/src/components/ui/Card.tsx
+++ b/web/src/components/ui/Card.tsx
@@ -2,17 +2,37 @@ import React, { type PropsWithChildren, type ReactNode, type HTMLAttributes } fr
 
 interface CardProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
   title?: ReactNode;
+  subtitle?: ReactNode;
+  titleMeta?: ReactNode;
   extra?: ReactNode;
+  variant?: 'default' | 'flush';
   className?: string;
 }
 
-export function Card({ title, extra, children, className, ...props }: PropsWithChildren<CardProps>) {
+export function Card({ title, subtitle, titleMeta, extra, variant = 'default', children, className, ...props }: PropsWithChildren<CardProps>) {
+  const cardClassName = [
+    'card',
+    variant === 'flush' ? 'card-flush' : '',
+    className,
+  ].filter(Boolean).join(' ');
+  const hasHeading = title || subtitle || titleMeta;
+
   return (
-    <div className={className ? `card ${className}` : 'card'} {...props}>
-      {(title || extra) && (
+    <div className={cardClassName} {...props}>
+      {(hasHeading || extra) && (
         <div className="card-header">
-          <div className="title">{title}</div>
-          {extra}
+          {hasHeading && (
+            <div className="keeper-card-heading">
+              {(title || titleMeta) && (
+                <div className="keeper-card-title-track">
+                  {title && <div className="keeper-card-title">{title}</div>}
+                  {titleMeta && <div className="keeper-card-title-meta">{titleMeta}</div>}
+                </div>
+              )}
+              {subtitle && <div className="keeper-card-subtitle">{subtitle}</div>}
+            </div>
+          )}
+          {extra && <div className="keeper-card-actions">{extra}</div>}
         </div>
       )}
       {children}

--- a/web/src/components/ui/Card.tsx
+++ b/web/src/components/ui/Card.tsx
@@ -25,11 +25,11 @@ export function Card({ title, subtitle, titleMeta, extra, variant = 'default', c
             <div className="keeper-card-heading">
               {(title || titleMeta) && (
                 <div className="keeper-card-title-track">
-                  {title && <div className="keeper-card-title">{title}</div>}
+                  {title && <h3 className="keeper-card-title">{title}</h3>}
                   {titleMeta && <div className="keeper-card-title-meta">{titleMeta}</div>}
                 </div>
               )}
-              {subtitle && <div className="keeper-card-subtitle">{subtitle}</div>}
+              {subtitle && <p className="keeper-card-subtitle">{subtitle}</p>}
             </div>
           )}
           {extra && <div className="keeper-card-actions">{extra}</div>}

--- a/web/src/components/ui/test/Card.test.tsx
+++ b/web/src/components/ui/test/Card.test.tsx
@@ -1,6 +1,10 @@
+import { resolve } from 'node:path';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { compile } from 'sass';
 import { describe, expect, it } from 'vitest';
 import { Card } from '../Card';
+
+const componentsCSS = compile(resolve(process.cwd(), 'src/styles/components.scss')).css;
 
 describe('Card', () => {
   it('renders the shared heading contract and flush surface variant', () => {
@@ -24,8 +28,25 @@ describe('Card', () => {
     expect(html).toContain('class="keeper-card-title-meta"');
     expect(html).toContain('class="keeper-card-subtitle"');
     expect(html).toContain('class="keeper-card-actions"');
-    expect(html).toContain('>Description</div>');
+    expect(html).toContain('>Description</p>');
     expect(html).toContain('>Body</div>');
+  });
+
+  it('preserves heading and paragraph semantics for the shared card copy', () => {
+    const html = renderToStaticMarkup(
+      <Card title="Title" subtitle="Description">
+        Body
+      </Card>,
+    );
+
+    expect(html).toContain('<h3 class="keeper-card-title">Title</h3>');
+    expect(html).toContain('<p class="keeper-card-subtitle">Description</p>');
+  });
+
+  it('stacks card header actions below the heading at the mobile breakpoint', () => {
+    expect(componentsCSS).toMatch(
+      /@media \(max-width: 768px\) \{[\s\S]*?\.card-header \{[^}]*grid-template-columns: minmax\(0, 1fr\);/,
+    );
   });
 
   it('keeps the default surface free of the flush modifier', () => {

--- a/web/src/components/ui/test/Card.test.tsx
+++ b/web/src/components/ui/test/Card.test.tsx
@@ -1,0 +1,36 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { Card } from '../Card';
+
+describe('Card', () => {
+  it('renders the shared heading contract and flush surface variant', () => {
+    const html = renderToStaticMarkup(
+      <Card
+        title="Title"
+        subtitle="Description"
+        titleMeta={<span>3 items</span>}
+        extra={<button type="button">Action</button>}
+        variant="flush"
+      >
+        Body
+      </Card>,
+    );
+
+    expect(html).toContain('class="card card-flush"');
+    expect(html).toContain('class="card-header"');
+    expect(html).toContain('class="keeper-card-heading"');
+    expect(html).toContain('class="keeper-card-title-track"');
+    expect(html).toContain('class="keeper-card-title"');
+    expect(html).toContain('class="keeper-card-title-meta"');
+    expect(html).toContain('class="keeper-card-subtitle"');
+    expect(html).toContain('class="keeper-card-actions"');
+    expect(html).toContain('>Description</div>');
+    expect(html).toContain('>Body</div>');
+  });
+
+  it('keeps the default surface free of the flush modifier', () => {
+    const html = renderToStaticMarkup(<Card>Body</Card>);
+
+    expect(html).toContain('class="card"');
+  });
+});

--- a/web/src/components/usage/ApiKeySettingsCard.tsx
+++ b/web/src/components/usage/ApiKeySettingsCard.tsx
@@ -8,15 +8,6 @@ import { useScrollBoundaryContainment } from '@/hooks/useScrollBoundaryContainme
 import type { CpaApiKeySettingsItem } from '@/lib/types';
 import styles from '@/pages/UsagePage.module.scss';
 
-interface ApiKeySettingsTitleProps {
-  title: string;
-  subtitle: string;
-  showFullApiKeys: boolean;
-  onToggleFullApiKeys: () => void;
-  showFullLabel: string;
-  hideFullLabel: string;
-}
-
 type ClipboardWriter = Pick<Clipboard, 'writeText'>;
 type CopyTextArea = {
   value: string;
@@ -92,31 +83,6 @@ export async function copyApiKeyToClipboard(apiKey: string, context: CopyContext
   }
 }
 
-function ApiKeySettingsTitle({ title, subtitle, showFullApiKeys, onToggleFullApiKeys, showFullLabel, hideFullLabel }: ApiKeySettingsTitleProps) {
-  const toggleLabel = showFullApiKeys ? hideFullLabel : showFullLabel;
-
-  return (
-    <div className={styles.sectionTitleBlock}>
-      <div className={styles.apiKeySettingsTitleRow}>
-        <h3 className={styles.sectionTitle}>{title}</h3>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className={`${styles.apiKeyVisibilityToggle} ${showFullApiKeys ? styles.apiKeyVisibilityToggleActive : ''}`.trim()}
-          onClick={onToggleFullApiKeys}
-          aria-label={toggleLabel}
-          aria-pressed={showFullApiKeys}
-          title={toggleLabel}
-        >
-          {showFullApiKeys ? <IconEye size={16} /> : <IconEyeOff size={16} />}
-        </Button>
-      </div>
-      <p className={styles.sectionSubtitle}>{subtitle}</p>
-    </div>
-  );
-}
-
 export interface ApiKeySettingsCardProps {
   apiKeys: CpaApiKeySettingsItem[];
   loading?: boolean;
@@ -162,18 +128,27 @@ export function ApiKeySettingsCard({ apiKeys, loading = false, savingId = null, 
       onNotice?.('error', t('usage_stats.api_key_settings_copy_failed'));
     }
   }, [onNotice, t]);
+  const toggleLabel = showFullApiKeys
+    ? t('usage_stats.api_key_settings_hide_full')
+    : t('usage_stats.api_key_settings_show_full');
 
   return (
     <Card
-      title={
-        <ApiKeySettingsTitle
-          title={t('usage_stats.api_key_settings_title')}
-          subtitle={t('usage_stats.api_key_settings_subtitle')}
-          showFullApiKeys={showFullApiKeys}
-          onToggleFullApiKeys={() => setShowFullApiKeys((current) => !current)}
-          showFullLabel={t('usage_stats.api_key_settings_show_full')}
-          hideFullLabel={t('usage_stats.api_key_settings_hide_full')}
-        />
+      title={t('usage_stats.api_key_settings_title')}
+      subtitle={t('usage_stats.api_key_settings_subtitle')}
+      titleMeta={
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className={`${styles.apiKeyVisibilityToggle} ${showFullApiKeys ? styles.apiKeyVisibilityToggleActive : ''}`.trim()}
+          onClick={() => setShowFullApiKeys((current) => !current)}
+          aria-label={toggleLabel}
+          aria-pressed={showFullApiKeys}
+          title={toggleLabel}
+        >
+          {showFullApiKeys ? <IconEye size={16} /> : <IconEyeOff size={16} />}
+        </Button>
       }
       className={`${styles.detailsFixedCard} ${styles.apiKeySettingsCard}`}
     >

--- a/web/src/components/usage/OverviewRealtimePanel.logic.test.tsx
+++ b/web/src/components/usage/OverviewRealtimePanel.logic.test.tsx
@@ -119,6 +119,9 @@ describe('OverviewRealtimePanel', () => {
     expect(html).toContain('usage_stats.overview_realtime_request_level');
     expect(html).toContain('usage_stats.overview_realtime_cache_level');
     expect(html).toContain('overviewRealtimeCardFull');
+    expect(html.match(/keeper-card-surface/g) ?? []).toHaveLength(6);
+    expect(html.match(/class="keeper-card-title-track"/g) ?? []).toHaveLength(6);
+    expect(html.match(/class="keeper-card-title"/g) ?? []).toHaveLength(6);
     expect(html).toContain('30m');
     expect(html).not.toMatch(/>5m<\/button>/);
     expect(html).toContain('usage_stats.overview_realtime_dimension_api_keys');

--- a/web/src/components/usage/OverviewRealtimePanel.tsx
+++ b/web/src/components/usage/OverviewRealtimePanel.tsx
@@ -515,6 +515,7 @@ function RealtimeCard({
 }) {
   const cardClassName = [
     styles.overviewRealtimeCard,
+    'keeper-card-surface',
     full ? styles.overviewRealtimeCardFull : '',
     compact ? styles.overviewRealtimeCardCompact : '',
     className ?? '',
@@ -522,7 +523,9 @@ function RealtimeCard({
   return (
     <section className={cardClassName}>
       <div className={styles.overviewRealtimeCardHeader}>
-        <h3 className={styles.overviewRealtimeCardTitle}>{title}</h3>
+        <div className="keeper-card-title-track">
+          <h3 className="keeper-card-title">{title}</h3>
+        </div>
         {metrics && metrics.length > 0 && (
           <div className={styles.overviewRealtimeMetrics}>
             {metrics.map((metric) => (

--- a/web/src/components/usage/PriceSettingsCard.tsx
+++ b/web/src/components/usage/PriceSettingsCard.tsx
@@ -77,15 +77,6 @@ export interface PricingDraftInput {
   multiplier: string;
 }
 
-function PriceSettingsTitle({ title, subtitle }: { title: string; subtitle: string }) {
-  return (
-    <div className={styles.sectionTitleBlock}>
-      <h3 className={styles.sectionTitle}>{title}</h3>
-      <p className={styles.sectionSubtitle}>{subtitle}</p>
-    </div>
-  );
-}
-
 const parsePriceValue = (value: string): number | null => {
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
@@ -552,12 +543,8 @@ export function PriceSettingsCard({
   return (
     <>
       <Card
-        title={
-          <PriceSettingsTitle
-            title={t('usage_stats.model_price_settings_title')}
-            subtitle={t('usage_stats.model_price_settings_subtitle')}
-          />
-        }
+        title={t('usage_stats.model_price_settings_title')}
+        subtitle={t('usage_stats.model_price_settings_subtitle')}
         className={`${styles.detailsFixedCard} ${styles.pricingFixedCard}`}
       >
         <div className={styles.pricingSection}>

--- a/web/src/components/usage/RequestEventsDetailsCard.test.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.test.tsx
@@ -69,6 +69,16 @@ const renderCard = (props: Partial<React.ComponentProps<typeof RequestEventsDeta
 const countOccurrences = (text: string, value: string) => text.split(value).length - 1;
 
 describe('RequestEventsDetailsCard pagination', () => {
+  it('renders the shared flush card heading without bolding its subtitle', () => {
+    const html = renderCard();
+
+    expect(html).toContain('card-flush');
+    expect(html).toContain('keeper-card-title');
+    expect(html).toContain('keeper-card-title-meta');
+    expect(html).toContain('keeper-card-subtitle');
+    expect(html).toMatch(/class="keeper-card-subtitle">[^<]+<\/div>/);
+  });
+
   it('renders the title without the Event Stream eyebrow', () => {
     const html = renderCard();
 
@@ -370,7 +380,7 @@ describe('RequestEventsDetailsCard pagination', () => {
     const html = renderCard();
 
     expect(html).toContain('_requestEventsFiltersGroup_');
-    expect(html).toContain('_requestEventsTitleRow_');
+    expect(html).toContain('keeper-card-title-track');
     expect(html).toContain('_requestEventsCountBadge_');
     expect(html).toContain('120 total events');
     expect(html).toContain('_requestEventsPaginationFooter_');

--- a/web/src/components/usage/RequestEventsDetailsCard.test.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.test.tsx
@@ -76,7 +76,7 @@ describe('RequestEventsDetailsCard pagination', () => {
     expect(html).toContain('keeper-card-title');
     expect(html).toContain('keeper-card-title-meta');
     expect(html).toContain('keeper-card-subtitle');
-    expect(html).toMatch(/class="keeper-card-subtitle">[^<]+<\/div>/);
+    expect(html).toMatch(/class="keeper-card-subtitle">[^<]+<\/p>/);
   });
 
   it('renders the title without the Event Stream eyebrow', () => {

--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -374,18 +374,6 @@ const parseRequestEndpoint = (rawEndpoint: unknown): { requestType: string; endp
   return { requestType, endpoint: normalizedPath || '-' };
 };
 
-function RequestEventsTitle({ title, subtitle, totalLabel }: { title: string; subtitle: string; totalLabel: string }) {
-  return (
-    <div className={styles.sectionTitleBlock}>
-      <div className={styles.requestEventsTitleRow}>
-        <h3 className={styles.sectionTitle}>{title}</h3>
-        <span className={styles.requestEventsCountBadge}>{totalLabel}</span>
-      </div>
-      <p className={styles.sectionSubtitle}>{subtitle}</p>
-    </div>
-  );
-}
-
 const copyRequestLogSectionContent = async (content: string) => {
   const clipboard = globalThis.navigator?.clipboard;
   if (clipboard) {
@@ -1179,12 +1167,13 @@ export function RequestEventsDetailsCard({
     <>
       <Card
         className={styles.requestEventsCard}
-        title={
-          <RequestEventsTitle
-            title={t('usage_stats.request_events_title')}
-            subtitle={t('usage_stats.request_events_subtitle')}
-            totalLabel={t('usage_stats.request_events_total_count', { count: totalCount })}
-          />
+        variant="flush"
+        title={t('usage_stats.request_events_title')}
+        subtitle={t('usage_stats.request_events_subtitle')}
+        titleMeta={
+          <span className={styles.requestEventsCountBadge}>
+            {t('usage_stats.request_events_total_count', { count: totalCount })}
+          </span>
         }
         extra={
           <div className={styles.requestEventsActions}>

--- a/web/src/components/usage/ServiceHealthCard.tsx
+++ b/web/src/components/usage/ServiceHealthCard.tsx
@@ -55,11 +55,13 @@ export function ServiceHealthCard({ activity, loading, requestIdentity }: Servic
     : t('status_bar.no_requests');
 
   return (
-    <article className={styles.activityCard} aria-busy={loading}>
+    <article className={`${styles.activityCard} keeper-card-surface`} aria-busy={loading}>
       <div className={styles.activityCardHeader}>
-        <div className={styles.sectionTitleBlock}>
-          <h3 className={styles.sectionTitle}>{t('usage_stats.service_health_title')}</h3>
-          <p className={styles.sectionSubtitle}>{t('usage_stats.service_health_subtitle')}</p>
+        <div className="keeper-card-heading">
+          <div className="keeper-card-title-track">
+            <h3 className="keeper-card-title">{t('usage_stats.service_health_title')}</h3>
+          </div>
+          <p className="keeper-card-subtitle">{t('usage_stats.service_health_subtitle')}</p>
         </div>
         <div className={styles.activitySummary} data-activity-summary="health">
           <span className={styles.activitySummaryLabel}>{t('usage_stats.success_rate')}</span>

--- a/web/src/components/usage/SessionSettingsCard.tsx
+++ b/web/src/components/usage/SessionSettingsCard.tsx
@@ -55,12 +55,8 @@ export function SessionSettingsCard({ sessions, loading = false, revokingId = nu
 
   return (
     <Card
-      title={
-        <div className={styles.sectionTitleBlock}>
-          <h3 className={styles.sectionTitle}>{t('usage_stats.session_settings_title')}</h3>
-          <p className={styles.sectionSubtitle}>{t('usage_stats.session_settings_subtitle')}</p>
-        </div>
-      }
+      title={t('usage_stats.session_settings_title')}
+      subtitle={t('usage_stats.session_settings_subtitle')}
       className={`${styles.detailsFixedCard} ${styles.sessionSettingsCard}`}
     >
       <div ref={sessionSettingsBodyRef} className={styles.sessionSettingsBody}>

--- a/web/src/components/usage/TokenActivityCard.tsx
+++ b/web/src/components/usage/TokenActivityCard.tsx
@@ -50,11 +50,13 @@ export function TokenActivityCard({ activity, loading, requestIdentity }: TokenA
   ].join(', ');
 
   return (
-    <article className={`${styles.activityCard} ${styles.tokenActivityCard}`} aria-busy={loading}>
+    <article className={`${styles.activityCard} ${styles.tokenActivityCard} keeper-card-surface`} aria-busy={loading}>
       <div className={styles.activityCardHeader}>
-        <div className={styles.sectionTitleBlock}>
-          <h3 className={styles.sectionTitle}>{t('usage_stats.token_activity_title')}</h3>
-          <p className={styles.sectionSubtitle}>{t('usage_stats.token_activity_subtitle')}</p>
+        <div className="keeper-card-heading">
+          <div className="keeper-card-title-track">
+            <h3 className="keeper-card-title">{t('usage_stats.token_activity_title')}</h3>
+          </div>
+          <p className="keeper-card-subtitle">{t('usage_stats.token_activity_subtitle')}</p>
         </div>
         <div className={styles.activitySummary} data-activity-summary="token">
           <span className={styles.activitySummaryLabel}>{t('usage_stats.token_activity_total_tokens')}</span>

--- a/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.logic.test.tsx
@@ -1459,8 +1459,8 @@ describe('AnalysisPanel token chart data', () => {
     expect(markup).toMatch(/Unpriced Key[\s\S]*\$0\.0000/);
     expect(markup).toContain('usage_stats.cost_need_price');
     expect(markup).toContain('<div class="_cardTitleLine_');
-    expect(markup).toContain('<h2>usage_stats.analysis_token_usage_title</h2><small class="_costHeaderHint_');
-    expect(markup).toContain('</small></div><p>usage_stats.analysis_token_usage_subtitle</p>');
+    expect(markup).toContain('<h2 class="keeper-card-title">usage_stats.analysis_token_usage_title</h2><small class="_costHeaderHint_');
+    expect(markup).toContain('</small></div><p class="keeper-card-subtitle">usage_stats.analysis_token_usage_subtitle</p>');
     expect(markup).not.toContain('usage_stats.analysis_token_usage_subtitle (usage_stats.cost_need_price)');
     expect(markup.match(/costHeaderHint/g)?.length).toBe(5);
     expect(markup).not.toContain('costWarning');
@@ -1497,7 +1497,7 @@ describe('AnalysisPanel token chart data', () => {
 
     const costDataset = chartCapture.barData?.datasets.find((dataset) => dataset.label === 'usage_stats.total_cost');
     expect(costDataset?.data).toEqual([9]);
-    expect(markup).toContain('<h2>usage_stats.analysis_cost_breakdown_title</h2><small class="_costHeaderHint_');
+    expect(markup).toContain('<h2 class="keeper-card-title">usage_stats.analysis_cost_breakdown_title</h2><small class="_costHeaderHint_');
     expect(markup).toContain('usage_stats.cost_need_price');
     expect(markup).toContain('usage_stats.total_cost</span><strong>$9.00</strong>');
     expect(markup).toContain('usage_stats.analysis_cost_per_million_tokens</span><strong>$8,181.82</strong>');

--- a/web/src/components/usage/analysis/AnalysisPanel.module.scss
+++ b/web/src/components/usage/analysis/AnalysisPanel.module.scss
@@ -8,11 +8,7 @@
 }
 
 .analysisCard {
-  border: 1px solid var(--border-color);
-  border-radius: 24px;
-  background: var(--bg-primary);
-  box-shadow: 0 18px 46px rgba(0, 0, 0, 0.07);
-  padding: 20px;
+  padding: var(--keeper-card-padding);
   min-width: 0;
 }
 
@@ -42,32 +38,13 @@
   flex-direction: column;
   gap: 6px;
   margin-bottom: 16px;
-
-  h2 {
-    margin: 0;
-    font-size: 18px;
-    line-height: 1.2;
-    color: var(--text-primary);
-  }
-
-  p {
-    margin: 0;
-    color: var(--text-secondary);
-    font-size: 13px;
-    line-height: 1.45;
-  }
 }
 
 .cardTitleLine {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
   gap: 14px;
   min-width: 0;
-
-  h2 {
-    min-width: 0;
-  }
 
   @include mobile {
     flex-wrap: wrap;

--- a/web/src/components/usage/analysis/AnalysisPanel.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.tsx
@@ -967,12 +967,12 @@ function CostHeaderHint({ show, label }: { show: boolean; label: string }) {
 
 function AnalysisCardHeader({ title, subtitle, showPricingHint, hint }: { title: string; subtitle: string; showPricingHint: boolean; hint: string }) {
   return (
-    <div className={styles.cardHeader}>
-      <div className={styles.cardTitleLine}>
-        <h2>{title}</h2>
+    <div className={`${styles.cardHeader} keeper-card-heading`}>
+      <div className={`${styles.cardTitleLine} keeper-card-title-track`}>
+        <h2 className="keeper-card-title">{title}</h2>
         <CostHeaderHint show={showPricingHint} label={hint} />
       </div>
-      <p>{subtitle}</p>
+      <p className="keeper-card-subtitle">{subtitle}</p>
     </div>
   );
 }
@@ -1085,7 +1085,7 @@ function TokenUsageChart({ rows, loading, isDark, isMobile }: { rows: ChartRow[]
   const legendItems = useMemo(() => buildTokenLegendItems(tokenLabels, averageTokenTotal, chartTheme.averageLine), [averageTokenTotal, chartTheme.averageLine, tokenLabels]);
   const hasUnavailableCost = rows.some((row) => !row.costAvailable);
   return (
-    <section className={`${styles.analysisCard} ${styles.tokenUsageCard}`}>
+    <section className={`${styles.analysisCard} ${styles.tokenUsageCard} keeper-card-surface`}>
       <AnalysisCardHeader
         title={t('usage_stats.analysis_token_usage_title')}
         subtitle={t('usage_stats.analysis_token_usage_subtitle')}
@@ -1275,7 +1275,7 @@ function LatencyDiagnosticsCard({ diagnostics, loading, error, isDark, isMobile 
   const unsupported = safeDiagnostics.supported === false;
   const hasData = toNumber(safeDiagnostics.total_points) > 0 && safeDiagnostics.points.length > 0;
   return (
-    <section className={`${styles.analysisCard} ${styles.latencyDiagnosticsCard}`}>
+    <section className={`${styles.analysisCard} ${styles.latencyDiagnosticsCard} keeper-card-surface`}>
       <AnalysisCardHeader
         title={t('usage_stats.analysis_latency_title')}
         subtitle={t('usage_stats.analysis_latency_subtitle')}
@@ -1352,7 +1352,7 @@ function CompositionPanel({ tabs, loading, isDark, windowMinutes }: { tabs: Comp
   const chartOptions = useMemo(() => buildCompositionChartOptions(chartTheme, tooltipLabels), [chartTheme, tooltipLabels]);
   const hasUnavailableCost = items.some((item) => item.cost_available === false);
   return (
-    <section className={`${styles.analysisCard} ${styles.compositionCard}`}>
+    <section className={`${styles.analysisCard} ${styles.compositionCard} keeper-card-surface`}>
       <AnalysisCardHeader
         title={t('usage_stats.analysis_composition_title')}
         subtitle={t('usage_stats.analysis_composition_subtitle')}
@@ -1480,7 +1480,7 @@ function CostBreakdownCard({ breakdown, rows, loading }: { breakdown: AnalysisCo
   };
   const hideCostTooltip = () => setCostTooltip(null);
   return (
-    <section className={`${styles.analysisCard} ${styles.costBreakdownCard}`}>
+    <section className={`${styles.analysisCard} ${styles.costBreakdownCard} keeper-card-surface`}>
       <AnalysisCardHeader
         title={t('usage_stats.analysis_cost_breakdown_title')}
         subtitle={t('usage_stats.analysis_cost_breakdown_subtitle')}
@@ -1840,7 +1840,7 @@ function ModelEfficiencyCard({ rows, loading, isDark, isMobile }: { rows: Analys
   const hasPricedData = pricedRows.length > 0;
   const hasUnavailableCost = rows.some((row) => row.cost_available === false);
   return (
-    <section className={`${styles.analysisCard} ${styles.modelEfficiencyCard}`}>
+    <section className={`${styles.analysisCard} ${styles.modelEfficiencyCard} keeper-card-surface`}>
       <AnalysisCardHeader
         title={t('usage_stats.analysis_model_efficiency_title')}
         subtitle={t('usage_stats.analysis_model_efficiency_subtitle')}
@@ -1936,7 +1936,7 @@ function Heatmap({ cells, apiKeys, apiKeyLabels, models, loading, isDark }: { ce
   };
   const hideTooltip = () => setTooltip(null);
   return (
-    <section className={`${styles.analysisCard} ${styles.heatmapCard} ${isDark ? styles.heatmapCardDark : styles.heatmapCardLight}`}>
+    <section className={`${styles.analysisCard} ${styles.heatmapCard} keeper-card-surface ${isDark ? styles.heatmapCardDark : styles.heatmapCardLight}`}>
       <AnalysisCardHeader
         title={t('usage_stats.analysis_heatmap_title')}
         subtitle={t('usage_stats.analysis_heatmap_subtitle')}

--- a/web/src/components/usage/credentials/CredentialSectionShell.tsx
+++ b/web/src/components/usage/credentials/CredentialSectionShell.tsx
@@ -35,15 +35,15 @@ interface CredentialTableHeaderProps {
 
 export function CredentialSectionShell({ title, subtitle, countLabel, titleExtra, actions, style, children }: CredentialSectionShellProps) {
   return (
-    <section className={styles.credentialSectionCard} style={style}>
+    <section className={`${styles.credentialSectionCard} keeper-card-surface`} style={style}>
       <div className={styles.credentialSectionHeader}>
         <div className={styles.credentialSectionTitleBlock}>
-          <div className={styles.credentialSectionTitleRow}>
-            <h3 className={styles.credentialSectionTitle}>{title}</h3>
+          <div className={`${styles.credentialSectionTitleRow} keeper-card-title-track`}>
+            <h3 className={`${styles.credentialSectionTitle} keeper-card-title`}>{title}</h3>
             <span className={styles.credentialCountBadge}>{countLabel}</span>
             {titleExtra}
           </div>
-          <p className={styles.credentialSectionSubtitle}>{subtitle}</p>
+          <p className={`${styles.credentialSectionSubtitle} keeper-card-subtitle`}>{subtitle}</p>
         </div>
         {actions && <div className={styles.credentialSectionActions}>{actions}</div>}
       </div>

--- a/web/src/components/usage/credentials/CredentialSections.module.scss
+++ b/web/src/components/usage/credentials/CredentialSections.module.scss
@@ -4,26 +4,35 @@
 .credentialSectionCard {
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--border-color);
-  border-radius: 24px;
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--bg-primary) 96%, rgba($primary-color, 0.03)), var(--bg-primary));
-  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.07);
   overflow: hidden;
 }
 
 .credentialSectionHeader {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: stretch;
-  gap: 18px;
-  padding: 20px 22px 16px;
+  column-gap: 18px;
+  row-gap: 0;
+  padding: var(--keeper-card-header-padding-top) var(--keeper-card-header-padding-x)
+    var(--keeper-card-header-padding-bottom);
   border-bottom: 1px solid var(--border-color);
 
   @include mobile {
-    flex-direction: column;
-    align-items: stretch;
+    grid-template-columns: minmax(0, 1fr);
     padding: 18px;
+
+    .credentialSectionTitleRow,
+    .credentialAuthFileTitleControls {
+      flex-wrap: wrap;
+    }
+
+    .credentialSectionActions {
+      align-self: stretch;
+      justify-content: flex-start;
+      margin-top: 12px;
+    }
   }
 }
 
@@ -33,16 +42,15 @@
 
 .credentialSectionTitleRow {
   display: flex;
+  min-height: 34px;
   align-items: center;
   gap: 10px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 
 .credentialSectionTitle {
   margin: 0;
-  color: var(--text-primary);
-  font-size: 18px;
-  font-weight: 800;
+  white-space: nowrap;
 }
 
 .credentialCountBadge {
@@ -60,14 +68,15 @@
 .credentialSectionSubtitle {
   max-width: 680px;
   margin: 6px 0 0;
-  color: var(--text-secondary);
-  font-size: 13px;
-  line-height: 1.55;
+  font-size: var(--keeper-card-subtitle-size);
+  font-weight: var(--keeper-card-subtitle-weight);
 }
 
 .credentialSectionActions {
   display: flex;
+  min-height: var(--keeper-card-title-track-height);
   align-items: center;
+  align-self: flex-end;
   justify-content: flex-end;
   flex: 0 0 auto;
 }
@@ -84,7 +93,7 @@
   display: inline-flex;
   align-items: center;
   gap: 12px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 
 .credentialDisplayModeControl {

--- a/web/src/components/usage/credentials/test/CredentialSections.styles.test.ts
+++ b/web/src/components/usage/credentials/test/CredentialSections.styles.test.ts
@@ -16,6 +16,30 @@ const cssBlock = (selector: string) => {
 }
 
 describe('Credential section styles', () => {
+  it('uses the global card contract and a stable credential title track', () => {
+    expect(credentialShellSource).toMatch(/className=\{`\$\{styles\.credentialSectionCard\} keeper-card-surface`\}/)
+    expect(credentialShellSource).toMatch(/className=\{`\$\{styles\.credentialSectionTitleRow\} keeper-card-title-track`\}/)
+    expect(credentialShellSource).toMatch(/className=\{`\$\{styles\.credentialSectionTitle\} keeper-card-title`\}/)
+    expect(credentialShellSource).toMatch(/className=\{`\$\{styles\.credentialSectionSubtitle\} keeper-card-subtitle`\}/)
+
+    expect(credentialStyles).toMatch(/\.credentialSectionHeader\s*\{[\s\S]*?display:\s*grid;[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) auto;/)
+    expect(credentialStyles).toMatch(/\.credentialSectionActions\s*\{[\s\S]*?min-height:\s*var\(--keeper-card-title-track-height\);[\s\S]*?align-items:\s*center;/)
+    expect(credentialStyles).toMatch(/\.credentialSectionTitleRow\s*\{[\s\S]*?flex-wrap:\s*nowrap;/)
+    expect(credentialStyles).toMatch(/\.credentialSectionTitleBlock\s*\{[\s\S]*?min-width:\s*0;/)
+    expect(cssBlock('.credentialSectionTitleBlock')).not.toContain('display: contents;')
+    expect(credentialStyles).toMatch(/\.credentialSectionTitleRow\s*\{[\s\S]*?min-height:\s*34px;/)
+    expect(credentialStyles).toMatch(/\.credentialSectionActions\s*\{[\s\S]*?align-self:\s*flex-end;/)
+    expect(credentialStyles).toMatch(/\.credentialSectionSubtitle\s*\{[\s\S]*?font-size:\s*var\(--keeper-card-subtitle-size\);[\s\S]*?font-weight:\s*var\(--keeper-card-subtitle-weight\);/)
+    expect(credentialStyles).toMatch(/@include mobile\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\);[\s\S]*?\.credentialSectionTitleRow\s*\{[\s\S]*?flex-wrap:\s*wrap;/)
+
+    const cardBlock = cssBlock('.credentialSectionCard')
+    expect(cardBlock).not.toContain('border: 1px solid')
+    expect(cardBlock).not.toContain('border-radius: 24px')
+    expect(cardBlock).not.toContain('box-shadow:')
+    expect(cssBlock('.credentialRefreshButton')).toContain('font-size: 12px;')
+    expect(cssBlock('.credentialRefreshButton')).not.toContain('font-size: 14px;')
+  })
+
   it('keeps Auth Files and AI Provider row sizing separate', () => {
     expect(credentialStyles).toMatch(/\.authFileCredentialRow\s*\{[\s\S]*?grid-template-columns:\s*236px minmax\(0, 448px\) minmax\(250px, 1fr\);/)
     expect(credentialStyles).toMatch(/\.authFileCredentialRow\s*\{[\s\S]*?\.credentialIdentityBlock\s*\{[\s\S]*?max-width:\s*236px;/)

--- a/web/src/components/usage/test/OverviewActivityCards.test.tsx
+++ b/web/src/components/usage/test/OverviewActivityCards.test.tsx
@@ -19,6 +19,9 @@ describe('OverviewActivityCards', () => {
     expect(html.match(/role="grid"/g)).toHaveLength(2);
     expect(html.match(/role="gridcell"/g)).toHaveLength(2 * 7 * 52);
     expect(html.match(new RegExp(`data-activity-start="${activity.blocks[0].start_time}"`, 'g'))).toHaveLength(2);
+    expect(html.match(/keeper-card-surface/g)).toHaveLength(2);
+    expect(html.match(/keeper-card-title-track/g)).toHaveLength(2);
+    expect(html.match(/keeper-card-subtitle/g)).toHaveLength(2);
   });
 
   it('does not own a second Activity request or range state', () => {

--- a/web/src/features/ranking/RankingPage.module.scss
+++ b/web/src/features/ranking/RankingPage.module.scss
@@ -15,9 +15,7 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
-  padding: 20px;
   overflow: hidden;
-  border-radius: 24px;
 }
 
 .leaderboardHeader {
@@ -32,12 +30,6 @@
   row-gap: 4px;
   padding: 0;
 
-  h2 {
-    margin: 0;
-    color: var(--text-primary);
-    font-size: 18px;
-    line-height: 1.2;
-  }
 }
 
 .leaderboardTitle {

--- a/web/src/features/ranking/RankingPage.tsx
+++ b/web/src/features/ranking/RankingPage.tsx
@@ -583,7 +583,9 @@ function LeaderboardCard({
     <article className={`card ${styles.leaderboardCard}`.trim()} aria-busy={loading}>
       <header className={styles.leaderboardHeader}>
         <div className={styles.leaderboardTitle} data-ranking-header-title>
-          <h2>{t(`ranking.metric_${metric}`)}</h2>
+          <div className="keeper-card-title-track">
+            <h2 className="keeper-card-title">{t(`ranking.metric_${metric}`)}</h2>
+          </div>
           {board && (
             <div className={styles.boardMeta}>
               {board.stale && <span className={styles.staleBadge} data-ranking-stale>{t('ranking.stale')} · {board.period_key}</span>}

--- a/web/src/features/ranking/test/RankingPage.styles.test.ts
+++ b/web/src/features/ranking/test/RankingPage.styles.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const styles = readFileSync(new URL('../RankingPage.module.scss', import.meta.url), 'utf8');
+const source = readFileSync(new URL('../RankingPage.tsx', import.meta.url), 'utf8');
 
 const rule = (selector: string, fromIndex = 0) => {
   const start = styles.indexOf(selector, fromIndex);
@@ -14,6 +15,13 @@ const rule = (selector: string, fromIndex = 0) => {
 };
 
 describe('Ranking table context styles', () => {
+  it('uses the global card title track instead of local card primitives', () => {
+    expect(source).toContain('keeper-card-title-track');
+    expect(source).toContain('keeper-card-title');
+    expect(rule('.leaderboardCard:global(.card)')).not.toContain('border-radius: 24px;');
+    expect(rule('.leaderboardCard:global(.card)')).not.toContain('padding: 20px;');
+  });
+
   it('keeps the header and first two columns visible without introducing a fixed table height', () => {
     const tableHeader = rule('.table thead th');
     const rankColumn = rule('.rankColumn');
@@ -61,6 +69,8 @@ describe('Ranking table context styles', () => {
     expect(rule('.periodButton')).toContain('border-radius: 999px;');
     expect(rule('.periodButton')).toContain('padding: 6px 8px;');
     expect(rule('.periodButton')).toContain('width: 100%;');
+    expect(rule('.periodButton')).toContain('font-size: 12px;');
+    expect(rule('.periodButton')).not.toContain('font-size: 14px;');
     expect(rule('.periodButton')).toContain('text-align: center;');
     expect(rule('.periodButton')).not.toContain('border-bottom:');
     expect(rule('.periodButtonActive')).toContain('border-color: color-mix(');
@@ -69,6 +79,7 @@ describe('Ranking table context styles', () => {
     expect(rule('.metricControl')).toContain('min-height: 40px;');
     expect(rule('.metricSelect')).toContain('height: 40px;');
     expect(rule('.metricSelect')).toContain('border-radius: 999px;');
+    expect(rule('.metricSelect')).not.toContain('font-size: 14px;');
     expect(rule('.metricWidthSizer')).toContain('visibility: hidden;');
   });
 
@@ -241,12 +252,11 @@ describe('Ranking table context styles', () => {
     const header = rule('.leaderboardHeader');
     const meta = rule('.boardMeta');
     expect(cardSelectors).toEqual(['.leaderboardCard:global(.card) {']);
-    expect(card).toContain('padding: 20px;');
-    expect(card).toContain('border-radius: 24px;');
+    expect(card).not.toContain('padding: 20px;');
+    expect(card).not.toContain('border-radius: 24px;');
     expect(card).toContain('gap: 14px;');
     expect(card).toContain('overflow: hidden;');
     expect(header).toContain('padding: 0;');
-    expect(header).toContain('margin: 0;');
     expect(meta).toContain('margin-top: 6px;');
     expect(meta).toContain('font-size: 13px;');
     expect(meta).toContain('line-height: 1.45;');

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -798,29 +798,6 @@
   }
 }
 
-.sectionTitleBlock {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
-}
-
-.sectionTitle {
-  margin: 0;
-  color: var(--text-primary);
-  font-size: 17px;
-  font-weight: 700;
-  line-height: 1.2;
-  letter-spacing: -0.01em;
-}
-
-.apiKeySettingsTitleRow {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-}
-
 .apiKeyVisibilityToggle:global(.btn) {
   width: 28px;
   height: 28px;
@@ -842,14 +819,6 @@
   border-color: color-mix(in srgb, var(--primary-color) 42%, var(--border-color));
   color: var(--primary-color);
   background: color-mix(in srgb, var(--primary-color) 10%, var(--bg-primary));
-}
-
-.sectionSubtitle {
-  margin: 0;
-  color: var(--text-secondary);
-  font-size: 12px;
-  line-height: 1.55;
-  max-width: 620px;
 }
 
 .cardHeaderCompact {
@@ -1125,6 +1094,14 @@
 
 .statCard.dailyAverageCard {
   --accent-border: rgba(139, 92, 246, 0.36);
+  --stat-card-accent-strip: linear-gradient(
+    90deg,
+    transparent 0%,
+    #3b82f6 var(--stat-card-strip-corner-offset),
+    #8b5cf6 28%,
+    #f59e0b 48%,
+    transparent var(--stat-card-strip-fade-end)
+  );
 
   height: 100%;
   min-width: 0;
@@ -1134,10 +1111,6 @@
     radial-gradient(90% 120% at 0% 0%, rgba(59, 130, 246, 0.14), transparent 58%),
     linear-gradient(180deg, rgba(139, 92, 246, 0.07), rgba(255, 255, 255, 0)),
     var(--bg-primary);
-
-  &::before {
-    background: linear-gradient(90deg, #3b82f6 0%, #8b5cf6 52%, #f59e0b 100%);
-  }
 
   @include desktop {
     padding-inline: 22px;
@@ -1251,13 +1224,23 @@
   --accent: var(--primary-color);
   --accent-soft: rgba($primary-color, 0.18);
   --accent-border: rgba($primary-color, 0.35);
+  --stat-card-strip-corner-offset: 12px;
+  --stat-card-strip-fade-end: calc(100% - clamp(18px, 4%, 32px));
+  --stat-card-accent-strip: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--accent) var(--stat-card-strip-corner-offset),
+    color-mix(in srgb, var(--accent) 68%, transparent) 42%,
+    transparent var(--stat-card-strip-fade-end)
+  );
 
   position: relative;
   padding: 18px;
   background:
     radial-gradient(120% 140% at 12% 0%, var(--accent-soft) 0%, rgba(0, 0, 0, 0) 62%),
     linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0)), var(--bg-primary);
-  border-radius: $radius-lg;
+  // 顶部七张统计卡的 24px 圆角试用项；需要退回时只恢复这一处。
+  border-radius: var(--keeper-card-radius);
   border: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
@@ -1273,12 +1256,48 @@
   &::before {
     content: '';
     position: absolute;
-    top: 0;
-    left: 0;
-    height: 3px;
-    width: 100%;
-    background: linear-gradient(90deg, var(--accent), rgba(0, 0, 0, 0));
+    inset: -1px;
+    border-radius: calc(var(--keeper-card-radius) + 1px);
+    padding: 4px;
+    background: var(--stat-card-accent-strip);
     opacity: 0.95;
+    pointer-events: none;
+    clip-path: inset(0 calc(100% - 56px) calc(100% - var(--keeper-card-radius)) 0);
+    -webkit-mask:
+      linear-gradient(#000 0 0) content-box,
+      linear-gradient(#000 0 0);
+    mask:
+      linear-gradient(#000 0 0) content-box,
+      linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+  }
+
+  // 左侧以固定像素错峰接入圆角；右侧以比例和像素下限适配不同卡片宽度。
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0 0 auto;
+    height: 3px;
+    background: var(--stat-card-accent-strip);
+    opacity: 0.95;
+    pointer-events: none;
+    -webkit-mask:
+      linear-gradient(90deg, #000 0%, #000 calc(var(--stat-card-strip-fade-end) - clamp(70px, 12%, 100px)), transparent var(--stat-card-strip-fade-end)) 0 0 / 100% 17% no-repeat,
+      linear-gradient(90deg, transparent 0%, transparent 12px, #000 32px, #000 calc(var(--stat-card-strip-fade-end) - clamp(82px, 14%, 112px)), transparent calc(var(--stat-card-strip-fade-end) - clamp(6px, 1%, 10px))) 0 20% / 100% 17% no-repeat,
+      linear-gradient(90deg, transparent 0%, transparent 16px, #000 38px, #000 calc(var(--stat-card-strip-fade-end) - clamp(94px, 16%, 126px)), transparent calc(var(--stat-card-strip-fade-end) - clamp(12px, 2%, 18px))) 0 40% / 100% 17% no-repeat,
+      linear-gradient(90deg, transparent 0%, transparent 20px, #000 44px, #000 calc(var(--stat-card-strip-fade-end) - clamp(106px, 18%, 144px)), transparent calc(var(--stat-card-strip-fade-end) - clamp(18px, 3%, 26px))) 0 60% / 100% 17% no-repeat,
+      linear-gradient(90deg, transparent 0%, transparent 24px, #000 50px, #000 calc(var(--stat-card-strip-fade-end) - clamp(118px, 21%, 162px)), transparent calc(var(--stat-card-strip-fade-end) - clamp(24px, 4%, 34px))) 0 80% / 100% 17% no-repeat,
+      linear-gradient(90deg, transparent 0%, transparent 28px, #000 56px, #000 calc(var(--stat-card-strip-fade-end) - clamp(130px, 24%, 180px)), transparent calc(var(--stat-card-strip-fade-end) - clamp(30px, 5%, 42px))) 0 100% / 100% 17% no-repeat;
+    mask:
+      linear-gradient(90deg, #000 0%, #000 calc(var(--stat-card-strip-fade-end) - clamp(70px, 12%, 100px)), transparent var(--stat-card-strip-fade-end)) 0 0 / 100% 17% no-repeat,
+      linear-gradient(90deg, transparent 0%, transparent 12px, #000 32px, #000 calc(var(--stat-card-strip-fade-end) - clamp(82px, 14%, 112px)), transparent calc(var(--stat-card-strip-fade-end) - clamp(6px, 1%, 10px))) 0 20% / 100% 17% no-repeat,
+      linear-gradient(90deg, transparent 0%, transparent 16px, #000 38px, #000 calc(var(--stat-card-strip-fade-end) - clamp(94px, 16%, 126px)), transparent calc(var(--stat-card-strip-fade-end) - clamp(12px, 2%, 18px))) 0 40% / 100% 17% no-repeat,
+      linear-gradient(90deg, transparent 0%, transparent 20px, #000 44px, #000 calc(var(--stat-card-strip-fade-end) - clamp(106px, 18%, 144px)), transparent calc(var(--stat-card-strip-fade-end) - clamp(18px, 3%, 26px))) 0 60% / 100% 17% no-repeat,
+      linear-gradient(90deg, transparent 0%, transparent 24px, #000 50px, #000 calc(var(--stat-card-strip-fade-end) - clamp(118px, 21%, 162px)), transparent calc(var(--stat-card-strip-fade-end) - clamp(24px, 4%, 34px))) 0 80% / 100% 17% no-repeat,
+      linear-gradient(90deg, transparent 0%, transparent 28px, #000 56px, #000 calc(var(--stat-card-strip-fade-end) - clamp(130px, 24%, 180px)), transparent calc(var(--stat-card-strip-fade-end) - clamp(30px, 5%, 42px))) 0 100% / 100% 17% no-repeat;
+    -webkit-mask-composite: source-over, source-over, source-over, source-over, source-over;
+    mask-composite: add, add, add, add, add;
   }
 
   &:hover {
@@ -1760,10 +1779,6 @@
 
 .settingsSections {
   --settings-list-scroll-height: 480px;
-}
-
-.settingsSections > :global(.card) {
-  box-shadow: var(--shadow-lg);
 }
 
 .requestEventsTableWrapper[data-scroll-boundary-contained='true'],
@@ -2600,22 +2615,7 @@
   flex: 1 0 auto;
   display: flex;
   flex-direction: column;
-  padding: 0;
   overflow: hidden;
-  box-shadow: var(--shadow-lg);
-
-  :global(.card-header) {
-    align-items: stretch;
-    margin-bottom: 0;
-    padding: 20px 22px 16px;
-    border-bottom: 1px solid var(--border-color);
-  }
-
-  @include mobile {
-    :global(.card-header) {
-      padding: 18px;
-    }
-  }
 }
 
 .requestEventsCard > .hint,
@@ -2625,13 +2625,6 @@
   min-height: 400px;
   align-items: center;
   justify-content: center;
-}
-
-.requestEventsTitleRow {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
 }
 
 .requestEventsCountBadge {
@@ -3764,14 +3757,10 @@
 .overviewRealtimeCard {
   min-width: 0;
   min-height: 310px;
-  background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: $radius-lg;
-  padding: 16px;
+  padding: var(--keeper-card-padding);
   display: flex;
   flex-direction: column;
   gap: 12px;
-  box-shadow: var(--shadow-lg);
 }
 
 .overviewRealtimeCardFull {
@@ -3800,7 +3789,6 @@
 
 .overviewRealtimeCardCompact {
   min-height: 250px;
-  padding: 14px 16px;
   gap: 10px;
 }
 
@@ -3818,15 +3806,6 @@
   @include mobile {
     flex-direction: column;
   }
-}
-
-.overviewRealtimeCardTitle {
-  margin: 0;
-  color: var(--text-primary);
-  font-size: 16px;
-  font-weight: 800;
-  letter-spacing: 0;
-  line-height: 1.2;
 }
 
 .overviewRealtimeMetrics {
@@ -4058,14 +4037,10 @@
 // Overview Activity cards share one fixed 7×52 grid and only vary metric semantics.
 .activityCard {
   min-width: 0;
-  background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: $radius-lg;
-  padding: 18px;
+  padding: var(--keeper-card-padding);
   display: flex;
   flex-direction: column;
   gap: 14px;
-  box-shadow: var(--shadow-lg);
   --activity-heatmap-gap: 3px;
   --activity-heatmap-idle: var(--border-secondary, #e5e7eb);
 }

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 const readSource = (url: URL) => readFileSync(url, 'utf8').replace(/\r\n/g, '\n')
 
 const globalStyles = readSource(new URL('../../styles/global.scss', import.meta.url))
+const componentsStyles = readSource(new URL('../../styles/components.scss', import.meta.url))
 const usagePageStyles = readSource(new URL('../UsagePage.module.scss', import.meta.url))
 const usagePageSource = readSource(new URL('../UsagePage.tsx', import.meta.url))
 const keyOverviewPageStyles = readSource(new URL('../KeyOverviewPage.module.scss', import.meta.url))
@@ -30,6 +31,7 @@ const overviewRealtimePanelSource = readSource(new URL('../../components/usage/O
 const overviewActivityCardsSource = readSource(new URL('../../components/usage/OverviewActivityCards.tsx', import.meta.url))
 const activityHeatmapGridSource = readSource(new URL('../../components/usage/ActivityHeatmapGrid.tsx', import.meta.url))
 const serviceHealthCardSource = readSource(new URL('../../components/usage/ServiceHealthCard.tsx', import.meta.url))
+const tokenActivityCardSource = readSource(new URL('../../components/usage/TokenActivityCard.tsx', import.meta.url))
 const statCardsSource = readSource(new URL('../../components/usage/StatCards.tsx', import.meta.url))
 const dailyAverageCardSource = readSource(new URL('../../components/usage/DailyAverageCard.tsx', import.meta.url))
 const timeRangeControlSource = readSource(new URL('../../components/usage/TimeRangeControl.tsx', import.meta.url))
@@ -77,6 +79,48 @@ describe('UsagePage toolbar styles', () => {
       expect(logo).toMatch(/font-size:\s*20px;/)
       expect(logo).not.toContain('box-shadow')
     }
+  })
+
+  it('routes Settings and Request Event Log headings through the global Card contract', () => {
+    expect(sessionSettingsSource).toContain("title={t('usage_stats.session_settings_title')}")
+    expect(sessionSettingsSource).toContain("subtitle={t('usage_stats.session_settings_subtitle')}")
+    expect(apiKeySettingsSource).toContain("title={t('usage_stats.api_key_settings_title')}")
+    expect(apiKeySettingsSource).toContain("subtitle={t('usage_stats.api_key_settings_subtitle')}")
+    expect(apiKeySettingsSource).toContain('titleMeta={')
+    expect(priceSettingsSource).toContain("title={t('usage_stats.model_price_settings_title')}")
+    expect(priceSettingsSource).toContain("subtitle={t('usage_stats.model_price_settings_subtitle')}")
+    expect(requestEventsSource).toContain('variant="flush"')
+    expect(requestEventsSource).toContain("title={t('usage_stats.request_events_title')}")
+    expect(requestEventsSource).toContain("subtitle={t('usage_stats.request_events_subtitle')}")
+    expect(requestEventsSource).toContain('titleMeta={')
+  })
+
+  it('keeps list internals square while subtitles use regular global weight', () => {
+    const subtitleBlock = styleRuleBlock(componentsStyles, '.keeper-card-subtitle')
+    const requestEventsCardBlock = styleRuleBlock(usagePageStyles, '.requestEventsCard:global(.card)')
+
+    expect(subtitleBlock).toContain('font-weight: var(--keeper-card-subtitle-weight);')
+    expect(requestEventsCardBlock).not.toContain('border-radius: 24px;')
+    expect(usagePageStyles).toMatch(/\.statCard\s*\{[\s\S]*?border-radius:\s*var\(--keeper-card-radius\);/)
+    expect(usagePageStyles).toMatch(/\.requestEventsTableWrapper\s*\{[\s\S]*?border:\s*0;[\s\S]*?border-radius:\s*0;/)
+  })
+
+  it('routes Analysis and Activity cards through the global surface and heading contract', () => {
+    const analysisChartSurface = styleRuleBlock(analysisPanelStyles, '\n.analysisChartSurface {')
+
+    expect(analysisPanelSource.match(/keeper-card-surface/g)).toHaveLength(6)
+    expect(analysisPanelSource).toContain('keeper-card-title-track')
+    expect(analysisPanelSource).toContain('keeper-card-title')
+    expect(analysisPanelSource).toContain('keeper-card-subtitle')
+    expect(serviceHealthCardSource).toContain('keeper-card-surface')
+    expect(serviceHealthCardSource).toContain('keeper-card-title-track')
+    expect(serviceHealthCardSource).toContain('keeper-card-title')
+    expect(serviceHealthCardSource).toContain('keeper-card-subtitle')
+    expect(tokenActivityCardSource).toContain('keeper-card-surface')
+    expect(tokenActivityCardSource).toContain('keeper-card-title-track')
+    expect(statCardsSource).not.toContain('keeper-card-surface')
+    expect(dailyAverageCardSource).not.toContain('keeper-card-surface')
+    expect(analysisChartSurface).toContain('border-radius: $radius-lg;')
   })
 
   it('keeps ranking filters out of the shared top toolbar so only Refresh remains there', () => {
@@ -393,6 +437,8 @@ describe('UsagePage toolbar styles', () => {
   })
 
   it('keeps overview stat cards in a primary row plus a four-card desktop grid', () => {
+    const statCard = styleRuleBlock(usagePageStyles, '\n.statCard {')
+
     expect(usagePageStyles).toMatch(/\.primaryStatsRow\s*\{[\s\S]*?display:\s*flex;/)
     expect(usagePageStyles).toMatch(/\.secondaryStatsGrid\s*\{[\s\S]*?grid-template-columns:\s*repeat\(4, minmax\(0, 1fr\)\);/)
     expect(usagePageStyles).toMatch(/\.statLabel\s*\{[\s\S]*?letter-spacing:\s*0;/)
@@ -403,6 +449,7 @@ describe('UsagePage toolbar styles', () => {
     expect(statCardsSource).toContain("key: 'cache-read-rate'")
     expect(statCardsSource).toContain("accent: '#14b8a6'")
     expect(statCardsSource.match(/accent:\s*'#[0-9a-f]{6}'/g)).toHaveLength(new Set(statCardsSource.match(/accent:\s*'#[0-9a-f]{6}'/g)).size)
+    expect(statCard).toContain('border-radius: var(--keeper-card-radius);')
   })
 
   it('expands Daily Average as the first compact primary card without changing row height', () => {
@@ -458,6 +505,65 @@ describe('UsagePage toolbar styles', () => {
     expect(dailyAverageCardStyles).not.toContain('radial-gradient(88% 110% at 100% 100%, rgba(245, 158, 11, 0.12)')
   })
 
+  it('keeps the overview accent strip full-width through the top-left curve', () => {
+    const statCardStart = usagePageStyles.indexOf('\n.statCard {')
+    const statCardEnd = usagePageStyles.indexOf('\n.primaryStatSlot', statCardStart)
+    const statCardStyles = usagePageStyles.slice(statCardStart, statCardEnd)
+    const accentCornerStyles = styleRuleBlock(statCardStyles, '&::before')
+
+    expect(statCardStyles).toContain('--stat-card-strip-corner-offset: 12px;')
+    expect(statCardStyles).toContain('--stat-card-accent-strip: linear-gradient(')
+    expect(accentCornerStyles).toContain('inset: -1px;')
+    expect(accentCornerStyles).toContain('border-radius: calc(var(--keeper-card-radius) + 1px);')
+    expect(accentCornerStyles).toContain('padding: 4px;')
+    expect(accentCornerStyles).toContain('background: var(--stat-card-accent-strip);')
+    expect(accentCornerStyles).toContain('clip-path: inset(0 calc(100% - 56px) calc(100% - var(--keeper-card-radius)) 0);')
+    expect(accentCornerStyles).toContain('-webkit-mask-composite: xor;')
+    expect(accentCornerStyles).toContain('mask-composite: exclude;')
+  })
+
+  it('keeps the right-side accent taper smooth across short and wide stat cards', () => {
+    const statCardStart = usagePageStyles.indexOf('\n.statCard {')
+    const statCardEnd = usagePageStyles.indexOf('\n.primaryStatSlot', statCardStart)
+    const statCardStyles = usagePageStyles.slice(statCardStart, statCardEnd)
+    const accentBodyStyles = styleRuleBlock(statCardStyles, '&::after')
+
+    expect(statCardStyles).toContain('--stat-card-strip-fade-end: calc(100% - clamp(18px, 4%, 32px));')
+    expect(accentBodyStyles).toContain('inset: 0 0 auto;')
+    expect(accentBodyStyles).toContain('height: 3px;')
+    expect(accentBodyStyles).toContain('background: var(--stat-card-accent-strip);')
+    expect(accentBodyStyles.match(/linear-gradient\(90deg/g)).toHaveLength(12)
+    expect(accentBodyStyles).toContain('linear-gradient(90deg, #000 0%, #000 calc(var(--stat-card-strip-fade-end) - clamp(70px, 12%, 100px)), transparent var(--stat-card-strip-fade-end)) 0 0 / 100% 17% no-repeat')
+    expect(accentBodyStyles).toContain('#000 calc(var(--stat-card-strip-fade-end) - clamp(94px, 16%, 126px)), transparent calc(var(--stat-card-strip-fade-end) - clamp(12px, 2%, 18px))) 0 40% / 100% 17% no-repeat')
+    expect(accentBodyStyles).toContain('#000 calc(var(--stat-card-strip-fade-end) - clamp(130px, 24%, 180px)), transparent calc(var(--stat-card-strip-fade-end) - clamp(30px, 5%, 42px))) 0 100% / 100% 17% no-repeat')
+    expect(accentBodyStyles).toContain('mask-composite: add, add, add, add, add;')
+  })
+
+  it('blends the left corner border into the full-width accent strip without a thickness jump', () => {
+    const statCardStart = usagePageStyles.indexOf('\n.statCard {')
+    const statCardEnd = usagePageStyles.indexOf('\n.primaryStatSlot', statCardStart)
+    const statCardStyles = usagePageStyles.slice(statCardStart, statCardEnd)
+    const accentBodyStyles = styleRuleBlock(statCardStyles, '&::after')
+
+    expect(accentBodyStyles).toContain('linear-gradient(90deg, transparent 0%, transparent 12px, #000 32px,')
+    expect(accentBodyStyles).toContain('linear-gradient(90deg, transparent 0%, transparent 16px, #000 38px,')
+    expect(accentBodyStyles).toContain('linear-gradient(90deg, transparent 0%, transparent 28px, #000 56px,')
+  })
+
+  it('compresses Daily Average colors forward before fading out like the other stat cards', () => {
+    const dailyAverageStart = usagePageStyles.indexOf('.statCard.dailyAverageCard')
+    const dailyAverageEnd = usagePageStyles.indexOf('\n.dailyAverageCardHeader', dailyAverageStart)
+    const dailyAverageStyles = usagePageStyles.slice(dailyAverageStart, dailyAverageEnd)
+
+    expect(dailyAverageStyles).toContain('--stat-card-accent-strip: linear-gradient(')
+    expect(dailyAverageStyles).toContain('transparent 0%')
+    expect(dailyAverageStyles).toContain('#3b82f6 var(--stat-card-strip-corner-offset)')
+    expect(dailyAverageStyles).toContain('#8b5cf6 28%')
+    expect(dailyAverageStyles).toContain('#f59e0b 48%')
+    expect(dailyAverageStyles).toContain('transparent var(--stat-card-strip-fade-end)')
+    expect(dailyAverageStyles).not.toContain('&::before')
+  })
+
   it('keeps primary overview cards stacked in one column on mobile', () => {
     expect(usagePageStyles).toMatch(/\.primaryStatsRow\s*\{[\s\S]*?@include mobile\s*\{[\s\S]*?flex-direction:\s*column;[\s\S]*?overflow:\s*visible;/)
     expect(usagePageStyles).toMatch(/\.dailyAverageSlot\s*\{[\s\S]*?@include mobile\s*\{[\s\S]*?flex:\s*0 0 auto;[\s\S]*?width:\s*100%;[\s\S]*?max-height:\s*0;[\s\S]*?margin-right:\s*0;[\s\S]*?margin-bottom:\s*-14px;/)
@@ -466,6 +572,9 @@ describe('UsagePage toolbar styles', () => {
   })
 
   it('renders Recent Activity between the stat cards and realtime metrics', () => {
+    const realtimeCard = styleRuleBlock(usagePageStyles, '.overviewRealtimeCard')
+    const realtimeCompactCard = styleRuleBlock(usagePageStyles, '.overviewRealtimeCardCompact')
+
     expect(usagePageSource).toContain('<OverviewRealtimePanel')
     expect(keyOverviewPageSource).toContain('<OverviewRealtimePanel')
     expect(usagePageSource).toContain('<RecentActivityPanel')
@@ -493,6 +602,9 @@ describe('UsagePage toolbar styles', () => {
     expect(usagePageStyles).toMatch(/\.overviewRealtimeCardFull\s*\{[\s\S]*?grid-column:\s*1 \/ -1;/)
     expect(usagePageStyles).toMatch(/\.overviewRealtimeWindowSwitcher\s*\{[\s\S]*?border-radius:\s*999px;/)
     expect(usagePageStyles).toMatch(/\.overviewRealtimeSection\s*\{[\s\S]*?margin-top:\s*12px;/)
+    expect(realtimeCard).toContain('padding: var(--keeper-card-padding);')
+    expect(realtimeCard).not.toMatch(/(?:background|border|border-radius|box-shadow):/)
+    expect(realtimeCompactCard).not.toContain('padding:')
     expect(usagePageStyles).not.toMatch(/\.overviewRealtimeSection\s*\{[\s\S]*?border-top:/)
     expect(usagePageStyles).not.toMatch(/\.overviewRealtimeSection\s*\{[\s\S]*?padding-top:/)
     expect(usagePageSource).toContain("value === '15m' || value === '30m' || value === '60m'")
@@ -574,9 +686,10 @@ describe('UsagePage toolbar styles', () => {
     expect(usagePageStyles).toMatch(/\.usageFilterTransitionImmediate\s+\.usageFilterTransitionInner\s*\{[\s\S]*?display:\s*contents;/)
   })
 
-  it('gives Request Events and Settings cards page-level elevation', () => {
-    expect(styleRuleBlock(usagePageStyles, '.requestEventsCard:global(.card)')).toContain('box-shadow: var(--shadow-lg);')
-    expect(styleRuleBlock(usagePageStyles, '.settingsSections > :global(.card)')).toContain('box-shadow: var(--shadow-lg);')
+  it('gets Request Events and Settings elevation from the global card surface', () => {
+    expect(styleRuleBlock(componentsStyles, '.keeper-card-surface')).toContain('box-shadow: var(--shadow-lg);')
+    expect(styleRuleBlock(usagePageStyles, '.requestEventsCard:global(.card)')).not.toContain('box-shadow:')
+    expect(usagePageStyles).not.toContain('.settingsSections > :global(.card)')
   })
 
   it('does not reload Request Events filter options for table query changes', () => {
@@ -1066,7 +1179,8 @@ describe('UsagePage toolbar styles', () => {
   })
 
   it('aligns Request Event Log pagination with credential pagination height', () => {
-    expect(usagePageStyles).toMatch(/\.requestEventsCard:global\(\.card\)\s*\{[\s\S]*?padding:\s*0;/)
+    expect(requestEventsSource).toContain('variant="flush"')
+    expect(styleRuleBlock(componentsStyles, '.card-flush')).toContain('padding: 0;')
     expect(requestEventsSource).toContain('className={styles.requestEventsCard}')
     expect(usagePageStyles).toMatch(/\.requestEventsPaginationFooter\s*\{[\s\S]*?--usage-pagination-bar-height:\s*51px;/)
     expect(usagePageStyles).toMatch(/\.requestEventsPaginationFooter\s*\{[\s\S]*?height:\s*var\(--usage-pagination-bar-height\);/)
@@ -1089,19 +1203,17 @@ describe('UsagePage toolbar styles', () => {
   })
 
   it('renders Request Event Log with a single outer frame instead of a nested table card', () => {
-    const cardBlock = usagePageStyles.slice(
-      usagePageStyles.indexOf('.requestEventsCard:global(.card) {'),
-      usagePageStyles.indexOf('.requestEventsTitleRow')
-    )
+    const cardBlock = styleRuleBlock(usagePageStyles, '.requestEventsCard:global(.card)')
+    const flushBlock = styleRuleBlock(componentsStyles, '.card-flush')
     const tableWrapperBlock = usagePageStyles.slice(
       usagePageStyles.indexOf('.requestEventsTableWrapper {'),
       usagePageStyles.indexOf('.requestEventsNoWrapCell')
     )
 
-    expect(cardBlock).toMatch(/padding:\s*0;/)
+    expect(flushBlock).toMatch(/padding:\s*0;/)
     expect(cardBlock).toMatch(/overflow:\s*hidden;/)
-    expect(cardBlock).toMatch(/:global\(\.card-header\)\s*\{[\s\S]*?margin-bottom:\s*0;/)
-    expect(cardBlock).toMatch(/:global\(\.card-header\)\s*\{[\s\S]*?border-bottom:\s*1px solid var\(--border-color\);/)
+    expect(componentsStyles).toMatch(/\.card-flush\s*>\s*\.card-header\s*\{[\s\S]*?margin-bottom:\s*0;[\s\S]*?border-bottom:\s*1px solid var\(--border-color\);/)
+    expect(componentsStyles).toMatch(/@media \(max-width:\s*\$breakpoint-mobile\)[\s\S]*?\.card-flush\s*>\s*\.card-header\s*\{[\s\S]*?padding:\s*18px;/)
     expect(tableWrapperBlock).toMatch(/border:\s*0;/)
     expect(tableWrapperBlock).toMatch(/border-radius:\s*0;/)
     expect(tableWrapperBlock).not.toMatch(/border:\s*1px solid/)

--- a/web/src/styles/components.scss
+++ b/web/src/styles/components.scss
@@ -602,6 +602,10 @@ textarea {
     padding: $spacing-md;
   }
 
+  .card-header {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   .card-flush > .card-header {
     padding: 18px;
   }

--- a/web/src/styles/components.scss
+++ b/web/src/styles/components.scss
@@ -6,10 +6,13 @@
   align-items: center;
   justify-content: center;
   gap: $spacing-sm;
+  min-height: var(--keeper-control-height-md);
   border: 1px solid transparent;
   border-radius: $radius-md;
-  padding: 10px 14px;
+  padding: 0 14px;
+  font-size: var(--keeper-control-font-size);
   font-weight: 600;
+  line-height: 1;
   cursor: pointer;
   transition: all $transition-fast;
   background-color: var(--bg-secondary);
@@ -49,12 +52,13 @@
   }
 
   &.btn-danger {
-    background-color: $error-color;
-    border-color: $error-color;
+    background-color: var(--danger-color);
+    border-color: var(--danger-color);
     color: #fff;
 
     &:hover {
-      background-color: color.adjust($error-color, $lightness: -5%);
+      background-color: color-mix(in srgb, var(--danger-color) 92%, #000);
+      border-color: color-mix(in srgb, var(--danger-color) 92%, #000);
     }
   }
 
@@ -63,8 +67,9 @@
   }
 
   &.btn-sm {
-    padding: 8px 10px;
-    font-size: 14px;
+    min-height: var(--keeper-control-height-sm);
+    padding: 0 12px;
+    font-size: var(--keeper-control-font-size);
   }
 
   &:disabled {
@@ -118,33 +123,79 @@ textarea {
   }
 }
 
-.card {
+.keeper-card-surface {
   background-color: var(--bg-primary);
   border: 1px solid var(--border-color);
-  border-radius: $radius-lg;
-  box-shadow: var(--shadow);
-  padding: $spacing-lg;
+  border-radius: var(--keeper-card-radius);
+  box-shadow: var(--shadow-lg);
+}
+
+.card {
+  @extend .keeper-card-surface;
+  padding: var(--keeper-card-padding);
+}
+
+.card-flush {
+  padding: 0;
 }
 
 .card-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: $spacing-sm;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 16px;
   margin-bottom: $spacing-md;
+}
 
-  > * {
-    min-width: 0;
-  }
+.card-flush > .card-header {
+  margin-bottom: 0;
+  padding: var(--keeper-card-header-padding-top) var(--keeper-card-header-padding-x)
+    var(--keeper-card-header-padding-bottom);
+  border-bottom: 1px solid var(--border-color);
+}
 
-  .title {
-    flex: 1 1 auto;
-    min-width: 0;
-    font-size: 18px;
-    font-weight: 700;
-    color: var(--text-primary);
-  }
+.keeper-card-heading {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.keeper-card-title-track {
+  display: flex;
+  min-width: 0;
+  min-height: var(--keeper-card-title-track-height);
+  align-items: center;
+  gap: 10px;
+}
+
+.keeper-card-title {
+  min-width: 0;
+  color: var(--text-primary);
+  font-size: var(--keeper-card-title-size);
+  font-weight: var(--keeper-card-title-weight);
+  line-height: var(--keeper-card-title-line-height);
+}
+
+.keeper-card-title-meta {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+}
+
+.keeper-card-subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--keeper-card-subtitle-size);
+  font-weight: var(--keeper-card-subtitle-weight);
+  line-height: var(--keeper-card-subtitle-line-height);
+}
+
+.keeper-card-actions {
+  display: flex;
+  min-height: var(--keeper-card-title-track-height);
+  align-items: center;
+  justify-content: flex-end;
 }
 
 .status-badge {
@@ -413,7 +464,7 @@ textarea {
 
 .modal {
   background: var(--bg-primary);
-  border-radius: $radius-lg;
+  border-radius: var(--keeper-card-radius);
   border: 1px solid var(--border-color);
   box-shadow: $shadow-lg;
   max-width: 100%;
@@ -518,12 +569,14 @@ textarea {
 .modal-header {
   display: flex;
   align-items: center;
+  min-height: calc(var(--keeper-card-title-track-height) + #{$spacing-md * 2});
   padding: $spacing-md $spacing-lg;
   border-bottom: 1px solid var(--border-color);
 
   .modal-title {
-    font-weight: 700;
-    font-size: 18px;
+    font-weight: var(--keeper-card-title-weight);
+    font-size: var(--keeper-card-title-size);
+    line-height: var(--keeper-card-title-line-height);
     color: var(--text-primary);
   }
 }
@@ -549,9 +602,13 @@ textarea {
     padding: $spacing-md;
   }
 
+  .card-flush > .card-header {
+    padding: 18px;
+  }
+
   .modal {
     max-height: calc(100vh - #{$spacing-md * 2});
-    border-radius: $radius-md;
+    border-radius: var(--keeper-card-radius);
   }
 
   @supports (height: 100dvh) {

--- a/web/src/styles/reset.scss
+++ b/web/src/styles/reset.scss
@@ -21,6 +21,7 @@ body {
 body {
   margin: 0;
   font-family: $font-family;
+  font-size: var(--keeper-body-font-size);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   line-height: 1.5;

--- a/web/src/styles/test/KeeperVisualFoundation.styles.test.ts
+++ b/web/src/styles/test/KeeperVisualFoundation.styles.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const themes = readFileSync(new URL('../themes.scss', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+const reset = readFileSync(new URL('../reset.scss', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+const components = readFileSync(new URL('../components.scss', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+
+describe('Keeper visual foundation', () => {
+  it('defines the global card, typography, and control scale', () => {
+    expect(themes).toContain('--keeper-card-radius: 24px;');
+    expect(themes).toContain('--keeper-card-padding: 20px;');
+    expect(themes).toContain('--keeper-card-title-size: 18px;');
+    expect(themes).toContain('--keeper-card-subtitle-size: 12px;');
+    expect(themes).toContain('--keeper-card-subtitle-weight: 400;');
+    expect(themes).toContain('--keeper-body-font-size: 12px;');
+    expect(themes).toContain('--keeper-control-font-size: 12px;');
+    expect(themes).toContain('--keeper-control-height-sm: 32px;');
+    expect(themes).toContain('--keeper-control-height-md: 36px;');
+    expect(themes).toContain('--keeper-toolbar-control-height: 42px;');
+    expect(reset).toMatch(/body\s*\{[\s\S]*?font-size:\s*var\(--keeper-body-font-size\);/);
+  });
+
+  it('makes cards, modals, titles, subtitles, and buttons consume the global contract', () => {
+    expect(components).toMatch(/\.keeper-card-surface\s*\{[\s\S]*?border-radius:\s*var\(--keeper-card-radius\);/);
+    expect(components).toMatch(/\.card\s*\{[\s\S]*?padding:\s*var\(--keeper-card-padding\);/);
+    expect(components).toMatch(/\.card-flush\s*\{[\s\S]*?padding:\s*0;/);
+    expect(components).toMatch(/\.keeper-card-title\s*\{[\s\S]*?font-size:\s*var\(--keeper-card-title-size\);[\s\S]*?font-weight:\s*var\(--keeper-card-title-weight\);/);
+    expect(components).toMatch(/\.keeper-card-subtitle\s*\{[\s\S]*?font-size:\s*var\(--keeper-card-subtitle-size\);[\s\S]*?font-weight:\s*var\(--keeper-card-subtitle-weight\);/);
+    expect(components).toMatch(/\.btn\s*\{[\s\S]*?min-height:\s*var\(--keeper-control-height-md\);[\s\S]*?font-size:\s*var\(--keeper-control-font-size\);/);
+    expect(components).toMatch(/&\.btn-sm\s*\{[\s\S]*?min-height:\s*var\(--keeper-control-height-sm\);[\s\S]*?font-size:\s*var\(--keeper-control-font-size\);/);
+    expect(components).toMatch(/\.modal\s*\{[\s\S]*?border-radius:\s*var\(--keeper-card-radius\);/);
+    expect(components).toMatch(/@media \(max-width:\s*\$breakpoint-mobile\)[\s\S]*?\.modal\s*\{[\s\S]*?border-radius:\s*var\(--keeper-card-radius\);/);
+  });
+});

--- a/web/src/styles/themes.scss
+++ b/web/src/styles/themes.scss
@@ -4,6 +4,25 @@
 
 // 浅色主题（默认）
 :root {
+  // Keeper 全局视觉基础：普通页面、embed 与 Portal Modal 共用。
+  --keeper-card-radius: 24px;
+  --keeper-card-padding: 20px;
+  --keeper-card-header-padding-x: 22px;
+  --keeper-card-header-padding-top: 20px;
+  --keeper-card-header-padding-bottom: 16px;
+  --keeper-card-title-size: 18px;
+  --keeper-card-title-weight: 700;
+  --keeper-card-title-line-height: 1.2;
+  --keeper-card-title-track-height: 32px;
+  --keeper-card-subtitle-size: 12px;
+  --keeper-card-subtitle-weight: 400;
+  --keeper-card-subtitle-line-height: 1.5;
+  --keeper-body-font-size: 12px;
+  --keeper-control-font-size: 12px;
+  --keeper-control-height-sm: 32px;
+  --keeper-control-height-md: 36px;
+  --keeper-toolbar-control-height: 42px;
+
   // 极简暖灰：浅色模式
   --bg-secondary: #faf9f5; // 页面背景（纸感）
   --bg-primary: #f0eee8; // 容器/卡片背景

--- a/web/src/test/AppCPAMCEmbed.test.ts
+++ b/web/src/test/AppCPAMCEmbed.test.ts
@@ -31,6 +31,14 @@ describe('App CPAMC embed shell', () => {
     expect(embedStyles).not.toContain('scale(');
   });
 
+  it('inherits the global card, modal, and title contract without embed overrides', () => {
+    expect(embedStyles).not.toContain('--keeper-card-');
+    expect(embedStyles).not.toMatch(/\.card(?:\s|,|\{)/);
+    expect(embedStyles).not.toMatch(/\.modal(?:\s|,|\{)/);
+    expect(embedStyles).not.toContain('keeper-card-title');
+    expect(embedStyles).not.toContain('font-size:');
+  });
+
   it('preserves the CPAMC embed query when normalizing app paths', () => {
     const replaceStateTargets = Array.from(appSource.matchAll(/window\.history\.replaceState\(null, '', ([\s\S]*?)\);/g)).map((match) => match[1]);
 


### PR DESCRIPTION
## Summary

- define shared card, heading, typography, and control tokens for dashboard surfaces
- apply the shared visual contract across Overview, Analysis, Ranking, Request Events, Settings, credentials, and modals
- align Overview statistic cards and accent treatments while preserving CPAMC embed isolation

## Validation

- `TZ=UTC GOCACHE=/root/.cache/codex-build/cpa-usage-keeper/go-build GOFLAGS=-count=1 make verify`