### PR TITLE
fix(request-events): default page size to 50

### DIFF
--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -81,7 +81,7 @@ const USAGE_TAB_LABEL_KEYS: Record<UsageTab, string> = {
 const DEFAULT_USAGE_TAB: UsageTab = 'overview';
 const USAGE_TAB_STORAGE_KEY = 'cli-proxy-usage-tab-v1';
 const REQUEST_EVENTS_PAGE_SIZES = [20, 50, 100, 500, 1000] as const;
-const REQUEST_EVENTS_DEFAULT_PAGE_SIZE = 100;
+const REQUEST_EVENTS_DEFAULT_PAGE_SIZE = 50;
 // v7 是完整列顺序格式；v8 加入客户端请求元数据列，并保留历史自定义顺序。
 const REQUEST_EVENTS_PREFERENCES_VERSION = 8;
 const ALL_REQUEST_EVENTS_FILTER = '__all__';

--- a/web/src/pages/test/UsagePage.logic.test.ts
+++ b/web/src/pages/test/UsagePage.logic.test.ts
@@ -521,6 +521,12 @@ describe('UsagePage request event filters', () => {
 });
 
 describe('UsagePage request event preferences', () => {
+  it('defaults to 50 rows when no request event preference is stored', () => {
+    const storage = createMemoryStorage();
+
+    expect(loadRequestEventsPreferences(storage).pageSize).toBe(50);
+  });
+
   it('normalizes persisted filters, page size, and visible columns', () => {
     const preferences = normalizeRequestEventsPreferences({
       version: 1,
@@ -558,7 +564,7 @@ describe('UsagePage request event preferences', () => {
       visibleColumnIds: ['not-a-column'],
     });
 
-    expect(preferences.pageSize).toBe(100);
+    expect(preferences.pageSize).toBe(50);
     expect(preferences.filters).toEqual({
       model: '__all__',
       source: '__all__',
@@ -665,7 +671,7 @@ describe('UsagePage request event preferences', () => {
       [REQUEST_EVENTS_PREFERENCES_STORAGE_KEY]: '{bad json',
     });
 
-    expect(loadRequestEventsPreferences(storage).pageSize).toBe(100);
+    expect(loadRequestEventsPreferences(storage).pageSize).toBe(50);
 
     saveRequestEventsPreferences({
       version: 4,


### PR DESCRIPTION
## Summary

- default Request Events to 50 rows when no valid browser preference exists
- keep user-selected page sizes persisted through the existing browser preference
- cover default and invalid-preference fallback behavior with tests

## Validation

- targeted UsagePage logic tests: 65 passed
- full frontend verification: 994 tests passed, lint passed, typecheck passed, production build passed