### PR TITLE
fix(credentials): reveal auth file names on hover

### DIFF
--- a/web/src/components/ui/PortalTooltip.module.scss
+++ b/web/src/components/ui/PortalTooltip.module.scss
@@ -1,0 +1,24 @@
+.tooltip {
+  position: fixed;
+  z-index: 2100;
+  display: grid;
+  gap: 3px;
+  width: max-content;
+  max-width: min(280px, calc(100vw - 16px));
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.22);
+  padding: 10px 12px;
+  pointer-events: none;
+  text-align: left;
+  font-size: 11px;
+  line-height: 1.45;
+
+  span {
+    display: block;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+}

--- a/web/src/components/ui/PortalTooltip.tsx
+++ b/web/src/components/ui/PortalTooltip.tsx
@@ -85,6 +85,12 @@ export function usePortalTooltip() {
     syncTooltip()
   }, [syncTooltip])
 
+  const dismiss = useCallback(() => {
+    hoverTargetRef.current = null
+    focusTargetRef.current = null
+    setTooltip(null)
+  }, [])
+
   useEffect(() => {
     const repositionTooltip = () => {
       if (hoverTargetRef.current || focusTargetRef.current) {
@@ -105,6 +111,7 @@ export function usePortalTooltip() {
     hideOnMouseLeave,
     showOnFocus,
     hideOnBlur,
+    dismiss,
   }
 }
 

--- a/web/src/components/ui/PortalTooltip.tsx
+++ b/web/src/components/ui/PortalTooltip.tsx
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import styles from './PortalTooltip.module.scss'
+
+const TOOLTIP_MAX_WIDTH = 280
+const TOOLTIP_ESTIMATED_HEIGHT = 72
+const TOOLTIP_OFFSET = 10
+const TOOLTIP_VIEWPORT_PADDING = 8
+
+export type PortalTooltipState = {
+  lines: string[]
+  x: number
+  y: number
+  placement: 'above' | 'below'
+}
+
+type PortalTooltipTarget = {
+  lines: string[]
+  anchor: HTMLElement
+}
+
+export function usePortalTooltip() {
+  const [tooltip, setTooltip] = useState<PortalTooltipState | null>(null)
+  const hoverTargetRef = useRef<PortalTooltipTarget | null>(null)
+  const focusTargetRef = useRef<PortalTooltipTarget | null>(null)
+
+  const positionTooltip = useCallback((target: PortalTooltipTarget | null) => {
+    if (!target?.anchor.isConnected) {
+      setTooltip(null)
+      return
+    }
+
+    // 浮层挂到 body 后不受滚动容器裁剪，并围绕当前 hover/focus 锚点限制在视口内。
+    const viewportWidth = typeof window === 'undefined' ? 1024 : window.innerWidth
+    const viewportHeight = typeof window === 'undefined' ? 768 : window.innerHeight
+    const rect = target.anchor.getBoundingClientRect()
+    const tooltipWidth = Math.min(
+      TOOLTIP_MAX_WIDTH,
+      Math.max(viewportWidth - TOOLTIP_VIEWPORT_PADDING * 2, 0),
+    )
+    const halfTooltipWidth = tooltipWidth / 2
+    const minX = TOOLTIP_VIEWPORT_PADDING + halfTooltipWidth
+    const maxX = viewportWidth - TOOLTIP_VIEWPORT_PADDING - halfTooltipWidth
+    const anchorX = rect.left + rect.width / 2
+    const x = maxX >= minX ? Math.max(minX, Math.min(anchorX, maxX)) : viewportWidth / 2
+    const spaceBelow = viewportHeight - rect.bottom - TOOLTIP_OFFSET - TOOLTIP_VIEWPORT_PADDING
+    const spaceAbove = rect.top - TOOLTIP_OFFSET - TOOLTIP_VIEWPORT_PADDING
+    const placement = spaceBelow >= TOOLTIP_ESTIMATED_HEIGHT || spaceBelow >= spaceAbove ? 'below' : 'above'
+    const y = placement === 'above' ? rect.top - TOOLTIP_OFFSET : rect.bottom + TOOLTIP_OFFSET
+
+    setTooltip({ lines: target.lines, x, y, placement })
+  }, [])
+
+  const syncTooltip = useCallback(() => {
+    if (hoverTargetRef.current && !hoverTargetRef.current.anchor.isConnected) {
+      hoverTargetRef.current = null
+    }
+    if (focusTargetRef.current && !focusTargetRef.current.anchor.isConnected) {
+      focusTargetRef.current = null
+    }
+    positionTooltip(hoverTargetRef.current ?? focusTargetRef.current)
+  }, [positionTooltip])
+
+  const showOnMouseEnter = useCallback((lines: string[], anchor: HTMLElement) => {
+    hoverTargetRef.current = { lines, anchor }
+    syncTooltip()
+  }, [syncTooltip])
+
+  const hideOnMouseLeave = useCallback((anchor: HTMLElement) => {
+    if (hoverTargetRef.current?.anchor === anchor) {
+      hoverTargetRef.current = null
+    }
+    syncTooltip()
+  }, [syncTooltip])
+
+  const showOnFocus = useCallback((lines: string[], anchor: HTMLElement) => {
+    focusTargetRef.current = { lines, anchor }
+    syncTooltip()
+  }, [syncTooltip])
+
+  const hideOnBlur = useCallback((anchor: HTMLElement) => {
+    if (focusTargetRef.current?.anchor === anchor) {
+      focusTargetRef.current = null
+    }
+    syncTooltip()
+  }, [syncTooltip])
+
+  useEffect(() => {
+    const repositionTooltip = () => {
+      if (hoverTargetRef.current || focusTargetRef.current) {
+        syncTooltip()
+      }
+    }
+    window.addEventListener('resize', repositionTooltip)
+    window.addEventListener('scroll', repositionTooltip, true)
+    return () => {
+      window.removeEventListener('resize', repositionTooltip)
+      window.removeEventListener('scroll', repositionTooltip, true)
+    }
+  }, [syncTooltip])
+
+  return {
+    tooltip,
+    showOnMouseEnter,
+    hideOnMouseLeave,
+    showOnFocus,
+    hideOnBlur,
+  }
+}
+
+export function PortalTooltip({ tooltip }: { tooltip: PortalTooltipState | null }) {
+  if (!tooltip || typeof document === 'undefined') return null
+
+  return createPortal(
+    <div
+      className={styles.tooltip}
+      role="tooltip"
+      style={{
+        left: tooltip.x,
+        top: tooltip.y,
+        transform: tooltip.placement === 'above'
+          ? 'translate(-50%, -100%)'
+          : 'translateX(-50%)',
+      }}
+    >
+      {tooltip.lines.map((line, index) => <span key={`${index}-${line}`}>{line}</span>)}
+    </div>,
+    document.body,
+  )
+}

--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -7,7 +7,6 @@ import React, {
   useState,
   type ReactNode,
 } from 'react';
-import { createPortal } from 'react-dom';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/Button';
@@ -15,6 +14,7 @@ import { Card } from '@/components/ui/Card';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { MainActionButton } from '@/components/ui/MainActionButton';
 import { Modal } from '@/components/ui/Modal';
+import { PortalTooltip, usePortalTooltip } from '@/components/ui/PortalTooltip';
 import { Select } from '@/components/ui/Select';
 import { IconCheck, IconChevronDown, IconCopy, IconDownload, IconScrollText, IconSettings } from '@/components/ui/icons';
 import type { UsageEvent, UsageEventRequestLogResponse, UsageSourceFilterOption } from '@/lib/types';
@@ -50,10 +50,6 @@ const REQUEST_LOG_VIRTUAL_PADDING_Y = 12;
 const REQUEST_LOG_VIRTUAL_CHUNK_CHARS = 2048;
 const REQUEST_LOG_VIRTUAL_BREAK_LOOKBACK = 256;
 const REQUEST_LOG_GRAPHEME_CONTEXT_CHARS = 64;
-const REQUEST_EVENTS_TOOLTIP_MAX_WIDTH = 280;
-const REQUEST_EVENTS_TOOLTIP_ESTIMATED_HEIGHT = 72;
-const REQUEST_EVENTS_TOOLTIP_OFFSET = 10;
-const REQUEST_EVENTS_TOOLTIP_VIEWPORT_PADDING = 8;
 const REQUEST_EVENT_CLIENT_IP_DISPLAY_LENGTH = 39;
 const REQUEST_EVENT_X_FORWARDED_FOR_DISPLAY_LENGTH = 48;
 const REQUEST_EVENT_USER_AGENT_DISPLAY_LENGTH = 48;
@@ -124,18 +120,6 @@ type RequestEventRow = {
   cacheReadRate: string;
   cost: number | null;
   costAvailable: boolean;
-};
-
-type RequestEventTooltipState = {
-  lines: string[];
-  x: number;
-  y: number;
-  placement: 'above' | 'below';
-};
-
-type RequestEventTooltipTarget = {
-  lines: string[];
-  anchor: HTMLTableCellElement;
 };
 
 type RequestEventColumnDefinition = {
@@ -661,11 +645,15 @@ export function RequestEventsDetailsCard({
   requestLogDownloading = false,
 }: RequestEventsDetailsCardProps) {
   const { t } = useTranslation();
-  const [requestEventsTooltip, setRequestEventsTooltip] = useState<RequestEventTooltipState | null>(null);
+  const {
+    tooltip: requestEventsTooltip,
+    showOnMouseEnter: handleRequestEventsTooltipMouseEnter,
+    hideOnMouseLeave: handleRequestEventsTooltipMouseLeave,
+    showOnFocus: handleRequestEventsTooltipFocus,
+    hideOnBlur: handleRequestEventsTooltipBlur,
+  } = usePortalTooltip();
   const [columnSettingsOpen, setColumnSettingsOpen] = useState(false);
   const [columnSettingsSession, setColumnSettingsSession] = useState(0);
-  const requestEventsTooltipHoverTargetRef = useRef<RequestEventTooltipTarget | null>(null);
-  const requestEventsTooltipFocusTargetRef = useRef<RequestEventTooltipTarget | null>(null);
   const requestEventsTableWrapperRef = useRef<HTMLDivElement | null>(null);
   const resultLocale = t('usage_stats.success') === 'Success' ? 'en' : 'zh';
   const latencyHint = t('usage_stats.latency_unit_hint', {
@@ -674,89 +662,6 @@ export function RequestEventsDetailsCard({
   });
   const ttftHint = t('usage_stats.ttft_hint');
   const speedHint = t('usage_stats.speed_hint');
-
-  const positionRequestEventsTooltip = useCallback((target: RequestEventTooltipTarget | null) => {
-    if (!target) {
-      setRequestEventsTooltip(null);
-      return;
-    }
-
-    // 浮层挂到 body 后不受表格滚动容器裁剪，并随当前 hover/focus 锚点保持在视口内。
-    const viewportWidth = typeof window === 'undefined' ? 1024 : window.innerWidth;
-    const viewportHeight = typeof window === 'undefined' ? 768 : window.innerHeight;
-    const rect = target.anchor.getBoundingClientRect();
-    const tooltipWidth = Math.min(
-      REQUEST_EVENTS_TOOLTIP_MAX_WIDTH,
-      Math.max(viewportWidth - REQUEST_EVENTS_TOOLTIP_VIEWPORT_PADDING * 2, 0),
-    );
-    const halfTooltipWidth = tooltipWidth / 2;
-    const minX = REQUEST_EVENTS_TOOLTIP_VIEWPORT_PADDING + halfTooltipWidth;
-    const maxX = viewportWidth - REQUEST_EVENTS_TOOLTIP_VIEWPORT_PADDING - halfTooltipWidth;
-    const anchorX = rect.left + rect.width / 2;
-    const x = maxX >= minX ? Math.max(minX, Math.min(anchorX, maxX)) : viewportWidth / 2;
-    const spaceBelow = viewportHeight
-      - rect.bottom
-      - REQUEST_EVENTS_TOOLTIP_OFFSET
-      - REQUEST_EVENTS_TOOLTIP_VIEWPORT_PADDING;
-    const spaceAbove = rect.top
-      - REQUEST_EVENTS_TOOLTIP_OFFSET
-      - REQUEST_EVENTS_TOOLTIP_VIEWPORT_PADDING;
-    const placement = spaceBelow >= REQUEST_EVENTS_TOOLTIP_ESTIMATED_HEIGHT || spaceBelow >= spaceAbove
-      ? 'below'
-      : 'above';
-    const y = placement === 'above'
-      ? rect.top - REQUEST_EVENTS_TOOLTIP_OFFSET
-      : rect.bottom + REQUEST_EVENTS_TOOLTIP_OFFSET;
-
-    setRequestEventsTooltip({ lines: target.lines, x, y, placement });
-  }, []);
-
-  const syncRequestEventsTooltip = useCallback(() => {
-    if (requestEventsTooltipHoverTargetRef.current && !requestEventsTooltipHoverTargetRef.current.anchor.isConnected) {
-      requestEventsTooltipHoverTargetRef.current = null;
-    }
-    if (requestEventsTooltipFocusTargetRef.current && !requestEventsTooltipFocusTargetRef.current.anchor.isConnected) {
-      requestEventsTooltipFocusTargetRef.current = null;
-    }
-    positionRequestEventsTooltip(
-      requestEventsTooltipHoverTargetRef.current ?? requestEventsTooltipFocusTargetRef.current,
-    );
-  }, [positionRequestEventsTooltip]);
-
-  const handleRequestEventsTooltipMouseEnter = useCallback((lines: string[], anchor: HTMLTableCellElement) => {
-    requestEventsTooltipHoverTargetRef.current = { lines, anchor };
-    syncRequestEventsTooltip();
-  }, [syncRequestEventsTooltip]);
-  const handleRequestEventsTooltipMouseLeave = useCallback((anchor: HTMLTableCellElement) => {
-    if (requestEventsTooltipHoverTargetRef.current?.anchor === anchor) {
-      requestEventsTooltipHoverTargetRef.current = null;
-    }
-    syncRequestEventsTooltip();
-  }, [syncRequestEventsTooltip]);
-  const handleRequestEventsTooltipFocus = useCallback((lines: string[], anchor: HTMLTableCellElement) => {
-    requestEventsTooltipFocusTargetRef.current = { lines, anchor };
-    syncRequestEventsTooltip();
-  }, [syncRequestEventsTooltip]);
-  const handleRequestEventsTooltipBlur = useCallback((anchor: HTMLTableCellElement) => {
-    if (requestEventsTooltipFocusTargetRef.current?.anchor === anchor) {
-      requestEventsTooltipFocusTargetRef.current = null;
-    }
-    syncRequestEventsTooltip();
-  }, [syncRequestEventsTooltip]);
-
-  useEffect(() => {
-    const repositionRequestEventsTooltip = () => {
-      if (requestEventsTooltipHoverTargetRef.current || requestEventsTooltipFocusTargetRef.current) {
-        syncRequestEventsTooltip();
-      }
-    };
-    window.addEventListener('resize', repositionRequestEventsTooltip);
-    window.addEventListener('scroll', repositionRequestEventsTooltip, true);
-    return () => {
-      window.removeEventListener('resize', repositionRequestEventsTooltip);
-      window.removeEventListener('scroll', repositionRequestEventsTooltip, true);
-    };
-  }, [syncRequestEventsTooltip]);
 
   const rows = useMemo<RequestEventRow[]>(() => {
     return events.map((event, index) => {
@@ -1389,24 +1294,7 @@ export function RequestEventsDetailsCard({
         onApply={handleColumnSettingsApply}
         onClose={() => setColumnSettingsOpen(false)}
       />
-      {requestEventsTooltip && typeof document !== 'undefined'
-        ? createPortal(
-            <div
-              className={styles.requestEventsSpeedModeTooltip}
-              role="tooltip"
-              style={{
-                left: requestEventsTooltip.x,
-                top: requestEventsTooltip.y,
-                transform: requestEventsTooltip.placement === 'above'
-                  ? 'translate(-50%, -100%)'
-                  : 'translateX(-50%)',
-              }}
-            >
-              {requestEventsTooltip.lines.map((line) => <span key={line}>{line}</span>)}
-            </div>,
-            document.body,
-          )
-        : null}
+      <PortalTooltip tooltip={requestEventsTooltip} />
       <Modal
         open={requestLogOpen}
         title={requestLogTitle}

--- a/web/src/components/usage/credentials/AuthFileCredentialsSection.tsx
+++ b/web/src/components/usage/credentials/AuthFileCredentialsSection.tsx
@@ -125,7 +125,12 @@ export function AuthFileCredentialsSection({ rows, total, page, totalPages, page
     hideOnMouseLeave: hideFilenameTooltipOnMouseLeave,
     showOnFocus: showFilenameTooltipOnFocus,
     hideOnBlur: hideFilenameTooltipOnBlur,
+    dismiss: dismissFilenameTooltip,
   } = usePortalTooltip()
+  const filenameTooltipRowsVersion = rows
+    .map((row) => `${row.identity.id || row.identity.identity}\u0000${row.identity.file_name?.trim() ?? ''}`)
+    .sort()
+    .join('\u0001')
   const expiryTooltipHoverTargetRef = useRef<CredentialExpiryTooltipTarget | null>(null)
   const expiryTooltipFocusTargetRef = useRef<CredentialExpiryTooltipTarget | null>(null)
   const showHealthMode = displayMode === 'health'
@@ -173,6 +178,11 @@ export function AuthFileCredentialsSection({ rows, total, page, totalPages, page
     }
     positionExpiryTooltip(expiryTooltipHoverTargetRef.current ?? expiryTooltipFocusTargetRef.current)
   }, [positionExpiryTooltip])
+
+  useEffect(() => {
+    // 当前页文件映射变化时清理旧事件快照；统计刷新但映射不变时保留正在查看的 tooltip。
+    dismissFilenameTooltip()
+  }, [dismissFilenameTooltip, filenameTooltipRowsVersion])
 
   useEffect(() => {
     window.addEventListener('resize', syncExpiryTooltip)

--- a/web/src/components/usage/credentials/AuthFileCredentialsSection.tsx
+++ b/web/src/components/usage/credentials/AuthFileCredentialsSection.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { MainActionButton } from '@/components/ui/MainActionButton'
 import { Modal } from '@/components/ui/Modal'
+import { PortalTooltip, usePortalTooltip } from '@/components/ui/PortalTooltip'
 import { IconChartLine, IconGaugeReset, IconRefreshCw, IconSearch, IconSettings, IconShield, IconTrash2 } from '@/components/ui/icons'
 import quotaCostIcon from '@/assets/icons/quota-cost.svg'
 import quotaTokenIcon from '@/assets/icons/quota-token.svg'
@@ -118,6 +119,13 @@ export function AuthFileCredentialsSection({ rows, total, page, totalPages, page
   const [quotaUsageMode, setQuotaUsageMode] = useState<QuotaUsageMode>('current')
   const [displayMode, setDisplayModeState] = useState<AuthFileDisplayMode>(() => readStoredAuthFileDisplayMode())
   const [expiryTooltip, setExpiryTooltip] = useState<CredentialExpiryTooltipState | null>(null)
+  const {
+    tooltip: filenameTooltip,
+    showOnMouseEnter: showFilenameTooltipOnMouseEnter,
+    hideOnMouseLeave: hideFilenameTooltipOnMouseLeave,
+    showOnFocus: showFilenameTooltipOnFocus,
+    hideOnBlur: hideFilenameTooltipOnBlur,
+  } = usePortalTooltip()
   const expiryTooltipHoverTargetRef = useRef<CredentialExpiryTooltipTarget | null>(null)
   const expiryTooltipFocusTargetRef = useRef<CredentialExpiryTooltipTarget | null>(null)
   const showHealthMode = displayMode === 'health'
@@ -247,6 +255,25 @@ export function AuthFileCredentialsSection({ rows, total, page, totalPages, page
         const rowExpiryTooltipText = row.expiresAtLabel
           ? t('usage_stats.credentials_expiry_tooltip', { value: row.expiresAtLabel })
           : ''
+        const fileName = row.identity.file_name?.trim() ?? ''
+        const filenameTooltipTargetProps = {
+          className: styles.credentialFileNameTooltipTarget,
+          'data-auth-file-name-tooltip-target': true,
+          tabIndex: fileName ? 0 : undefined,
+          'aria-label': fileName ? `${row.displayName}; ${fileName}` : undefined,
+          onMouseEnter: fileName
+            ? (event: React.MouseEvent<HTMLSpanElement>) => showFilenameTooltipOnMouseEnter([fileName], event.currentTarget)
+            : undefined,
+          onMouseLeave: fileName
+            ? (event: React.MouseEvent<HTMLSpanElement>) => hideFilenameTooltipOnMouseLeave(event.currentTarget)
+            : undefined,
+          onFocus: fileName
+            ? (event: React.FocusEvent<HTMLSpanElement>) => showFilenameTooltipOnFocus([fileName], event.currentTarget)
+            : undefined,
+          onBlur: fileName
+            ? (event: React.FocusEvent<HTMLSpanElement>) => hideFilenameTooltipOnBlur(event.currentTarget)
+            : undefined,
+        }
         return (
           <CredentialRowShell
             key={rowKey}
@@ -257,9 +284,10 @@ export function AuthFileCredentialsSection({ rows, total, page, totalPages, page
                 alias={row.identity.alias}
                 saving={aliasSavingId === row.identity.id}
                 disabled={isCredentialAliasEditorDisabled(row.identity.id, row.identity.is_deleted, aliasSavingId)}
+                displayNameProps={filenameTooltipTargetProps}
                 onSaveAlias={onSaveAlias}
               />
-            ) : row.displayName}
+            ) : <span {...filenameTooltipTargetProps}>{row.displayName}</span>}
             subtitle={(
               <span className={styles.credentialIdentityBadges}>
                 <CredentialBadge>{row.typeLabel}</CredentialBadge>
@@ -362,6 +390,7 @@ export function AuthFileCredentialsSection({ rows, total, page, totalPages, page
         onSortChange={(nextSort) => onSortChange(nextSort as UsageIdentityPageSort)}
       />
       </CredentialSectionShell>
+      <PortalTooltip tooltip={filenameTooltip} />
       {expiryTooltip && activeExpiryTooltipText && typeof document !== 'undefined'
         ? createPortal(
             <div

--- a/web/src/components/usage/credentials/CredentialAliasEditor.tsx
+++ b/web/src/components/usage/credentials/CredentialAliasEditor.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, type HTMLAttributes } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { IconCheck, IconPencil, IconX } from '@/components/ui/icons'
@@ -10,6 +10,7 @@ interface CredentialAliasEditorProps {
   alias?: string | null
   saving: boolean
   disabled?: boolean
+  displayNameProps?: HTMLAttributes<HTMLSpanElement>
   onSaveAlias: (id: string, alias: string) => Promise<void>
 }
 
@@ -17,13 +18,14 @@ export function isCredentialAliasEditorDisabled(identityId: string, isDeleted?: 
   return Boolean(isDeleted || (aliasSavingId && aliasSavingId !== identityId))
 }
 
-export function CredentialAliasEditor({ identityId, displayName, alias, saving, disabled = false, onSaveAlias }: CredentialAliasEditorProps) {
+export function CredentialAliasEditor({ identityId, displayName, alias, saving, disabled = false, displayNameProps, onSaveAlias }: CredentialAliasEditorProps) {
   const { t } = useTranslation()
   const [editing, setEditing] = useState(false)
   const [draftAlias, setDraftAlias] = useState(alias ?? '')
   const currentAlias = alias ?? ''
   const canEdit = !disabled && identityId.trim() !== ''
   const canSave = !saving && draftAlias.trim() !== currentAlias.trim()
+  const displayNameClassName = `${styles.credentialAliasNameSlot} ${displayNameProps?.className ?? ''}`.trim()
 
   const startEditing = () => {
     if (!canEdit) return
@@ -100,7 +102,7 @@ export function CredentialAliasEditor({ identityId, displayName, alias, saving, 
   return (
     <span className={styles.credentialAliasEditor}>
       <span className={styles.credentialAliasDisplayLayout}>
-        <span className={styles.credentialAliasNameSlot}>{displayName}</span>
+        <span {...displayNameProps} className={displayNameClassName}>{displayName}</span>
         <span className={styles.credentialAliasActionSlot}>
           {canEdit && (
             <button

--- a/web/src/components/usage/credentials/CredentialSections.module.scss
+++ b/web/src/components/usage/credentials/CredentialSections.module.scss
@@ -1660,6 +1660,16 @@
   overflow-wrap: anywhere;
 }
 
+.credentialFileNameTooltipTarget {
+  cursor: default;
+
+  &:focus-visible {
+    border-radius: 3px;
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+  }
+}
+
 .credentialAliasActionSlot {
   display: inline-flex;
   align-items: center;

--- a/web/src/components/usage/credentials/test/AuthFileFilenameTooltip.test.tsx
+++ b/web/src/components/usage/credentials/test/AuthFileFilenameTooltip.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { AuthFileCredentialsSection } from '../AuthFileCredentialsSection'
+import type { AuthFileCredentialRow } from '../credentialViewModels'
+
+const longFileName = 'claude-account-with-a-very-long-workspace-and-profile-name-2026-07-30.json'
+
+const row = (fileName?: string) => ({
+  identity: {
+    id: 'auth-1',
+    identity: 'auth-1',
+    file_name: fileName,
+    is_deleted: false,
+  },
+  displayName: 'same@example.com',
+  maskedIdentity: 'auth-1',
+  providerLabel: 'Claude',
+  typeLabel: 'claude',
+  authTypeLabel: 'oauth',
+  totalRequests: 0,
+  successCount: 0,
+  failureCount: 0,
+  successRate: null,
+  totalTokens: 0,
+  cacheReadRate: null,
+  quota: [],
+  quotaLoading: false,
+  displayQuotas: [],
+}) as AuthFileCredentialRow
+
+const sectionProps = {
+  total: 1,
+  page: 1,
+  totalPages: 1,
+  pageSize: 10,
+  activeOnly: false,
+  sort: 'priority' as const,
+  loading: false,
+  quotaRefreshing: false,
+  quotaRefreshError: '',
+  quotaInspectionStatus: null,
+  quotaInspectionLoading: false,
+  quotaInspectionStarting: false,
+  quotaInspectionError: '',
+  onPageChange: () => undefined,
+  onPageSizeChange: () => undefined,
+  onActiveOnlyChange: () => undefined,
+  onSortChange: () => undefined,
+  onRefreshQuota: async () => undefined,
+  onRefreshQuotaForAuthIndex: async () => undefined,
+  onResetQuotaForAuthIndex: async () => undefined,
+  onSaveAlias: async () => undefined,
+  onRefreshInspectionStatus: async () => undefined,
+  onStartInspection: async () => undefined,
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('AuthFileCredentialsSection filename tooltip', () => {
+  it('shows the complete filename only in the shared portal tooltip', async () => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    await act(async () => root.render(<AuthFileCredentialsSection {...sectionProps} rows={[row(longFileName)]} />))
+
+    const name = container.querySelector('[data-auth-file-name-tooltip-target]') as HTMLSpanElement
+    expect(name.textContent).toBe('same@example.com')
+    expect(name.getAttribute('title')).toBeNull()
+    expect(name.tabIndex).toBe(0)
+    expect(container.textContent).not.toContain(longFileName)
+
+    await act(async () => name.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })))
+    let tooltip = document.body.querySelector('[role="tooltip"]')
+    expect(tooltip?.textContent).toBe(longFileName)
+    expect(tooltip?.querySelectorAll('span')).toHaveLength(1)
+
+    await act(async () => name.dispatchEvent(new MouseEvent('mouseout', { bubbles: true })))
+    expect(document.body.querySelector('[role="tooltip"]')).toBeNull()
+
+    await act(async () => name.focus())
+    tooltip = document.body.querySelector('[role="tooltip"]')
+    expect(tooltip?.textContent).toBe(longFileName)
+
+    await act(async () => name.blur())
+    expect(document.body.querySelector('[role="tooltip"]')).toBeNull()
+
+    await act(async () => root.unmount())
+    container.remove()
+  })
+
+  it('does not make a name without a filename interactive', async () => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    await act(async () => root.render(<AuthFileCredentialsSection {...sectionProps} rows={[row()]} />))
+
+    const name = container.querySelector('[data-auth-file-name-tooltip-target]') as HTMLSpanElement
+    expect(name.tabIndex).toBe(-1)
+    await act(async () => name.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })))
+    expect(document.body.querySelector('[role="tooltip"]')).toBeNull()
+
+    await act(async () => root.unmount())
+    container.remove()
+  })
+})

--- a/web/src/components/usage/credentials/test/AuthFileFilenameTooltip.test.tsx
+++ b/web/src/components/usage/credentials/test/AuthFileFilenameTooltip.test.tsx
@@ -109,4 +109,36 @@ describe('AuthFileCredentialsSection filename tooltip', () => {
     await act(async () => root.unmount())
     container.remove()
   })
+
+  it('clears stale tooltip content only when the current filename mapping changes', async () => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    const renderRows = async (rows: AuthFileCredentialRow[]) => {
+      await act(async () => root.render(<AuthFileCredentialsSection {...sectionProps} rows={rows} total={rows.length} />))
+    }
+
+    await renderRows([row(longFileName)])
+    let name = container.querySelector('[data-auth-file-name-tooltip-target]') as HTMLSpanElement
+    await act(async () => name.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })))
+    expect(document.body.querySelector('[role="tooltip"]')?.textContent).toBe(longFileName)
+
+    await renderRows([{ ...row(longFileName), totalRequests: 1 }])
+    expect(document.body.querySelector('[role="tooltip"]')?.textContent).toBe(longFileName)
+
+    const renamedFile = 'renamed-claude-account.json'
+    await renderRows([row(renamedFile)])
+    expect(document.body.querySelector('[role="tooltip"]')).toBeNull()
+
+    name = container.querySelector('[data-auth-file-name-tooltip-target]') as HTMLSpanElement
+    await act(async () => name.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })))
+    expect(document.body.querySelector('[role="tooltip"]')?.textContent).toBe(renamedFile)
+
+    await renderRows([])
+    expect(document.body.querySelector('[role="tooltip"]')).toBeNull()
+
+    await act(async () => root.unmount())
+    container.remove()
+  })
 })

--- a/web/src/components/usage/credentials/test/CredentialSections.styles.test.ts
+++ b/web/src/components/usage/credentials/test/CredentialSections.styles.test.ts
@@ -277,6 +277,11 @@ describe('Credential section styles', () => {
     expect(credentialStyles).not.toMatch(/\.credentialAliasDisplay\s*\{/)
   })
 
+  it('keeps the Auth File filename tooltip target on the normal arrow cursor', () => {
+    expect(credentialStyles).toMatch(/\.credentialFileNameTooltipTarget\s*\{[\s\S]*?cursor:\s*default;/)
+    expect(credentialStyles).not.toMatch(/\.credentialFileNameTooltipTarget\s*\{[\s\S]*?cursor:\s*help;/)
+  })
+
   it('keeps Auth Files inspection separate from the quota refresh pill', () => {
     expect(authFileSectionSource).toContain('credentialSectionActionButtons')
     expect(authFileSectionSource).toMatch(/<MainActionButton[\s\S]*?credentialInspectionButton[\s\S]*?<MainActionButton/)

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -2981,31 +2981,6 @@
   }
 }
 
-.requestEventsSpeedModeTooltip {
-  position: fixed;
-  z-index: 2100;
-  display: grid;
-  gap: 3px;
-  width: max-content;
-  max-width: min(280px, calc(100vw - 16px));
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  background: var(--bg-primary);
-  color: var(--text-secondary);
-  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.22);
-  padding: 10px 12px;
-  pointer-events: none;
-  text-align: left;
-  font-size: 11px;
-  line-height: 1.45;
-
-  span {
-    display: block;
-    white-space: normal;
-    overflow-wrap: anywhere;
-  }
-}
-
 .requestEventsSourceCell,
 .requestEventsAPIKeyCell {
   font-family:


### PR DESCRIPTION
## Summary

- show complete CPA auth file names when hovering or focusing credential names
- preserve the existing credential row layout and normal arrow cursor
- reuse the Request Events portal tooltip behavior for long values

## Testing

- npm test (104 files, 963 tests)
- npm run lint
- npm run typecheck
- npm run build
- integrated backend preview and health checks

Fixes #372