### PR TITLE
docs(readme): remove star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,16 +461,6 @@ When CPA and Keeper share a browser origin, `CPA_PUBLIC_URL` can be omitted and 
 CPA_PUBLIC_URL=https://cpa.example.com
 ```
 
-## Star History
-
-<a href="https://www.star-history.com/?repos=willxup%2Fcpa-usage-keeper&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=willxup/cpa-usage-keeper&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=willxup/cpa-usage-keeper&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=willxup/cpa-usage-keeper&type=date&legend=top-left" />
- </picture>
-</a>
-
 ## License
 
 This project is open source under the [MIT License](./LICENSE).

--- a/README.zh.md
+++ b/README.zh.md
@@ -461,17 +461,6 @@ CPA 与 Keeper 浏览器同源时，可以不设置 `CPA_PUBLIC_URL`，“返回
 CPA_PUBLIC_URL=https://cpa.example.com
 ```
 
-## Star History
-
-<a href="https://www.star-history.com/?repos=willxup%2Fcpa-usage-keeper&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=willxup/cpa-usage-keeper&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=willxup/cpa-usage-keeper&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=willxup/cpa-usage-keeper&type=date&legend=top-left" />
- </picture>
-</a>
-
-
 ## License
 
 本项目基于 [MIT License](./LICENSE) 开源。


### PR DESCRIPTION
## Summary

- Remove the unavailable Star History chart from the English README.
- Keep the Chinese README in sync.

## Validation

- git diff --check
- Confirmed both README files contain no Star History references.