### PR TITLE
test(usage): stabilize latency retention clocks

### DIFF
--- a/internal/poller/test/usage_aggregation_runner_shared_test.go
+++ b/internal/poller/test/usage_aggregation_runner_shared_test.go
@@ -42,7 +42,7 @@ func TestUsageAggregationRunnerSharedTurnReadsOneEventPageAndAdvancesAllRollups(
 	}
 	t.Cleanup(func() { _ = db.Callback().Query().Remove(callbackName) })
 
-	runner := poller.NewUsageAggregationRunnerWithOptions(db, poller.UsageAggregationRunnerOptions{DebounceInterval: 10 * time.Millisecond})
+	runner := newUsageAggregationRunnerAt(db, now, 10*time.Millisecond)
 	result, err := runner.RunOnce(context.Background())
 	if err != nil {
 		t.Fatalf("run shared rollups turn: %v", err)
@@ -115,7 +115,7 @@ func TestUsageAggregationRunnerFallbackCatchesUpEachCursorThenRestoresSharedRead
 	}
 	t.Cleanup(func() { _ = db.Callback().Query().Remove(callbackName) })
 
-	runner := poller.NewUsageAggregationRunner(db)
+	runner := newUsageAggregationRunnerAt(db, now, 0)
 	result, err := runner.RunOnce(context.Background())
 	if err != nil {
 		t.Fatalf("run fallback rollups turn: %v", err)
@@ -203,7 +203,7 @@ func TestUsageAggregationRunnerPreservesEarlierRollupCommitsWhenLaterWriteFails(
 				t.Fatalf("create write-failure trigger: %v", err)
 			}
 
-			runner := poller.NewUsageAggregationRunner(db)
+			runner := newUsageAggregationRunnerAt(db, now, 0)
 			result, err := runner.RunOnce(context.Background())
 			if err == nil {
 				t.Fatal("expected forced later rollup write failure")
@@ -237,7 +237,7 @@ func TestUsageAggregationRunnerIdentityFailureDoesNotFreezeLaterRollups(t *testi
 		t.Fatalf("create identity failure trigger: %v", err)
 	}
 
-	runner := poller.NewUsageAggregationRunnerWithOptions(db, poller.UsageAggregationRunnerOptions{DebounceInterval: 20 * time.Millisecond})
+	runner := newUsageAggregationRunnerAt(db, now, 20*time.Millisecond)
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() { done <- runner.Run(ctx) }()
@@ -286,7 +286,7 @@ func TestUsageAggregationRunnerSkipsEmptyIdentityTurnBetweenRollupPages(t *testi
 		t.Fatalf("seed multi-page rollup backlog: %v", err)
 	}
 
-	runner := poller.NewUsageAggregationRunner(db)
+	runner := newUsageAggregationRunnerAt(db, now, 0)
 	for turn := 1; turn <= 3; turn++ {
 		if _, err := runner.RunOnce(context.Background()); err != nil {
 			t.Fatalf("prepare turn %d: %v", turn, err)
@@ -326,7 +326,7 @@ func TestUsageAggregationRunnerStopsBetweenRollupWritesWhenCPAInboxAppears(t *te
 		t.Fatalf("create between-write inbox trigger: %v", err)
 	}
 
-	runner := poller.NewUsageAggregationRunner(db)
+	runner := newUsageAggregationRunnerAt(db, now, 0)
 	result, err := runner.RunOnce(context.Background())
 	if err != nil {
 		t.Fatalf("run inbox-priority turn: %v", err)
@@ -360,7 +360,7 @@ func TestUsageAggregationRunnerAlternatesOneRollupPageWithOneIdentityPage(t *tes
 		t.Fatalf("seed fair events: %v", err)
 	}
 
-	runner := poller.NewUsageAggregationRunner(db)
+	runner := newUsageAggregationRunnerAt(db, now, 0)
 	wantKinds := []poller.UsageAggregationKind{
 		poller.UsageAggregationKindRollups,
 		poller.UsageAggregationKindIdentity,
@@ -485,7 +485,7 @@ func TestUsageAggregationRunnerDebounceDoesNotResetAndStartupDoesNotWait(t *test
 		if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{{EventKey: "startup-immediate", APIGroupKey: "provider-a", Model: "model-a", Timestamp: now}}); err != nil {
 			t.Fatalf("insert startup event: %v", err)
 		}
-		runner := poller.NewUsageAggregationRunnerWithOptions(db, poller.UsageAggregationRunnerOptions{DebounceInterval: 500 * time.Millisecond})
+		runner := newUsageAggregationRunnerAt(db, now, 500*time.Millisecond)
 		ctx, cancel := context.WithCancel(context.Background())
 		done := make(chan error, 1)
 		go func() { done <- runner.Run(ctx) }()
@@ -500,13 +500,13 @@ func TestUsageAggregationRunnerDebounceDoesNotResetAndStartupDoesNotWait(t *test
 
 	t.Run("later notifications share the first fixed window", func(t *testing.T) {
 		db := openUsageAggregationRunnerDatabase(t)
-		runner := poller.NewUsageAggregationRunnerWithOptions(db, poller.UsageAggregationRunnerOptions{DebounceInterval: 500 * time.Millisecond})
+		now := time.Date(2026, 7, 26, 12, 30, 0, 0, time.UTC)
+		runner := newUsageAggregationRunnerAt(db, now, 500*time.Millisecond)
 		ctx, cancel := context.WithCancel(context.Background())
 		done := make(chan error, 1)
 		go func() { done <- runner.Run(ctx) }()
 		// 等待启动 MAX(id) 与空 Identity 扫描结束，后续事件只能走 debounce 路径。
 		time.Sleep(80 * time.Millisecond)
-		now := time.Date(2026, 7, 26, 12, 30, 0, 0, time.UTC)
 		if _, _, err := repository.InsertUsageEvents(db, []entities.UsageEvent{{EventKey: "debounce-1", APIGroupKey: "provider-a", Model: "model-a", Timestamp: now}}); err != nil {
 			t.Fatalf("insert first debounce event: %v", err)
 		}
@@ -561,7 +561,7 @@ func TestUsageAggregationRunnerBackgroundFailureStillLetsIdentityRun(t *testing.
 		BEGIN SELECT RAISE(ABORT, 'forced background activity failure'); END`).Error; err != nil {
 		t.Fatalf("create background failure trigger: %v", err)
 	}
-	runner := poller.NewUsageAggregationRunner(db)
+	runner := newUsageAggregationRunnerAt(db, now, 0)
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() { done <- runner.Run(ctx) }()
@@ -593,7 +593,7 @@ func TestUsageAggregationRunnerPersistentRollupFailureDoesNotFreezeHealthyRollup
 		t.Fatalf("create persistent Activity failure trigger: %v", err)
 	}
 
-	runner := poller.NewUsageAggregationRunnerWithOptions(db, poller.UsageAggregationRunnerOptions{DebounceInterval: 20 * time.Millisecond})
+	runner := newUsageAggregationRunnerAt(db, now, 20*time.Millisecond)
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() { done <- runner.Run(ctx) }()
@@ -671,4 +671,11 @@ func waitForUsageAggregationRunnerCondition(t *testing.T, timeout time.Duration,
 	if !condition() {
 		t.Fatal("usage aggregation runner condition was not reached before timeout")
 	}
+}
+
+func newUsageAggregationRunnerAt(db *gorm.DB, now time.Time, debounceInterval time.Duration) *poller.UsageAggregationRunner {
+	return poller.NewUsageAggregationRunnerWithOptions(db, poller.UsageAggregationRunnerOptions{
+		DebounceInterval: debounceInterval,
+		NowFunc:          func() time.Time { return now },
+	})
 }

--- a/internal/poller/usage_aggregation_runner.go
+++ b/internal/poller/usage_aggregation_runner.go
@@ -52,9 +52,10 @@ type UsageAggregationRunResult struct {
 	DeferredForInbox bool
 }
 
-// UsageAggregationRunnerOptions 只开放测试需要缩短的时间窗口，不增加用户配置项。
+// UsageAggregationRunnerOptions 只开放测试需要控制的时钟和时间窗口，不增加用户配置项。
 type UsageAggregationRunnerOptions struct {
 	DebounceInterval time.Duration
+	NowFunc          func() time.Time
 }
 
 // UsageAggregationRunner 在一个 goroutine 内公平调度共享 rollups 与既有 Identity。
@@ -94,15 +95,19 @@ func NewUsageAggregationRunner(db *gorm.DB) *UsageAggregationRunner {
 	return NewUsageAggregationRunnerWithOptions(db, UsageAggregationRunnerOptions{})
 }
 
-// NewUsageAggregationRunnerWithOptions 创建可缩短 debounce 的内部测试 runner。
+// NewUsageAggregationRunnerWithOptions 创建可控制时钟和 debounce 的内部测试 runner。
 func NewUsageAggregationRunnerWithOptions(db *gorm.DB, options UsageAggregationRunnerOptions) *UsageAggregationRunner {
 	debounceInterval := options.DebounceInterval
 	if debounceInterval <= 0 {
 		debounceInterval = usageAggregationDefaultDebounceInterval
 	}
+	now := options.NowFunc
+	if now == nil {
+		now = time.Now
+	}
 	return &UsageAggregationRunner{
 		db:                       db,
-		now:                      time.Now,
+		now:                      now,
 		debounceInterval:         debounceInterval,
 		nextKind:                 UsageAggregationKindRollups,
 		identityTargetGeneration: 1, // 启动时必须覆盖一次进程启动前已经存在的 identities。

--- a/internal/repository/migration/20260726_usage_latency_stats.go
+++ b/internal/repository/migration/20260726_usage_latency_stats.go
@@ -34,7 +34,8 @@ func usageLatencyStatsMigration(db *gorm.DB) error {
 			return fmt.Errorf("load usage latency migration target: %w", err)
 		}
 	}
-	now := timeutil.NormalizeStorageTime(time.Now())
+	// 复用数据库时钟，让 migration 与 GORM 写入及可重复测试共享同一时间来源。
+	now := timeutil.NormalizeStorageTime(db.NowFunc())
 
 	// 每页是一个独立短事务；重启时直接从已提交的 Latency checkpoint 继续。
 	for {

--- a/internal/repository/migration/test/usage_latency_stats_test.go
+++ b/internal/repository/migration/test/usage_latency_stats_test.go
@@ -30,7 +30,7 @@ func TestUsageLatencyStatsMigrationMatchesRuntimeAggregation(t *testing.T) {
 	}
 
 	// migration 数据库只具备新 migration 所需的最小前置 schema。
-	migrationDB := openUsageAggregationCheckpointMigrationDatabase(t, "latency-migration.db")
+	migrationDB := openUsageLatencyMigrationDatabaseAt(t, "latency-migration.db", now)
 	prepareUsageLatencyMigrationDatabase(t, migrationDB, events)
 	if err := migration.Run(migrationDB); err != nil {
 		t.Fatalf("run latency stats migration: %v", err)
@@ -40,7 +40,7 @@ func TestUsageLatencyStatsMigrationMatchesRuntimeAggregation(t *testing.T) {
 	assertUsageLatencyMigrationApplied(t, migrationDB, true)
 
 	// 运行时数据库直接用同一 BuildRows 和 Apply 入口处理同一页。
-	runtimeDB := openUsageAggregationCheckpointMigrationDatabase(t, "latency-runtime.db")
+	runtimeDB := openUsageLatencyMigrationDatabaseAt(t, "latency-runtime.db", now)
 	if err := runtimeDB.AutoMigrate(&entities.UsageAggregationCheckpoint{}, &entities.UsageLatencyStat{}); err != nil {
 		t.Fatalf("create runtime latency schema: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestUsageLatencyStatsMigrationResumesAfterCommittedPage(t *testing.T) {
 		}
 		events = append(events, latencyMigrationEvent(id, apiGroupKey, now.Add(-time.Minute), 100, 900))
 	}
-	db := openUsageAggregationCheckpointMigrationDatabase(t, "latency-resume.db")
+	db := openUsageLatencyMigrationDatabaseAt(t, "latency-resume.db", now)
 	prepareUsageLatencyMigrationDatabase(t, db, events)
 	if err := db.AutoMigrate(&entities.UsageLatencyStat{}); err != nil {
 		t.Fatalf("create latency table before trigger: %v", err)
@@ -123,7 +123,7 @@ func TestUsageLatencyStatsMigrationEnablesUsageEventCleanup(t *testing.T) {
 		latencyMigrationEvent(1, "key-a", now.AddDate(0, 0, -92), 100, 900),
 		latencyMigrationEvent(2, "key-a", now.AddDate(0, 0, -91), 200, 1200),
 	}
-	db := openUsageAggregationCheckpointMigrationDatabase(t, "latency-cleanup.db")
+	db := openUsageLatencyMigrationDatabaseAt(t, "latency-cleanup.db", now)
 	prepareUsageLatencyMigrationDatabase(t, db, events)
 	// Cleanup 后续步骤依赖这些当前实体表；保持空表即可，不掺入其它业务数据。
 	if err := db.AutoMigrate(&entities.RedisUsageInbox{}, &entities.UsageActivityStat{}, &entities.UsageIdentity{}); err != nil {
@@ -173,6 +173,13 @@ func latencyMigrationEvent(id int64, apiGroupKey string, timestamp time.Time, tt
 	// migration fixture 直接给出最终合法事件字段，聚焦回填分页和可恢复事务。
 	generate := true
 	return entities.UsageEvent{ID: id, EventKey: fmt.Sprintf("latency-%d", id), APIGroupKey: apiGroupKey, Timestamp: timestamp, Generate: &generate, TTFTMS: &ttftMS, LatencyMS: latencyMS}
+}
+
+func openUsageLatencyMigrationDatabaseAt(t *testing.T, name string, now time.Time) *gorm.DB {
+	t.Helper()
+	db := openUsageAggregationCheckpointMigrationDatabase(t, name)
+	db.NowFunc = func() time.Time { return now }
+	return db
 }
 
 func loadUsageLatencyMigrationRows(t *testing.T, db *gorm.DB) []entities.UsageLatencyStat {


### PR DESCRIPTION
## Summary

- make the usage aggregation runner clock injectable for deterministic retention tests
- make the Latency migration reuse the configured GORM database clock
- pin runner and migration fixtures so hourly and daily expectations do not expire over time

## Validation

- focused affected tests with `TZ=UTC` and `GOFLAGS=-count=1`
- focused affected tests with `TZ=Asia/Shanghai` and `GOFLAGS=-count=1`
- project skill backend verification