### PR TITLE
build: standardize on Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: npm
           cache-dependency-path: web/package-lock.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:22-alpine AS web-builder
+FROM node:24-alpine AS web-builder
 WORKDIR /app/web
 COPY web/package.json web/package-lock.json ./
 RUN npm ci


### PR DESCRIPTION
## Summary

- use Node.js 24 for the Docker web builder
- align pull request CI with the existing Node.js 24 binary release workflows

## Validation

- full local baseline: Go tests, 113 frontend test files / 1061 tests, lint, typecheck, and production build
- `docker build -t cpa-usage-keeper:ci .`
- `git diff --check`