### PR TITLE
feat(credentials): add premium subscription badges

### DIFF
--- a/web/src/components/usage/credentials/AuthFileCredentialsSection.tsx
+++ b/web/src/components/usage/credentials/AuthFileCredentialsSection.tsx
@@ -1547,7 +1547,16 @@ function formatInspectionDate(value: string | undefined): string {
 }
 
 function CredentialPlanBadge({ children, tone = 'neutral' }: { children: string; tone?: PlanTypeTone }) {
-  return <span className={`${styles.credentialPlanBadge} ${styles[`credentialPlanBadge${capitalize(tone)}`]}`.trim()}>{children}</span>
+  const hasPremiumMotion = tone !== 'free' && tone !== 'neutral'
+
+  return (
+    <span className={`${styles.credentialPlanBadge} ${styles[`credentialPlanBadge${capitalize(tone)}`]}`.trim()}>
+      {/* 将 A5 的流动底纹和日冕拆到独立 transform 图层，避免逐帧重绘渐变。 */}
+      {hasPremiumMotion && <span className={styles.credentialPlanBadgeFlow} aria-hidden="true" />}
+      {hasPremiumMotion && <span className={styles.credentialPlanBadgeCorona} aria-hidden="true" />}
+      <span className={styles.credentialPlanBadgeLabel}>{children}</span>
+    </span>
+  )
 }
 
 function QuotaUsageModeSwitch({ label, mode, onChange }: { label: string; mode: QuotaUsageMode; onChange: (mode: QuotaUsageMode) => void }) {

--- a/web/src/components/usage/credentials/CredentialSections.module.scss
+++ b/web/src/components/usage/credentials/CredentialSections.module.scss
@@ -1827,54 +1827,127 @@ $credential-name-column-width: $credential-name-content-width + $credential-prov
 }
 
 .credentialPriorityBadge {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 4px;
   min-width: 22px;
   min-height: 18px;
-  padding: 2px 6px;
+  padding: 2px 7px;
   border-radius: $radius-full;
-  border: 1px solid color-mix(in srgb, var(--primary-color) 34%, var(--border-color));
-  background: color-mix(in srgb, var(--primary-color) 10%, var(--bg-primary));
-  color: color-mix(in srgb, var(--text-primary) 82%, var(--primary-color));
+  border: 1px solid color-mix(in srgb, #7c3aed 38%, var(--border-color));
+  background: linear-gradient(135deg, color-mix(in srgb, #f5f3ff 88%, var(--bg-primary)), color-mix(in srgb, #c4b5fd 36%, var(--bg-primary)));
+  color: #5b21b6;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.72),
+    0 1px 3px rgba(91, 33, 182, 0.12);
   font-size: 10px;
   font-weight: 900;
+  letter-spacing: 0.035em;
   line-height: 1.3;
   font-variant-numeric: tabular-nums;
+
+  &::before {
+    content: '';
+    width: 4px;
+    height: 4px;
+    flex: 0 0 auto;
+    border-radius: 50%;
+    background: currentColor;
+    box-shadow: 0 0 6px currentColor;
+    opacity: 0.72;
+  }
 }
 
 .credentialRemainingDaysBadge,
 .credentialPlanBadge {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
   display: inline-flex;
   align-items: center;
   min-height: 18px;
-  padding: 2px 7px;
+  padding: 2px 8px;
   border-radius: $radius-full;
   border: 1px solid var(--border-color);
   background: var(--bg-primary);
   color: var(--text-secondary);
   font-size: 10px;
   font-weight: 900;
+  letter-spacing: 0.02em;
   line-height: 1.3;
-  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.03);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.58),
+    0 1px 3px rgba(15, 23, 42, 0.06);
+}
+
+.credentialPlanBadge {
+  contain: paint;
 }
 
 .credentialPlanBadgeFree {
-  background: var(--bg-primary);
-  color: var(--text-primary);
+  border-color: color-mix(in srgb, #cbd5e1 78%, #94a3b8);
+  background: linear-gradient(145deg, #ffffff 0%, #f8fafc 42%, #e2e8f0 72%, #cbd5e1 100%);
+  color: #475569;
+  text-shadow: 0 1px 0 #ffffff;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.98),
+    inset 0 -2px 3px rgba(100, 116, 139, 0.18),
+    0 2px 4px rgba(15, 23, 42, 0.14),
+    0 0 6px rgba(226, 232, 240, 0.42);
+}
+
+.credentialPlanBadgeFree::before {
+  content: '';
+  position: absolute;
+  z-index: 3;
+  inset: -60% auto -60% -45%;
+  width: 38%;
+  background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.52) 22%, rgba(255, 255, 255, 0.92) 50%, rgba(255, 255, 255, 0.52) 78%, transparent 100%);
+  pointer-events: none;
+  transform: translate3d(-180%, 0, 0) skewX(-18deg);
+  animation: credentialPlanBadgeSheen 10s ease-in-out infinite;
 }
 
 .credentialPlanBadgeTeam {
-  border-color: color-mix(in srgb, #14532d 42%, var(--border-color));
-  background: color-mix(in srgb, #14532d 18%, var(--bg-primary));
-  color: #14532d;
+  --credential-plan-tone-1: #b8f6d8;
+  --credential-plan-tone-2: #10ad74;
+  --credential-plan-tone-3: #075536;
+  --credential-plan-ink: #f7fffb;
+  --credential-plan-glow: rgba(16, 173, 116, 0.4);
+  --credential-plan-flow-duration: 7.6s;
+  --credential-plan-sheen-duration: 8.8s;
+  --credential-plan-corona-duration: 13s;
+  --credential-plan-corona-opacity: 0.52;
+  --credential-plan-ray-opacity: 46%;
+  border-color: color-mix(in srgb, #16a34a 68%, #075536);
 }
 
 .credentialRemainingDaysBadge {
-  border-color: color-mix(in srgb, #86efac 48%, var(--border-color));
-  background: color-mix(in srgb, #bbf7d0 32%, var(--bg-primary));
-  color: #166534;
+  gap: 5px;
+  border-color: color-mix(in srgb, #10b981 42%, var(--border-color));
+  background:
+    radial-gradient(circle at 18% 12%, rgba(255, 255, 255, 0.9) 0%, rgba(255, 255, 255, 0) 42%),
+    linear-gradient(135deg, color-mix(in srgb, #ecfdf5 92%, var(--bg-primary)), color-mix(in srgb, #6ee7b7 34%, var(--bg-primary)));
+  color: #047857;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.72),
+    0 1px 4px rgba(5, 150, 105, 0.12);
   cursor: default;
+
+  &::before {
+    content: '';
+    width: 5px;
+    height: 5px;
+    flex: 0 0 auto;
+    border: 1px solid color-mix(in srgb, currentColor 76%, transparent);
+    border-radius: 50%;
+    background: color-mix(in srgb, currentColor 20%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, #fff 46%, transparent);
+  }
 
   &:focus-visible {
     outline: 2px solid var(--primary-color);
@@ -1900,20 +1973,218 @@ $credential-name-column-width: $credential-name-content-width + $credential-prov
 }
 
 .credentialPlanBadgePlus {
-  border-color: color-mix(in srgb, #2563eb 34%, var(--border-color));
-  background: color-mix(in srgb, #2563eb 12%, var(--bg-primary));
-  color: #1d4ed8;
+  --credential-plan-tone-1: #c8e9ff;
+  --credential-plan-tone-2: #1687ff;
+  --credential-plan-tone-3: #07388f;
+  --credential-plan-ink: #f8fcff;
+  --credential-plan-glow: rgba(22, 135, 255, 0.42);
+  --credential-plan-flow-duration: 8.4s;
+  --credential-plan-sheen-duration: 10s;
+  --credential-plan-corona-duration: 15s;
+  --credential-plan-corona-opacity: 0.42;
+  --credential-plan-ray-opacity: 38%;
+  border-color: color-mix(in srgb, #2563eb 72%, #07388f);
 }
 
-.credentialPlanBadgePro {
-  border-color: color-mix(in srgb, #d97706 42%, var(--border-color));
-  background: linear-gradient(135deg, color-mix(in srgb, #facc15 22%, var(--bg-primary)), color-mix(in srgb, #d97706 12%, var(--bg-primary)));
-  color: #92400e;
+.credentialPlanBadgePro5x {
+  --credential-plan-tone-1: #fffed4;
+  --credential-plan-tone-2: #f6dc37;
+  --credential-plan-tone-3: #e5a80b;
+  --credential-plan-ink: #433000;
+  --credential-plan-glow: rgba(244, 205, 35, 0.52);
+  --credential-plan-flow-duration: 6.8s;
+  --credential-plan-sheen-duration: 7.2s;
+  --credential-plan-corona-duration: 11s;
+  --credential-plan-corona-opacity: 0.64;
+  --credential-plan-ray-opacity: 46%;
+  border-color: color-mix(in srgb, #e5a80b 78%, #f6dc37);
+}
+
+.credentialPlanBadgePro20x {
+  --credential-plan-tone-1: #fffed4;
+  --credential-plan-tone-2: #f6dc37;
+  --credential-plan-tone-3: #e5a80b;
+  --credential-plan-ink: #433000;
+  --credential-plan-glow: rgba(244, 205, 35, 0.68);
+  --credential-plan-flow-duration: 4.5s;
+  --credential-plan-sheen-duration: 4.8s;
+  --credential-plan-corona-duration: 7s;
+  --credential-plan-corona-opacity: 0.9;
+  --credential-plan-ray-opacity: 58%;
+  border-color: color-mix(in srgb, #e5a80b 62%, #fffed4);
+  border-width: 1.5px;
+}
+
+.credentialPlanBadgeEnterprise {
+  --credential-plan-tone-1: #ffffff;
+  --credential-plan-tone-2: #e0f2fe;
+  --credential-plan-tone-3: #c4b5fd;
+  --credential-plan-ink: #334155;
+  --credential-plan-glow: rgba(129, 140, 248, 0.42);
+  --credential-plan-flow-duration: 8s;
+  --credential-plan-sheen-duration: 7.8s;
+  --credential-plan-corona-duration: 10s;
+  --credential-plan-corona-opacity: 0.7;
+  --credential-plan-ray-opacity: 42%;
+  border-color: color-mix(in srgb, #c4b5fd 72%, #94a3b8);
 }
 
 .credentialPlanBadgeNeutral {
-  background: var(--bg-secondary);
+  border-color: color-mix(in srgb, #64748b 30%, var(--border-color));
+  background: linear-gradient(135deg, var(--bg-primary), var(--bg-secondary));
   color: var(--text-secondary);
+}
+
+.credentialPlanBadgePlus,
+.credentialPlanBadgeTeam,
+.credentialPlanBadgePro5x,
+.credentialPlanBadgePro20x,
+.credentialPlanBadgeEnterprise {
+  background: var(--credential-plan-tone-3);
+  color: var(--credential-plan-ink);
+  text-shadow: 0 1px color-mix(in srgb, var(--credential-plan-tone-1) 58%, transparent);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.88),
+    inset 0 -3px 5px color-mix(in srgb, var(--credential-plan-tone-3) 34%, transparent),
+    0 2px 5px rgba(15, 23, 42, 0.15),
+    0 0 9px var(--credential-plan-glow);
+  &::before {
+    content: '';
+    position: absolute;
+    z-index: 3;
+    inset: -60% auto -60% -45%;
+    width: 38%;
+    background: linear-gradient(90deg, transparent 0%, color-mix(in srgb, var(--credential-plan-tone-1) 52%, transparent) 22%, color-mix(in srgb, #fff 82%, transparent) 50%, color-mix(in srgb, var(--credential-plan-tone-1) 52%, transparent) 78%, transparent 100%);
+    pointer-events: none;
+    transform: translate3d(-180%, 0, 0) skewX(-18deg);
+    animation: credentialPlanBadgeSheen var(--credential-plan-sheen-duration) ease-in-out infinite;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    z-index: 2;
+    inset: 0;
+    background: radial-gradient(circle at 18% 12%, color-mix(in srgb, var(--credential-plan-tone-1) 92%, transparent) 0 5%, transparent 25%);
+    pointer-events: none;
+  }
+}
+
+.credentialPlanBadgeFlow {
+  position: absolute;
+  z-index: 0;
+  top: 0;
+  bottom: 0;
+  left: -152px;
+  width: calc(100% + 304px);
+  // 152px 位移在两层斜纹上恰好跨过完整周期，末帧与首帧纹理相位一致。
+  background:
+    repeating-linear-gradient(116deg, transparent 0 24px, color-mix(in srgb, var(--credential-plan-tone-1) var(--credential-plan-ray-opacity), transparent) 29px, transparent 42px 68.30835px),
+    repeating-linear-gradient(112deg, var(--credential-plan-tone-3) 0 19px, var(--credential-plan-tone-2) 35px, var(--credential-plan-tone-1) 56px, var(--credential-plan-tone-2) 85px, var(--credential-plan-tone-3) 108px 140.93195px);
+  pointer-events: none;
+  transform: translate3d(0, 0, 0);
+  animation: credentialPlanBadgeSolarFlow var(--credential-plan-flow-duration) linear infinite;
+}
+
+.credentialPlanBadgeCorona {
+  position: absolute;
+  z-index: 1;
+  inset: -52%;
+  background: conic-gradient(from 0deg, transparent, color-mix(in srgb, var(--credential-plan-tone-1) 42%, transparent), transparent 22% 50%, color-mix(in srgb, var(--credential-plan-tone-1) 28%, transparent), transparent 72%);
+  mix-blend-mode: screen;
+  opacity: var(--credential-plan-corona-opacity);
+  pointer-events: none;
+  transform: translate3d(0, 0, 0) rotate(0deg);
+  animation: credentialPlanBadgeSolarRotate var(--credential-plan-corona-duration) linear infinite;
+}
+
+.credentialPlanBadgePro20x::after {
+  inset: 0;
+  background:
+    linear-gradient(90deg, transparent 8%, color-mix(in srgb, var(--credential-plan-tone-1) 84%, transparent) 48%, transparent 88%) 50% 3px / calc(100% - 24px) 28% no-repeat,
+    radial-gradient(circle at 18% 12%, color-mix(in srgb, var(--credential-plan-tone-1) 96%, transparent) 0 6%, transparent 26%);
+}
+
+.credentialPlanBadgePro20x {
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.96),
+    inset 0 -3px 5px color-mix(in srgb, var(--credential-plan-tone-3) 30%, transparent),
+    0 2px 6px rgba(133, 77, 14, 0.24),
+    0 0 13px var(--credential-plan-glow),
+    0 0 5px color-mix(in srgb, var(--credential-plan-tone-1) 72%, transparent);
+}
+
+.credentialPlanBadgePro20x .credentialPlanBadgeCorona {
+  inset: -88%;
+  background: conic-gradient(from 0deg, transparent 0 8%, color-mix(in srgb, #fffed4 64%, transparent) 13%, transparent 20% 37%, color-mix(in srgb, #f6dc37 42%, transparent) 43%, transparent 51% 68%, color-mix(in srgb, #fffed4 52%, transparent) 74%, transparent 82%);
+}
+
+.credentialPlanBadgeEnterprise .credentialPlanBadgeCorona {
+  background: conic-gradient(from 18deg, transparent 0 9%, rgba(103, 232, 249, 0.5) 16%, transparent 25% 45%, rgba(196, 181, 253, 0.58) 54%, transparent 64% 82%, rgba(255, 255, 255, 0.64) 90%, transparent);
+}
+
+.credentialPlanBadgeLabel {
+  position: relative;
+  z-index: 4;
+}
+
+@keyframes credentialPlanBadgeSolarFlow {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+
+  to {
+    transform: translate3d(152px, 0, 0);
+  }
+}
+
+@keyframes credentialPlanBadgeSolarRotate {
+  to {
+    transform: translate3d(0, 0, 0) rotate(360deg);
+  }
+}
+
+@keyframes credentialPlanBadgeSheen {
+  0%,
+  62% {
+    transform: translate3d(-180%, 0, 0) skewX(-18deg);
+  }
+
+  82%,
+  100% {
+    transform: translate3d(520%, 0, 0) skewX(-18deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce), (update: slow) {
+  .credentialPlanBadgeFlow,
+  .credentialPlanBadgeCorona,
+  .credentialPlanBadgeFree::before,
+  .credentialPlanBadgePlus::before,
+  .credentialPlanBadgeTeam::before,
+  .credentialPlanBadgePro5x::before,
+  .credentialPlanBadgePro20x::before,
+  .credentialPlanBadgeEnterprise::before {
+    animation: none;
+  }
+
+  .credentialPlanBadgeFlow {
+    transform: translate3d(76px, 0, 0);
+  }
+
+  .credentialPlanBadgeCorona {
+    transform: translate3d(0, 0, 0) rotate(18deg);
+  }
+
+  .credentialPlanBadgeFree::before,
+  .credentialPlanBadgePlus::before,
+  .credentialPlanBadgeTeam::before,
+  .credentialPlanBadgePro5x::before,
+  .credentialPlanBadgePro20x::before,
+  .credentialPlanBadgeEnterprise::before {
+    opacity: 0.28;
+    transform: translate3d(260%, 0, 0) skewX(-18deg);
+  }
 }
 
 .credentialMetricHeaderGroup,
@@ -2764,27 +3035,89 @@ $credential-name-column-width: $credential-name-content-width + $credential-prov
 }
 
 :global([data-theme='dark']) {
+  .credentialPriorityBadge {
+    border-color: color-mix(in srgb, #c4b5fd 48%, var(--border-color));
+    background: linear-gradient(135deg, color-mix(in srgb, #4c1d95 32%, var(--bg-primary)), color-mix(in srgb, #7c3aed 24%, var(--bg-primary)));
+    color: #ddd6fe;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12), 0 1px 5px rgba(124, 58, 237, 0.2);
+  }
+
+  .credentialPlanBadgeFree {
+    border-color: #aeb8c6;
+    background: linear-gradient(145deg, #e2e8f0 0%, #cbd5e1 38%, #aeb8c6 70%, #8795a8 100%);
+    color: #334155;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.68),
+      inset 0 -2px 3px rgba(51, 65, 85, 0.25),
+      0 2px 5px rgba(0, 0, 0, 0.26),
+      0 0 5px rgba(203, 213, 225, 0.12);
+  }
+
+  .credentialPlanBadgeFree::before {
+    opacity: 0.58;
+  }
+
   .credentialPlanBadgeTeam {
-    border-color: color-mix(in srgb, #86efac 46%, var(--border-color));
-    background: color-mix(in srgb, #16a34a 22%, var(--bg-primary));
-    color: #bbf7d0;
+    --credential-plan-tone-1: #48e0a3;
+    --credential-plan-tone-2: #0a8a61;
+    --credential-plan-tone-3: #075536;
+    --credential-plan-glow: rgba(72, 224, 163, 0.35);
+    border-color: color-mix(in srgb, #48e0a3 70%, #075536);
+    color: #edfff7;
   }
 
   .credentialPlanBadgePlus {
-    border-color: color-mix(in srgb, #60a5fa 46%, var(--border-color));
-    background: color-mix(in srgb, #2563eb 24%, var(--bg-primary));
-    color: #bfdbfe;
+    --credential-plan-tone-1: #3da4ff;
+    --credential-plan-tone-2: #1162db;
+    --credential-plan-tone-3: #07388f;
+    --credential-plan-glow: rgba(61, 164, 255, 0.4);
+    border-color: color-mix(in srgb, #3da4ff 70%, #07388f);
+    color: #edf8ff;
   }
 
-  .credentialPlanBadgePro {
-    border-color: color-mix(in srgb, #facc15 48%, var(--border-color));
-    background: linear-gradient(135deg, color-mix(in srgb, #facc15 18%, var(--bg-primary)), color-mix(in srgb, #d97706 24%, var(--bg-primary)));
-    color: #fde68a;
+  .credentialPlanBadgePro5x {
+    --credential-plan-tone-1: #fff49b;
+    --credential-plan-tone-2: #e4c223;
+    --credential-plan-tone-3: #c99505;
+    --credential-plan-glow: rgba(255, 229, 92, 0.46);
+    border-color: color-mix(in srgb, #fff49b 62%, #c99505);
+    color: #302200;
+  }
+
+  .credentialPlanBadgePro20x {
+    --credential-plan-tone-1: #fff49b;
+    --credential-plan-tone-2: #e4c223;
+    --credential-plan-tone-3: #c99505;
+    --credential-plan-glow: rgba(255, 229, 92, 0.62);
+    border-color: color-mix(in srgb, #fff49b 72%, #c99505);
+    color: #302200;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.96),
+      inset 0 -3px 5px color-mix(in srgb, #c99505 30%, transparent),
+      0 2px 6px rgba(0, 0, 0, 0.28),
+      0 0 13px var(--credential-plan-glow),
+      0 0 5px color-mix(in srgb, #fff49b 72%, transparent);
+  }
+
+  .credentialPlanBadgeEnterprise {
+    --credential-plan-tone-1: #f8fafc;
+    --credential-plan-tone-2: #bae6fd;
+    --credential-plan-tone-3: #a78bfa;
+    --credential-plan-glow: rgba(165, 180, 252, 0.48);
+    border-color: color-mix(in srgb, #c4b5fd 72%, #94a3b8);
+    color: #26324a;
+  }
+
+  .credentialPlanBadgeNeutral {
+    border-color: color-mix(in srgb, #94a3b8 32%, var(--border-color));
+    background: linear-gradient(135deg, var(--bg-primary), color-mix(in srgb, #64748b 12%, var(--bg-secondary)));
   }
 
   .credentialRemainingDaysBadge {
     border-color: color-mix(in srgb, #86efac 48%, var(--border-color));
-    background: color-mix(in srgb, #16a34a 22%, var(--bg-primary));
+    background:
+      radial-gradient(circle at 18% 12%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 42%),
+      linear-gradient(135deg, color-mix(in srgb, #064e3b 34%, var(--bg-primary)), color-mix(in srgb, #10b981 22%, var(--bg-primary)));
     color: #bbf7d0;
   }
 }

--- a/web/src/components/usage/credentials/credentialViewModels.ts
+++ b/web/src/components/usage/credentials/credentialViewModels.ts
@@ -8,7 +8,9 @@ const THIRTY_DAY_WINDOW_SECONDS = 30 * 24 * 60 * 60
 const AVERAGE_MONTH_WINDOW_SECONDS = 365 * 24 * 60 * 60 / 12
 
 type QuotaStatus = 'ok' | 'warning' | 'danger' | 'unknown'
-export type PlanTypeTone = 'free' | 'team' | 'plus' | 'pro' | 'neutral'
+export type PlanTypeTone = 'free' | 'team' | 'plus' | 'pro5x' | 'pro20x' | 'enterprise' | 'neutral'
+
+const CODEX_PRO_5X_PLAN_TYPES = new Set(['prolite', 'pro-lite', 'pro_lite'])
 
 export interface QuotaWindowUsageDisplay {
   tokens: string
@@ -465,18 +467,30 @@ function credentialPlanTypeLabel(planType?: string): string | undefined {
   if (!tone) {
     return undefined
   }
+  if (tone === 'pro5x') {
+    return 'Pro 5x'
+  }
+  if (tone === 'pro20x') {
+    return 'Pro 20x'
+  }
   const label = tone === 'neutral' ? firstNonEmpty(planType) : tone
   return label ? label.charAt(0).toUpperCase() + label.slice(1) : undefined
 }
 
 function credentialPlanTypeTone(planType?: string): PlanTypeTone | undefined {
-  // planType 展示只做宽松匹配和样式分类，不改变后端原始字段。
+  // 与 CPAMC 保持同一展示契约：pro 是 20x，pro-lite 的三种拼法是 5x。
   const normalized = planType?.trim().toLowerCase()
   if (!normalized) {
     return undefined
   }
-  if (normalized.includes('pro')) {
-    return 'pro'
+  if (normalized === 'pro') {
+    return 'pro20x'
+  }
+  if (CODEX_PRO_5X_PLAN_TYPES.has(normalized)) {
+    return 'pro5x'
+  }
+  if (normalized === 'enterprise') {
+    return 'enterprise'
   }
   if (normalized === 'plus') {
     return 'plus'

--- a/web/src/components/usage/credentials/test/AuthFileCredentialsSection.test.ts
+++ b/web/src/components/usage/credentials/test/AuthFileCredentialsSection.test.ts
@@ -145,6 +145,48 @@ describe('AuthFileCredentialsSection title', () => {
     expect(html).toContain('usage_stats.total_tokens')
     expect(html).toContain('usage_stats.cache_rate')
   })
+
+  it('renders isolated decorative layers for animated subscription badges', () => {
+    const row = {
+      identity: { id: '1', identity: 'auth-1', is_deleted: false },
+      displayName: 'Codex Pro Account',
+      maskedIdentity: 'auth-1',
+      providerLabel: 'Codex',
+      typeLabel: 'codex',
+      authTypeLabel: 'oauth',
+      planTypeLabel: 'Pro 20x',
+      planTypeTone: 'pro20x',
+      totalRequests: 0,
+      successCount: 0,
+      failureCount: 0,
+      successRate: null,
+      totalTokens: 0,
+      cacheReadRate: null,
+      quota: [],
+      quotaLoading: false,
+      displayQuotas: [],
+    } as AuthFileCredentialRow
+
+    const html = renderToStaticMarkup(createElement(AuthFileCredentialsSection, createAuthFileSectionProps({ rows: [row], total: 1 })))
+
+    expect(html).toContain('credentialPlanBadgeFlow')
+    expect(html).toContain('credentialPlanBadgeCorona')
+    expect(html).toContain('credentialPlanBadgeLabel')
+    expect(html).toMatch(/credentialPlanBadgeFlow[^>]+aria-hidden="true"/)
+    expect(html).toMatch(/credentialPlanBadgeCorona[^>]+aria-hidden="true"/)
+
+    for (const [planTypeLabel, planTypeTone] of [['Free', 'free'], ['Custom', 'neutral']] as const) {
+      const lightweightHtml = renderToStaticMarkup(createElement(AuthFileCredentialsSection, createAuthFileSectionProps({
+        rows: [{ ...row, planTypeLabel, planTypeTone }],
+        total: 1,
+      })))
+
+      expect(lightweightHtml).toContain('credentialPlanBadgeLabel')
+      expect(lightweightHtml).toContain(planTypeLabel)
+      expect(lightweightHtml).not.toContain('credentialPlanBadgeFlow')
+      expect(lightweightHtml).not.toContain('credentialPlanBadgeCorona')
+    }
+  })
 })
 
 describe('AuthFileCredentialsSection quota reset action', () => {

--- a/web/src/components/usage/credentials/test/CredentialSections.styles.test.ts
+++ b/web/src/components/usage/credentials/test/CredentialSections.styles.test.ts
@@ -16,6 +16,26 @@ const cssBlock = (selector: string) => {
   return credentialStyles.slice(start, next === -1 ? undefined : next)
 }
 
+const scssRule = (source: string, selector: string, occurrence = 0) => {
+  let start = -selector.length
+  for (let index = 0; index <= occurrence; index += 1) {
+    start = source.indexOf(selector, start + selector.length)
+    expect(start).toBeGreaterThanOrEqual(0)
+  }
+
+  const openingBrace = source.indexOf('{', start + selector.length)
+  expect(openingBrace).toBeGreaterThan(start)
+  let depth = 1
+  for (let index = openingBrace + 1; index < source.length; index += 1) {
+    if (source[index] === '{') {
+      depth += 1
+    } else if (source[index] === '}' && --depth === 0) {
+      return source.slice(start, index + 1)
+    }
+  }
+  throw new Error(`Unclosed SCSS rule: ${selector}`)
+}
+
 describe('Credential section styles', () => {
   it('uses the global card contract and a stable credential title track', () => {
     expect(credentialShellSource).toMatch(/className=\{`\$\{styles\.credentialSectionCard\} keeper-card-surface`\}/)
@@ -457,10 +477,64 @@ describe('Credential section styles', () => {
     expect(credentialStyles).toMatch(/@include mobile\s*\{[\s\S]*?\.credentialPageSizeControl\s*\{[\s\S]*?flex:\s*0 0 auto;/)
   })
 
+  it('gives every Auth Files credential label a dedicated visual treatment', () => {
+    const freeRule = scssRule(credentialStyles, '.credentialPlanBadgeFree')
+    const freeSheenRule = scssRule(credentialStyles, '.credentialPlanBadgeFree::before')
+    const plusRule = scssRule(credentialStyles, '.credentialPlanBadgePlus')
+    const teamRule = scssRule(credentialStyles, '.credentialPlanBadgeTeam')
+    const pro5xRule = scssRule(credentialStyles, '.credentialPlanBadgePro5x')
+    const pro20xRule = scssRule(credentialStyles, '.credentialPlanBadgePro20x')
+    const enterpriseRule = scssRule(credentialStyles, '.credentialPlanBadgeEnterprise')
+    const remainingDaysRule = scssRule(credentialStyles, '.credentialRemainingDaysBadge', 1)
+    const priorityRule = scssRule(credentialStyles, '.credentialPriorityBadge')
+
+    expect(freeRule).toContain('background: linear-gradient')
+    expect(freeRule).toMatch(/box-shadow:[\s\S]*?inset 0 1px 0/)
+    expect(freeSheenRule).toMatch(/animation:\s*credentialPlanBadgeSheen\s*10s/)
+    expect(plusRule).toContain('#2563eb')
+    expect(teamRule).toContain('#16a34a')
+    expect(pro5xRule).toContain('--credential-plan-tone-2: #f6dc37')
+    expect(pro20xRule).toContain('--credential-plan-tone-2: #f6dc37')
+    expect(enterpriseRule).toContain('#c4b5fd')
+    expect(remainingDaysRule).toContain('radial-gradient')
+    expect(priorityRule).toContain('linear-gradient')
+  })
+
+  it('preserves every selected Solar Citrine motion layer with compositor-friendly transforms', () => {
+    expect(credentialStyles).not.toContain('@keyframes credentialFreeBadgeRefresh')
+    expect(credentialStyles).toContain('@keyframes credentialPlanBadgeSolarFlow')
+    expect(credentialStyles).toContain('@keyframes credentialPlanBadgeSolarRotate')
+    expect(credentialStyles).toContain('@keyframes credentialPlanBadgeSheen')
+    expect(credentialStyles).toMatch(/\.credentialPlanBadgeFlow\s*\{[\s\S]*?repeating-linear-gradient[\s\S]*?animation:\s*credentialPlanBadgeSolarFlow/)
+    expect(credentialStyles).toMatch(/\.credentialPlanBadgeCorona\s*\{[\s\S]*?conic-gradient[\s\S]*?animation:\s*credentialPlanBadgeSolarRotate/)
+    expect(credentialStyles).toMatch(/repeating-linear-gradient\(116deg,[\s\S]*?68\.30835px\)/)
+    expect(credentialStyles).toMatch(/repeating-linear-gradient\(112deg,[\s\S]*?140\.93195px\)/)
+    expect(credentialStyles).toMatch(/@keyframes credentialPlanBadgeSolarFlow[\s\S]*?translate3d\(152px, 0, 0\)/)
+    expect(credentialStyles).toMatch(/\.credentialPlanBadgePro20x::after\s*\{[\s\S]*?linear-gradient/)
+    expect(credentialStyles).toMatch(/\.credentialPlanBadgePro20x\s*\{[\s\S]*?--credential-plan-sheen-duration:\s*4\.8s/)
+    expect(credentialStyles).toMatch(/\.credentialPlanBadge\s*\{[\s\S]*?contain:\s*paint;/)
+    expect(credentialStyles).not.toContain('background-position:')
+  })
+
+  it('disables badge motion for reduced-motion and slow-update devices', () => {
+    expect(credentialStyles).toMatch(/prefers-reduced-motion:\s*reduce\),\s*\(update:\s*slow\)[\s\S]*?\.credentialPlanBadgeFlow[\s\S]*?\.credentialPlanBadgeCorona[\s\S]*?animation:\s*none/)
+    expect(credentialStyles).toMatch(/prefers-reduced-motion:\s*reduce\),\s*\(update:\s*slow\)[\s\S]*?\.credentialPlanBadgeFree::before[\s\S]*?animation:\s*none/)
+    expect(credentialStyles).toMatch(/prefers-reduced-motion:\s*reduce\),\s*\(update:\s*slow\)[\s\S]*?\.credentialPlanBadgeEnterprise::before[\s\S]*?animation:\s*none/)
+  })
+
   it('keeps plan and remaining-day badges readable in dark mode', () => {
-    expect(credentialStyles).toMatch(/\[data-theme='dark'\][\s\S]*\.credentialPlanBadgeTeam[\s\S]*?color:\s*#bbf7d0;/)
-    expect(credentialStyles).toMatch(/\[data-theme='dark'\][\s\S]*\.credentialPlanBadgePlus[\s\S]*?color:\s*#bfdbfe;/)
-    expect(credentialStyles).toMatch(/\[data-theme='dark'\][\s\S]*\.credentialPlanBadgePro[\s\S]*?color:\s*#fde68a;/)
-    expect(credentialStyles).toMatch(/\[data-theme='dark'\][\s\S]*\.credentialRemainingDaysBadge[\s\S]*?color:\s*#bbf7d0;/)
+    const darkRules = scssRule(credentialStyles, ":global([data-theme='dark'])")
+    const darkFreeRule = scssRule(darkRules, '.credentialPlanBadgeFree')
+
+    expect(darkFreeRule).toContain('linear-gradient(145deg, #e2e8f0')
+    expect(darkFreeRule).toContain('#8795a8')
+    expect(darkFreeRule).toContain('color: #334155;')
+    expect(scssRule(darkRules, '.credentialPlanBadgeFree::before')).toContain('opacity: 0.58;')
+    expect(scssRule(darkRules, '.credentialPlanBadgeTeam')).toContain('color: #edfff7;')
+    expect(scssRule(darkRules, '.credentialPlanBadgePlus')).toContain('color: #edf8ff;')
+    expect(scssRule(darkRules, '.credentialPlanBadgePro5x')).toContain('color: #302200;')
+    expect(scssRule(darkRules, '.credentialPlanBadgePro20x')).toContain('color: #302200;')
+    expect(scssRule(darkRules, '.credentialPlanBadgeEnterprise')).toContain('color: #26324a;')
+    expect(scssRule(darkRules, '.credentialRemainingDaysBadge')).toContain('color: #bbf7d0;')
   })
 })

--- a/web/src/components/usage/credentials/test/credentialViewModels.test.ts
+++ b/web/src/components/usage/credentials/test/credentialViewModels.test.ts
@@ -64,19 +64,31 @@ describe('credentialViewModels', () => {
     expect(groups.aiProviders.map((item) => item.identity)).toEqual(['api-key'])
   })
 
-  it('builds auth file plan badges from plan type with case-insensitive matching', () => {
+  it('builds auth file plan badges with CPAMC-compatible Codex Pro tiers', () => {
     const rows = buildAuthFileCredentialRows([
       identity({ identity: 'free-auth', plan_type: 'free' }),
       identity({ identity: 'team-auth', plan_type: 'TEAM' }),
       identity({ identity: 'plus-auth', plan_type: 'Plus' }),
-      identity({ identity: 'pro-auth', plan_type: 'chatgpt-pro-monthly' }),
+      identity({ identity: 'pro-lite-auth', plan_type: 'Pro-Lite' }),
+      identity({ identity: 'prolite-auth', plan_type: 'prolite' }),
+      identity({ identity: 'pro-lite-underscore-auth', plan_type: 'pro_lite' }),
+      identity({ identity: 'pro-auth', plan_type: '  PRO  ' }),
+      identity({ identity: 'enterprise-auth', plan_type: '  ENTERPRISE  ' }),
+      identity({ identity: 'unknown-pro-auth', plan_type: 'chatgpt-pro-monthly' }),
+      identity({ identity: 'unknown-enterprise-auth', plan_type: 'enterprise-trial' }),
     ])
 
     expect(rows.map((row) => [row.planTypeLabel, row.planTypeTone])).toEqual([
       ['Free', 'free'],
       ['Team', 'team'],
       ['Plus', 'plus'],
-      ['Pro', 'pro'],
+      ['Pro 5x', 'pro5x'],
+      ['Pro 5x', 'pro5x'],
+      ['Pro 5x', 'pro5x'],
+      ['Pro 20x', 'pro20x'],
+      ['Enterprise', 'enterprise'],
+      ['Chatgpt-pro-monthly', 'neutral'],
+      ['Enterprise-trial', 'neutral'],
     ])
   })
 
@@ -91,11 +103,11 @@ describe('credentialViewModels', () => {
       identity({ identity: 'auth-1', plan_type: 'plus' }),
     ], quotas)
 
-    expect(rows[0].planTypeLabel).toBe('Pro')
-    expect(rows[0].planTypeTone).toBe('pro')
+    expect(rows[0].planTypeLabel).toBe('Pro 20x')
+    expect(rows[0].planTypeTone).toBe('pro20x')
   })
 
-  it('formats unknown refreshed quota plan types in the frontend', () => {
+  it('uses the dedicated Enterprise badge for refreshed quota plan types', () => {
     const quotas = new Map<string, UsageQuotaCheckResponse>([
       ['auth-1', quotaResponse('auth-1', [
         { key: 'rate_limit.primary_window', planType: ' enterprise ' },
@@ -107,7 +119,7 @@ describe('credentialViewModels', () => {
     ], quotas)
 
     expect(rows[0].planTypeLabel).toBe('Enterprise')
-    expect(rows[0].planTypeTone).toBe('neutral')
+    expect(rows[0].planTypeTone).toBe('enterprise')
   })
 
   it('builds active-until remaining days badge with zero as the minimum', () => {


### PR DESCRIPTION
## Summary

- give Free, Plus, Team, Pro 5x, Pro 20x, and Enterprise credentials dedicated plan badges
- align Codex Pro tier labels with the CPAMC plan contract while preserving unknown-plan fallback behavior
- isolate animated textures on transform layers with reduced-motion and slow-update fallbacks
- preserve expiry and priority badges and strengthen the badge regression tests

## Validation

- `npm test` (110 files, 1016 tests)
- `npm run lint`
- `npm run typecheck`
- `npm run build`