### PR TITLE
fix: align analysis ranges and ranking avatar layout

### DIFF
--- a/internal/latency/aggregate.go
+++ b/internal/latency/aggregate.go
@@ -28,8 +28,8 @@ type aggregateRowBuilder struct {
 }
 
 const (
-	// HourRetentionDays 为最长 30 天滚动查询保留一天边界余量。
-	HourRetentionDays = 31
+	// HourRetentionDays 为最长 24 小时查询保留三天 hourly 数据。
+	HourRetentionDays = 3
 	// DayRetentionDays 覆盖页面允许选择的最近 365 个自然日。
 	DayRetentionDays = 365
 )

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -364,7 +364,7 @@ func CleanupStorage(db *gorm.DB, now time.Time, options ...CleanupStorageOptions
 	if err := CleanupUsageActivityStats(db, now); err != nil {
 		return dto.StorageCleanupResult{RedisInbox: redisResult, UsageEventsDeleted: usageEventsDeleted}, err
 	}
-	// Latency 小时保留 31 天、自然日保留 365 天，并复用本轮最后一次 VACUUM。
+	// Latency 小时保留 3 天、自然日保留 365 天，并复用本轮最后一次 VACUUM。
 	if err := CleanupUsageLatencyStats(db, now); err != nil {
 		return dto.StorageCleanupResult{RedisInbox: redisResult, UsageEventsDeleted: usageEventsDeleted}, err
 	}

--- a/internal/repository/test/usage_analysis_latency_rollup_test.go
+++ b/internal/repository/test/usage_analysis_latency_rollup_test.go
@@ -145,10 +145,25 @@ func TestAnalysisLatencyRollupSupportsAllAnalysisRangeKinds(t *testing.T) {
 		rangeName string
 		start     time.Time
 		end       time.Time
+		wantDaily bool
+		skipHour  bool
 	}{
 		{
 			name: "rolling thirty days", rangeName: "30d",
-			start: time.Date(2026, 6, 26, 10, 30, 0, 0, location),
+			start:     time.Date(2026, 6, 26, 10, 30, 0, 0, location),
+			end:       time.Date(2026, 7, 26, 10, 30, 0, 0, location),
+			wantDaily: true,
+			skipHour:  true,
+		},
+		{
+			name: "rolling two days", rangeName: "2d",
+			start:     time.Date(2026, 7, 24, 10, 30, 0, 0, location),
+			end:       time.Date(2026, 7, 26, 10, 30, 0, 0, location),
+			wantDaily: true,
+		},
+		{
+			name: "rolling twenty four hours", rangeName: "24h",
+			start: time.Date(2026, 7, 25, 10, 30, 0, 0, location),
 			end:   time.Date(2026, 7, 26, 10, 30, 0, 0, location),
 		},
 		{
@@ -162,14 +177,20 @@ func TestAnalysisLatencyRollupSupportsAllAnalysisRangeKinds(t *testing.T) {
 			end:   time.Date(2026, 7, 25, 23, 59, 59, int(time.Second-time.Nanosecond), location),
 		},
 	} {
-		t.Run(testCase.name+" uses hour buckets", func(t *testing.T) {
+		bucketName := "hour"
+		if testCase.wantDaily {
+			bucketName = "day"
+		}
+		t.Run(testCase.name+" uses "+bucketName+" buckets", func(t *testing.T) {
 			db := openTestDatabase(t)
 			hourTTFT := int64(2600 + caseIndex*100)
 			dayTTFT := hourTTFT + 1
 			eventTime := testCase.start.Add(12*time.Hour + 10*time.Minute)
-			seedAnalysisLatencyRows(t, db, testCase.end, entities.UsageLatencyBucketHour, []entities.UsageEvent{
-				analysisLatencyEvent(int64(2201+caseIndex*10), "target", eventTime, hourTTFT, hourTTFT*10),
-			})
+			if !testCase.skipHour {
+				seedAnalysisLatencyRows(t, db, testCase.end, entities.UsageLatencyBucketHour, []entities.UsageEvent{
+					analysisLatencyEvent(int64(2201+caseIndex*10), "target", eventTime, hourTTFT, hourTTFT*10),
+				})
+			}
 			seedAnalysisLatencyRows(t, db, testCase.end, entities.UsageLatencyBucketDay, []entities.UsageEvent{
 				analysisLatencyEvent(int64(2202+caseIndex*10), "target", eventTime, dayTTFT, dayTTFT*10),
 			})
@@ -180,7 +201,11 @@ func TestAnalysisLatencyRollupSupportsAllAnalysisRangeKinds(t *testing.T) {
 			if err != nil {
 				t.Fatalf("BuildAnalysisLatencyDiagnosticsWithFilter returned error: %v", err)
 			}
-			assertSingleAnalysisLatencyPoint(t, diagnostics, hourTTFT, hourTTFT*10)
+			wantTTFT := hourTTFT
+			if testCase.wantDaily {
+				wantTTFT = dayTTFT
+			}
+			assertSingleAnalysisLatencyPoint(t, diagnostics, wantTTFT, wantTTFT*10)
 		})
 	}
 }

--- a/internal/repository/test/usage_latency_stats_test.go
+++ b/internal/repository/test/usage_latency_stats_test.go
@@ -18,11 +18,11 @@ import (
 	"gorm.io/plugin/dbresolver"
 )
 
-func TestAggregateUsageLatencyStatsKeepsHoursForThirtyOneDaysAndDaysForThreeHundredSixtyFiveDays(t *testing.T) {
-	// 小时只服务最长 30 天滚动窗口；自然日继续覆盖页面允许的最近 365 天。
+func TestAggregateUsageLatencyStatsKeepsHoursForThreeDaysAndDaysForThreeHundredSixtyFiveDays(t *testing.T) {
+	// 小时只服务最长 24 小时窗口并保留三天余量；自然日继续覆盖页面允许的最近 365 天。
 	db := openTestDatabase(t)
 	now := time.Date(2026, 7, 26, 12, 30, 0, 0, time.Local)
-	hourCutoff := now.Add(-31 * 24 * time.Hour).Truncate(time.Hour)
+	hourCutoff := now.Add(-3 * 24 * time.Hour).Truncate(time.Hour)
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
 	events := []entities.UsageEvent{
 		validLatencyEvent(1, "recent", now.Add(-time.Hour), 100, 900),
@@ -56,7 +56,7 @@ func TestAggregateUsageLatencyStatsKeepsHoursForThirtyOneDaysAndDaysForThreeHund
 }
 
 func TestCleanupStorageRemovesExpiredLatencyHourAndDayRows(t *testing.T) {
-	// 每日维护复用现有 cleanup/VACUUM，只删除31天前小时行和365天窗口外的自然日行。
+	// 每日维护复用现有 cleanup/VACUUM，只删除三天前小时行和365天窗口外的自然日行。
 	db := openTestDatabase(t)
 	now := time.Date(2026, 7, 26, 12, 30, 0, 0, time.Local)
 	templates := buildLatencyRowsForTest(t, []entities.UsageEvent{validLatencyEvent(1, "template", now, 100, 900)})
@@ -66,8 +66,8 @@ func TestCleanupStorageRemovesExpiredLatencyHourAndDayRows(t *testing.T) {
 	}
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
 	rows := []entities.UsageLatencyStat{
-		latencyRetentionRow(templateByType[entities.UsageLatencyBucketHour], "expired-hour", now.Add(-32*24*time.Hour).Truncate(time.Hour), now),
-		latencyRetentionRow(templateByType[entities.UsageLatencyBucketHour], "kept-hour", now.Add(-30*24*time.Hour).Truncate(time.Hour), now),
+		latencyRetentionRow(templateByType[entities.UsageLatencyBucketHour], "expired-hour", now.Add(-4*24*time.Hour).Truncate(time.Hour), now),
+		latencyRetentionRow(templateByType[entities.UsageLatencyBucketHour], "kept-hour", now.Add(-2*24*time.Hour).Truncate(time.Hour), now),
 		latencyRetentionRow(templateByType[entities.UsageLatencyBucketDay], "expired-day", today.AddDate(0, 0, -365), now),
 		latencyRetentionRow(templateByType[entities.UsageLatencyBucketDay], "kept-day", today.AddDate(0, 0, -364), now),
 	}
@@ -108,7 +108,7 @@ func TestCleanupUsageLatencyStatsUsesStoredTimezoneAtExactRetentionBoundary(t *t
 			}
 
 			// 这些边界由固定墙钟时间手工给出，避免用被测 retention helper 反推期望值。
-			hourCutoff := time.Date(2026, 6, 25, 12, 0, 0, 0, location)
+			hourCutoff := time.Date(2026, 7, 23, 12, 0, 0, 0, location)
 			dayCutoff := time.Date(2025, 7, 27, 0, 0, 0, 0, location)
 			rows := []entities.UsageLatencyStat{
 				latencyRetentionRow(templateByType[entities.UsageLatencyBucketHour], "expired-hour", hourCutoff.Add(-time.Hour), now),

--- a/internal/repository/test/usage_rolling_range_test.go
+++ b/internal/repository/test/usage_rolling_range_test.go
@@ -156,11 +156,12 @@ func TestBuildAnalysisUsesOnlyDailyStatsForRollingDayRanges(t *testing.T) {
 		}
 	}{
 		{
-			name: "twelve days excludes the partial left day", rangeName: "12d", days: 12,
+			name: "twelve days includes the start day", rangeName: "12d", days: 12,
 			wantBuckets: []struct {
 				bucket time.Time
 				tokens int64
 			}{
+				{bucket: time.Date(2026, 7, 15, 0, 0, 0, 0, location), tokens: 671_404_633},
 				{bucket: time.Date(2026, 7, 27, 0, 0, 0, 0, location), tokens: 222},
 			},
 		},
@@ -224,6 +225,11 @@ func TestBuildAnalysisUsesOnlyDailyStatsForRollingDayRanges(t *testing.T) {
 			}
 			if analysis.Granularity != repodto.AnalysisGranularityDaily {
 				t.Fatalf("expected daily granularity, got %q", analysis.Granularity)
+			}
+			wantRangeStart := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, location)
+			wantRangeEnd := time.Date(end.Year(), end.Month(), end.Day(), 0, 0, 0, 0, location).AddDate(0, 0, 1)
+			if analysis.RangeStart == nil || !analysis.RangeStart.Equal(wantRangeStart) || analysis.RangeEnd == nil || !analysis.RangeEnd.Equal(wantRangeEnd) {
+				t.Fatalf("range = [%v, %v), want [%v, %v)", analysis.RangeStart, analysis.RangeEnd, wantRangeStart, wantRangeEnd)
 			}
 			if len(analysis.TokenUsage) != len(testCase.wantBuckets) {
 				t.Fatalf("token usage = %+v, want %d daily buckets", analysis.TokenUsage, len(testCase.wantBuckets))

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -384,8 +384,16 @@ func BuildAnalysisWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, costResol
 	}
 
 	if bucketByDay {
-		// 日坐标桶必须完整来自 daily 汇总；Analysis 不读取 raw events，不能再用 hourly 拼接不完整自然日。
-		dailyRows, err := loadAnalysisOverviewDailyStatsWithFilter(db, filter, *filter.StartTime, *filter.EndTime, activeFields)
+		dailyStart := timeutil.NormalizeStorageTime(*filter.StartTime)
+		dailyEnd := timeutil.NormalizeStorageTime(*filter.EndTime)
+		if timeutil.IsUsageRollingDayRange(filter.Range) {
+			// Rolling Days 与 Custom + Day 统一为包含首尾日期的自然日半开区间。
+			dailyStart, dailyEnd = analysisRollingDayWindow(dailyStart, dailyEnd)
+		}
+		record.RangeStart = &dailyStart
+		record.RangeEnd = &dailyEnd
+		// Custom + Day 已由解析层对齐自然日；两类日范围都只读取 daily 汇总。
+		dailyRows, err := loadAnalysisOverviewDailyStatsWithFilter(db, filter, dailyStart, dailyEnd, activeFields)
 		if err != nil {
 			return nil, err
 		}
@@ -413,6 +421,15 @@ func BuildAnalysisWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, costResol
 	applyAnalysisHourlyRows(record, rows, identityLookup, costResolver)
 	fillAnalysisFullDayHourlyBuckets(record, filter)
 	return record, nil
+}
+
+// analysisRollingDayWindow 把滚动日范围扩展为包含首尾日期的本地自然日半开区间。
+func analysisRollingDayWindow(start, end time.Time) (time.Time, time.Time) {
+	localStart := timeutil.NormalizeStorageTime(start)
+	localEnd := timeutil.NormalizeStorageTime(end)
+	windowStart := time.Date(localStart.Year(), localStart.Month(), localStart.Day(), 0, 0, 0, 0, localStart.Location())
+	windowEnd := time.Date(localEnd.Year(), localEnd.Month(), localEnd.Day(), 0, 0, 0, 0, localEnd.Location()).AddDate(0, 0, 1)
+	return windowStart, windowEnd
 }
 
 func analysisHourlyStatsEnd(filter dto.UsageQueryFilter, fullEnd time.Time) time.Time {

--- a/internal/repository/usage_analysis_latency_rollup.go
+++ b/internal/repository/usage_analysis_latency_rollup.go
@@ -14,7 +14,7 @@ import (
 	"gorm.io/plugin/dbresolver"
 )
 
-const analysisLatencyHourRangeMaxDays = 30
+const analysisLatencyHourRangeMax = 24 * time.Hour
 
 // BuildAnalysisLatencyDiagnosticsWithFilter 只读取现有 Latency 聚合行并在内存合并诊断结果。
 func BuildAnalysisLatencyDiagnosticsWithFilter(db *gorm.DB, filter dto.UsageQueryFilter) (dto.AnalysisLatencyDiagnosticsRecord, error) {
@@ -35,9 +35,16 @@ func BuildAnalysisLatencyDiagnosticsWithFilter(db *gorm.DB, filter dto.UsageQuer
 	if err != nil {
 		return empty, err
 	}
-	// 两侧都向上取整：舍弃左侧不完整桶，并纳入右侧当前桶已经落入聚合表的数据。
-	alignedStart := alignAnalysisLatencyBucketEnd(start, bucketType)
-	alignedEnd := alignAnalysisLatencyBucketEnd(end, bucketType)
+	alignedStart := start
+	alignedEnd := end
+	if bucketType == entities.UsageLatencyBucketDay && !(filter.Range == "custom" && strings.TrimSpace(filter.CustomUnit) == "day") {
+		// 超过 24 小时的滚动范围与 Analysis 主数据共用完整自然日边界。
+		alignedStart, alignedEnd = analysisRollingDayWindow(start, end)
+	} else {
+		// 小时范围两侧向上取整；Custom + Day 已经由解析层提供完整自然日边界。
+		alignedStart = alignAnalysisLatencyBucketEnd(start, bucketType)
+		alignedEnd = alignAnalysisLatencyBucketEnd(end, bucketType)
+	}
 	if !alignedEnd.After(alignedStart) {
 		return empty, nil
 	}
@@ -79,7 +86,7 @@ func analysisLatencyBucketType(filter dto.UsageQueryFilter, start, end time.Time
 		// Custom 天已经是完整自然日区间，始终读取长期保留的 day 桶。
 		return entities.UsageLatencyBucketDay, nil
 	}
-	if end.Sub(start) <= analysisLatencyHourRangeMaxDays*24*time.Hour {
+	if end.Sub(start) <= analysisLatencyHourRangeMax {
 		return entities.UsageLatencyBucketHour, nil
 	}
 	return entities.UsageLatencyBucketDay, nil

--- a/web/src/features/ranking/RankingPage.module.scss
+++ b/web/src/features/ranking/RankingPage.module.scss
@@ -963,7 +963,7 @@
   }
 
   .profileModal .avatarGrid {
-    grid-template-columns: repeat(6, minmax(44px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(44px, 1fr));
   }
 
   .profileActionFooter {

--- a/web/src/features/ranking/test/RankingPage.styles.test.ts
+++ b/web/src/features/ranking/test/RankingPage.styles.test.ts
@@ -257,6 +257,17 @@ describe('Ranking table context styles', () => {
     expect(mobile).toMatch(/\.profileModal\s+:global\(\.modal-body\)\s*\{[\s\S]*?max-height:\s*min\(60dvh,/);
   });
 
+  it('adapts profile avatar columns to narrow mobile modal widths', () => {
+    const mobileStart = styles.indexOf('@include mobile');
+    const mobileEnd = styles.indexOf('@media (prefers-reduced-motion', mobileStart);
+    const mobile = styles.slice(mobileStart, mobileEnd);
+
+    expect(mobile).toMatch(
+      /\.profileModal\s+\.avatarGrid\s*\{[\s\S]*?grid-template-columns:\s*repeat\(auto-fill,\s*minmax\(44px,\s*1fr\)\);/,
+    );
+    expect(mobile).not.toMatch(/\.profileModal\s+\.avatarGrid\s*\{[\s\S]*?repeat\(6,/);
+  });
+
   it('separates the destructive action from the normal profile actions and stacks cleanly on mobile', () => {
     const footer = rule('.profileActionFooter');
     expect(footer).toContain('display: flex;');


### PR DESCRIPTION
## Summary

- align rolling Analysis day ranges with Custom Day natural-day boundaries
- use daily latency rollups beyond 24 hours and retain hourly rollups for three days
- make the ranking profile avatar grid responsive in the mobile join modal

## Validation

- full backend test suite
- frontend: 102 test files and 948 tests
- frontend lint, typecheck, and production build
- targeted range and retention tests in UTC and Asia/Shanghai
- five-agent adversarial review: no findings