### PR TITLE
fix(pricing): align rules help icon with ranking modal

### DIFF
--- a/web/src/components/usage/pricing/PriceRulesHelp.tsx
+++ b/web/src/components/usage/pricing/PriceRulesHelp.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
-import { IconCircleHelp } from '@/components/ui/icons'
 import styles from './PriceRulesModal.module.scss'
 
 const VIEWPORT_PADDING = 16
@@ -166,7 +165,7 @@ export function PriceRulesHelp() {
           setTouchOpen(true)
         }}
       >
-        <IconCircleHelp size={15} />
+        ?
       </button>
       {typeof document === 'undefined' ? tooltip : createPortal(tooltip, document.body)}
     </span>

--- a/web/src/components/usage/pricing/PriceRulesModal.module.scss
+++ b/web/src/components/usage/pricing/PriceRulesModal.module.scss
@@ -27,24 +27,27 @@
 }
 
 .helpButton {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
+  appearance: none;
+  display: inline-grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
   padding: 0;
   border: 1px solid var(--border-color);
-  border-radius: 999px;
-  background: var(--bg-primary);
+  border-radius: 50%;
   color: var(--text-secondary);
-  cursor: help;
-}
+  background: var(--bg-secondary);
+  font-size: 11px;
+  font-weight: 750;
+  line-height: 1;
+  font-family: inherit;
+  cursor: default;
+  user-select: none;
 
-.helpButton:hover,
-.helpButton:focus-visible {
-  border-color: var(--border-hover);
-  color: var(--text-primary);
-  outline: none;
+  &:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+  }
 }
 
 .helpTooltip {

--- a/web/src/components/usage/pricing/test/PriceRulesModal.test.tsx
+++ b/web/src/components/usage/pricing/test/PriceRulesModal.test.tsx
@@ -319,9 +319,17 @@ describe('PriceRulesModal', () => {
 
 	const helpButton = document.body.querySelector<HTMLButtonElement>('[aria-label="How pricing rules work"]')
 	expect(helpButton).not.toBeNull()
+	expect(helpButton?.textContent).toBe('?')
+	expect(modalStylesSource).toMatch(/\.helpButton\s*\{[\s\S]*display:\s*inline-grid;/)
+	expect(modalStylesSource).toMatch(/\.helpButton\s*\{[\s\S]*width:\s*18px;/)
+	expect(modalStylesSource).toMatch(/\.helpButton\s*\{[\s\S]*height:\s*18px;/)
+	expect(modalStylesSource).toMatch(/\.helpButton\s*\{[\s\S]*background:\s*var\(--bg-secondary\);/)
+	expect(modalStylesSource).toMatch(/\.helpButton\s*\{[\s\S]*font-size:\s*11px;/)
+	expect(modalStylesSource).toMatch(/\.helpButton\s*\{[\s\S]*font-weight:\s*750;/)
+	expect(modalStylesSource).toMatch(/\.helpButton\s*\{[\s\S]*cursor:\s*default;/)
 	helpButton!.getBoundingClientRect = () => ({
-	  x: 280, y: 160, left: 280, top: 160, right: 306, bottom: 186,
-	  width: 26, height: 26, toJSON: () => ({}),
+	  x: 280, y: 160, left: 280, top: 160, right: 298, bottom: 178,
+	  width: 18, height: 18, toJSON: () => ({}),
 	})
 	await act(async () => helpButton!.focus())
 	const describedBy = helpButton?.getAttribute('aria-describedby')


### PR DESCRIPTION
## Summary

- match the pricing rules help trigger to the compact question-mark style used by the ranking participation modal
- preserve the existing hover, keyboard, touch, and accessible tooltip behavior
- add regression coverage for the shared visual characteristics

## Testing

- `npm exec vitest run src/components/usage/pricing/test/PriceRulesModal.test.tsx` (14 tests)
- frontend verification (103 test files, 956 tests, lint, typecheck, production build)