### PR TITLE
fix(analysis): use daily rollups for day ranges

### DIFF
--- a/internal/repository/test/usage_analysis_projection_test.go
+++ b/internal/repository/test/usage_analysis_projection_test.go
@@ -212,7 +212,7 @@ func TestAnalysisProjectionPreservesHourlyResultsAndAPIKeyFiltering(t *testing.T
 	assertAnalysisProjectionComposition(t, filtered.APIKeyComposition, "group-a", "", 2, 1_300_000, 9.3)
 }
 
-func TestAnalysisProjectionPreservesDailyAndBoundaryHourlyResults(t *testing.T) {
+func TestAnalysisProjectionPreservesDailyResultsWithoutBoundaryHourlyRows(t *testing.T) {
 	db := openTestDatabase(t)
 	start := time.Date(2026, 2, 1, 5, 0, 0, 0, time.Local)
 	end := time.Date(2026, 2, 4, 8, 0, 0, 0, time.Local)
@@ -234,11 +234,19 @@ func TestAnalysisProjectionPreservesDailyAndBoundaryHourlyResults(t *testing.T) 
 	}).Error; err != nil {
 		t.Fatalf("seed boundary hourly stats: %v", err)
 	}
-	if err := db.Create(&entities.UsageOverviewDailyStat{
-		BucketStart: time.Date(2026, 2, 2, 0, 0, 0, 0, time.Local), APIGroupKey: "group-a", Model: "model-a",
-		AuthIndex: "identity-a", ModelAlias: "alias-a", ResponseServiceTier: "batch", ReasoningEffort: "xhigh", ExecutorType: "cli",
-		RequestCount: 2, InputTokens: 200, OutputTokens: 20, ReasoningTokens: 4, CacheReadTokens: 40,
-		CacheCreationTokens: 20, TotalTokens: 220,
+	if err := db.Create(&[]entities.UsageOverviewDailyStat{
+		{
+			BucketStart: time.Date(2026, 2, 2, 0, 0, 0, 0, time.Local), APIGroupKey: "group-a", Model: "model-a",
+			AuthIndex: "identity-a", ModelAlias: "alias-a", ResponseServiceTier: "batch", ReasoningEffort: "xhigh", ExecutorType: "cli",
+			RequestCount: 2, InputTokens: 200, OutputTokens: 20, ReasoningTokens: 4, CacheReadTokens: 40,
+			CacheCreationTokens: 20, TotalTokens: 220,
+		},
+		{
+			BucketStart: time.Date(2026, 2, 4, 0, 0, 0, 0, time.Local), APIGroupKey: "group-a", Model: "model-a",
+			AuthIndex: "identity-a", ModelAlias: "alias-a", ResponseServiceTier: "batch", ReasoningEffort: "xhigh", ExecutorType: "cli",
+			RequestCount: 3, InputTokens: 300, OutputTokens: 30, ReasoningTokens: 6, CacheReadTokens: 60,
+			CacheCreationTokens: 30, TotalTokens: 330,
+		},
 	}).Error; err != nil {
 		t.Fatalf("seed daily stat: %v", err)
 	}
@@ -254,7 +262,7 @@ func TestAnalysisProjectionPreservesDailyAndBoundaryHourlyResults(t *testing.T) 
 		t.Fatalf("BuildAnalysisWithFilter: %v", err)
 	}
 
-	if analysis.Granularity != repodto.AnalysisGranularityDaily || len(analysis.TokenUsage) != 3 {
+	if analysis.Granularity != repodto.AnalysisGranularityDaily || len(analysis.TokenUsage) != 2 {
 		t.Fatalf("unexpected daily result: %+v", analysis)
 	}
 	wantBuckets := []struct {
@@ -262,7 +270,6 @@ func TestAnalysisProjectionPreservesDailyAndBoundaryHourlyResults(t *testing.T) 
 		requests int64
 		tokens   int64
 	}{
-		{time.Date(2026, 2, 1, 0, 0, 0, 0, time.Local), 1, 110},
 		{time.Date(2026, 2, 2, 0, 0, 0, 0, time.Local), 2, 220},
 		{time.Date(2026, 2, 4, 0, 0, 0, 0, time.Local), 3, 330},
 	}
@@ -272,23 +279,23 @@ func TestAnalysisProjectionPreservesDailyAndBoundaryHourlyResults(t *testing.T) 
 			t.Fatalf("token usage[%d] = %+v, want bucket=%v requests=%d total=%d", i, got, want.bucket, want.requests, want.tokens)
 		}
 	}
