### PR TITLE
feat(quota): add xAI weekly token and cost usage

### DIFF
--- a/internal/quota/normalize.go
+++ b/internal/quota/normalize.go
@@ -431,7 +431,7 @@ func xaiWeeklyQuotaRow(config *XAIBillingConfig) (QuotaRow, bool) {
 	usedPercent := *config.CreditUsagePercent
 	limitReached := usedPercent >= 100
 	return QuotaRow{
-		Key:          "billing.weekly",
+		Key:          xaiWeeklyBillingQuotaKey,
 		Label:        "Weekly",
 		Scope:        "billing",
 		Metric:       "weekly",

--- a/internal/quota/test/xai_usage_stats_test.go
+++ b/internal/quota/test/xai_usage_stats_test.go
@@ -1,0 +1,128 @@
+package test
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/pricing"
+	. "cpa-usage-keeper/internal/quota"
+	"cpa-usage-keeper/internal/repository"
+	repositorydto "cpa-usage-keeper/internal/repository/dto"
+	"cpa-usage-keeper/internal/timeutil"
+)
+
+func TestAttachWindowUsageStatsBackfillsOnlyXAIWeeklyBilling(t *testing.T) {
+	db := openQuotaUsageStatsTestDB(t)
+	if _, err := repository.UpsertModelPriceSetting(db, repositorydto.ModelPriceSettingInput{
+		Model:                "grok-priced",
+		PricingStyle:         entities.ModelPricingStyleOpenAI,
+		PromptPricePer1M:     2,
+		CompletionPricePer1M: 10,
+	}); err != nil {
+		t.Fatalf("UpsertModelPriceSetting: %v", err)
+	}
+	snapshot, err := repository.LoadPricingSnapshot(context.Background(), db)
+	if err != nil {
+		t.Fatalf("LoadPricingSnapshot: %v", err)
+	}
+	service := NewServiceWithRegistry(db, NewProviderRegistry(nil), pricing.NewCatalog(snapshot))
+	defer service.StopRefreshTasks()
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	weeklyResetAt := now.Add(48 * time.Hour)
+	weeklyStart := weeklyResetAt.Add(-7 * 24 * time.Hour)
+	for _, event := range []entities.UsageEvent{
+		{
+			EventKey:     "xai-weekly-current",
+			AuthIndex:    "xai-auth",
+			Model:        "grok-priced",
+			Timestamp:    now.Add(-30 * time.Minute),
+			InputTokens:  1_000_000,
+			OutputTokens: 500_000,
+			TotalTokens:  1_500_000,
+		},
+		{
+			EventKey:     "xai-weekly-expired",
+			AuthIndex:    "xai-auth",
+			Model:        "grok-priced",
+			Timestamp:    weeklyStart.Add(-time.Minute),
+			InputTokens:  2_000_000,
+			OutputTokens: 1_000_000,
+			TotalTokens:  3_000_000,
+		},
+		{
+			EventKey:     "xai-weekly-other-auth",
+			AuthIndex:    "other-xai-auth",
+			Model:        "grok-priced",
+			Timestamp:    now.Add(-30 * time.Minute),
+			InputTokens:  4_000_000,
+			OutputTokens: 2_000_000,
+			TotalTokens:  6_000_000,
+		},
+	} {
+		if err := db.Create(&event).Error; err != nil {
+			t.Fatalf("seed usage event %q: %v", event.EventKey, err)
+		}
+	}
+
+	weeklySeconds := int64(7 * 24 * time.Hour / time.Second)
+	monthlySeconds := int64(30 * 24 * time.Hour / time.Second)
+	response := attachWindowUsageStats(service, context.Background(), "xai-auth", CheckResponse{
+		ID: "xai-auth",
+		Quota: []QuotaRow{
+			{
+				Key:         "billing.weekly",
+				Label:       "Weekly",
+				Scope:       "billing",
+				Metric:      "weekly",
+				UsedPercent: floatPtr(25),
+				Window:      &QuotaWindow{Seconds: &weeklySeconds},
+				ResetAt:     timeutil.FormatStorageTime(weeklyResetAt),
+			},
+			{
+				Key:     "billing.monthly",
+				Label:   "Monthly Spend",
+				Scope:   "billing",
+				Metric:  "usd_cents",
+				Window:  &QuotaWindow{Seconds: &monthlySeconds},
+				ResetAt: timeutil.FormatStorageTime(now.Add(10 * 24 * time.Hour)),
+			},
+			{
+				Key:     "billing.on_demand",
+				Label:   "Pay-as-you-go",
+				Scope:   "billing",
+				Metric:  "usd_cents",
+				Window:  &QuotaWindow{Seconds: &monthlySeconds},
+				ResetAt: timeutil.FormatStorageTime(now.Add(10 * 24 * time.Hour)),
+			},
+			{
+				Key:         "billing.weekly.product.grokbuild",
+				Label:       "GrokBuild Usage",
+				Scope:       "product",
+				Metric:      "GrokBuild",
+				UsedPercent: floatPtr(40),
+				Window:      &QuotaWindow{Seconds: &weeklySeconds},
+				ResetAt:     timeutil.FormatStorageTime(weeklyResetAt),
+			},
+		},
+	}, now)
+
+	weekly := findQuotaUsageStatsRow(t, response.Quota, "billing.weekly")
+	if weekly.WindowUsageTokens == nil || *weekly.WindowUsageTokens != 1_500_000 {
+		t.Fatalf("xAI weekly tokens = %#v, want 1500000", weekly.WindowUsageTokens)
+	}
+	const wantWeeklyCost = 7.0
+	if weekly.WindowUsageCost == nil || math.Abs(*weekly.WindowUsageCost-wantWeeklyCost) > 1e-9 {
+		t.Fatalf("xAI weekly cost = %#v, want %.2f", weekly.WindowUsageCost, wantWeeklyCost)
+	}
+
+	for _, key := range []string{"billing.monthly", "billing.on_demand", "billing.weekly.product.grokbuild"} {
+		row := findQuotaUsageStatsRow(t, response.Quota, key)
+		if row.WindowUsageTokens != nil || row.WindowUsageCost != nil {
+			t.Fatalf("%s must not receive auth-level window usage, got tokens=%#v cost=%#v", key, row.WindowUsageTokens, row.WindowUsageCost)
+		}
+	}
+}

--- a/internal/quota/usage_stats.go
+++ b/internal/quota/usage_stats.go
@@ -88,8 +88,9 @@ func shouldBackfillWindowUsageStats(row QuotaRow) bool {
 	if row.WindowUsageTokens != nil && row.WindowUsageCost != nil {
 		return false
 	}
-	// 本地 usage_events 兜底只适用于普通 5h/Weekly/Monthly window scope。
-	if !strings.EqualFold(strings.TrimSpace(row.Scope), "window") {
+	// 普通窗口和 xAI canonical Weekly 都能安全映射到当前 auth_index 的明确时间范围。
+	ordinaryWindow := strings.EqualFold(strings.TrimSpace(row.Scope), "window")
+	if !ordinaryWindow && !isXAIWeeklyUsageWindowQuotaRow(row) {
 		return false
 	}
 	if row.Window == nil || row.Window.Seconds == nil {

--- a/internal/quota/xai.go
+++ b/internal/quota/xai.go
@@ -15,6 +15,8 @@ type xaiProvider struct {
 	monthlyConfig APICallConfig
 }
 
+const xaiWeeklyBillingQuotaKey = "billing.weekly"
+
 func NewXAIProvider(caller ManagementAPICaller, weeklyConfig APICallConfig, monthlyConfig APICallConfig) ProviderHandler {
 	return xaiProvider{caller: caller, weeklyConfig: weeklyConfig, monthlyConfig: monthlyConfig}
 }
@@ -108,4 +110,9 @@ func hasXAIBillingQuotaRows(billing *XAIBillingPayload, period string) bool {
 		return false
 	}
 	return len(normalizeXAIQuotaRows(result)) > 0
+}
+
+func isXAIWeeklyUsageWindowQuotaRow(row QuotaRow) bool {
+	// xAI Weekly 虽来自 billing endpoint，但它有明确的 auth 级七天窗口，可以复用本地窗口统计。
+	return row.Key == xaiWeeklyBillingQuotaKey && strings.EqualFold(strings.TrimSpace(row.Scope), "billing")
 }


### PR DESCRIPTION
## Summary

- Populate the canonical xAI weekly billing row with token and cost statistics from the existing auth-scoped usage window calculator.
- Reuse the shared repository and pricing resolver instead of Codex-specific calculation code.
- Keep xAI monthly spend, pay-as-you-go, and product quota rows excluded from local window statistics.

Fixes #329

## Validation

- RED confirmed xAI weekly token usage was absent before implementation.
- go test ./internal/quota/test -run ^TestAttachWindowUsageStatsBackfillsOnlyXAIWeeklyBilling$ -count=1
- go test ./internal/quota/test -count=1 (231 tests)
- Project private backend verification passed across all Go packages.
- git diff --check passed.
- gofmt reported no diff.
- Read-only project review found no P0-P3 issues.

## Live protocol validation

No compatible xAI account was available for a real billing request. The existing xAI billing protocol is unchanged by this PR; live behavior will be monitored through user feedback.