### PR TITLE
fix(ui): remove pill chrome from header logos

### DIFF
--- a/web/src/pages/KeyOverviewPage.module.scss
+++ b/web/src/pages/KeyOverviewPage.module.scss
@@ -61,19 +61,14 @@
   align-items: center;
   justify-content: center;
   min-height: var(--keeper-toolbar-control-height, 42px);
-  padding: 0 20px;
-  border-radius: 999px;
-  border: 1px solid rgba($primary-color, 0.24);
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--bg-primary) 94%, rgba($primary-color, 0.06)), color-mix(in srgb, var(--bg-secondary) 82%, transparent)),
-    var(--bg-secondary);
-  box-shadow:
-    0 8px 20px rgba(0, 0, 0, 0.08),
-    0 1px 0 rgba(255, 255, 255, 0.05) inset;
-  color: color-mix(in srgb, var(--text-primary) 88%, var(--primary-color));
-  font-size: 18px;
-  font-weight: 800;
-  letter-spacing: 0.08em;
+  padding: 0;
+  border-radius: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 20px;
+  font-weight: 900;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   white-space: nowrap;
 }

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -61,19 +61,14 @@
   align-items: center;
   justify-content: center;
   min-height: var(--keeper-toolbar-control-height, 42px);
-  padding: 0 20px;
-  border-radius: 999px;
-  border: 1px solid rgba($primary-color, 0.24);
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--bg-primary) 94%, rgba($primary-color, 0.06)), color-mix(in srgb, var(--bg-secondary) 82%, transparent)),
-    var(--bg-secondary);
-  box-shadow:
-    0 8px 20px rgba(0, 0, 0, 0.08),
-    0 1px 0 rgba(255, 255, 255, 0.05) inset;
-  color: color-mix(in srgb, var(--text-primary) 88%, var(--primary-color));
-  font-size: 18px;
-  font-weight: 800;
-  letter-spacing: 0.08em;
+  padding: 0;
+  border-radius: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 20px;
+  font-weight: 900;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   white-space: nowrap;
 }

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -66,6 +66,19 @@ const styleRuleBlock = (source: string, selector: string) => {
 }
 
 describe('UsagePage toolbar styles', () => {
+  it('renders every authenticated page header logo at 20px without pill chrome', () => {
+    for (const pageStyles of [usagePageStyles, keyOverviewPageStyles]) {
+      const logo = styleRuleBlock(pageStyles, '.eyebrow')
+
+      expect(logo).toMatch(/padding:\s*0;/)
+      expect(logo).toMatch(/border-radius:\s*0;/)
+      expect(logo).toMatch(/border:\s*0;/)
+      expect(logo).toMatch(/background:\s*transparent;/)
+      expect(logo).toMatch(/font-size:\s*20px;/)
+      expect(logo).not.toContain('box-shadow')
+    }
+  })
+
   it('keeps ranking filters out of the shared top toolbar so only Refresh remains there', () => {
     expect(usagePageSource).not.toContain("import { RankingToolbar }")
     expect(usagePageSource).not.toContain('<RankingToolbar')


### PR DESCRIPTION
## Summary

- align Usage and Key Overview header branding with the login page
- render the header brand at 20px without pill chrome
- cover both authenticated page headers with a style regression test

## Verification

- TZ=UTC GOCACHE=/root/.cache/codex-build/cpa-usage-keeper/header-logo-verify GOFLAGS=-count=1 make verify