### PR TITLE
fix(auth): harden login and HTTP request boundaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,18 +31,22 @@ APP_BASE_PATH=
 # Public CPA URL for the "Back to CPA" link. When empty, the current page origin is used and /management.html is appended.
 CPA_PUBLIC_URL=
 
+# 除本机 loopback 外允许提供 X-Forwarded-For 的代理 CIDR，多个值用逗号分隔。仅填写实际反向代理地址或网段，禁止使用 0.0.0.0/0 或 ::/0。必填：否。默认值：空。
+# Proxy CIDRs, in addition to local loopback, that may supply X-Forwarded-For; separate multiple values with commas. List only actual reverse-proxy addresses or networks; 0.0.0.0/0 and ::/0 are rejected. Required: no. Default: empty.
+TRUSTED_PROXY_CIDRS=
+
 
 # =============================================================================
 # 3. 登录保护 / Login protection
 # =============================================================================
 
-# 是否启用登录保护。公网部署建议设为 true。必填：否。默认值：false。
-# Whether to enable login protection. Recommended for public deployments. Required: no. Default: false.
-AUTH_ENABLED=false
+# 是否启用登录保护。仅在访问范围已由部署环境可靠隔离时才显式关闭。必填：否。默认值：true。
+# Whether to enable login protection. Disable it explicitly only when the deployment environment reliably isolates access. Required: no. Default: true.
+AUTH_ENABLED=true
 
-# 登录密码；仅在启用登录保护时必填。默认值：无。
-# Login password; required only when login protection is enabled. Default: none.
-LOGIN_PASSWORD=replace-with-your-login-password
+# 登录密码；启用登录保护时必填。示例保持为空，设置私有密码前服务会拒绝启动。默认值：无。
+# Login password; required when login protection is enabled. The example stays empty so the service refuses to start until a private password is set. Default: none.
+LOGIN_PASSWORD=
 
 # 登录 session 的有效时长。必填：否。默认值：168h。
 # Lifetime of the login session. Required: no. Default: 168h.

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -359,7 +359,7 @@ jobs:
 
                   #{etc}/cpa-usage-keeper.env
 
