### PR TITLE
fix(ranking): refine responsive leaderboard header

### DIFF
--- a/web/src/features/ranking/RankingPage.module.scss
+++ b/web/src/features/ranking/RankingPage.module.scss
@@ -474,7 +474,7 @@
   gap: 8px;
   margin-top: 6px;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: 12px;
   line-height: 1.45;
   text-align: left;
 }
@@ -928,13 +928,14 @@
   }
 
   .leaderboardHeader {
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr);
     grid-template-areas:
-      'toolbar toolbar'
-      'title profile';
-    align-items: center;
-    column-gap: 12px;
-    row-gap: 10px;
+      'title'
+      'toolbar'
+      'profile';
+    align-items: stretch;
+    column-gap: 0;
+    row-gap: 14px;
     padding: 0;
   }
 
@@ -969,22 +970,32 @@
     width: 100%;
   }
 
+  .leaderboardTitle {
+    width: 100%;
+  }
+
   .boardMeta {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
     justify-content: flex-start;
     text-align: left;
   }
 
   .leaderboardHeaderActions {
-    justify-content: flex-end;
+    justify-content: center;
+    justify-self: center;
+    max-width: 100%;
     width: auto;
+    margin-right: 0;
   }
 
   .profileActionShell {
-    max-width: min(210px, 46vw);
+    max-width: 100%;
   }
 
   .profileActionShellActive {
-    max-width: min(260px, 52vw);
+    max-width: 100%;
   }
 
   .toolbar {

--- a/web/src/features/ranking/test/RankingPage.styles.test.ts
+++ b/web/src/features/ranking/test/RankingPage.styles.test.ts
@@ -142,16 +142,20 @@ describe('Ranking table context styles', () => {
     expect(rule('.profileActionAvatar')).toContain('flex: 0 0 22px;');
   });
 
-  it('keeps the filters above the title and profile entry on mobile', () => {
+  it('stacks the header in scan order with compact time text and a centered profile entry on mobile', () => {
     const mobileStart = styles.indexOf('@include mobile');
     const mobileEnd = styles.indexOf('@media (prefers-reduced-motion', mobileStart);
     const mobile = styles.slice(mobileStart, mobileEnd);
 
-    expect(mobile).toContain("'toolbar toolbar'");
-    expect(mobile).toContain("'title profile'");
+    expect(mobile).toContain("grid-template-areas:\n      'title'\n      'toolbar'\n      'profile';");
+    expect(mobile).toMatch(/\.boardMeta\s*\{[\s\S]*?align-items:\s*flex-start;/);
+    expect(mobile).toMatch(/\.boardMeta\s*\{[\s\S]*?flex-direction:\s*column;/);
     expect(mobile).toContain('.leaderboardHeaderToolbar');
     expect(mobile).toContain('justify-self: stretch;');
-    expect(mobile).toContain('max-width: min(260px, 52vw);');
+    expect(mobile).toMatch(/\.leaderboardHeaderActions\s*\{[\s\S]*?justify-content:\s*center;/);
+    expect(mobile).toMatch(/\.leaderboardHeaderActions\s*\{[\s\S]*?justify-self:\s*center;/);
+    expect(mobile).toMatch(/\.leaderboardHeaderActions\s*\{[\s\S]*?margin-right:\s*0;/);
+    expect(mobile).toMatch(/\.profileActionShellActive\s*\{[\s\S]*?max-width:\s*100%;/);
   });
 
   it('gives loading, empty, and error content a tall centered viewport', () => {
@@ -258,7 +262,7 @@ describe('Ranking table context styles', () => {
     expect(card).toContain('overflow: hidden;');
     expect(header).toContain('padding: 0;');
     expect(meta).toContain('margin-top: 6px;');
-    expect(meta).toContain('font-size: 13px;');
+    expect(meta).toContain('font-size: 12px;');
     expect(meta).toContain('line-height: 1.45;');
 
     const mobileStart = styles.indexOf('@include mobile');


### PR DESCRIPTION
## Summary

- stack the Ranking title, update metadata, filters, and profile entry in a stable mobile scan order
- center the mobile profile entry while preserving the desktop header layout
- render leaderboard update metadata at 12px across desktop and mobile

## Testing

- full make verify baseline with TZ=UTC and GOFLAGS=-count=1