### PR TITLE
fix(ranking): adapt mobile participant column width

### DIFF
--- a/web/src/features/ranking/RankingPage.module.scss
+++ b/web/src/features/ranking/RankingPage.module.scss
@@ -961,6 +961,11 @@
 @include mobile {
   @include ranking-header-stacked;
 
+  .participantColumn,
+  .participantCell {
+    min-width: 0;
+  }
+
   .profileModal :global(.modal-body) {
     max-height: min(60dvh, calc(100dvh - 180px));
     overflow: auto;

--- a/web/src/features/ranking/test/RankingPage.styles.test.ts
+++ b/web/src/features/ranking/test/RankingPage.styles.test.ts
@@ -190,6 +190,16 @@ describe('Ranking table context styles', () => {
     expect(mobile).toContain('@include ranking-header-stacked;');
   });
 
+  it('lets the sticky participant column follow the display name width on mobile', () => {
+    const mobileStart = styles.indexOf('@include mobile');
+    const mobileEnd = styles.indexOf('@media (prefers-reduced-motion', mobileStart);
+    const mobile = styles.slice(mobileStart, mobileEnd);
+
+    expect(mobile).toMatch(
+      /\.participantColumn,\s*\.participantCell\s*\{[\s\S]*?min-width:\s*0;/,
+    );
+  });
+
   it('gives loading, empty, and error content a tall centered viewport', () => {
     const state = rule('.loadingState');
     expect(rule('.page')).toContain('flex: 1 0 auto;');


### PR DESCRIPTION
## Summary

- let the sticky participant column follow the actual display name width on mobile
- preserve the existing desktop leaderboard layout
- add regression coverage for the mobile width override

## Validation

- frontend verification: 103 test files, 959 tests
- ESLint
- TypeScript typecheck
- production build