-	assertAnalysisProjectionComposition(t, analysis.APIKeyComposition, "group-a", "", 6, 660, 0.01656)
-	assertAnalysisProjectionComposition(t, analysis.ModelComposition, "model-a", "", 6, 660, 0.01656)
-	assertAnalysisProjectionComposition(t, analysis.AuthFilesComposition, "identity-a", "Auth Account", 6, 660, 0.01656)
-	assertAnalysisProjectionComposition(t, analysis.AIProviderComposition, "identity-a", "Provider Account", 6, 660, 0.01656)
-	if len(analysis.Heatmap) != 1 || analysis.Heatmap[0].Requests != 6 || analysis.Heatmap[0].TotalTokens != 660 {
+	assertAnalysisProjectionComposition(t, analysis.APIKeyComposition, "group-a", "", 5, 550, 0.0138)
+	assertAnalysisProjectionComposition(t, analysis.ModelComposition, "model-a", "", 5, 550, 0.0138)
+	assertAnalysisProjectionComposition(t, analysis.AuthFilesComposition, "identity-a", "Auth Account", 5, 550, 0.0138)
+	assertAnalysisProjectionComposition(t, analysis.AIProviderComposition, "identity-a", "Provider Account", 5, 550, 0.0138)
+	if len(analysis.Heatmap) != 1 || analysis.Heatmap[0].Requests != 5 || analysis.Heatmap[0].TotalTokens != 550 {
 		t.Fatalf("unexpected daily heatmap: %+v", analysis.Heatmap)
 	}
-	assertFloatClose(t, analysis.Heatmap[0].CostUSD, 0.01656)
-	if len(analysis.ModelEfficiency) != 1 || analysis.ModelEfficiency[0].Requests != 6 || analysis.ModelEfficiency[0].TotalTokens != 660 {
+	assertFloatClose(t, analysis.Heatmap[0].CostUSD, 0.0138)
+	if len(analysis.ModelEfficiency) != 1 || analysis.ModelEfficiency[0].Requests != 5 || analysis.ModelEfficiency[0].TotalTokens != 550 {
 		t.Fatalf("unexpected daily model efficiency: %+v", analysis.ModelEfficiency)
 	}
-	assertFloatClose(t, analysis.ModelEfficiency[0].CostUSD, 0.01656)
-	assertFloatClose(t, analysis.CostBreakdown.UncachedInputCostUSD, 0.01008)
-	assertFloatClose(t, analysis.CostBreakdown.CacheReadCostUSD, 0.00144)
-	assertFloatClose(t, analysis.CostBreakdown.CacheWriteCostUSD, 0.00216)
-	assertFloatClose(t, analysis.CostBreakdown.OutputCostUSD, 0.00288)
-	assertFloatClose(t, analysis.CostBreakdown.TotalCostUSD, 0.01656)
+	assertFloatClose(t, analysis.ModelEfficiency[0].CostUSD, 0.0138)
+	assertFloatClose(t, analysis.CostBreakdown.UncachedInputCostUSD, 0.0084)
+	assertFloatClose(t, analysis.CostBreakdown.CacheReadCostUSD, 0.0012)
+	assertFloatClose(t, analysis.CostBreakdown.CacheWriteCostUSD, 0.0018)
+	assertFloatClose(t, analysis.CostBreakdown.OutputCostUSD, 0.0024)
+	assertFloatClose(t, analysis.CostBreakdown.TotalCostUSD, 0.0138)
 }
 
 func TestBuildAnalysisWithoutUsageEventsUsesOnlyRollupTables(t *testing.T) {

--- a/internal/repository/test/usage_rolling_range_test.go
+++ b/internal/repository/test/usage_rolling_range_test.go
@@ -11,7 +11,7 @@ import (
 	repodto "cpa-usage-keeper/internal/repository/dto"
 )
 
-func TestBuildAnalysisIncludesCurrentHourStatsForArbitraryHourRange(t *testing.T) {
+func TestBuildAnalysisKeepsTwentyFourHourAndDirectOneDayRangesOnHourlyStats(t *testing.T) {
 	previousLocal := time.Local
 	location, err := time.LoadLocation("Asia/Shanghai")
 	if err != nil {
@@ -25,8 +25,8 @@ func TestBuildAnalysisIncludesCurrentHourStatsForArbitraryHourRange(t *testing.T
 		t.Fatalf("OpenDatabase returned error: %v", err)
 	}
 	closeTestDatabase(t, db)
-	start := time.Date(2026, 5, 20, 20, 14, 21, 0, location)
 	end := time.Date(2026, 5, 21, 9, 14, 21, 0, location)
+	start := end.Add(-24 * time.Hour)
 	currentHour := time.Date(2026, 5, 21, 9, 0, 0, 0, location)
 	if err := db.Create(&entities.CPAAPIKey{APIKey: "sk-target-key", DisplayKey: "sk-*********target"}).Error; err != nil {
 		t.Fatalf("insert CPA API key: %v", err)
@@ -41,16 +41,208 @@ func TestBuildAnalysisIncludesCurrentHourStatsForArbitraryHourRange(t *testing.T
 		t.Fatalf("drop usage_events: %v", err)
 	}
 
-	analysis, err := repository.BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{Range: "13h", StartTime: &start, EndTime: &end}, emptyPricingResolverForTest())
-	if err != nil {
-		t.Fatalf("BuildAnalysisWithFilter returned error: %v", err)
-	}
-	if len(analysis.TokenUsage) != 1 || !analysis.TokenUsage[0].Bucket.Equal(currentHour) || analysis.TokenUsage[0].TotalTokens != 100 {
-		t.Fatalf("expected arbitrary hour range to include current hour stats, got %+v", analysis.TokenUsage)
+	for _, rangeName := range []string{"24h", "1d"} {
+		t.Run(rangeName, func(t *testing.T) {
+			analysis, err := repository.BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{Range: rangeName, StartTime: &start, EndTime: &end}, emptyPricingResolverForTest())
+			if err != nil {
+				t.Fatalf("BuildAnalysisWithFilter returned error: %v", err)
+			}
+			if analysis.Granularity != repodto.AnalysisGranularityHourly {
+				t.Fatalf("expected hourly granularity, got %q", analysis.Granularity)
+			}
+			if len(analysis.TokenUsage) != 1 || !analysis.TokenUsage[0].Bucket.Equal(currentHour) || analysis.TokenUsage[0].TotalTokens != 100 {
+				t.Fatalf("expected %s range to include current hourly stats, got %+v", rangeName, analysis.TokenUsage)
+			}
+		})
 	}
 }
 
-func TestBuildAnalysisIncludesCurrentHourStatsForRollingDayRange(t *testing.T) {
+func TestBuildAnalysisMatchesOverviewCustomRollupRouting(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	t.Cleanup(func() { time.Local = previousLocal })
+	time.Local = location
+
+	dayStart := time.Date(2026, 5, 20, 0, 0, 0, 0, location)
+	hourStart := time.Date(2026, 5, 20, 8, 0, 0, 0, location)
+	for _, testCase := range []struct {
+		name            string
+		unit            string
+		start           time.Time
+		end             time.Time
+		wantGranularity repodto.AnalysisGranularity
+		wantBucket      time.Time
+		wantTokens      int64
+		wantTable       string
+	}{
+		{
+			name: "custom day uses daily including a single day", unit: "day",
+			start: dayStart, end: dayStart.AddDate(0, 0, 1),
+			wantGranularity: repodto.AnalysisGranularityDaily, wantBucket: dayStart, wantTokens: 100,
+			wantTable: "usage_overview_daily_stats",
+		},
+		{
+			name: "custom hour uses hourly", unit: "hour",
+			start: hourStart, end: hourStart.Add(5 * time.Hour),
+			wantGranularity: repodto.AnalysisGranularityHourly, wantBucket: hourStart, wantTokens: 900,
+			wantTable: "usage_overview_hourly_stats",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			db, err := repository.OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "analysis-custom-rollup.db")})
+			if err != nil {
+				t.Fatalf("OpenDatabase returned error: %v", err)
+			}
+			closeTestDatabase(t, db)
+			if err := db.Create(&entities.CPAAPIKey{APIKey: "sk-target-key", DisplayKey: "sk-*********target"}).Error; err != nil {
+				t.Fatalf("insert CPA API key: %v", err)
+			}
+			if err := db.Create(&entities.UsageOverviewDailyStat{
+				BucketStart: dayStart, APIGroupKey: "sk-target-key", Model: "claude-sonnet",
+				RequestCount: 1, InputTokens: 90, OutputTokens: 10, TotalTokens: 100,
+			}).Error; err != nil {
+				t.Fatalf("insert daily stat: %v", err)
+			}
+			if err := db.Create(&entities.UsageOverviewHourlyStat{
+				BucketStart: hourStart, APIGroupKey: "sk-target-key", Model: "claude-sonnet",
+				RequestCount: 9, InputTokens: 800, OutputTokens: 100, TotalTokens: 900,
+			}).Error; err != nil {
+				t.Fatalf("insert hourly stat: %v", err)
+			}
+			if err := db.Migrator().DropTable(&entities.UsageEvent{}); err != nil {
+				t.Fatalf("drop usage_events: %v", err)
+			}
+
+			queries := captureAnalysisRollupQueries(t, db)
+			analysis, err := repository.BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{
+				Range: "custom", CustomUnit: testCase.unit, StartTime: &testCase.start, EndTime: &testCase.end, EndExclusive: true,
+			}, emptyPricingResolverForTest())
+			if err != nil {
+				t.Fatalf("BuildAnalysisWithFilter returned error: %v", err)
+			}
+			if analysis.Granularity != testCase.wantGranularity {
+				t.Fatalf("granularity = %q, want %q", analysis.Granularity, testCase.wantGranularity)
+			}
+			if len(analysis.TokenUsage) != 1 || !analysis.TokenUsage[0].Bucket.Equal(testCase.wantBucket) || analysis.TokenUsage[0].TotalTokens != testCase.wantTokens {
+				t.Fatalf("token usage = %+v, want bucket=%s total_tokens=%d", analysis.TokenUsage, testCase.wantBucket, testCase.wantTokens)
+			}
+			if len(*queries) != 1 {
+				t.Fatalf("Analysis rollup queries = %#v, want one query", *queries)
+			}
+			requireSingleAnalysisRollupQuery(t, *queries, testCase.wantTable)
+		})
+	}
+}
+
+func TestBuildAnalysisUsesOnlyDailyStatsForRollingDayRanges(t *testing.T) {
+	previousLocal := time.Local
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	t.Cleanup(func() { time.Local = previousLocal })
+	time.Local = location
+
+	for _, testCase := range []struct {
+		name        string
+		rangeName   string
+		days        int
+		wantBuckets []struct {
+			bucket time.Time
+			tokens int64
+		}
+	}{
+		{
+			name: "twelve days excludes the partial left day", rangeName: "12d", days: 12,
+			wantBuckets: []struct {
+				bucket time.Time
+				tokens int64
+			}{
+				{bucket: time.Date(2026, 7, 27, 0, 0, 0, 0, location), tokens: 222},
+			},
+		},
+		{
+			name: "thirteen days keeps the full left day", rangeName: "13d", days: 13,
+			wantBuckets: []struct {
+				bucket time.Time
+				tokens int64
+			}{
+				{bucket: time.Date(2026, 7, 15, 0, 0, 0, 0, location), tokens: 671_404_633},
+				{bucket: time.Date(2026, 7, 27, 0, 0, 0, 0, location), tokens: 222},
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			db, err := repository.OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "analysis-daily-range.db")})
+			if err != nil {
+				t.Fatalf("OpenDatabase returned error: %v", err)
+			}
+			closeTestDatabase(t, db)
+
+			end := time.Date(2026, 7, 27, 17, 14, 21, 0, location)
+			start := end.Add(-time.Duration(testCase.days) * 24 * time.Hour)
+			if err := db.Create(&entities.CPAAPIKey{APIKey: "sk-target-key", DisplayKey: "sk-*********target"}).Error; err != nil {
+				t.Fatalf("insert CPA API key: %v", err)
+			}
+			if err := db.Create(&[]entities.UsageOverviewDailyStat{
+				{
+					BucketStart: time.Date(2026, 7, 15, 0, 0, 0, 0, location), APIGroupKey: "sk-target-key", Model: "claude-sonnet",
+					RequestCount: 5_177, InputTokens: 668_642_798, OutputTokens: 2_761_835, TotalTokens: 671_404_633,
+				},
+				{
+					BucketStart: time.Date(2026, 7, 27, 0, 0, 0, 0, location), APIGroupKey: "sk-target-key", Model: "claude-sonnet",
+					RequestCount: 2, InputTokens: 200, OutputTokens: 22, TotalTokens: 222,
+				},
+			}).Error; err != nil {
+				t.Fatalf("insert daily stats: %v", err)
+			}
+			if err := db.Create(&[]entities.UsageOverviewHourlyStat{
+				{
+					BucketStart: time.Date(2026, 7, 15, 18, 0, 0, 0, location), APIGroupKey: "sk-target-key", Model: "claude-sonnet",
+					RequestCount: 2_724, InputTokens: 338_914_706, OutputTokens: 1_251_623, TotalTokens: 340_166_329,
+				},
+				{
+					BucketStart: time.Date(2026, 7, 27, 17, 0, 0, 0, location), APIGroupKey: "sk-target-key", Model: "claude-sonnet",
+					RequestCount: 1, InputTokens: 100, OutputTokens: 11, TotalTokens: 111,
+				},
+			}).Error; err != nil {
+				t.Fatalf("insert hourly decoys: %v", err)
+			}
+			if err := db.Migrator().DropTable(&entities.UsageEvent{}); err != nil {
+				t.Fatalf("drop usage_events: %v", err)
+			}
+
+			queries := captureAnalysisRollupQueries(t, db)
+			analysis, err := repository.BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{
+				Range: testCase.rangeName, StartTime: &start, EndTime: &end,
+			}, emptyPricingResolverForTest())
+			if err != nil {
+				t.Fatalf("BuildAnalysisWithFilter returned error: %v", err)
+			}
+			if analysis.Granularity != repodto.AnalysisGranularityDaily {
+				t.Fatalf("expected daily granularity, got %q", analysis.Granularity)
+			}
+			if len(analysis.TokenUsage) != len(testCase.wantBuckets) {
+				t.Fatalf("token usage = %+v, want %d daily buckets", analysis.TokenUsage, len(testCase.wantBuckets))
+			}
+			for index, want := range testCase.wantBuckets {
+				got := analysis.TokenUsage[index]
+				if !got.Bucket.Equal(want.bucket) || got.TotalTokens != want.tokens {
+					t.Fatalf("token usage[%d] = %+v, want bucket=%s total_tokens=%d", index, got, want.bucket, want.tokens)
+				}
+			}
+			if len(*queries) != 1 {
+				t.Fatalf("Analysis rollup queries = %#v, want one daily query", *queries)
+			}
+			requireSingleAnalysisRollupQuery(t, *queries, "usage_overview_daily_stats")
+		})
+	}
+}
+
+func TestBuildAnalysisIncludesCurrentDailyStatsForRollingDayRange(t *testing.T) {
 	previousLocal := time.Local
 	location, err := time.LoadLocation("Asia/Shanghai")
 	if err != nil {
@@ -66,15 +258,15 @@ func TestBuildAnalysisIncludesCurrentHourStatsForRollingDayRange(t *testing.T) {
 	closeTestDatabase(t, db)
 	end := time.Date(2026, 5, 21, 9, 14, 21, 0, location)
 	start := end.Add(-13 * 24 * time.Hour)
-	currentHour := time.Date(2026, 5, 21, 9, 0, 0, 0, location)
+	currentDay := time.Date(2026, 5, 21, 0, 0, 0, 0, location)
 	if err := db.Create(&entities.CPAAPIKey{APIKey: "sk-target-key", DisplayKey: "sk-*********target"}).Error; err != nil {
 		t.Fatalf("insert CPA API key: %v", err)
 	}
-	if err := db.Create(&entities.UsageOverviewHourlyStat{
-		BucketStart: currentHour, APIGroupKey: "sk-target-key", Model: "claude-sonnet",
+	if err := db.Create(&entities.UsageOverviewDailyStat{
+		BucketStart: currentDay, APIGroupKey: "sk-target-key", Model: "claude-sonnet",
 		RequestCount: 6, InputTokens: 90, OutputTokens: 10, TotalTokens: 100,
 	}).Error; err != nil {
-		t.Fatalf("insert current hour stat: %v", err)
+		t.Fatalf("insert current day stat: %v", err)
 	}
 	if err := db.Migrator().DropTable(&entities.UsageEvent{}); err != nil {
 		t.Fatalf("drop usage_events: %v", err)
@@ -84,47 +276,7 @@ func TestBuildAnalysisIncludesCurrentHourStatsForRollingDayRange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildAnalysisWithFilter returned error: %v", err)
 	}
-	currentDay := time.Date(2026, 5, 21, 0, 0, 0, 0, location)
 	if len(analysis.TokenUsage) != 1 || !analysis.TokenUsage[0].Bucket.Equal(currentDay) || analysis.TokenUsage[0].TotalTokens != 100 {
-		t.Fatalf("expected rolling day range to include current hour stats, got %+v", analysis.TokenUsage)
-	}
-}
-
-func TestBuildAnalysisKeepsDailyStatsAcrossDSTBoundary(t *testing.T) {
-	previousLocal := time.Local
-	location, err := time.LoadLocation("America/New_York")
-	if err != nil {
-		t.Fatalf("load location: %v", err)
-	}
-	t.Cleanup(func() { time.Local = previousLocal })
-	time.Local = location
-
-	db, err := repository.OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "analysis-dst-day.db")})
-	if err != nil {
-		t.Fatalf("OpenDatabase returned error: %v", err)
-	}
-	closeTestDatabase(t, db)
-	start := time.Date(2026, 3, 8, 9, 14, 0, 0, location)
-	end := time.Date(2026, 3, 16, 9, 14, 0, 0, location)
-	dailyBucket := time.Date(2026, 3, 9, 0, 0, 0, 0, location)
-	if err := db.Create(&entities.CPAAPIKey{APIKey: "sk-target-key", DisplayKey: "sk-*********target"}).Error; err != nil {
-		t.Fatalf("insert CPA API key: %v", err)
-	}
-	if err := db.Create(&entities.UsageOverviewDailyStat{
-		BucketStart: dailyBucket, APIGroupKey: "sk-target-key", Model: "claude-sonnet",
-		RequestCount: 6, InputTokens: 90, OutputTokens: 10, TotalTokens: 100,
-	}).Error; err != nil {
-		t.Fatalf("insert daily stat: %v", err)
-	}
-	if err := db.Migrator().DropTable(&entities.UsageEvent{}); err != nil {
-		t.Fatalf("drop usage_events: %v", err)
-	}
-
-	analysis, err := repository.BuildAnalysisWithFilter(db, repodto.UsageQueryFilter{Range: "8d", StartTime: &start, EndTime: &end}, emptyPricingResolverForTest())
-	if err != nil {
-		t.Fatalf("BuildAnalysisWithFilter returned error: %v", err)
-	}
-	if len(analysis.TokenUsage) != 1 || !analysis.TokenUsage[0].Bucket.Equal(dailyBucket) || analysis.TokenUsage[0].TotalTokens != 100 {
-		t.Fatalf("expected DST-adjacent daily stat to remain included, got %+v", analysis.TokenUsage)
+		t.Fatalf("expected rolling day range to include current daily stats, got %+v", analysis.TokenUsage)
 	}
 }

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -356,10 +356,19 @@ func BuildAnalysisWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, costResol
 	if filter.StartTime == nil || filter.EndTime == nil {
 		return nil, fmt.Errorf("analysis requires start_time and end_time")
 	}
-	// 同一请求内固定一次价格字段快照，确保 daily 与两侧 hourly 边界使用完全相同的查询维度。
+	// 同一请求内固定一次价格字段快照，确保所选 hourly 或 daily 粒度使用完全相同的查询维度。
 	activeFields := costResolver.ActiveFields()
 	windowMinutes := computeWindowMinutes(filter)
 	bucketByDay := windowMinutes > 24*60
+	if strings.TrimSpace(filter.Range) == "custom" {
+		// Custom 显式粒度与 Overview 保持一致，不能用单日跨度反推 hourly。
+		switch strings.TrimSpace(filter.CustomUnit) {
+		case "day":
+			bucketByDay = true
+		case "hour":
+			bucketByDay = false
+		}
+	}
 	record := &dto.AnalysisRecord{
 		Granularity: func() dto.AnalysisGranularity {
 			if bucketByDay {
@@ -374,22 +383,9 @@ func BuildAnalysisWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, costResol
 		},
 	}
 
-	fullStart, fullEnd := usageOverviewFullHourWindow(*filter.StartTime, *filter.EndTime)
-	fullEnd = analysisHourlyStatsEnd(filter, fullEnd)
-	if !fullEnd.After(fullStart) {
-		return record, nil
-	}
 	if bucketByDay {
-		fullDayStart, fullDayEnd := usageOverviewFullDayWindow(fullStart, fullEnd)
-		var dailyRows []analysisOverviewStatProjection
-		if fullDayEnd.After(fullDayStart) {
-			var err error
-			dailyRows, err = loadAnalysisOverviewDailyStatsWithFilter(db, filter, fullDayStart, fullDayEnd, activeFields)
-			if err != nil {
-				return nil, err
-			}
-		}
-		hourlyRows, err := loadAnalysisDailyBoundaryHourlyStatsWithFilter(db, filter, fullStart, fullDayStart, fullDayEnd, fullEnd, activeFields)
+		// 日坐标桶必须完整来自 daily 汇总；Analysis 不读取 raw events，不能再用 hourly 拼接不完整自然日。
+		dailyRows, err := loadAnalysisOverviewDailyStatsWithFilter(db, filter, *filter.StartTime, *filter.EndTime, activeFields)
 		if err != nil {
 			return nil, err
 		}
@@ -397,11 +393,13 @@ func BuildAnalysisWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, costResol
 		if err != nil {
 			return nil, err
 		}
-		hourlyIdentityLookup, err := loadAnalysisProjectionIdentityLookup(db, hourlyRows)
-		if err != nil {
-			return nil, err
-		}
-		applyAnalysisDailyAndBoundaryHourlyRows(record, dailyRows, dailyIdentityLookup, hourlyRows, hourlyIdentityLookup, costResolver)
+		applyAnalysisDailyRows(record, dailyRows, dailyIdentityLookup, costResolver)
+		return record, nil
+	}
+
+	fullStart, fullEnd := usageOverviewFullHourWindow(*filter.StartTime, *filter.EndTime)
+	fullEnd = analysisHourlyStatsEnd(filter, fullEnd)
+	if !fullEnd.After(fullStart) {
 		return record, nil
 	}
 	rows, err := loadAnalysisOverviewHourlyStatsWithFilter(db, filter, fullStart, fullEnd, activeFields)
@@ -518,7 +516,7 @@ func applyAnalysisHourlyRows(record *dto.AnalysisRecord, rows []analysisOverview
 	finalizeAnalysisRecord(record, bucketTotals, apiTotals, modelTotals, authFileTotals, aiProviderTotals, heatmapTotals)
 }
 
-func applyAnalysisDailyAndBoundaryHourlyRows(record *dto.AnalysisRecord, dailyRows []analysisOverviewStatProjection, dailyIdentityLookup analysisIdentityLookup, hourlyRows []analysisOverviewStatProjection, hourlyIdentityLookup analysisIdentityLookup, costResolver pricing.Resolver) {
+func applyAnalysisDailyRows(record *dto.AnalysisRecord, dailyRows []analysisOverviewStatProjection, dailyIdentityLookup analysisIdentityLookup, costResolver pricing.Resolver) {
 	bucketTotals := map[time.Time]*dto.AnalysisTokenUsageBucketRecord{}
 	apiTotals := map[string]*dto.AnalysisCompositionRecord{}
 	modelTotals := map[string]*dto.AnalysisCompositionRecord{}
@@ -531,14 +529,6 @@ func applyAnalysisDailyAndBoundaryHourlyRows(record *dto.AnalysisRecord, dailyRo
 		cost, costAvailable := costResult.Cost, costResult.Available
 		applyAnalysisRow(record, bucketTotals, apiTotals, modelTotals, heatmapTotals, bucket, row.APIGroupKey, row.Model, row.RequestCount, row.InputTokens, row.OutputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, row.TotalTokens, cost, costAvailable)
 		applyAnalysisIdentityComposition(dailyIdentityLookup, authFileTotals, aiProviderTotals, row.AuthIndex, row.RequestCount, row.InputTokens, row.OutputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, row.TotalTokens, cost, costAvailable)
-	}
-	for _, row := range hourlyRows {
-		bucketStart := timeutil.NormalizeStorageTime(row.BucketStart)
-		bucket := time.Date(bucketStart.Year(), bucketStart.Month(), bucketStart.Day(), 0, 0, 0, 0, bucketStart.Location())
-		costResult := calculateAnalysisOverviewProjectionCost(costResolver, row)
-		cost, costAvailable := costResult.Cost, costResult.Available
-		applyAnalysisRow(record, bucketTotals, apiTotals, modelTotals, heatmapTotals, bucket, row.APIGroupKey, row.Model, row.RequestCount, row.InputTokens, row.OutputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, row.TotalTokens, cost, costAvailable)
-		applyAnalysisIdentityComposition(hourlyIdentityLookup, authFileTotals, aiProviderTotals, row.AuthIndex, row.RequestCount, row.InputTokens, row.OutputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, row.TotalTokens, cost, costAvailable)
 	}
 	finalizeAnalysisRecord(record, bucketTotals, apiTotals, modelTotals, authFileTotals, aiProviderTotals, heatmapTotals)
 }
@@ -1092,25 +1082,6 @@ func mergeUsageOverviewRawEventWindows(windows []usageOverviewRawEventWindow) []
 func usageOverviewEventInsideWindow(event entities.UsageEvent, start, end time.Time) bool {
 	timestamp := timeutil.NormalizeStorageTime(event.Timestamp)
 	return !timestamp.Before(start) && timestamp.Before(end)
-}
-
-func analysisDailyBoundaryHourlyWindows(fullStart, fullDayStart, fullDayEnd, fullEnd time.Time) []usageOverviewRawEventWindow {
-	windows := make([]usageOverviewRawEventWindow, 0, 2)
-	leftEnd := fullDayStart
-	if fullEnd.Before(leftEnd) {
-		leftEnd = fullEnd
-	}
-	if fullStart.Before(leftEnd) {
-		windows = append(windows, usageOverviewRawEventWindow{start: fullStart, end: leftEnd})
-	}
-	rightStart := fullDayEnd
-	if rightStart.Before(fullStart) {
-		rightStart = fullStart
-	}
-	if rightStart.Before(fullEnd) {
-		windows = append(windows, usageOverviewRawEventWindow{start: rightStart, end: fullEnd})
-	}
-	return mergeUsageOverviewRawEventWindows(windows)
 }
 
 func loadUsageOverviewRawEventWindowsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, windows []usageOverviewRawEventWindow, recentCache *UsageRecentEventCache, activeFields pricing.ActiveFields) ([]entities.UsageEvent, error) {

--- a/internal/repository/usage_analysis_projection.go
+++ b/internal/repository/usage_analysis_projection.go
@@ -94,19 +94,6 @@ func loadAnalysisOverviewStatProjection(query *gorm.DB, filter dto.UsageQueryFil
 	return rows, nil
 }
 
-func loadAnalysisDailyBoundaryHourlyStatsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, fullStart, fullDayStart, fullDayEnd, fullEnd time.Time, activeFields pricing.ActiveFields) ([]analysisOverviewStatProjection, error) {
-	windows := analysisDailyBoundaryHourlyWindows(fullStart, fullDayStart, fullDayEnd, fullEnd)
-	rows := make([]analysisOverviewStatProjection, 0)
-	for _, window := range windows {
-		windowRows, err := loadAnalysisOverviewHourlyStatsWithFilter(db, filter, window.start, window.end, activeFields)
-		if err != nil {
-			return nil, err
-		}
-		rows = append(rows, windowRows...)
-	}
-	return rows, nil
-}
-
 func calculateAnalysisOverviewProjectionCost(costResolver pricing.Resolver, row analysisOverviewStatProjection) pricing.CostResult {
 	return costResolver.Calculate(newUsagePricingCostSubject(
 		row.APIGroupKey,

--- a/internal/repository/usage_test.go
+++ b/internal/repository/usage_test.go
@@ -488,24 +488,36 @@ func TestBuildAnalysisWithFilterFillsTodayAndYesterdayHourlyBucketsFromStats(t *
 	}
 }
 
-func TestBuildAnalysisWithFilterIncludesPartialCurrentDayInDailyRanges(t *testing.T) {
+func TestBuildAnalysisWithFilterUsesCurrentDailyRollupInDailyRanges(t *testing.T) {
 	withRepositoryTestLocation(t, "UTC")
 	db := openUsageTestDatabase(t)
 	start := time.Date(2026, 5, 11, 10, 15, 0, 0, time.UTC)
 	end := time.Date(2026, 5, 18, 18, 30, 0, 0, time.UTC)
 	yesterday := time.Date(2026, 5, 17, 0, 0, 0, 0, time.UTC)
+	currentDay := time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC)
 	currentDayHour := time.Date(2026, 5, 18, 9, 0, 0, 0, time.UTC)
 	if err := db.Create(&entities.CPAAPIKey{APIKey: "sk-target-key", DisplayKey: "sk-*********target"}).Error; err != nil {
 		t.Fatalf("insert CPA API key: %v", err)
 	}
-	if err := db.Create(&entities.UsageOverviewDailyStat{
-		BucketStart:  yesterday,
-		APIGroupKey:  "sk-target-key",
-		Model:        "claude-sonnet",
-		RequestCount: 2,
-		InputTokens:  10,
-		OutputTokens: 20,
-		TotalTokens:  30,
+	if err := db.Create([]entities.UsageOverviewDailyStat{
+		{
+			BucketStart:  yesterday,
+			APIGroupKey:  "sk-target-key",
+			Model:        "claude-sonnet",
+			RequestCount: 2,
+			InputTokens:  10,
+			OutputTokens: 20,
+			TotalTokens:  30,
+		},
+		{
+			BucketStart:  currentDay,
+			APIGroupKey:  "sk-target-key",
+			Model:        "claude-sonnet",
+			RequestCount: 4,
+			InputTokens:  40,
+			OutputTokens: 50,
+			TotalTokens:  90,
+		},
 	}).Error; err != nil {
 		t.Fatalf("insert daily stat: %v", err)
 	}
@@ -523,10 +535,10 @@ func TestBuildAnalysisWithFilterIncludesPartialCurrentDayInDailyRanges(t *testin
 			BucketStart:  currentDayHour,
 			APIGroupKey:  "sk-target-key",
 			Model:        "claude-sonnet",
-			RequestCount: 4,
-			InputTokens:  40,
-			OutputTokens: 50,
-			TotalTokens:  90,
+			RequestCount: 40,
+			InputTokens:  400,
+			OutputTokens: 500,
+			TotalTokens:  900,
 		},
 	}).Error; err != nil {
 		t.Fatalf("insert hourly stats: %v", err)
@@ -551,11 +563,11 @@ func TestBuildAnalysisWithFilterIncludesPartialCurrentDayInDailyRanges(t *testin
 			if !analysis.TokenUsage[0].Bucket.Equal(yesterday) || analysis.TokenUsage[0].TotalTokens != 30 || analysis.TokenUsage[0].Requests != 2 {
 				t.Fatalf("expected yesterday daily stats first, got %+v", analysis.TokenUsage[0])
 			}
-			if !analysis.TokenUsage[1].Bucket.Equal(time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC)) || analysis.TokenUsage[1].TotalTokens != 90 || analysis.TokenUsage[1].Requests != 4 {
-				t.Fatalf("expected current-day hourly stats to be folded into daily bucket, got %+v", analysis.TokenUsage[1])
+			if !analysis.TokenUsage[1].Bucket.Equal(currentDay) || analysis.TokenUsage[1].TotalTokens != 90 || analysis.TokenUsage[1].Requests != 4 {
+				t.Fatalf("expected current-day daily stats, got %+v", analysis.TokenUsage[1])
 			}
 			if len(analysis.APIKeyComposition) != 1 || analysis.APIKeyComposition[0].TotalTokens != 120 || analysis.APIKeyComposition[0].Requests != 6 {
-				t.Fatalf("expected compositions to include daily and current-day hourly stats, got %+v", analysis.APIKeyComposition)
+				t.Fatalf("expected compositions to include only daily stats, got %+v", analysis.APIKeyComposition)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- read Analysis ranges longer than 24 hours exclusively from daily Overview rollups
- route Custom day ranges to daily rollups and Custom hour ranges to hourly rollups
- preserve Today, Yesterday, 24h, and direct 1d hourly behavior while removing daily boundary stitching

## Validation

- Analysis repository tests under UTC and Asia/Shanghai
- full backend verification