-                Required values include CPA_BASE_URL and CPA_MANAGEMENT_KEY.
+                Required values include CPA_BASE_URL and CPA_MANAGEMENT_KEY. LOGIN_PASSWORD is also required unless authentication is explicitly disabled.
 
                 Start the service with:
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Docker Compose is the recommended deployment method. Use the full stack when dep
 | Linux without containers | [Linux binary](#linux-binary) | `amd64`, `arm64` |
 | Windows | [Windows binary](#windows-binary) | `amd64`, `arm64` |
 
-For public deployments, enable `AUTH_ENABLED=true` and configure `LOGIN_PASSWORD` to protect your data.
+Login protection is enabled by default. Configure `LOGIN_PASSWORD` before starting Keeper, or explicitly set `AUTH_ENABLED=false` only when access is reliably isolated by the deployment environment.
 
 ## Project Structure
 
@@ -209,7 +209,7 @@ services:
       CPA_MANAGEMENT_KEY: replace-with-your-management-key
       REDIS_QUEUE_ADDR: cli-proxy-api:8317
       AUTH_ENABLED: true
-      LOGIN_PASSWORD: replace-with-your-login-password
+      LOGIN_PASSWORD: ${KEEPER_LOGIN_PASSWORD:?set KEEPER_LOGIN_PASSWORD}
     volumes:
       - ./keeper:/data
     networks:
@@ -219,6 +219,8 @@ networks:
   cpa-network:
     driver: bridge
 ```
+
+Set `KEEPER_LOGIN_PASSWORD` in the shell or the Compose `.env` file before starting.
 
 Run `docker compose up -d` to start the stack and `docker compose down` to stop it.
 
@@ -240,8 +242,10 @@ For CPA running on the Docker host, start with:
 CPA_BASE_URL=http://host.docker.internal:8317
 CPA_MANAGEMENT_KEY=replace-with-your-management-key
 AUTH_ENABLED=true
-LOGIN_PASSWORD=replace-with-your-login-password
+LOGIN_PASSWORD=
 ```
+
+Set a private `LOGIN_PASSWORD` before starting the container.
 
 Set `CPA_BASE_URL` to the reachable CPA address for other network layouts. If CPA uses a non-default Redis/RESP address, also set `REDIS_QUEUE_ADDR`.
 
@@ -272,7 +276,7 @@ brew tap Willxup/cpa-usage-keeper
 brew install cpa-usage-keeper
 ```
 
-Set at least `CPA_BASE_URL` and `CPA_MANAGEMENT_KEY`, then start the service:
+Set `CPA_BASE_URL`, `CPA_MANAGEMENT_KEY`, and a private `LOGIN_PASSWORD`, then start the service:
 
 ```bash
 vim "$(brew --prefix)/etc/cpa-usage-keeper.env"
@@ -339,7 +343,7 @@ notepad .env
 .\cpa-usage-keeper.exe
 ```
 
-Set at least `CPA_BASE_URL` and `CPA_MANAGEMENT_KEY` before starting. For public deployments, also set `AUTH_ENABLED=true` and `LOGIN_PASSWORD`.
+Set `CPA_BASE_URL`, `CPA_MANAGEMENT_KEY`, and a private `LOGIN_PASSWORD` before starting. Authentication is enabled by default; set `AUTH_ENABLED=false` explicitly only for an isolated deployment.
 
 ## Configuration
 
@@ -366,12 +370,14 @@ For first-time deployments, start with "Minimum required" and "Web access and re
 | `APP_PORT` | No | `8080` | Keeper HTTP listen port |
 | `APP_BASE_PATH` | No | root path | Keeper subpath prefix, such as `/keeper`; empty means `/` |
 | `CPA_PUBLIC_URL` | No | current browser origin root | Public CPA URL for the "Back to CPA" link and CPAMC frame trust |
+| `TRUSTED_PROXY_CIDRS` | No | local loopback only | Additional reverse-proxy CIDRs allowed to provide `X-Forwarded-For`, separated by commas |
 
 - The `--host` startup flag overrides `APP_HOST`. When neither is set, Keeper preserves its existing behavior and listens on all available network interfaces.
 - For Docker/Compose, keep `APP_HOST` empty. To restrict access to the Docker host, publish the port as `127.0.0.1:8080:8080`.
 - `APP_BASE_PATH` must be empty or start with `/`; `/cpa/` is normalized to `/cpa`.
 - `CPA_BASE_URL` is the server-side CPA address and may use a private host or Docker service name.
 - `CPA_PUBLIC_URL` controls browser navigation and cross-origin CPAMC frame trust. Leave it empty for same-origin `/management.html`, or set an explicit public CPA URL when domains, ports, or paths differ.
+- Keeper trusts `X-Forwarded-For` only from local loopback and `TRUSTED_PROXY_CIDRS`. Direct clients cannot change their login-rate-limit source with this header. Configure only the exact proxy address or network; universal CIDRs are rejected.
 
 For cross-origin CPAMC embedding, `CPA_PUBLIC_URL` must be a complete `http://` or `https://` URL with a host. Relative paths affect navigation only.
 
@@ -379,7 +385,7 @@ For cross-origin CPAMC embedding, `CPA_PUBLIC_URL` must be a complete `http://` 
 
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
-| `AUTH_ENABLED` | No | `false` | Enable login protection |
+| `AUTH_ENABLED` | No | `true` | Enable login protection |
 | `LOGIN_PASSWORD` | When auth is enabled | - | Login password |
 | `AUTH_SESSION_TTL` | No | `168h` | Login session lifetime |
 
@@ -437,7 +443,7 @@ Usually, HTTPS should be terminated at nginx, Caddy, or another reverse proxy. S
 Security and data notes:
 
 - Browser APIs redact key-like fields, but the SQLite database and its unencrypted backups contain original data.
-- For public deployments, enable `AUTH_ENABLED=true` and terminate HTTPS at a reverse proxy.
+- Authentication is enabled by default. If it is explicitly disabled, restrict Keeper access at the deployment boundary; terminate public HTTPS at a reverse proxy.
 - Login session hashes persist in SQLite until logout or `AUTH_SESSION_TTL` expiry.
 - CPAMC uses a separate embed session: an `HttpOnly` cookie when available, or a per-tab header token in browser session storage as a fallback.
 - Same-origin embedding works by default. For cross-origin embedding, set `CPA_PUBLIC_URL` to the public CPA/CPAMC origin used for `frame-ancestors`.
@@ -455,6 +461,8 @@ location /cpa/ {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 ```
+
+The loopback Nginx configuration above works without additional Keeper settings. If the reverse proxy reaches Keeper from a container or another host, add that exact proxy network, for example `TRUSTED_PROXY_CIDRS=172.18.0.0/16`.
 
 When CPA and Keeper share a browser origin, `CPA_PUBLIC_URL` can be omitted and "Back to CPA" uses `/management.html`. For another domain, port, or path, set the public CPA URL:
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -100,7 +100,7 @@ Docker Compose 是推荐部署方式：首次部署可同时运行 CPA + Keeper�
 | Linux 不使用容器 | [Linux 二进制](#linux-二进制) | `amd64`、`arm64` |
 | Windows | [Windows Binary](#windows-binary) | `amd64`、`arm64` |
 
-公网部署建议启用 `AUTH_ENABLED=true`，并配置 `LOGIN_PASSWORD` 保护数据。
+登录保护默认启用。启动 Keeper 前请配置 `LOGIN_PASSWORD`；只有部署环境已可靠隔离访问时，才显式设置 `AUTH_ENABLED=false`。
 
 ## 项目结构
 
@@ -209,7 +209,7 @@ services:
       CPA_MANAGEMENT_KEY: replace-with-your-management-key
       REDIS_QUEUE_ADDR: cli-proxy-api:8317
       AUTH_ENABLED: true
-      LOGIN_PASSWORD: replace-with-your-login-password
+      LOGIN_PASSWORD: ${KEEPER_LOGIN_PASSWORD:?set KEEPER_LOGIN_PASSWORD}
     volumes:
       - ./keeper:/data
     networks:
@@ -219,6 +219,8 @@ networks:
   cpa-network:
     driver: bridge
 ```
+
+启动前请在 shell 或 Compose `.env` 文件中设置 `KEEPER_LOGIN_PASSWORD`。
 
 运行 `docker compose up -d` 启动，使用 `docker compose down` 停止。
 
@@ -240,8 +242,10 @@ CPA 运行在 Docker 宿主机上时，可从以下配置开始：
 CPA_BASE_URL=http://host.docker.internal:8317
 CPA_MANAGEMENT_KEY=replace-with-your-management-key
 AUTH_ENABLED=true
-LOGIN_PASSWORD=replace-with-your-login-password
+LOGIN_PASSWORD=
 ```
+
+启动容器前请设置私有的 `LOGIN_PASSWORD`。
 
 其它网络环境请将 `CPA_BASE_URL` 改为容器可访问的 CPA 地址。CPA 使用非默认 Redis/RESP 地址时，再设置 `REDIS_QUEUE_ADDR`。
 
@@ -272,7 +276,7 @@ brew tap Willxup/cpa-usage-keeper
 brew install cpa-usage-keeper
 ```
 
-至少设置 `CPA_BASE_URL` 和 `CPA_MANAGEMENT_KEY`，然后启动服务：
+设置 `CPA_BASE_URL`、`CPA_MANAGEMENT_KEY` 和私有的 `LOGIN_PASSWORD`，然后启动服务：
 
 ```bash
 vim "$(brew --prefix)/etc/cpa-usage-keeper.env"
@@ -339,7 +343,7 @@ notepad .env
 .\cpa-usage-keeper.exe
 ```
 
-启动前至少设置 `CPA_BASE_URL` 和 `CPA_MANAGEMENT_KEY`。公网部署还应设置 `AUTH_ENABLED=true` 和 `LOGIN_PASSWORD`。
+启动前请设置 `CPA_BASE_URL`、`CPA_MANAGEMENT_KEY` 和私有的 `LOGIN_PASSWORD`。认证默认启用；只有隔离部署才显式设置 `AUTH_ENABLED=false`。
 
 ## 配置
 
@@ -366,12 +370,14 @@ cp .env.example .env
 | `APP_PORT` | 否 | `8080` | Keeper HTTP 监听端口 |
 | `APP_BASE_PATH` | 否 | 根路径 | Keeper 子路径部署前缀，例如 `/keeper`；留空表示部署在 `/` |
 | `CPA_PUBLIC_URL` | 否 | 当前浏览器同源根路径 | 浏览器访问 CPA 的公开地址，用于“返回 CPA”跳转和 CPAMC frame 信任来源 |
+| `TRUSTED_PROXY_CIDRS` | 否 | 仅本机 loopback | 允许提供 `X-Forwarded-For` 的额外反向代理 CIDR，多个值用逗号分隔 |
 
 - 启动参数 `--host` 的优先级高于 `APP_HOST`。两者都未设置时，Keeper 保持现有行为，监听所有可用网络接口。
 - Docker/Compose 请保持 `APP_HOST` 为空；如需仅允许 Docker 宿主机访问，请将端口发布为 `127.0.0.1:8080:8080`。
 - `APP_BASE_PATH` 必须为空或以 `/` 开头；`/cpa/` 会规范为 `/cpa`。
 - `CPA_BASE_URL` 是服务端访问 CPA 的地址，可以使用内网地址或 Docker 服务名。
 - `CPA_PUBLIC_URL` 控制浏览器跳转和跨域 CPAMC frame 信任。同源且 CPA 位于 `/management.html` 时可留空；域名、端口或路径不同时应设置公开 CPA 地址。
+- Keeper 只信任本机 loopback 和 `TRUSTED_PROXY_CIDRS` 提供的 `X-Forwarded-For`；直连客户端不能通过该请求头切换登录限流来源。只配置实际代理地址或网段，全网 CIDR 会被拒绝。
 
 跨域嵌入 CPAMC 时，`CPA_PUBLIC_URL` 必须是带 host 的完整 `http://` 或 `https://` URL；相对路径只影响浏览器跳转。
 
@@ -379,7 +385,7 @@ cp .env.example .env
 
 | 变量 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- |
-| `AUTH_ENABLED` | 否 | `false` | 是否启用登录保护 |
+| `AUTH_ENABLED` | 否 | `true` | 是否启用登录保护 |
 | `LOGIN_PASSWORD` | 鉴权启用时必填 | - | 登录密码 |
 | `AUTH_SESSION_TTL` | 否 | `168h` | 登录 session 有效时长 |
 
@@ -437,7 +443,7 @@ Keeper 会在每天 04:30 的维护窗口中，把早于 90 个本地自然日�
 安全与数据说明：
 
 - 浏览器 API 会脱敏 key 类字段，但 SQLite 数据库及其未加密备份仍包含原始数据。
-- 公网部署建议启用 `AUTH_ENABLED=true`，并在反向代理层启用 HTTPS。
+- 认证默认启用。若显式关闭，请在部署边界限制 Keeper 访问；公网访问应在反向代理层启用 HTTPS。
 - 登录 session hash 会保存在 SQLite 中，直到用户退出或超过 `AUTH_SESSION_TTL`。
 - CPAMC 使用独立的 embed session：优先使用 `HttpOnly` Cookie，不可用时回退到保存在浏览器 session storage 中的单标签页请求头 token。
 - 同源嵌入默认可用；跨域嵌入时，将 `CPA_PUBLIC_URL` 设置为用于 `frame-ancestors` 的公开 CPA/CPAMC 来源。
@@ -455,6 +461,8 @@ location /cpa/ {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 ```
+
+上面的本机 Nginx 配置无需额外设置 Keeper。若反向代理通过容器或其它主机访问 Keeper，请加入准确的代理网段，例如 `TRUSTED_PROXY_CIDRS=172.18.0.0/16`。
 
 CPA 与 Keeper 浏览器同源时，可以不设置 `CPA_PUBLIC_URL`，“返回 CPA”默认使用 `/management.html`。CPA 位于其它域名、端口或路径时，设置公开地址：
 

--- a/cmd/server/test/auth_startup_test.go
+++ b/cmd/server/test/auth_startup_test.go
@@ -1,0 +1,45 @@
+package test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestAuthenticationConfigurationFailuresAreLoggedAtStartup(t *testing.T) {
+	binaryPath := buildCLI(t)
+	baseEnv := []string{
+		"TZ=UTC",
+		"CPA_BASE_URL=http://127.0.0.1:8317",
+		"CPA_MANAGEMENT_KEY=test-management-key",
+	}
+	for _, testCase := range []struct {
+		name    string
+		env     []string
+		message string
+	}{
+		{
+			name:    "missing auth setting and password",
+			message: "AUTH_ENABLED is not set, so authentication defaults to true; LOGIN_PASSWORD is required",
+		},
+		{
+			name:    "public example password",
+			env:     []string{"AUTH_ENABLED=true", "LOGIN_PASSWORD=replace-with-your-login-password"},
+			message: "LOGIN_PASSWORD must not use the public example value",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			command := exec.Command(binaryPath)
+			command.Dir = t.TempDir()
+			command.Env = append(append([]string{}, baseEnv...), testCase.env...)
+			output, err := command.CombinedOutput()
+			if err == nil {
+				t.Fatal("expected invalid authentication configuration to stop startup")
+			}
+			text := string(output)
+			if !strings.Contains(text, "initialize app") || !strings.Contains(text, testCase.message) {
+				t.Fatalf("expected startup log to explain the authentication configuration error, got %q", text)
+			}
+		})
+	}
+}

--- a/cmd/server/test/version_flag_test.go
+++ b/cmd/server/test/version_flag_test.go
@@ -48,6 +48,7 @@ func TestHostFlagOverridesEnvFileInBuiltCLI(t *testing.T) {
 		"CPA_BASE_URL=http://127.0.0.1:1",
 		"CPA_MANAGEMENT_KEY=secret",
 		"REDIS_QUEUE_ADDR=127.0.0.1:1",
+		"AUTH_ENABLED=false",
 		"WORK_DIR=./data",
 		"LOG_FILE_ENABLED=false",
 		"BACKUP_ENABLED=false",

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -2,8 +2,8 @@ package api
 
 import (
 	"crypto/subtle"
-	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -26,7 +26,12 @@ const (
 	requestIntentHeaderValueFetch = "fetch"
 )
 
-const maxFailedLoginAttempts = 5
+const (
+	maxFailedLoginAttempts = 5
+	loginAttemptWindow     = time.Minute
+	loginAttemptGlobalMax  = 60
+	loginAttemptSourceMax  = 4096
+)
 
 type AuthConfig struct {
 	Enabled              bool
@@ -34,15 +39,16 @@ type AuthConfig struct {
 	SessionTTL           time.Duration
 	BasePath             string
 	FrameAncestorOrigins []string
+	TrustedProxyCIDRs    []string
 }
 
 type authHandler struct {
 	config            AuthConfig
 	sessions          *auth.SessionManager
 	cpaAPIKeyProvider service.CPAAPIKeyProvider
+	loginAttempts     *auth.LoginAttemptLimiter
 
 	mu                  sync.Mutex
-	failedAttempts      map[string]int
 	keyOverviewRequests map[string]time.Time
 }
 
@@ -91,7 +97,17 @@ type resolvedSessionToken struct {
 }
 
 func NewAuthHandler(config AuthConfig, sessions *auth.SessionManager) *authHandler {
-	return &authHandler{config: config, sessions: sessions, failedAttempts: make(map[string]int), keyOverviewRequests: make(map[string]time.Time)}
+	return &authHandler{
+		config:   config,
+		sessions: sessions,
+		loginAttempts: auth.NewLoginAttemptLimiter(auth.LoginAttemptLimiterOptions{
+			Window:         loginAttemptWindow,
+			PerSourceLimit: maxFailedLoginAttempts,
+			GlobalLimit:    loginAttemptGlobalMax,
+			MaxSources:     loginAttemptSourceMax,
+		}),
+		keyOverviewRequests: make(map[string]time.Time),
+	}
 }
 
 func (h *authHandler) setCPAAPIKeyProvider(provider service.CPAAPIKeyProvider) {
@@ -218,26 +234,27 @@ func (h *authHandler) login(c *gin.Context) {
 		writeInternalError(c, "session manager is not configured", nil)
 		return
 	}
+	clientKey := loginClientKey(c)
+	if !h.allowLoginAttempt(c, clientKey) {
+		return
+	}
 
 	var request loginRequest
 	if err := c.ShouldBindJSON(&request); err != nil {
+		if isRequestEntityTooLarge(err) {
+			writeRequestEntityTooLarge(c)
+			return
+		}
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	clientKey := loginClientKey(c)
 	passwordMatches := subtle.ConstantTimeCompare([]byte(request.Password), []byte(h.config.LoginPassword)) == 1
-	if h.tooManyFailedAttempts(clientKey) && !passwordMatches {
-		c.JSON(http.StatusTooManyRequests, gin.H{"error": "too many failed login attempts"})
-		return
-	}
-
 	if !passwordMatches {
-		h.recordFailedAttempt(clientKey)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid password"})
 		return
 	}
-	h.clearFailedAttempts(clientKey)
+	h.loginAttempts.Reset(clientKey)
 
 	resolved := resolveSessionToken(c)
 	token, expiresAt, err := h.sessions.CreateWithSource(resolved.Source)
@@ -260,27 +277,24 @@ func (h *authHandler) apiKeyLogin(c *gin.Context) {
 		return
 	}
 	clientKey := loginClientKey(c)
+	if !h.allowLoginAttempt(c, clientKey) {
+		return
+	}
 	var request apiKeyLoginRequest
 	if err := c.ShouldBindJSON(&request); err != nil {
-		if h.tooManyFailedAttempts(clientKey) {
-			c.JSON(http.StatusTooManyRequests, gin.H{"error": "too many failed login attempts"})
+		if isRequestEntityTooLarge(err) {
+			writeRequestEntityTooLarge(c)
 			return
 		}
-		h.recordFailedAttempt(clientKey)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
 		return
 	}
 	row, err := h.cpaAPIKeyProvider.FindActiveCPAAPIKeyByValue(c.Request.Context(), request.APIKey)
 	if err != nil {
-		if h.tooManyFailedAttempts(clientKey) {
-			c.JSON(http.StatusTooManyRequests, gin.H{"error": "too many failed login attempts"})
-			return
-		}
-		h.recordFailedAttempt(clientKey)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
 		return
 	}
-	h.clearFailedAttempts(clientKey)
+	h.loginAttempts.Reset(clientKey)
 	resolved := resolveSessionToken(c)
 	token, expiresAt, err := h.sessions.CreateAPIKeyViewerWithSource(row.ID, resolved.Source)
 	if err != nil {
@@ -322,22 +336,18 @@ func (h *authHandler) logout(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-func (h *authHandler) tooManyFailedAttempts(key string) bool {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	return h.failedAttempts[key] >= maxFailedLoginAttempts
-}
-
-func (h *authHandler) recordFailedAttempt(key string) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.failedAttempts[key]++
-}
-
-func (h *authHandler) clearFailedAttempts(key string) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	delete(h.failedAttempts, key)
+func (h *authHandler) allowLoginAttempt(c *gin.Context, key string) bool {
+	allowed, retryAfter := h.loginAttempts.Allow(key)
+	if allowed {
+		return true
+	}
+	seconds := int64((retryAfter + time.Second - 1) / time.Second)
+	if seconds < 1 {
+		seconds = 1
+	}
+	c.Header("Retry-After", strconv.FormatInt(seconds, 10))
+	c.JSON(http.StatusTooManyRequests, gin.H{"error": "too many login attempts"})
+	return false
 }
 
 func (h *authHandler) allowKeyOverviewRequest(token string, scopes ...string) bool {
@@ -394,10 +404,6 @@ func (h *authHandler) clearSessionState(token string) {
 }
 
 func loginClientKey(c *gin.Context) string {
-	host, _, err := net.SplitHostPort(c.Request.RemoteAddr)
-	if err == nil && host != "" {
-		return host
-	}
 	return c.ClientIP()
 }
 

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -237,7 +237,7 @@ func TestAuthAPIKeyLoginSuccessClearsFailedAttempts(t *testing.T) {
 	keyProvider := &authCPAAPIKeyStub{findErr: context.Canceled}
 	router := NewRouter(nil, nil, nil, nil, config, NewAuthHandler(config, sessions), "", OptionalProviders{CPAAPIKeys: keyProvider})
 
-	for i := 0; i < maxFailedLoginAttempts; i++ {
+	for i := 0; i < maxFailedLoginAttempts-1; i++ {
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/api-key-login", strings.NewReader(`{"apiKey":"missing"}`))
 		req.Header.Set(requestIntentHeaderName, requestIntentHeaderValueFetch)
@@ -669,7 +669,7 @@ func TestAuthLoginRateLimitsRepeatedFailures(t *testing.T) {
 	}
 }
 
-func TestAuthLoginAllowsCorrectPasswordAfterRateLimitThreshold(t *testing.T) {
+func TestAuthLoginRateLimitBlocksCorrectPasswordAfterThreshold(t *testing.T) {
 	sessions := auth.NewSessionManager(time.Hour)
 	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
 	router := NewRouter(nil, nil, nil, nil, config, NewAuthHandler(config, sessions), "")
@@ -693,8 +693,11 @@ func TestAuthLoginAllowsCorrectPasswordAfterRateLimitThreshold(t *testing.T) {
 	req.RemoteAddr = "198.51.100.2:1234"
 	router.ServeHTTP(resp, req)
 
-	if resp.Code != http.StatusNoContent {
-		t.Fatalf("expected correct password to clear failed attempts and login, got %d", resp.Code)
+	if resp.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected correct password to remain rate limited, got %d", resp.Code)
+	}
+	if resp.Header().Get("Retry-After") == "" {
+		t.Fatal("expected rate-limited login to include Retry-After")
 	}
 }
 

--- a/internal/api/request_limits.go
+++ b/internal/api/request_limits.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	unauthenticatedLoginBodyLimit   int64 = 4 << 10
+	unauthenticatedLoginReadTimeout       = 15 * time.Second
+)
+
+func unauthenticatedLoginRequestLimits(basePath string) gin.HandlerFunc {
+	prefix := strings.TrimSuffix(basePath, "/") + "/api/v1/auth/"
+	loginPath := prefix + "login"
+	apiKeyLoginPath := prefix + "api-key-login"
+	return func(c *gin.Context) {
+		if c.Request.Method != http.MethodPost || (c.Request.URL.Path != loginPath && c.Request.URL.Path != apiKeyLoginPath) {
+			c.Next()
+			return
+		}
+
+		// 匿名登录入口先建立读取期限，保证后续校验提前返回或关闭 body 时仍有时间上限。
+		controller := http.NewResponseController(c.Writer)
+		deadlineSet := controller.SetReadDeadline(time.Now().Add(unauthenticatedLoginReadTimeout)) == nil
+		defer func() {
+			if c.Request.Body != nil {
+				_ = c.Request.Body.Close()
+			}
+			if deadlineSet {
+				_ = controller.SetReadDeadline(time.Time{})
+			}
+		}()
+
+		if c.Request.ContentLength > unauthenticatedLoginBodyLimit {
+			writeRequestEntityTooLarge(c)
+			c.Abort()
+			return
+		}
+		if c.Request.Body != nil {
+			c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, unauthenticatedLoginBodyLimit)
+		}
+
+		c.Next()
+	}
+}
+
+func isRequestEntityTooLarge(err error) bool {
+	var maxBytesError *http.MaxBytesError
+	return errors.As(err, &maxBytesError)
+}
+
+func writeRequestEntityTooLarge(c *gin.Context) {
+	c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "request body too large"})
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -25,6 +25,8 @@ import (
 
 const appBasePathPlaceholder = "__APP_BASE_PATH__"
 
+var loopbackTrustedProxyCIDRs = []string{"127.0.0.1/32", "::1/128"}
+
 type StatusProvider interface {
 	Status() poller.Status
 }
@@ -67,13 +69,17 @@ func NewRouter(
 	optionalProviders ...OptionalProviders,
 ) *gin.Engine {
 	router := gin.New()
-	_ = router.SetTrustedProxies(nil)
+	trustedProxyCIDRs := append([]string{}, loopbackTrustedProxyCIDRs...)
+	trustedProxyCIDRs = append(trustedProxyCIDRs, authConfig.TrustedProxyCIDRs...)
+	_ = router.SetTrustedProxies(trustedProxyCIDRs)
+	router.RemoteIPHeaders = []string{"X-Forwarded-For"}
 	router.Use(logging.NewGinRecovery())
 
 	appGroup := router.Group(basePath)
 	registerHealthRoutes(appGroup)
 
 	apiV1 := appGroup.Group("/api/v1")
+	apiV1.Use(unauthenticatedLoginRequestLimits(basePath))
 	apiV1.Use(requestIntentMiddleware())
 	if debugAPIRoutesEnabled() {
 		registerPingRoutes(apiV1)

--- a/internal/api/test/login_security_test.go
+++ b/internal/api/test/login_security_test.go
@@ -1,0 +1,339 @@
+package test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	keeperapi "cpa-usage-keeper/internal/api"
+	keeperauth "cpa-usage-keeper/internal/auth"
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/service"
+)
+
+func TestPasswordLoginCannotBypassAttemptLimitWithCorrectPassword(t *testing.T) {
+	router := newLoginSecurityRouter(nil)
+	remoteAddr := "198.51.100.21:1234"
+	for index := 0; index < 5; index++ {
+		response := performLoginRequest(router, "/api/v1/auth/login", `{"password":"wrong"}`, remoteAddr)
+		if response.Code != http.StatusUnauthorized {
+			t.Fatalf("failed attempt %d: expected 401, got %d", index+1, response.Code)
+		}
+	}
+
+	response := performLoginRequest(router, "/api/v1/auth/login", `{"password":"secret"}`, remoteAddr)
+	if response.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected a correct password to remain rate limited, got %d", response.Code)
+	}
+	if retryAfter := response.Header().Get("Retry-After"); retryAfter == "" {
+		t.Fatal("expected rate-limited login to include Retry-After")
+	}
+}
+
+func TestAPIKeyLoginDoesNotQueryProviderWhenAttemptLimitIsReached(t *testing.T) {
+	provider := &countingCPAAPIKeyProvider{findErr: errors.New("not found")}
+	router := newLoginSecurityRouter(provider)
+	remoteAddr := "198.51.100.22:1234"
+	for index := 0; index < 5; index++ {
+		response := performLoginRequest(router, "/api/v1/auth/api-key-login", `{"apiKey":"missing"}`, remoteAddr)
+		if response.Code != http.StatusUnauthorized {
+			t.Fatalf("failed attempt %d: expected 401, got %d", index+1, response.Code)
+		}
+	}
+
+	response := performLoginRequest(router, "/api/v1/auth/api-key-login", `{"apiKey":"still-missing"}`, remoteAddr)
+	if response.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected API key login to be rate limited, got %d", response.Code)
+	}
+	if provider.findCalls != 5 {
+		t.Fatalf("expected the provider not to be queried after limiting, got %d calls", provider.findCalls)
+	}
+}
+
+func TestUnauthenticatedLoginEndpointsRejectBodiesLargerThanFourKiB(t *testing.T) {
+	router := newLoginSecurityRouter(&countingCPAAPIKeyProvider{findErr: errors.New("not found")})
+	for _, testCase := range []struct {
+		name string
+		path string
+		body string
+	}{
+		{name: "password", path: "/api/v1/auth/login", body: `{"password":"` + strings.Repeat("x", 4096) + `"}`},
+		{name: "api key", path: "/api/v1/auth/api-key-login", body: `{"apiKey":"` + strings.Repeat("x", 4096) + `"}`},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			response := performLoginRequest(router, testCase.path, testCase.body, "198.51.100.23:1234")
+			if response.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("expected 413, got %d body=%s", response.Code, response.Body.String())
+			}
+		})
+	}
+}
+
+func TestUnauthenticatedLoginEndpointsRejectChunkedBodiesLargerThanFourKiB(t *testing.T) {
+	router := newLoginSecurityRouter(&countingCPAAPIKeyProvider{findErr: errors.New("not found")})
+	for _, testCase := range []struct {
+		name string
+		path string
+		body string
+	}{
+		{name: "password", path: "/api/v1/auth/login", body: `{"password":"` + strings.Repeat("x", 4096) + `"}`},
+		{name: "api key", path: "/api/v1/auth/api-key-login", body: `{"apiKey":"` + strings.Repeat("x", 4096) + `"}`},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			request := newLoginRequest(testCase.path, testCase.body, "198.51.100.24:1234")
+			request.ContentLength = -1
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, request)
+			if response.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("expected 413, got %d body=%s", response.Code, response.Body.String())
+			}
+		})
+	}
+}
+
+func TestUnauthenticatedLoginLimitsRunBeforeRequestIntentCheck(t *testing.T) {
+	for _, testCase := range []struct {
+		name     string
+		basePath string
+		path     string
+	}{
+		{name: "password login", path: "/api/v1/auth/login"},
+		{name: "API key login with base path", basePath: "/cpa", path: "/cpa/api/v1/auth/api-key-login"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			router := newLoginSecurityRouterWithBasePath(nil, testCase.basePath)
+			writer := newDeadlineTrackingResponseWriter()
+			body := &deadlineCheckingBody{
+				reader:         strings.NewReader("x"),
+				deadlineActive: writer.readDeadlineActive,
+			}
+			request := httptest.NewRequest(http.MethodPost, testCase.path, nil)
+			request.Body = body
+			request.ContentLength = 1
+			request.Header.Set("Content-Type", "application/json")
+			request.RemoteAddr = "198.51.100.25:1234"
+
+			router.ServeHTTP(writer, request)
+
+			if writer.Code != http.StatusForbidden {
+				t.Fatalf("expected missing request intent to return 403, got %d", writer.Code)
+			}
+			if !writer.sawReadDeadline {
+				t.Fatal("expected login read deadline to be set before request intent validation")
+			}
+			if !body.closedWithDeadline {
+				t.Fatal("expected rejected login body to close while the read deadline is active")
+			}
+		})
+	}
+}
+
+func TestKnownOversizedLoginBodyClosesAfterReadDeadline(t *testing.T) {
+	router := newLoginSecurityRouter(nil)
+	writer := newDeadlineTrackingResponseWriter()
+	body := &deadlineCheckingBody{
+		reader:         strings.NewReader("x"),
+		deadlineActive: writer.readDeadlineActive,
+	}
+	request := newLoginRequest("/api/v1/auth/login", "", "198.51.100.26:1234")
+	request.Body = body
+	request.ContentLength = 4097
+
+	router.ServeHTTP(writer, request)
+
+	if writer.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected oversized login body to return 413, got %d", writer.Code)
+	}
+	if !body.closedWithDeadline {
+		t.Fatal("expected oversized login body to close while the read deadline is active")
+	}
+}
+
+func TestTrustedLoopbackProxySeparatesLoginAttemptSources(t *testing.T) {
+	router := newLoginSecurityRouter(nil)
+	for index := 0; index < 5; index++ {
+		response := performForwardedLoginRequest(router, "198.51.100.31", "127.0.0.1:4100")
+		if response.Code != http.StatusUnauthorized {
+			t.Fatalf("failed attempt %d: expected 401, got %d", index+1, response.Code)
+		}
+	}
+
+	otherClient := performForwardedLoginRequest(router, "198.51.100.32", "127.0.0.1:4101")
+	if otherClient.Code != http.StatusUnauthorized {
+		t.Fatalf("expected a different client behind the trusted proxy to keep its own budget, got %d", otherClient.Code)
+	}
+
+	limitedClient := performForwardedLoginRequest(router, "198.51.100.31", "127.0.0.1:4102")
+	if limitedClient.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected the original forwarded client to remain limited, got %d", limitedClient.Code)
+	}
+}
+
+func TestDirectClientCannotSpoofLoginSourceWithForwardedHeader(t *testing.T) {
+	router := newLoginSecurityRouter(nil)
+	for index := 0; index < 5; index++ {
+		response := performForwardedLoginRequest(router, "203.0.113."+strconv.Itoa(index+1), "198.51.100.41:4200")
+		if response.Code != http.StatusUnauthorized {
+			t.Fatalf("failed attempt %d: expected 401, got %d", index+1, response.Code)
+		}
+	}
+
+	response := performForwardedLoginRequest(router, "203.0.113.99", "198.51.100.41:4201")
+	if response.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected direct client to remain limited despite changing X-Forwarded-For, got %d", response.Code)
+	}
+}
+
+func TestExplicitTrustedProxyCIDRSeparatesLoginAttemptSources(t *testing.T) {
+	config := keeperapi.AuthConfig{
+		Enabled:           true,
+		LoginPassword:     "secret",
+		SessionTTL:        time.Hour,
+		TrustedProxyCIDRs: []string{"192.0.2.0/24"},
+	}
+	sessions := keeperauth.NewSessionManager(time.Hour)
+	router := keeperapi.NewRouter(nil, nil, nil, nil, config, keeperapi.NewAuthHandler(config, sessions), "")
+
+	for index := 0; index < 5; index++ {
+		response := performForwardedLoginRequest(router, "198.51.100.51", "192.0.2.10:4300")
+		if response.Code != http.StatusUnauthorized {
+			t.Fatalf("failed attempt %d: expected 401, got %d", index+1, response.Code)
+		}
+	}
+	response := performForwardedLoginRequest(router, "198.51.100.52", "192.0.2.10:4301")
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("expected configured proxy CIDR to separate forwarded clients, got %d", response.Code)
+	}
+}
+
+func TestAuthenticatedBusinessRouteDoesNotUseLoginBodyLimit(t *testing.T) {
+	sessions := keeperauth.NewSessionManager(time.Hour)
+	config := keeperapi.AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
+	handler := keeperapi.NewAuthHandler(config, sessions)
+	provider := &authFilesManagementProvider{}
+	router := keeperapi.NewRouter(nil, nil, nil, nil, config, handler, "", keeperapi.OptionalProviders{AuthFiles: provider})
+	token, _, err := sessions.Create()
+	if err != nil {
+		t.Fatalf("create admin session: %v", err)
+	}
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPatch, "/api/v1/auth-files/status", strings.NewReader(`{"names":["`+strings.Repeat("x", 4096)+`"],"disabled":true}`))
+	request.Header.Set(requestIntentHeaderName, requestIntentHeaderValueFetch)
+	request.Header.Set("Content-Type", "application/json")
+	request.AddCookie(&http.Cookie{Name: standardSessionCookieName, Value: token})
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected authenticated business body to remain accepted, got %d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func newLoginSecurityRouter(provider service.CPAAPIKeyProvider) http.Handler {
+	return newLoginSecurityRouterWithBasePath(provider, "")
+}
+
+func newLoginSecurityRouterWithBasePath(provider service.CPAAPIKeyProvider, basePath string) http.Handler {
+	sessions := keeperauth.NewSessionManager(time.Hour)
+	config := keeperapi.AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour, BasePath: basePath}
+	handler := keeperapi.NewAuthHandler(config, sessions)
+	return keeperapi.NewRouter(nil, nil, nil, nil, config, handler, basePath, keeperapi.OptionalProviders{CPAAPIKeys: provider})
+}
+
+func performLoginRequest(router http.Handler, path, body, remoteAddr string) *httptest.ResponseRecorder {
+	response := httptest.NewRecorder()
+	request := newLoginRequest(path, body, remoteAddr)
+	router.ServeHTTP(response, request)
+	return response
+}
+
+func performForwardedLoginRequest(router http.Handler, clientIP, remoteAddr string) *httptest.ResponseRecorder {
+	request := newLoginRequest("/api/v1/auth/login", `{"password":"wrong"}`, remoteAddr)
+	request.Header.Set("X-Forwarded-For", clientIP)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	return response
+}
+
+func newLoginRequest(path, body, remoteAddr string) *http.Request {
+	request := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	request.Header.Set(requestIntentHeaderName, requestIntentHeaderValueFetch)
+	request.Header.Set("Content-Type", "application/json")
+	request.RemoteAddr = remoteAddr
+	return request
+}
+
+type countingCPAAPIKeyProvider struct {
+	findCalls int
+	findErr   error
+}
+
+func (p *countingCPAAPIKeyProvider) ListCPAAPIKeys(context.Context) ([]entities.CPAAPIKey, error) {
+	return nil, nil
+}
+
+func (p *countingCPAAPIKeyProvider) FindActiveCPAAPIKeyByValue(context.Context, string) (entities.CPAAPIKey, error) {
+	p.findCalls++
+	return entities.CPAAPIKey{}, p.findErr
+}
+
+func (p *countingCPAAPIKeyProvider) FindActiveCPAAPIKeyByID(context.Context, int64) (entities.CPAAPIKey, error) {
+	return entities.CPAAPIKey{}, errors.New("not found")
+}
+
+func (p *countingCPAAPIKeyProvider) UpdateCPAAPIKeyAlias(context.Context, int64, string) (entities.CPAAPIKey, error) {
+	return entities.CPAAPIKey{}, nil
+}
+
+type authFilesManagementProvider struct{}
+
+func (p *authFilesManagementProvider) SetAuthFilesDisabled(_ context.Context, names []string, _ bool) (service.AuthFilesManagementResponse, error) {
+	return service.AuthFilesManagementResponse{Names: names, Affected: len(names)}, nil
+}
+
+func (p *authFilesManagementProvider) DeleteAuthFiles(_ context.Context, names []string) (service.AuthFilesManagementResponse, error) {
+	return service.AuthFilesManagementResponse{Names: names, Affected: len(names)}, nil
+}
+
+type deadlineTrackingResponseWriter struct {
+	*httptest.ResponseRecorder
+	readDeadline    time.Time
+	sawReadDeadline bool
+}
+
+func newDeadlineTrackingResponseWriter() *deadlineTrackingResponseWriter {
+	return &deadlineTrackingResponseWriter{ResponseRecorder: httptest.NewRecorder()}
+}
+
+func (w *deadlineTrackingResponseWriter) SetReadDeadline(deadline time.Time) error {
+	w.readDeadline = deadline
+	if !deadline.IsZero() {
+		w.sawReadDeadline = true
+	}
+	return nil
+}
+
+func (w *deadlineTrackingResponseWriter) readDeadlineActive() bool {
+	return !w.readDeadline.IsZero()
+}
+
+type deadlineCheckingBody struct {
+	reader             io.Reader
+	deadlineActive     func() bool
+	closedWithDeadline bool
+}
+
+func (b *deadlineCheckingBody) Read(buffer []byte) (int, error) {
+	return b.reader.Read(buffer)
+}
+
+func (b *deadlineCheckingBody) Close() error {
+	b.closedWithDeadline = b.deadlineActive != nil && b.deadlineActive()
+	return nil
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"strings"
 	"sync"
@@ -282,6 +281,7 @@ func NewWithConfig(cfg config.Config) (*App, error) {
 		SessionTTL:           cfg.AuthSessionTTL,
 		BasePath:             cfg.AppBasePath,
 		FrameAncestorOrigins: frameAncestorOrigins(cfg),
+		TrustedProxyCIDRs:    cfg.TrustedProxyCIDRs,
 	}
 	authHandler := api.NewAuthHandler(authConfig, sessionManager)
 
@@ -473,11 +473,7 @@ func (a *App) Run() error {
 		})
 	}
 
-	server := &http.Server{
-		Addr:     a.Config.ListenAddress(),
-		Handler:  a.Router,
-		ErrorLog: logging.NewStandardLogger(logrus.ErrorLevel),
-	}
+	server := NewHTTPServer(*a.Config, a.Router)
 	if a.Config.TLSEnabled {
 		return server.ListenAndServeTLS(a.Config.TLSCertFile, a.Config.TLSKeyFile)
 	}

--- a/internal/app/http_server.go
+++ b/internal/app/http_server.go
@@ -1,0 +1,27 @@
+package app
+
+import (
+	"net/http"
+	"time"
+
+	"cpa-usage-keeper/internal/config"
+	"cpa-usage-keeper/internal/logging"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	httpReadHeaderTimeout = 5 * time.Second
+	httpIdleTimeout       = 60 * time.Second
+	httpMaxHeaderBytes    = 64 << 10
+)
+
+func NewHTTPServer(cfg config.Config, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              cfg.ListenAddress(),
+		Handler:           handler,
+		ErrorLog:          logging.NewStandardLogger(logrus.ErrorLevel),
+		ReadHeaderTimeout: httpReadHeaderTimeout,
+		IdleTimeout:       httpIdleTimeout,
+		MaxHeaderBytes:    httpMaxHeaderBytes,
+	}
+}

--- a/internal/app/test/http_server_security_test.go
+++ b/internal/app/test/http_server_security_test.go
@@ -1,0 +1,27 @@
+package test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	keeperapp "cpa-usage-keeper/internal/app"
+	"cpa-usage-keeper/internal/config"
+)
+
+func TestHTTPServerProtectsConnectionSetupWithoutLimitingAuthenticatedResponses(t *testing.T) {
+	server := keeperapp.NewHTTPServer(config.Config{AppHost: "127.0.0.1", AppPort: "8080"}, http.NotFoundHandler())
+
+	if server.ReadHeaderTimeout != 5*time.Second {
+		t.Fatalf("expected five second read-header timeout, got %s", server.ReadHeaderTimeout)
+	}
+	if server.IdleTimeout != 60*time.Second {
+		t.Fatalf("expected sixty second idle timeout, got %s", server.IdleTimeout)
+	}
+	if server.MaxHeaderBytes != 64<<10 {
+		t.Fatalf("expected 64 KiB header limit, got %d", server.MaxHeaderBytes)
+	}
+	if server.ReadTimeout != 0 || server.WriteTimeout != 0 {
+		t.Fatalf("expected active authenticated requests and responses to remain unrestricted, got read=%s write=%s", server.ReadTimeout, server.WriteTimeout)
+	}
+}

--- a/internal/auth/login_limiter.go
+++ b/internal/auth/login_limiter.go
@@ -1,0 +1,151 @@
+package auth
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	defaultLoginAttemptWindow         = time.Minute
+	defaultLoginAttemptPerSourceLimit = 5
+	defaultLoginAttemptGlobalLimit    = 60
+	defaultLoginAttemptMaxSources     = 4096
+)
+
+type LoginAttemptLimiterOptions struct {
+	Window         time.Duration
+	PerSourceLimit int
+	GlobalLimit    int
+	MaxSources     int
+	Now            func() time.Time
+}
+
+type loginAttemptWindow struct {
+	StartedAt time.Time
+	LastSeen  time.Time
+	Attempts  int
+}
+
+type LoginAttemptLimiter struct {
+	mu sync.Mutex
+
+	window         time.Duration
+	perSourceLimit int
+	globalLimit    int
+	maxSources     int
+	now            func() time.Time
+
+	sources map[string]loginAttemptWindow
+	global  loginAttemptWindow
+}
+
+func NewLoginAttemptLimiter(options LoginAttemptLimiterOptions) *LoginAttemptLimiter {
+	if options.Window <= 0 {
+		options.Window = defaultLoginAttemptWindow
+	}
+	if options.PerSourceLimit <= 0 {
+		options.PerSourceLimit = defaultLoginAttemptPerSourceLimit
+	}
+	if options.GlobalLimit <= 0 {
+		options.GlobalLimit = defaultLoginAttemptGlobalLimit
+	}
+	if options.MaxSources <= 0 {
+		options.MaxSources = defaultLoginAttemptMaxSources
+	}
+	if options.Now == nil {
+		options.Now = time.Now
+	}
+	return &LoginAttemptLimiter{
+		window:         options.Window,
+		perSourceLimit: options.PerSourceLimit,
+		globalLimit:    options.GlobalLimit,
+		maxSources:     options.MaxSources,
+		now:            options.Now,
+		sources:        make(map[string]loginAttemptWindow),
+	}
+}
+
+func (l *LoginAttemptLimiter) Allow(source string) (bool, time.Duration) {
+	if l == nil {
+		return true, 0
+	}
+	if source == "" {
+		source = "unknown"
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	l.resetGlobalWindowLocked(now)
+	l.removeExpiredSourcesLocked(now)
+
+	if l.global.Attempts >= l.globalLimit {
+		return false, retryAfter(now, l.global.StartedAt, l.window)
+	}
+
+	state, exists := l.sources[source]
+	if !exists {
+		l.makeSourceCapacityLocked()
+		state = loginAttemptWindow{StartedAt: now}
+	}
+	if state.Attempts >= l.perSourceLimit {
+		state.LastSeen = now
+		l.sources[source] = state
+		return false, retryAfter(now, state.StartedAt, l.window)
+	}
+
+	state.Attempts++
+	state.LastSeen = now
+	l.sources[source] = state
+	l.global.Attempts++
+	l.global.LastSeen = now
+	return true, 0
+}
+
+func (l *LoginAttemptLimiter) Reset(source string) {
+	if l == nil || source == "" {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.sources, source)
+}
+
+func (l *LoginAttemptLimiter) resetGlobalWindowLocked(now time.Time) {
+	if l.global.StartedAt.IsZero() || now.Sub(l.global.StartedAt) >= l.window {
+		l.global = loginAttemptWindow{StartedAt: now, LastSeen: now}
+	}
+}
+
+func (l *LoginAttemptLimiter) removeExpiredSourcesLocked(now time.Time) {
+	for source, state := range l.sources {
+		if now.Sub(state.StartedAt) >= l.window {
+			delete(l.sources, source)
+		}
+	}
+}
+
+func (l *LoginAttemptLimiter) makeSourceCapacityLocked() {
+	if len(l.sources) < l.maxSources {
+		return
+	}
+	// 来源表达到硬上限时淘汰最久未访问项，避免公网来源轮换导致状态无界增长。
+	var oldestSource string
+	var oldestSeen time.Time
+	for source, state := range l.sources {
+		if oldestSource == "" || state.LastSeen.Before(oldestSeen) {
+			oldestSource = source
+			oldestSeen = state.LastSeen
+		}
+	}
+	delete(l.sources, oldestSource)
+}
+
+func retryAfter(now, startedAt time.Time, window time.Duration) time.Duration {
+	retry := startedAt.Add(window).Sub(now)
+	if retry <= 0 {
+		return time.Second
+	}
+	return retry
+}

--- a/internal/auth/test/login_limiter_test.go
+++ b/internal/auth/test/login_limiter_test.go
@@ -1,0 +1,99 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/auth"
+)
+
+func TestLoginAttemptLimiterRecoversAfterWindow(t *testing.T) {
+	now := time.Date(2026, time.July, 31, 12, 0, 0, 0, time.UTC)
+	limiter := auth.NewLoginAttemptLimiter(auth.LoginAttemptLimiterOptions{
+		Window:         time.Minute,
+		PerSourceLimit: 1,
+		GlobalLimit:    10,
+		MaxSources:     10,
+		Now:            func() time.Time { return now },
+	})
+
+	if allowed, _ := limiter.Allow("source-a"); !allowed {
+		t.Fatal("expected first attempt to be allowed")
+	}
+	if allowed, retryAfter := limiter.Allow("source-a"); allowed || retryAfter != time.Minute {
+		t.Fatalf("expected source limit with one minute retry, got allowed=%v retry=%s", allowed, retryAfter)
+	}
+
+	now = now.Add(time.Minute)
+	if allowed, _ := limiter.Allow("source-a"); !allowed {
+		t.Fatal("expected attempt to be allowed after the window resets")
+	}
+}
+
+func TestLoginAttemptLimiterAppliesGlobalLimitAcrossSources(t *testing.T) {
+	now := time.Date(2026, time.July, 31, 12, 0, 0, 0, time.UTC)
+	limiter := auth.NewLoginAttemptLimiter(auth.LoginAttemptLimiterOptions{
+		Window:         time.Minute,
+		PerSourceLimit: 5,
+		GlobalLimit:    2,
+		MaxSources:     10,
+		Now:            func() time.Time { return now },
+	})
+
+	for _, source := range []string{"source-a", "source-b"} {
+		if allowed, _ := limiter.Allow(source); !allowed {
+			t.Fatalf("expected %s to be allowed", source)
+		}
+	}
+	if allowed, retryAfter := limiter.Allow("source-c"); allowed || retryAfter != time.Minute {
+		t.Fatalf("expected global limit with one minute retry, got allowed=%v retry=%s", allowed, retryAfter)
+	}
+}
+
+func TestLoginAttemptLimiterBoundsTrackedSources(t *testing.T) {
+	now := time.Date(2026, time.July, 31, 12, 0, 0, 0, time.UTC)
+	limiter := auth.NewLoginAttemptLimiter(auth.LoginAttemptLimiterOptions{
+		Window:         time.Minute,
+		PerSourceLimit: 1,
+		GlobalLimit:    100,
+		MaxSources:     2,
+		Now:            func() time.Time { return now },
+	})
+
+	if allowed, _ := limiter.Allow("oldest"); !allowed {
+		t.Fatal("expected oldest source to be allowed")
+	}
+	now = now.Add(time.Second)
+	if allowed, _ := limiter.Allow("newer"); !allowed {
+		t.Fatal("expected newer source to be allowed")
+	}
+	now = now.Add(time.Second)
+	if allowed, _ := limiter.Allow("newest"); !allowed {
+		t.Fatal("expected newest source to be allowed")
+	}
+	if allowed, _ := limiter.Allow("oldest"); !allowed {
+		t.Fatal("expected the evicted oldest source to receive a fresh window")
+	}
+}
+
+func TestLoginAttemptLimiterResetClearsOnlyTheSource(t *testing.T) {
+	now := time.Date(2026, time.July, 31, 12, 0, 0, 0, time.UTC)
+	limiter := auth.NewLoginAttemptLimiter(auth.LoginAttemptLimiterOptions{
+		Window:         time.Minute,
+		PerSourceLimit: 1,
+		GlobalLimit:    10,
+		MaxSources:     10,
+		Now:            func() time.Time { return now },
+	})
+
+	_, _ = limiter.Allow("source-a")
+	_, _ = limiter.Allow("source-b")
+	limiter.Reset("source-a")
+
+	if allowed, _ := limiter.Allow("source-a"); !allowed {
+		t.Fatal("expected reset source to be allowed")
+	}
+	if allowed, _ := limiter.Allow("source-b"); allowed {
+		t.Fatal("expected another source to remain limited")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	DefaultTimeZone                = "Asia/Shanghai"
+	publicLoginPasswordPlaceholder = "replace-with-your-login-password"
 	RedisQueueBatchSizeDefault     = 10000
 	MetadataSyncIntervalDefault    = 30 * time.Second
 	QuotaRefreshWorkerLimitDefault = 10
@@ -42,6 +43,8 @@ type Config struct {
 	AppBasePath string
 	// CPAPublicURL 是浏览器访问 CPA 的公开地址；为空时前端按同源根路径跳转。
 	CPAPublicURL string
+	// TrustedProxyCIDRs 是除本机 loopback 外允许提供客户端转发地址的代理网段。
+	TrustedProxyCIDRs []string
 	// TLSEnabled 控制是否以 HTTPS 模式启动 HTTP 服务。
 	TLSEnabled bool
 	// TLSCertFile 是 HTTPS 证书文件路径。
@@ -203,7 +206,12 @@ func Load(options LoadOptions) (*Config, error) {
 		return nil, fmt.Errorf("AUTH_SESSION_TTL must be positive")
 	}
 
-	authEnabled, err := getBool("AUTH_ENABLED", false)
+	authEnabledValue := strings.TrimSpace(os.Getenv("AUTH_ENABLED"))
+	authEnabled, err := getBool("AUTH_ENABLED", true)
+	if err != nil {
+		return nil, err
+	}
+	trustedProxyCIDRs, err := getCIDRs("TRUSTED_PROXY_CIDRS")
 	if err != nil {
 		return nil, err
 	}
@@ -238,6 +246,7 @@ func Load(options LoadOptions) (*Config, error) {
 		AppPort:                    getString("APP_PORT", "8080"),
 		AppBasePath:                appBasePath,
 		CPAPublicURL:               strings.TrimSpace(os.Getenv("CPA_PUBLIC_URL")),
+		TrustedProxyCIDRs:          trustedProxyCIDRs,
 		TLSEnabled:                 tlsEnabled,
 		TLSCertFile:                strings.TrimSpace(os.Getenv("TLS_CERT_FILE")),
 		TLSKeyFile:                 strings.TrimSpace(os.Getenv("TLS_KEY_FILE")),
@@ -275,8 +284,16 @@ func Load(options LoadOptions) (*Config, error) {
 	if cfg.CPAManagementKey == "" {
 		return nil, fmt.Errorf("CPA_MANAGEMENT_KEY is required")
 	}
-	if cfg.AuthEnabled && cfg.LoginPassword == "" {
-		return nil, fmt.Errorf("LOGIN_PASSWORD is required when AUTH_ENABLED is true")
+	if cfg.AuthEnabled {
+		if cfg.LoginPassword == "" && authEnabledValue == "" {
+			return nil, fmt.Errorf("AUTH_ENABLED is not set, so authentication defaults to true; LOGIN_PASSWORD is required")
+		}
+		if cfg.LoginPassword == "" {
+			return nil, fmt.Errorf("LOGIN_PASSWORD is required when AUTH_ENABLED is true")
+		}
+		if cfg.LoginPassword == publicLoginPasswordPlaceholder {
+			return nil, fmt.Errorf("LOGIN_PASSWORD must not use the public example value %q", publicLoginPasswordPlaceholder)
+		}
 	}
 	if cfg.TLSEnabled {
 		if cfg.TLSCertFile == "" {
@@ -407,6 +424,32 @@ func getString(key, fallback string) string {
 		return fallback
 	}
 	return value
+}
+
+func getCIDRs(key string) ([]string, error) {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		candidate := strings.TrimSpace(part)
+		if candidate == "" {
+			return nil, fmt.Errorf("%s must contain non-empty CIDR values", key)
+		}
+		_, network, err := net.ParseCIDR(candidate)
+		if err != nil {
+			return nil, fmt.Errorf("%s contains invalid CIDR %q: %w", key, candidate, err)
+		}
+		ones, _ := network.Mask.Size()
+		if ones == 0 {
+			return nil, fmt.Errorf("%s must not trust every address via %q", key, candidate)
+		}
+		result = append(result, network.String())
+	}
+	return result, nil
 }
 
 func getDuration(key string, fallback time.Duration) (time.Duration, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,7 +17,7 @@ var configEnvKeys = []string{
 	"USAGE_SYNC_MODE", "REDIS_QUEUE_ADDR", "REDIS_QUEUE_TLS", "REDIS_QUEUE_BATCH_SIZE", "REDIS_QUEUE_IDLE_INTERVAL",
 	"SQLITE_PATH", "BACKUP_ENABLED", "BACKUP_DIR", "BACKUP_INTERVAL", "BACKUP_RETENTION_DAYS",
 	"REQUEST_TIMEOUT", "LOG_LEVEL", "LOG_FILE_ENABLED", "LOG_DIR", "LOG_RETENTION_DAYS",
-	"AUTH_ENABLED", "LOGIN_PASSWORD", "AUTH_SESSION_TTL", "TZ", "TLS_SKIP_VERIFY", "QUOTA_REFRESH_WORKER_LIMIT",
+	"AUTH_ENABLED", "LOGIN_PASSWORD", "AUTH_SESSION_TTL", "TRUSTED_PROXY_CIDRS", "TZ", "TLS_SKIP_VERIFY", "QUOTA_REFRESH_WORKER_LIMIT",
 }
 
 func TestMain(m *testing.M) {
@@ -28,6 +28,9 @@ func TestMain(m *testing.M) {
 		if err := os.Unsetenv(key); err != nil {
 			panic(err)
 		}
+	}
+	if err := os.Setenv("LOGIN_PASSWORD", "test-login-password"); err != nil {
+		panic(err)
 	}
 	code := m.Run()
 	for _, key := range configEnvKeys {
@@ -53,6 +56,9 @@ func withIsolatedEnvFiles(t *testing.T) {
 		if err := os.Unsetenv(key); err != nil {
 			t.Fatalf("unset %s: %v", key, err)
 		}
+	}
+	if err := os.Setenv("LOGIN_PASSWORD", "test-login-password"); err != nil {
+		t.Fatalf("set test login password: %v", err)
 	}
 	t.Cleanup(func() {
 		for _, key := range configEnvKeys {
@@ -125,8 +131,8 @@ func TestLoadFromEnvAppliesDefaults(t *testing.T) {
 	if cfg.SQLitePath != filepath.Join("data", "app.db") {
 		t.Fatalf("expected default sqlite path data/app.db, got %s", cfg.SQLitePath)
 	}
-	if cfg.AuthEnabled {
-		t.Fatal("expected auth to be disabled by default")
+	if !cfg.AuthEnabled {
+		t.Fatal("expected auth to be enabled by default")
 	}
 	if cfg.AuthSessionTTL != 7*24*time.Hour {
 		t.Fatalf("expected default auth session ttl 168h, got %s", cfg.AuthSessionTTL)
@@ -366,6 +372,7 @@ func TestLoadFromEnvRequiresCriticalValues(t *testing.T) {
 		t.Setenv("CPA_BASE_URL", "http://127.0.0.1:"+cpa.ManagementRedisDefaultPort)
 		t.Setenv("CPA_MANAGEMENT_KEY", "secret")
 		t.Setenv("AUTH_ENABLED", "true")
+		t.Setenv("LOGIN_PASSWORD", "")
 
 		_, err := LoadFromEnv()
 		if err == nil || err.Error() != "LOGIN_PASSWORD is required when AUTH_ENABLED is true" {

--- a/internal/config/test/auth_defaults_test.go
+++ b/internal/config/test/auth_defaults_test.go
@@ -1,0 +1,105 @@
+package test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"cpa-usage-keeper/internal/config"
+)
+
+const publicLoginPasswordPlaceholder = "replace-with-your-login-password"
+
+func TestAuthenticationDefaultsToEnabledAndRequiresPassword(t *testing.T) {
+	t.Setenv("AUTH_ENABLED", "")
+	t.Setenv("LOGIN_PASSWORD", "")
+	t.Setenv("TZ", "UTC")
+
+	_, err := config.Load(config.LoadOptions{EnvFile: writeAuthConfig(t, "")})
+	if err == nil || !strings.Contains(err.Error(), "AUTH_ENABLED is not set") || !strings.Contains(err.Error(), "LOGIN_PASSWORD is required") {
+		t.Fatalf("expected missing default authentication password error, got %v", err)
+	}
+}
+
+func TestAuthenticationCanBeExplicitlyDisabled(t *testing.T) {
+	t.Setenv("AUTH_ENABLED", "")
+	t.Setenv("LOGIN_PASSWORD", "")
+	t.Setenv("TZ", "UTC")
+
+	cfg, err := config.Load(config.LoadOptions{EnvFile: writeAuthConfig(t, "AUTH_ENABLED=false\n")})
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg.AuthEnabled {
+		t.Fatal("expected explicit AUTH_ENABLED=false to remain supported")
+	}
+}
+
+func TestAuthenticationRejectsPublicExamplePassword(t *testing.T) {
+	t.Setenv("AUTH_ENABLED", "")
+	t.Setenv("LOGIN_PASSWORD", "")
+	t.Setenv("TZ", "UTC")
+
+	_, err := config.Load(config.LoadOptions{EnvFile: writeAuthConfig(t, "AUTH_ENABLED=true\nLOGIN_PASSWORD="+publicLoginPasswordPlaceholder+"\n")})
+	if err == nil || !strings.Contains(err.Error(), "public example value") {
+		t.Fatalf("expected public example password error, got %v", err)
+	}
+}
+
+func TestAuthenticationUsesSecureDefaultWithPrivatePassword(t *testing.T) {
+	t.Setenv("AUTH_ENABLED", "")
+	t.Setenv("LOGIN_PASSWORD", "")
+	t.Setenv("TZ", "UTC")
+
+	cfg, err := config.Load(config.LoadOptions{EnvFile: writeAuthConfig(t, "LOGIN_PASSWORD=private-test-password\n")})
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if !cfg.AuthEnabled {
+		t.Fatal("expected authentication to default to enabled")
+	}
+}
+
+func TestTrustedProxyCIDRsAcceptExplicitProxyNetworks(t *testing.T) {
+	t.Setenv("AUTH_ENABLED", "")
+	t.Setenv("LOGIN_PASSWORD", "")
+	t.Setenv("TRUSTED_PROXY_CIDRS", "")
+	t.Setenv("TZ", "UTC")
+
+	cfg, err := config.Load(config.LoadOptions{EnvFile: writeAuthConfig(t, "LOGIN_PASSWORD=private-test-password\nTRUSTED_PROXY_CIDRS=172.18.0.0/16,2001:db8::/64\n")})
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	want := []string{"172.18.0.0/16", "2001:db8::/64"}
+	if !slices.Equal(cfg.TrustedProxyCIDRs, want) {
+		t.Fatalf("expected trusted proxy CIDRs %v, got %v", want, cfg.TrustedProxyCIDRs)
+	}
+}
+
+func TestTrustedProxyCIDRsRejectInvalidOrUniversalNetworks(t *testing.T) {
+	for _, value := range []string{"not-a-cidr", "0.0.0.0/0", "::/0"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv("AUTH_ENABLED", "")
+			t.Setenv("LOGIN_PASSWORD", "")
+			t.Setenv("TRUSTED_PROXY_CIDRS", "")
+			t.Setenv("TZ", "UTC")
+
+			_, err := config.Load(config.LoadOptions{EnvFile: writeAuthConfig(t, "LOGIN_PASSWORD=private-test-password\nTRUSTED_PROXY_CIDRS="+value+"\n")})
+			if err == nil || !strings.Contains(err.Error(), "TRUSTED_PROXY_CIDRS") {
+				t.Fatalf("expected trusted proxy CIDR validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func writeAuthConfig(t *testing.T, extra string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "keeper.env")
+	content := "CPA_BASE_URL=http://127.0.0.1:8317\nCPA_MANAGEMENT_KEY=test-management-key\nWORK_DIR=./data\n" + extra
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+	return path
+}

--- a/internal/config/test/config_cleanup_test.go
+++ b/internal/config/test/config_cleanup_test.go
@@ -15,7 +15,7 @@ var isolatedConfigEnvKeys = []string{
 	"REDIS_QUEUE_ADDR", "REDIS_QUEUE_TLS", "REDIS_QUEUE_BATCH_SIZE", "REDIS_QUEUE_IDLE_INTERVAL",
 	"BACKUP_ENABLED", "BACKUP_INTERVAL", "BACKUP_RETENTION_DAYS",
 	"REQUEST_TIMEOUT", "LOG_LEVEL", "LOG_FILE_ENABLED", "LOG_DIR", "LOG_RETENTION_DAYS",
-	"AUTH_ENABLED", "LOGIN_PASSWORD", "AUTH_SESSION_TTL", "TZ", "TLS_ENABLED", "TLS_CERT_FILE", "TLS_KEY_FILE",
+	"AUTH_ENABLED", "LOGIN_PASSWORD", "AUTH_SESSION_TTL", "TRUSTED_PROXY_CIDRS", "TZ", "TLS_ENABLED", "TLS_CERT_FILE", "TLS_KEY_FILE",
 	"TLS_SKIP_VERIFY", "QUOTA_REFRESH_WORKER_LIMIT",
 }
 
@@ -60,6 +60,9 @@ func isolateConfigEnv(t *testing.T) {
 		if err := os.Unsetenv(key); err != nil {
 			t.Fatalf("unset %s: %v", key, err)
 		}
+	}
+	if err := os.Setenv("LOGIN_PASSWORD", "test-login-password"); err != nil {
+		t.Fatalf("set test login password: %v", err)
 	}
 	t.Cleanup(func() {
 		time.Local = previousLocal


### PR DESCRIPTION
## Summary

- enable authentication by default while preserving explicit `AUTH_ENABLED=false`
- reject missing and public example login passwords with clear startup errors
- rate-limit and bound unauthenticated login requests without limiting authenticated business payloads
- resolve login sources through trusted proxies and document optional proxy CIDRs

## Validation

- project backend verification
- targeted race tests for login and proxy boundaries
- focused security review
- `git diff --check`