### PR TITLE
fix(ui): prevent API key filter clipping

### DIFF
--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -1930,7 +1930,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                         onChange={setSelectedApiKeyId}
                         className={styles.apiKeySelectControl}
                         ariaLabel={t('usage_stats.api_key_filter')}
-                        fullWidth
+                        fullWidth={false}
                         dropdownMinWidth={180}
                       />
                     </label>

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -1157,6 +1157,10 @@ describe('UsagePage toolbar styles', () => {
   })
 
   it('preserves the API Key sizing while removing the legacy range select and Custom UI', () => {
+    const apiKeySelectStart = usagePageSource.indexOf('<Select\n                        value={selectedApiKeyId}')
+    const apiKeySelectBlock = usagePageSource.slice(apiKeySelectStart, usagePageSource.indexOf('/>', apiKeySelectStart))
+
+    expect(apiKeySelectBlock).toContain('fullWidth={false}')
     expect(usagePageStyles).toMatch(/\.toolbarActionsRight\s*\{[\s\S]*?align-items:\s*center;/)
     expect(usagePageStyles).toMatch(/\.usageFilterBar\s*\{[\s\S]*?align-items:\s*center;/)
     expect(usagePageStyles).toMatch(/\.usageFilterBar\s*\{[\s\S]*?flex:\s*1 1 auto;/)


### PR DESCRIPTION
## Summary

- remove the generic full-width wrapper from the Overview API key filter
- preserve the existing 172px desktop trigger and full-width mobile layout
- add regression coverage for the cross-browser sizing conflict

## Validation

- targeted UsagePage style tests: 90 passed, with RED then GREEN evidence
- full frontend verification: 102 test files and 948 tests passed
- ESLint, TypeScript typecheck, and production build passed
- project review: no actionable findings

Fixes #374