### PR TITLE
fix(credentials): avoid WebKit subscription badge artifacts

### DIFF
--- a/web/src/components/usage/credentials/CredentialSections.module.scss
+++ b/web/src/components/usage/credentials/CredentialSections.module.scss
@@ -2083,6 +2083,13 @@ $credential-name-column-width: $credential-name-content-width + $credential-prov
   animation: credentialPlanBadgeSolarRotate var(--credential-plan-corona-duration) linear infinite;
 }
 
+// Safari/WebKit 的混合合成层可能绕过父级圆角裁剪，仅对该引擎降级光晕混合。
+@supports (-webkit-nbsp-mode: space) {
+  .credentialPlanBadgeCorona {
+    mix-blend-mode: normal;
+  }
+}
+
 .credentialPlanBadgePro20x::after {
   inset: 0;
   background:

--- a/web/src/components/usage/credentials/test/CredentialSections.styles.test.ts
+++ b/web/src/components/usage/credentials/test/CredentialSections.styles.test.ts
@@ -536,6 +536,15 @@ describe('Credential section styles', () => {
     expect(credentialStyles).not.toContain('will-change:')
   })
 
+  it('keeps screen blending by default and disables it only for Safari WebKit', () => {
+    const coronaRule = scssRule(credentialStyles, '.credentialPlanBadgeCorona')
+    const safariWebKitRule = scssRule(credentialStyles, '@supports (-webkit-nbsp-mode: space)')
+
+    expect(coronaRule).toContain('mix-blend-mode: screen;')
+    expect(scssRule(safariWebKitRule, '.credentialPlanBadgeCorona')).toContain('mix-blend-mode: normal;')
+    expect(safariWebKitRule).not.toContain('.credentialPlanBadgeFlow')
+  })
+
   it('disables badge motion for reduced-motion and slow-update devices', () => {
     expect(credentialStyles).toMatch(/prefers-reduced-motion:\s*reduce\),\s*\(update:\s*slow\)[\s\S]*?\.credentialPlanBadgeFlow[\s\S]*?\.credentialPlanBadgeCorona[\s\S]*?animation:\s*none/)
     expect(credentialStyles).toMatch(/prefers-reduced-motion:\s*reduce\),\s*\(update:\s*slow\)[\s\S]*?\.credentialPlanBadgeEnterprise::before[\s\S]*?animation:\s*none/)


### PR DESCRIPTION
## Summary

- disable the affected subscription badge corona blend layer only on WebKit
- preserve the existing Chrome and other non-WebKit animation appearance
- add regression coverage for the engine-scoped CSS override

## Validation

- frontend test suite: 113 files, 1062 tests
- frontend lint, typecheck, and production build
- iOS Safari manual verification
- macOS Safari manual verification
- `git diff --check`