### PR TITLE
test(benchmark): add production capacity suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Docker Compose is the recommended deployment method. Use the full stack when dep
 
 Login protection is enabled by default. Configure `LOGIN_PASSWORD` before starting Keeper, or explicitly set `AUTH_ENABLED=false` only when access is reliably isolated by the deployment environment.
 
+## Benchmark
+
+Production-style `linux/amd64` capacity measurements for sustained ingestion, Dashboard latency, CPU utilization, and Keeper cgroup peak memory are available in the [Capacity Benchmark Report](./internal/benchmark/REPORT.md).
+
 ## Project Structure
 
 ```text
@@ -116,6 +120,7 @@ internal/repository/     SQLite persistence and aggregations
 internal/service/        Usage, pricing, and identity services
 internal/quota/          Provider quota refresh and inspection
 internal/ranking/        Community ranking aggregation and sync
+internal/benchmark/      Capacity suite, reports, manifests, and legacy microbenchmarks
 deploy/linux/            systemd service template
 web/                     React + TypeScript frontend
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -104,6 +104,10 @@ Docker Compose 是推荐部署方式：首次部署可同时运行 CPA + Keeper�
 
 登录保护默认启用。启动 Keeper 前请配置 `LOGIN_PASSWORD`；只有部署环境已可靠隔离访问时，才显式设置 `AUTH_ENABLED=false`。
 
+## Benchmark
+
+`linux/amd64` 生产型容量测试覆盖持续 ingestion、Dashboard 延迟、CPU 利用率和 Keeper cgroup 峰值内存，完整结果见 [容量 Benchmark 报告](./internal/benchmark/REPORT.zh.md)。
+
 ## 项目结构
 
 ```text
@@ -116,6 +120,7 @@ internal/repository/     SQLite 持久化与聚合
 internal/service/        用量、定价与身份服务
 internal/quota/          Provider 限额刷新与巡检
 internal/ranking/        社区排名聚合与同步
+internal/benchmark/      容量套件、报告、manifest 与历史 Go microbenchmark
 deploy/linux/            systemd 服务模板
 web/                     React + TypeScript 前端
 ```

--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -1,0 +1,146 @@
+<p align="center">
+  <a href="./README.md"><strong>English</strong></a> ｜ <a href="./README.zh.md">简体中文</a>
+</p>
+
+# Capacity Benchmark
+
+`internal/benchmark` contains both code-level Go microbenchmarks and a production-style capacity suite that exercises the complete Keeper binary, SQLite, Redis, and real Dashboard HTTP queries. The formal suite is `capacity-v1` and targets `linux/amd64` only.
+
+## Test Objectives
+
+The capacity suite changes only the CPU available to Keeper: 1C, 2C, and 4C. All profiles reuse the same canonical database. Keeper memory is unlimited during a run, and the suite reads cgroup v2 `memory.peak` afterward. This includes the Keeper process, SQLite mmap/page cache, and database cache charged to the Keeper cgroup.
+
+The formal results report:
+
+- the maximum sustained ingestion rate over five minutes;
+- the maximum rate that also keeps the aggregate p99 of six Dashboard endpoints within three seconds after the ingestion hard pass succeeds;
+- CPU utilization and Keeper cgroup peak memory at the capacity point;
+- a conservative sustained-rate recommendation set to 70% of Dashboard capacity.
+
+Core p95 is retained as an experience indicator but is not a `capacity-v1` pass gate.
+
+## Reference Dataset
+
+The reference dataset ID is `reference-2m`.
+
+| Item | Count |
+| --- | ---: |
+| Total events | 2,035,740 |
+| Events in the latest 30 days | 1,226,326 |
+| Hot events in the latest 90 days | 1,946,550 |
+| Archived events | 89,190 |
+| Identities | 323 |
+| Models | 52 |
+| API keys | 27 |
+| Database size | 1,171,144,704 bytes (about 1.09 GiB) |
+
+The dataset retains 90 days of active events plus older archived history to represent the storage, query, and aggregation load of a long-running deployment.
+
+API keys are deterministically assigned to high-, medium-, and low-usage tiers in a 30%/50%/20% split. Per-key weights are 10:3:1, and `usage_events` are normalized across those weights. All 323 identities, 52 models, and 27 API keys are referenced by events.
+
+The canonical database must pass row-count, cardinality, orphan-reference, token-semantics, derived rollup/checkpoint, `PRAGMA quick_check`, and semantic-fingerprint validation. Dataset generation is not CPU- or memory-limited. Each runtime probe creates an independent clone from the canonical database so backlog, WAL, GC, and cache state do not affect the next point.
+
+## Directory Layout
+
+```text
+internal/benchmark/
+├── README.md
+├── README.zh.md
+├── REPORT.md
+├── REPORT.zh.md
+├── legacy/                     # Existing Go microbenchmarks
+├── capacity/                   # Dataset, load, cgroup runner, and summary logic
+│   └── test/                   # Capacity-suite unit tests
+├── cmd/benchctl/               # plan/generate/validate/run/resume/summarize
+├── manifest/capacity-v1.json
+├── schema/                     # JSON result contracts
+└── scripts/run-capacity.sh
+```
+
+The runtime directory is selected with `BENCHMARK_ROOT`:
+
+```text
+<benchmark-root>/
+├── benchmark.lock
+├── bin/
+├── config/
+├── datasets/reference-2m/
+│   ├── app.db                  # or app.db.zst
+│   └── dataset.json
+└── runs/
+    ├── <controller-id>/
+    │   ├── controller.tsv
+    │   ├── environment.txt
+    │   └── summary.md
+    └── <controller-id>-<cell-run>/
+        ├── run.json
+        ├── results.jsonl
+        ├── summary.json
+        ├── summary.csv
+        ├── report.md
+        └── cells/<cell-id>/
+```
+
+## Requirements
+
+- Linux amd64 with at least four online logical CPUs;
+- cgroup v2 and systemd transient units;
+- Go, GCC, the SQLite CLI, Redis server, `jq`, and `taskset`;
+- enough disk space for the canonical database, probe clones, WAL files, logs, and results;
+- permission to use `systemd-run` and read the corresponding cgroup metrics.
+
+## Running the Suite
+
+Run directly from the repository on the benchmark host:
+
+```bash
+BENCHMARK_ROOT=/path/to/benchmark-data \
+PREPARE_DATASET=1 \
+internal/benchmark/scripts/run-capacity.sh
+```
+
+`PREPARE_DATASET=1` takes effect only when the canonical dataset is missing. After the first generation and validation, omit it to reuse the same dataset:
+
+```bash
+BENCHMARK_ROOT=/path/to/benchmark-data \
+internal/benchmark/scripts/run-capacity.sh
+```
+
+The suite can also be invoked over SSH from a controller machine:
+
+```bash
+BENCHMARK_HOST=<ssh-target> \
+BENCHMARK_REMOTE_REPOSITORY=<repository-path-on-target> \
+BENCHMARK_ROOT=<benchmark-data-path-on-target> \
+internal/benchmark/scripts/run-capacity.sh
+```
+
+Optional variables:
+
+- `CPU_LIST=1,2,4`: select formal CPU profiles;
+- `CONTROLLER_ID=<neutral-run-id>`: select a resumable controller run ID;
+- `BENCHCTL_BINARY`, `KEEPER_BINARY`: reuse traceable prebuilt binaries;
+- `REDIS_PORT`, `APP_PORT`: avoid conflicts with other tests on the same machine;
+- `BENCHMARK_MANIFEST`: use another compatible manifest explicitly.
+
+By default, the script builds Keeper and `benchctl` on the target, creates an immutable plan, validates the canonical dataset, performs a 20-second discrete search for each CPU profile, and runs five-minute fixed-rate validation only for the required candidates. Existing results are reused by run ID; the canonical dataset is not regenerated and completed cells are not overwritten.
+
+## Pass Criteria
+
+An ingestion hard pass requires all of the following:
+
+- at least 99.9% of offered events are published successfully;
+- the final durable ratio is at least 99%;
+- Redis inbox backlog does not grow;
+- Overview, Activity, and Latency checkpoints and Identity aggregation catch up;
+- no OOM, panic, SQLite busy error, HTTP error, or load-driver publish error occurs.
+
+A Dashboard pass first requires the ingestion hard pass, then requires the aggregate p99 across six endpoints to remain within 3000ms. Dashboard replay runs at 1 request/s, warms the endpoints first, then rotates through Realtime Overview, Overview 30d, Activity, Analysis, Request Events, and Analysis Latency 30d.
+
+Each formal capacity point runs for 300 seconds. Short probes select candidates only and do not become final capacity results. `offered_events`, `published_events`, and `durable_events` are recorded separately so load-driver shortfalls cannot be reported as Keeper capacity.
+
+## Result Files
+
+Each run produces `run.json`, `results.jsonl`, `summary.json`, `summary.csv`, and `report.md`. The controller also produces `controller.tsv`, `environment.txt`, and a capacity `summary.md`.
+
+See the current formal measurements in the [Capacity Benchmark Report](REPORT.md).

--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -12,33 +12,36 @@ The capacity suite changes only the CPU available to Keeper: 1C, 2C, and 4C. All
 
 The formal results report:
 
-- the maximum sustained ingestion rate over five minutes;
-- the maximum rate that also keeps the aggregate p99 of six Dashboard endpoints within three seconds after the ingestion hard pass succeeds;
+- the highest verified five-minute ingestion pass and the lowest observed failure above it;
+- the corresponding five-minute Core Dashboard pass/fail interval under the three-second aggregate p99 SLA;
 - CPU utilization and Keeper cgroup peak memory at the capacity point;
+- a separate Analysis Latency diagnostic summary with sample count, errors, status, and latency percentiles;
 - a conservative sustained-rate recommendation set to 70% of Dashboard capacity.
 
-Core p95 is retained as an experience indicator but is not a `capacity-v1` pass gate.
+Core p95 is retained as an experience indicator but is not a `capacity-v1` pass gate. Analysis Latency is a heavier diagnostic query and does not participate in the three-second Core Dashboard gate.
 
 ## Reference Dataset
 
-The reference dataset ID is `reference-2m`.
+The reference dataset ID is `reference-3m`.
 
 | Item | Count |
 | --- | ---: |
-| Total events | 2,035,740 |
-| Events in the latest 30 days | 1,226,326 |
-| Hot events in the latest 90 days | 1,946,550 |
-| Archived events | 89,190 |
-| Identities | 323 |
-| Models | 52 |
-| API keys | 27 |
-| Database size | 1,171,144,704 bytes (about 1.09 GiB) |
+| Total events | 3,205,740 |
+| Events in the 30 days ending at generation | 1,226,326 |
+| Hot events in the latest 90 days | 3,205,740 |
+| Archived events | 0 |
+| Identities | 500 |
+| Models | 50 |
+| API keys | 50 |
+| Database size | 2,044,776,448 bytes (about 1.90 GiB) |
 
-The dataset retains 90 days of active events plus older archived history to represent the storage, query, and aggregation load of a long-running deployment.
+The dataset retains 90 days of active events. The archive table is intentionally empty because the production Dashboard paths covered by this suite do not query cold events.
 
-API keys are deterministically assigned to high-, medium-, and low-usage tiers in a 30%/50%/20% split. Per-key weights are 10:3:1, and `usage_events` are normalized across those weights. All 323 identities, 52 models, and 27 API keys are referenced by events.
+The 50 API keys are deterministically assigned to 15 high-, 25 medium-, and 10 low-usage keys. Per-key weights are 10:3:1, and `usage_events` are normalized across those weights. All 500 identities, 50 models, and 50 API keys are active and referenced by events. Failed events account for 1% of the generated workload.
 
-The canonical database must pass row-count, cardinality, orphan-reference, token-semantics, derived rollup/checkpoint, `PRAGMA quick_check`, and semantic-fingerprint validation. Dataset generation is not CPU- or memory-limited. Each runtime probe creates an independent clone from the canonical database so backlog, WAL, GC, and cache state do not affect the next point.
+The canonical database must pass row-count, cardinality, orphan-reference, token-semantics, derived rollup/checkpoint, `PRAGMA quick_check`, dimension-distribution, and semantic-fingerprint validation. Its metadata also binds the configured failure rate and traffic tiers, so a canonical generated for a different workload cannot be relabeled by a changed manifest. Generation uses the actual generation time as the dataset anchor. A formal run rejects a dataset whose newest event is more than seven days old and records the effective 30-day query count in `dataset-validation.json`.
+
+Dataset generation is not CPU- or memory-limited. Each runtime probe creates an independent clone from the canonical database so backlog, WAL, GC, and cache state do not affect the next point. The clone is synced and evicted from the controller's page cache before Keeper starts, causing SQLite pages faulted during the probe to be charged to the Keeper cgroup.
 
 ## Directory Layout
 
@@ -64,12 +67,14 @@ The runtime directory is selected with `BENCHMARK_ROOT`:
 ├── benchmark.lock
 ├── bin/
 ├── config/
-├── datasets/reference-2m/
+├── datasets/reference-3m/
 │   ├── app.db                  # or app.db.zst
 │   └── dataset.json
 └── runs/
     ├── <controller-id>/
+    │   ├── controller-inputs.sha256
     │   ├── controller.tsv
+    │   ├── dataset-validation.json
     │   ├── environment.txt
     │   └── summary.md
     └── <controller-id>-<cell-run>/
@@ -85,7 +90,7 @@ The runtime directory is selected with `BENCHMARK_ROOT`:
 
 - Linux amd64 with at least four online logical CPUs;
 - cgroup v2 and systemd transient units;
-- Go, GCC, the SQLite CLI, Redis server, `jq`, and `taskset`;
+- Go, GCC, the SQLite CLI, Redis server, `jq`, and `taskset`; `zstd` is also required when the canonical database is compressed;
 - enough disk space for the canonical database, probe clones, WAL files, logs, and results;
 - permission to use `systemd-run` and read the corresponding cgroup metrics.
 
@@ -99,7 +104,7 @@ PREPARE_DATASET=1 \
 internal/benchmark/scripts/run-capacity.sh
 ```
 
-`PREPARE_DATASET=1` takes effect only when the canonical dataset is missing. After the first generation and validation, omit it to reuse the same dataset:
+`PREPARE_DATASET=1` takes effect only when the canonical dataset is missing. After the first generation and validation, omit it to reuse the same dataset for the formal test campaign:
 
 ```bash
 BENCHMARK_ROOT=/path/to/benchmark-data \
@@ -123,7 +128,11 @@ Optional variables:
 - `REDIS_PORT`, `APP_PORT`: avoid conflicts with other tests on the same machine;
 - `BENCHMARK_MANIFEST`: use another compatible manifest explicitly.
 
-By default, the script builds Keeper and `benchctl` on the target, creates an immutable plan, validates the canonical dataset, performs a 20-second discrete search for each CPU profile, and runs five-minute fixed-rate validation only for the required candidates. Existing results are reused by run ID; the canonical dataset is not regenerated and completed cells are not overwritten.
+By default, the script builds Keeper and `benchctl` on the target, creates an immutable plan, and strictly validates the canonical dataset once. For each CPU profile, discovery starts at 25 events/s and ramps upward; if 25 events/s fails, the same search bisects the configured 20/15/10/5/1 events/s fallback range. It then bisects the resulting pass/fail interval and rechecks both sides of the ingestion boundary for 60 seconds. Only the resulting candidates proceed to five-minute fixed-rate validation. Five-minute ingestion refinement uses 25 events/s steps where possible and the configured manifest rates when an interval falls below that step. If no short Dashboard probe passes, the 1 event/s floor still receives one five-minute validation; after the first five-minute Dashboard pass, the controller bisects upward against the known five-minute failure until it finds the highest configured passing point. Every child run reuses the same validation proof instead of rescanning the full database. A controller ID is resumable only while its controller script, result contract, manifest, plan, binaries, dataset metadata, validation proof, CPU list, ports, search strategy, and durations remain unchanged.
+
+Expected fixed-rate capacity failures remain terminal boundary evidence and are reused by `resume` when their provenance matches; they are not executed again after a controller restart. Missing results, stale validation, panic, runtime/sampler errors, and load-driver failures still stop the controller with a non-zero status. The controller writes a completed summary only after every requested CPU has exactly one formal row.
+
+The controller fixes `TZ=Asia/Shanghai` for generation, validation, Keeper, and result collection. Dataset directories and cell IDs are resolved from the selected manifest and its expanded plan, so compatible custom manifests do not inherit the reference dataset name.
 
 ## Pass Criteria
 
@@ -133,14 +142,17 @@ An ingestion hard pass requires all of the following:
 - the final durable ratio is at least 99%;
 - Redis inbox backlog does not grow;
 - Overview, Activity, and Latency checkpoints and Identity aggregation catch up;
-- no OOM, panic, SQLite busy error, HTTP error, or load-driver publish error occurs.
+- post-load catch-up completes within 15 seconds; the remaining 30-second drain window is retained only for diagnostics;
+- no OOM, panic, or load-driver publish error occurs.
 
-A Dashboard pass first requires the ingestion hard pass, then requires the aggregate p99 across six endpoints to remain within 3000ms. Dashboard replay runs at 1 request/s, warms the endpoints first, then rotates through Realtime Overview, Overview 30d, Activity, Analysis, Request Events, and Analysis Latency 30d.
+A Core Dashboard pass first requires the ingestion hard pass, then requires zero Core HTTP errors and the aggregate p99 across Realtime Overview 60m, Overview 30d, Activity 30d, Analysis 30d, and Request Events 30d to remain within 3000ms. Core Dashboard replay runs at 1 request/s after warmup.
 
-Each formal capacity point runs for 300 seconds. Short probes select candidates only and do not become final capacity results. `offered_events`, `published_events`, and `durable_events` are recorded separately so load-driver shortfalls cannot be reported as Keeper capacity.
+Analysis Latency 30d is warmed once and then requested every 30 seconds during the probe. Its successful sample count, error count, status, and p50/p95/p99/max are reported separately. A diagnostic error does not change ingestion or Core Dashboard capacity; OOM, panic, or another global Keeper failure still invalidates the run.
+
+Each formal capacity point runs at a fixed rate for 300 seconds. Short ramp and boundary probes select candidates only and do not become final capacity results. The controller reports the highest five-minute passing rate together with the lowest observed failing rate, so the measured capacity is an interval rather than an unsupported claim of an exact absolute maximum. A zero failure boundary means no failure was observed within the configured rate matrix. `offered_events`, `published_events`, and `durable_events` are recorded separately so load-driver shortfalls cannot be reported as Keeper capacity.
 
 ## Result Files
 
-Each run produces `run.json`, `results.jsonl`, `summary.json`, `summary.csv`, and `report.md`. The controller also produces `controller.tsv`, `environment.txt`, and a capacity `summary.md`.
+Each run produces `run.json`, `results.jsonl`, `summary.json`, `summary.csv`, and `report.md`. The controller also produces `controller-inputs.sha256`, `dataset-validation.json`, `controller.tsv`, `environment.txt`, and a capacity `summary.md`.
 
 See the current formal measurements in the [Capacity Benchmark Report](REPORT.md).

--- a/internal/benchmark/README.zh.md
+++ b/internal/benchmark/README.zh.md
@@ -1,0 +1,146 @@
+<p align="center">
+  <a href="./README.md">English</a> ｜ <a href="./README.zh.md"><strong>简体中文</strong></a>
+</p>
+
+# 容量 Benchmark
+
+`internal/benchmark` 同时包含代码级 Go microbenchmark，以及使用完整 Keeper、SQLite、Redis 和真实 Dashboard HTTP 查询的生产型容量测试。正式容量套件为 `capacity-v1`，只测试 `linux/amd64`。
+
+## 测试目标
+
+容量测试只改变 Keeper 可用 CPU：1C、2C、4C。三档均使用同一份 canonical 数据库，Keeper 内存不设上限，测试结束后读取 cgroup v2 `memory.peak`。该数值包含 Keeper 进程、SQLite mmap/page cache 及归属于 Keeper cgroup 的数据库缓存。
+
+正式结论同时给出：
+
+- 五分钟持续 ingestion 上限；
+- ingestion hard pass 前提下，六个 Dashboard 接口整体 p99 不超过 3 秒的上限；
+- 容量点 CPU 利用率和 Keeper cgroup 峰值内存；
+- 按 Dashboard 上限 70% 计算的保守持续流量建议。
+
+core p95 继续记录，用于判断页面体验，但不参与 `capacity-v1` 的通过判定。
+
+## 参考数据集
+
+参考数据集 ID 为 `reference-2m`。
+
+| 项目 | 数量 |
+| --- | ---: |
+| 全库 events | 2,035,740 |
+| 最近 30 天 events | 1,226,326 |
+| 最近 90 天 hot events | 1,946,550 |
+| archive events | 89,190 |
+| identities | 323 |
+| models | 52 |
+| API keys | 27 |
+| 数据库大小 | 1,171,144,704 bytes（约 1.09 GiB） |
+
+数据集保留最近 90 天的活跃事件及更早的归档历史，用于覆盖长期运行后的存储、查询和聚合负载。
+
+API keys 按 30%/50%/20% 确定性分入高、中、低用量档，每 Key 权重为 10:3:1；`usage_events` 数量根据这些权重归一化分配。323 identities、52 models 和 27 API keys 都被事件实际引用。
+
+canonical 必须通过行数、基数、孤儿引用、token 语义、派生 rollup/checkpoint、`PRAGMA quick_check` 和 semantic fingerprint 验证。生成阶段不限制 CPU 或内存；运行阶段每个 probe 都从 canonical 创建独立 clone，避免 backlog、WAL、GC 和缓存污染下一个点。
+
+## 目录
+
+```text
+internal/benchmark/
+├── README.md
+├── README.zh.md
+├── REPORT.md
+├── REPORT.zh.md
+├── legacy/                     # 原有 Go microbenchmark
+├── capacity/                   # 数据生成、负载、cgroup runner、汇总
+│   └── test/                   # 容量套件单元测试
+├── cmd/benchctl/               # plan/generate/validate/run/resume/summarize
+├── manifest/capacity-v1.json
+├── schema/                     # JSON 结果协议
+└── scripts/run-capacity.sh
+```
+
+运行目录由 `BENCHMARK_ROOT` 指定：
+
+```text
+<benchmark-root>/
+├── benchmark.lock
+├── bin/
+├── config/
+├── datasets/reference-2m/
+│   ├── app.db                  # 或 app.db.zst
+│   └── dataset.json
+└── runs/
+    ├── <controller-id>/
+    │   ├── controller.tsv
+    │   ├── environment.txt
+    │   └── summary.md
+    └── <controller-id>-<cell-run>/
+        ├── run.json
+        ├── results.jsonl
+        ├── summary.json
+        ├── summary.csv
+        ├── report.md
+        └── cells/<cell-id>/
+```
+
+## 环境要求
+
+- Linux amd64，至少 4 个在线逻辑 CPU；
+- cgroup v2 和 systemd transient units；
+- Go、GCC、SQLite CLI、Redis server、`jq`、`taskset`；
+- 足够存放 canonical、probe clone、WAL、日志与结果的磁盘空间；
+- 运行用户有权使用 `systemd-run` 和读取对应 cgroup 指标。
+
+## 运行
+
+直接在 benchmark 主机的仓库中运行：
+
+```bash
+BENCHMARK_ROOT=/path/to/benchmark-data \
+PREPARE_DATASET=1 \
+internal/benchmark/scripts/run-capacity.sh
+```
+
+`PREPARE_DATASET=1` 只在 canonical 不存在时生效。首次生成并验证完成后，后续运行应省略该变量以复用相同数据：
+
+```bash
+BENCHMARK_ROOT=/path/to/benchmark-data \
+internal/benchmark/scripts/run-capacity.sh
+```
+
+也可以从控制机通过 SSH 调用，不需要把目标写入仓库：
+
+```bash
+BENCHMARK_HOST=<ssh-target> \
+BENCHMARK_REMOTE_REPOSITORY=<repository-path-on-target> \
+BENCHMARK_ROOT=<benchmark-data-path-on-target> \
+internal/benchmark/scripts/run-capacity.sh
+```
+
+可选变量：
+
+- `CPU_LIST=1,2,4`：选择正式 CPU 档；
+- `CONTROLLER_ID=<neutral-run-id>`：指定可恢复的运行组 ID；
+- `BENCHCTL_BINARY`、`KEEPER_BINARY`：复用已构建且可追溯的二进制；
+- `REDIS_PORT`、`APP_PORT`：避免与同机其它测试冲突；
+- `BENCHMARK_MANIFEST`：显式使用另一份兼容 manifest。
+
+默认会在目标机上构建 Keeper 和 `benchctl`、生成不可变 plan、验证 canonical，然后对每个 CPU 档先做 20 秒离散搜索，只对必要候选执行五分钟固定速率验证。已存在的结果按 run ID 复用，不会重复生成 canonical 或覆盖完成的 cell。
+
+## 判定规则
+
+Ingestion hard pass 必须同时满足：
+
+- 至少 99.9% 目标事件成功发布；
+- 最终 durable ratio 至少 99%；
+- Redis inbox backlog 不增长；
+- Overview、Activity、Latency checkpoint 和 Identity 聚合追平；
+- 无 OOM、panic、SQLite busy、HTTP 错误或负载器 publish error。
+
+Dashboard pass 先要求 hard pass，再要求六接口整体 p99 不超过 3000ms。Dashboard replay 为 1 req/s，先预热，再在 Realtime Overview、Overview 30d、Activity、Analysis、Request Events、Analysis Latency 30d 之间轮转。
+
+每个正式容量点持续 300 秒。短探测只选择候选，不进入最终容量结论。结果中的 `offered_events`、`published_events` 和 `durable_events` 分开记录，不能把负载器未达到目标速率误报为 Keeper 容量。
+
+## 结果文件
+
+每个运行点生成 `run.json`、`results.jsonl`、`summary.json`、`summary.csv` 和 `report.md`；控制器额外生成汇总表 `controller.tsv`、环境规格 `environment.txt` 和容量摘要 `summary.md`。
+
+当前正式测量结果见 [REPORT.zh.md](REPORT.zh.md)。

--- a/internal/benchmark/README.zh.md
+++ b/internal/benchmark/README.zh.md
@@ -12,33 +12,36 @@
 
 正式结论同时给出：
 
-- 五分钟持续 ingestion 上限；
-- ingestion hard pass 前提下，六个 Dashboard 接口整体 p99 不超过 3 秒的上限；
+- ingestion 的最高五分钟成功点及其上方最低已观察失败点；
+- ingestion hard pass 前提下，五个核心 Dashboard 接口整体 p99 不超过 3 秒的五分钟成功/失败区间；
 - 容量点 CPU 利用率和 Keeper cgroup 峰值内存；
+- 单独列出的 Analysis Latency 样本数、错误数、状态与延迟分位数；
 - 按 Dashboard 上限 70% 计算的保守持续流量建议。
 
-core p95 继续记录，用于判断页面体验，但不参与 `capacity-v1` 的通过判定。
+core p95 继续记录，用于判断页面体验，但不参与 `capacity-v1` 的通过判定。Analysis Latency 属于更重的诊断查询，不参与核心 Dashboard 的 3 秒门槛。
 
 ## 参考数据集
 
-参考数据集 ID 为 `reference-2m`。
+参考数据集 ID 为 `reference-3m`。
 
 | 项目 | 数量 |
 | --- | ---: |
-| 全库 events | 2,035,740 |
-| 最近 30 天 events | 1,226,326 |
-| 最近 90 天 hot events | 1,946,550 |
-| archive events | 89,190 |
-| identities | 323 |
-| models | 52 |
-| API keys | 27 |
-| 数据库大小 | 1,171,144,704 bytes（约 1.09 GiB） |
+| 全库 events | 3,205,740 |
+| 截至生成锚点的 30 天 events | 1,226,326 |
+| 最近 90 天 hot events | 3,205,740 |
+| archive events | 0 |
+| identities | 500 |
+| models | 50 |
+| API keys | 50 |
+| 数据库大小 | 2,044,776,448 bytes（约 1.90 GiB） |
 
-数据集保留最近 90 天的活跃事件及更早的归档历史，用于覆盖长期运行后的存储、查询和聚合负载。
+数据集只保留最近 90 天的活跃事件。archive 表刻意保持为空，因为本套件覆盖的生产 Dashboard 路径不会查询冷数据。
 
-API keys 按 30%/50%/20% 确定性分入高、中、低用量档，每 Key 权重为 10:3:1；`usage_events` 数量根据这些权重归一化分配。323 identities、52 models 和 27 API keys 都被事件实际引用。
+50 个 API keys 确定性分为 15 个大用量、25 个中用量、10 个小用量 Key，每 Key 权重为 10:3:1；`usage_events` 数量根据这些权重归一化分配。500 identities、50 models 和 50 API keys 均有效且被事件实际引用，failed events 占生成负载的 1%。
 
-canonical 必须通过行数、基数、孤儿引用、token 语义、派生 rollup/checkpoint、`PRAGMA quick_check` 和 semantic fingerprint 验证。生成阶段不限制 CPU 或内存；运行阶段每个 probe 都从 canonical 创建独立 clone，避免 backlog、WAL、GC 和缓存污染下一个点。
+canonical 必须通过行数、基数、孤儿引用、token 语义、派生 rollup/checkpoint、`PRAGMA quick_check`、维度分布和 semantic fingerprint 验证。metadata 还会绑定配置的错误率与流量分层，修改 manifest 后不能把不同负载配置生成的 canonical 重新标记为当前数据集。生成时以实际生成时间作为数据锚点；正式运行会拒绝最新事件已超过七天的数据集，并在 `dataset-validation.json` 中记录本次 30 天查询实际覆盖的 events 数量。
+
+生成阶段不限制 CPU 或内存；运行阶段每个 probe 都从 canonical 创建独立 clone，避免 backlog、WAL、GC 和缓存污染下一个点。clone 会先落盘并从 controller page cache 中清除，再启动 Keeper，使 probe 期间读入的 SQLite 页面归入 Keeper cgroup。
 
 ## 目录
 
@@ -64,12 +67,14 @@ internal/benchmark/
 ├── benchmark.lock
 ├── bin/
 ├── config/
-├── datasets/reference-2m/
+├── datasets/reference-3m/
 │   ├── app.db                  # 或 app.db.zst
 │   └── dataset.json
 └── runs/
     ├── <controller-id>/
+    │   ├── controller-inputs.sha256
     │   ├── controller.tsv
+    │   ├── dataset-validation.json
     │   ├── environment.txt
     │   └── summary.md
     └── <controller-id>-<cell-run>/
@@ -85,7 +90,7 @@ internal/benchmark/
 
 - Linux amd64，至少 4 个在线逻辑 CPU；
 - cgroup v2 和 systemd transient units；
-- Go、GCC、SQLite CLI、Redis server、`jq`、`taskset`；
+- Go、GCC、SQLite CLI、Redis server、`jq`、`taskset`；canonical 使用压缩数据库时还需要 `zstd`；
 - 足够存放 canonical、probe clone、WAL、日志与结果的磁盘空间；
 - 运行用户有权使用 `systemd-run` 和读取对应 cgroup 指标。
 
@@ -99,7 +104,7 @@ PREPARE_DATASET=1 \
 internal/benchmark/scripts/run-capacity.sh
 ```
 
-`PREPARE_DATASET=1` 只在 canonical 不存在时生效。首次生成并验证完成后，后续运行应省略该变量以复用相同数据：
+`PREPARE_DATASET=1` 只在 canonical 不存在时生效。首次生成并验证完成后，本轮正式测试应省略该变量以复用相同数据：
 
 ```bash
 BENCHMARK_ROOT=/path/to/benchmark-data \
@@ -123,7 +128,11 @@ internal/benchmark/scripts/run-capacity.sh
 - `REDIS_PORT`、`APP_PORT`：避免与同机其它测试冲突；
 - `BENCHMARK_MANIFEST`：显式使用另一份兼容 manifest。
 
-默认会在目标机上构建 Keeper 和 `benchctl`、生成不可变 plan、验证 canonical，然后对每个 CPU 档先做 20 秒离散搜索，只对必要候选执行五分钟固定速率验证。已存在的结果按 run ID 复用，不会重复生成 canonical 或覆盖完成的 cell。
+默认会在目标机上构建 Keeper 和 `benchctl`、生成不可变 plan，并只对 canonical 做一次严格验证。每个 CPU 档从 25 events/s 开始向上递增；若 25 events/s 失败，同一搜索才在配置的 20/15/10/5/1 events/s 回退区间内二分。之后继续在成功/失败区间二分，并对 ingestion 边界两侧各做 60 秒复核；只有由此选出的候选才进入五分钟固定速率验证。五分钟 ingestion 细分在可行时使用 25 events/s 步进，区间小于该步进时改用 manifest 中配置的真实速率。如果所有 Dashboard 短测均未通过，最低 1 event/s 仍会接受一次五分钟正式验证；找到首个五分钟 Dashboard 通过点后，controller 会针对已知五分钟失败上界向上二分，直到找到配置中最高的通过点。各子运行复用同一份验证凭据，不会反复扫描完整数据库。只有 controller 脚本、结果契约、manifest、plan、二进制、数据 metadata、验证凭据、CPU 列表、端口、搜索策略和时长均未变化时，原 controller ID 才可恢复。
+
+预期的固定速率容量失败属于终态边界证据；provenance 一致时，`resume` 会直接复用，不会在 controller 重启后再次执行。缺失结果、过期验证、panic、runtime/sampler 错误和负载器故障仍会让 controller 非零退出。只有每个请求 CPU 都恰好生成一行正式结果后，controller 才写入完成摘要。
+
+controller 会为生成、验证、Keeper 与结果采集统一固定 `TZ=Asia/Shanghai`。数据集目录和 cell ID 从所选 manifest 及展开后的 plan 读取，因此兼容的自定义 manifest 不会继承参考数据集名称。
 
 ## 判定规则
 
@@ -133,14 +142,17 @@ Ingestion hard pass 必须同时满足：
 - 最终 durable ratio 至少 99%；
 - Redis inbox backlog 不增长；
 - Overview、Activity、Latency checkpoint 和 Identity 聚合追平；
-- 无 OOM、panic、SQLite busy、HTTP 错误或负载器 publish error。
+- 停止发送后 15 秒内完成追平；剩余 30 秒 drain 窗口只保留作诊断；
+- 无 OOM、panic 或负载器 publish error。
 
-Dashboard pass 先要求 hard pass，再要求六接口整体 p99 不超过 3000ms。Dashboard replay 为 1 req/s，先预热，再在 Realtime Overview、Overview 30d、Activity、Analysis、Request Events、Analysis Latency 30d 之间轮转。
+核心 Dashboard pass 先要求 hard pass，再要求核心 HTTP 错误为 0，并要求 Realtime Overview 60m、Overview 30d、Activity 30d、Analysis 30d 和 Request Events 30d 的整体 p99 不超过 3000ms；预热后以 1 req/s 轮询这五个接口。
 
-每个正式容量点持续 300 秒。短探测只选择候选，不进入最终容量结论。结果中的 `offered_events`、`published_events` 和 `durable_events` 分开记录，不能把负载器未达到目标速率误报为 Keeper 容量。
+Analysis Latency 30d 先预热一次，probe 期间每 30 秒请求一次，单独报告成功样本数、错误数、状态以及 p50/p95/p99/max。诊断错误不改变 ingestion 或核心 Dashboard 容量；OOM、panic 或其它 Keeper 全局故障仍会使本轮无效。
+
+每个正式容量点都以固定速率持续 300 秒。短时升压和边界探测只选择候选，不进入最终容量结论。controller 同时报告最高五分钟成功速率和最低已观察失败速率，因此容量结论是一个区间，而不是未经证明的绝对精确上限；失败边界为零表示在配置的速率矩阵内没有观察到失败。结果中的 `offered_events`、`published_events` 和 `durable_events` 分开记录，不能把负载器未达到目标速率误报为 Keeper 容量。
 
 ## 结果文件
 
-每个运行点生成 `run.json`、`results.jsonl`、`summary.json`、`summary.csv` 和 `report.md`；控制器额外生成汇总表 `controller.tsv`、环境规格 `environment.txt` 和容量摘要 `summary.md`。
+每个运行点生成 `run.json`、`results.jsonl`、`summary.json`、`summary.csv` 和 `report.md`；控制器额外生成 `controller-inputs.sha256`、`dataset-validation.json`、汇总表 `controller.tsv`、环境规格 `environment.txt` 和容量摘要 `summary.md`。
 
 当前正式测量结果见 [REPORT.zh.md](REPORT.zh.md)。

--- a/internal/benchmark/REPORT.md
+++ b/internal/benchmark/REPORT.md
@@ -1,0 +1,180 @@
+<p align="center">
+  <a href="./REPORT.md"><strong>English</strong></a> ｜ <a href="./REPORT.zh.md">简体中文</a>
+</p>
+
+# CPA Usage Keeper Capacity Benchmark Report
+
+Test date: 2026-08-07 (Asia/Shanghai)
+
+Suite: `capacity-v1`
+
+Dataset: `reference-2m`
+
+## Conclusions
+
+This benchmark reused the same SQLite database containing about 2.036 million events. Only Keeper CPU was limited; Keeper memory remained unlimited. Every formal capacity result comes from a five-minute fixed-rate run with ingestion and Dashboard traffic active concurrently.
+
+| Keeper CPU | Five-minute ingestion max | 3-second Dashboard max | Conservative sustained rate | CPU at ingestion max | Keeper cgroup peak memory | Recommended memory |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1C | 150 events/s | 100 events/s | Dashboard 70; ingestion-only 105 events/s | 57.3% | 304.4 MiB | 512 MiB |
+| 2C | 200 events/s | 200 events/s | 140 events/s | 35.9% | 417.0 MiB | 1 GiB |
+| 4C | 650 events/s | 650 events/s | 455 events/s | 29.5% | 1,078.2 MiB | 2 GiB |
+
+The default production recommendation is **2C / 1 GiB with sustained traffic no higher than 140 events/s**. On the reference dataset, this profile reached both the 200 events/s ingestion and Dashboard limits while maintaining materially lower page latency than the 4C maximum-capacity point.
+
+For higher traffic, use **4C / 2 GiB with sustained traffic no higher than 455 events/s**. At 4C/650, overall p99 was 1970.0ms and therefore met the three-second target, but core p95 reached 1387.6ms. This point should be treated as usable within three seconds, not as a low-latency configuration.
+
+For lightweight deployments, use **1C / 512 MiB**. The Dashboard recommendation is about 70 events/s. If concurrent Dashboard use is not required, an ingestion-only deployment can conservatively use about 105 events/s.
+
+Memory recommendations add deployment headroom to the observed peaks; they are not hard-cap validation results. Formal peak memory comes from cgroup v2 `memory.peak` and includes the Keeper process, SQLite mmap/page cache, and database cache charged to the Keeper cgroup.
+
+## Test Machine
+
+| Item | Configuration |
+| --- | --- |
+| Operating system | Debian GNU/Linux 13 |
+| Platform | Linux amd64 |
+| Virtualization | KVM |
+| CPU | Intel Xeon Gold 6138 |
+| Online logical CPUs | 4 vCPU |
+| Available physical memory | About 9.5 GiB |
+| Go | 1.26.2 |
+| GCC | 14.2.0 |
+| SQLite CLI | 3.46.1 |
+| Redis | 8.0.2 |
+
+The 1C, 2C, and 4C Keeper profiles used cgroup `cpu.max=100000/200000/400000 100000` and `AllowedCPUs=0/0-1/0-3`. All profiles used `memory.max=max` and `memory.swap.max=0`. Dataset generation, cloning, load generation, and result aggregation were outside the Keeper cgroup.
+
+For 1C and 2C, the load driver used the remaining CPUs. At 4C, Keeper and the load driver shared all four vCPUs. Raw results mark this as `shared_driver=true`, so the 4C figures should be treated as conservative whole-machine results.
+
+## Dataset
+
+| Item | Measured value |
+| --- | ---: |
+| Dataset ID | `reference-2m` |
+| Database size | 1,171,144,704 bytes (about 1.09 GiB) |
+| Total events | 2,035,740 |
+| Events in the latest 30 days | 1,226,326 |
+| Hot events in the latest 90 days | 1,946,550 |
+| Archived events | 89,190 |
+| Identities | 323 |
+| Models | 52 |
+| API keys | 27 |
+| `PRAGMA quick_check` | `ok` |
+| Semantic fingerprint | `eb9dc034942bd6fd16477e037452cb64324158cdf8b48d2671647e409d4ca8d2` |
+
+The dataset contains 1,226,326 events in the latest 30 days, 1,946,550 active events in the latest 90 days, and 89,190 archived events. This represents the storage, page-cache, rollup, and query load of a continuously running deployment.
+
+The 27 API keys are deterministically assigned to high-, medium-, and low-usage tiers in a 30%/50%/20% split. Per-key weights are 10:3:1, and events are normalized across those weights. All 323 identities, 52 models, and 27 API keys are referenced by events. The dataset also passed orphan-reference, token-semantics, derived rollup/checkpoint, and semantic-fingerprint validation.
+
+## Method and Pass Criteria
+
+- Each formal point created an independent working copy from the same canonical database, restarted Keeper, warmed six Dashboard endpoints sequentially, and then ran at a fixed rate for 300 seconds.
+- Offered load was published through Redis `usage`. Dashboard replay ran at 1 request/s and rotated through six real page endpoints.
+- An ingestion hard pass required at least 99.9% of target events to publish successfully, a final durable ratio of at least 99%, no backlog growth, caught-up Overview/Activity/Latency checkpoints and Identity aggregation, and no OOM, panic, SQLite busy, HTTP, or publish errors.
+- A Dashboard pass first required the hard pass and then required aggregate p99 across the six endpoints to remain within 3000ms.
+- Core p95 was retained as an experience indicator but was not a formal pass gate.
+- Capacity points were measured for five minutes. The 20-second search selected candidates only and did not become a final capacity limit.
+- Adjacent boundaries converged to a 25 events/s interval or an interval of approximately 10% or less.
+
+Every result table uses the ingestion hard pass and Dashboard overall p99 <=3000ms criteria above.
+
+## All Five-Minute Formal Points
+
+Each of the following 24 points independently restored the canonical database, restarted Keeper, and ran for 300 seconds. `Hard` covers ingestion, durability, checkpoint, and aggregation integrity. `Dashboard` additionally requires the three-second SLA.
+
+### 1C / Unlimited Memory
+
+| Rate | Hard | Dashboard | Durable / Offered | Durable | CPU | Peak memory | Core p95 | Overall p99 | Failure reason |
+| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 25 | Pass | Pass | 7,500 / 7,500 | 100% | 47.4% | 174.0 MiB | 274.8ms | 2,586.7ms | — |
+| 50 | Pass | Pass | 15,000 / 15,000 | 100% | 49.4% | 193.1 MiB | 316.3ms | 2,602.0ms | — |
+| 75 | Pass | Pass | 22,500 / 22,500 | 100% | 50.0% | 248.0 MiB | 376.3ms | 2,717.1ms | — |
+| 100 | Pass | Pass | 30,000 / 30,000 | 100% | 53.0% | 290.7 MiB | 465.7ms | 2,892.5ms | — |
+| 150 | Pass | Fail | 45,000 / 45,000 | 100% | 57.3% | 304.4 MiB | 593.0ms | 3,917.1ms | overall p99 >3s |
+| 200 | Fail | Fail | 53,972 / 60,000 | 89.95% | 58.2% | 328.7 MiB | 613.6ms | 3,549.3ms | durable, overall p99 |
+| 250 | Fail | Fail | 59,894 / 75,000 | 79.86% | 59.8% | 417.2 MiB | 718.1ms | 3,751.1ms | durable, overall p99 |
+| 500 | Fail | Fail | 74,441 / 150,000 | 49.63% | 63.1% | 453.0 MiB | 891.0ms | 5,061.7ms | durable, overall p99 |
+| 1,000 | Fail | Fail | 117,279 / 300,000 | 39.09% | 79.8% | 756.5 MiB | 2,187.7ms | 6,200.1ms | durable, overall p99 |
+| 3,000 | Fail | Fail | 264,819 / 900,000 | 29.42% | 86.2% | 1,705.7 MiB | 4,834.3ms | 8,793.5ms | errors, durable, backlog, checkpoint, Identity, overall p99 |
+
+At 1C, 25, 50, 75, and 100 events/s all met the three-second target. The highest Dashboard pass was 100 events/s. At 150 events/s, all events were durable, but overall p99 increased to 3917.1ms.
+
+### 2C / Unlimited Memory
+
+| Rate | Hard | Dashboard | Durable / Offered | Durable | CPU | Peak memory | Core p95 | Overall p99 | Failure reason |
+| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 200 | Pass | Pass | 60,000 / 60,000 | 100% | 35.9% | 417.0 MiB | 449.3ms | 2,085.8ms | — |
+| 225 | Fail | Fail | 60,741 / 67,500 | 89.99% | 35.6% | 378.2 MiB | 447.8ms | 2,065.0ms | durable |
+| 250 | Fail | Fail | 72,522 / 75,000 | 96.70% | 37.9% | 479.1 MiB | 548.3ms | 2,102.9ms | durable |
+| 300 | Fail | Fail | 80,969 / 90,000 | 89.97% | 39.2% | 454.2 MiB | 589.2ms | 2,196.9ms | durable |
+
+The 2C boundary was clear: 200 events/s passed all criteria, while 225 events/s already failed durable throughput. The failed points did not OOM, so additional memory alone would not move this boundary.
+
+### 4C / Unlimited Memory
+
+| Rate | Hard | Dashboard | Durable / Offered | Durable | CPU | Peak memory | Core p95 | Overall p99 | Failure reason |
+| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 200 | Pass | Pass | 60,000 / 60,000 | 100% | 18.9% | 326.4 MiB | 434.6ms | 1,947.4ms | — |
+| 250 | Pass | Pass | 74,999 / 75,000 | 99.999% | 20.2% | 383.5 MiB | 498.8ms | 1,947.8ms | — |
+| 275 | Pass | Pass | 82,500 / 82,500 | 100% | 20.7% | 435.2 MiB | 556.7ms | 1,973.6ms | — |
+| 300 | Pass | Pass | 90,000 / 90,000 | 100% | 21.4% | 499.8 MiB | 588.4ms | 1,953.7ms | — |
+| 400 | Pass | Pass | 120,000 / 120,000 | 100% | 24.1% | 654.3 MiB | 744.7ms | 1,945.0ms | — |
+| 500 | Pass | Pass | 150,000 / 150,000 | 100% | 25.2% | 661.5 MiB | 978.3ms | 1,974.7ms | — |
+| 600 | Pass | Pass | 180,000 / 180,000 | 100% | 28.4% | 985.9 MiB | 1,130.8ms | 1,964.7ms | — |
+| 650 | Pass | Pass | 195,000 / 195,000 | 100% | 29.5% | 1,078.2 MiB | 1,387.6ms | 1,970.0ms | — |
+| 675 | Fail | Fail | 182,212 / 202,500 | 89.98% | 30.1% | 979.5 MiB | 1,229.5ms | 1,991.5ms | durable |
+| 750 | Fail | Fail | 225,000 / 225,000 | 100% | 30.0% | 1,321.2 MiB | 1,527.8ms | 1,987.1ms | checkpoint lag=39,762 |
+
+The 4C/750 result shows why counting durable `usage_events` alone overstates capacity: all 225,000 events were durable, but the rollup checkpoint still lagged by 39,762 events, so the hard pass failed.
+
+## Ingestion Boundary
+
+| CPU | Highest pass | First adjacent failure | Durable at pass | Failure reason | CPU at pass | Keeper cgroup peak memory |
+| --- | ---: | ---: | ---: | --- | ---: | ---: |
+| 1C | 150 | 200 | 45,000 / 45,000 | 200 persisted only 53,972 / 60,000 | 57.3% | 304.4 MiB |
+| 2C | 200 | 225 | 60,000 / 60,000 | 225 persisted only 60,741 / 67,500 | 35.9% | 417.0 MiB |
+| 4C | 650 | 675 | 195,000 / 195,000 | 675 persisted only 182,212 / 202,500 | 29.5% | 1,078.2 MiB |
+
+CPU utilization is normalized by the CPUs assigned to Keeper. Therefore, 29.5% at 4C/650 corresponds to approximately 1.18 logical CPUs of total CPU time. Every formal point used unlimited memory. The failed points did not OOM; the primary limits were durable/rollup throughput and Dashboard latency under higher traffic.
+
+## Dashboard Assessment
+
+| CPU | Evaluated rate | Hard | Keeper cgroup peak memory | Core p95 | Overall p99 | Slowest endpoint p99 | Conclusion |
+| --- | ---: | --- | ---: | ---: | ---: | ---: | --- |
+| 1C | 100 events/s | Pass | 290.7 MiB | 465.7ms | 2,892.5ms | Analysis Latency 2,946.8ms | Pass; p99 at 150 was 3,917.1ms |
+| 2C | 200 events/s | Pass | 417.0 MiB | 449.3ms | 2,085.8ms | Analysis Latency 2,114.9ms | Pass; ingestion already failed at 225 |
+| 4C | 650 events/s | Pass | 1,078.2 MiB | 1,387.6ms | 1,970.0ms | Analysis Latency 2,008.3ms | Passes within three seconds, but is not a low-latency point |
+
+Steady-state per-endpoint latency at 4C/650:
+
+| Endpoint | p50 | p95 | p99 |
+| --- | ---: | ---: | ---: |
+| Analysis | 1.6ms | 1.8ms | 1.8ms |
+| Request Events | 147.1ms | 171.5ms | 193.8ms |
+| Activity | 171.0ms | 209.0ms | 245.9ms |
+| Realtime Overview | 589.5ms | 1,447.2ms | 1,729.2ms |
+| Overview 30d | 717.0ms | 1,498.4ms | 1,550.7ms |
+| Analysis Latency 30d | 1,902.8ms | 1,970.0ms | 2,008.3ms |
+
+If the deployment goal is faster pages rather than merely staying within three seconds, retain more headroom below the capacity limit and continue monitoring core p95.
+
+## Scale-up Gains
+
+- 1C → 2C: ingestion max increased from 150 to 200 (+33%), and the three-second Dashboard max increased from 100 to 200. Peak memory increased from 304.4 MiB to 417.0 MiB.
+- 2C → 4C: ingestion and Dashboard max increased from 200 to 650 (3.25x). Peak memory increased to about 1.05 GiB.
+- Increasing available memory alone does not automatically increase capacity. The formal points already used unlimited memory; failures came from durable throughput, checkpoint lag, or the Dashboard SLA.
+- For the reference dataset, 2C is the default balance between throughput, latency, and memory. 4C provides higher throughput but materially increases core page p95.
+
+## Limitations
+
+- Each final boundary has one five-minute formal run. The suite did not repeat each point or run a 24-hour soak. These results support capacity planning but do not prove a long-term SLO.
+- At 4C, Keeper shared the host CPUs with the load driver, making the result conservative.
+- No 256/512/768/1024 MiB hard cap was applied. The report can provide observed peak memory and recommendations with headroom, but it cannot claim a verified minimum startup memory.
+- events/s represents five-minute sustained traffic on a database preloaded with about 2.036 million historical events. It cannot be multiplied directly by 30 days as a safe monthly capacity because query and aggregation costs will change as the database grows.
+- Conclusions apply only to the recorded hardware specification, dataset fingerprint, binary, and method.
+
+## Reproducibility
+
+- Keeper binary SHA-256: `4782fc7bfacc1c72667436e4d4471cd26755ed2ae192173beff77bcae4bd27d6`
+- Dataset semantic fingerprint: `eb9dc034942bd6fd16477e037452cb64324158cdf8b48d2671647e409d4ca8d2`

--- a/internal/benchmark/REPORT.md
+++ b/internal/benchmark/REPORT.md
@@ -4,177 +4,187 @@
 
 # CPA Usage Keeper Capacity Benchmark Report
 
-Test date: 2026-08-07 (Asia/Shanghai)
+Test date: 2026-08-10 (Asia/Shanghai)
 
 Suite: `capacity-v1`
 
-Dataset: `reference-2m`
+Dataset: `reference-3m`
 
-## Conclusions
+Platform: Linux amd64
 
-This benchmark reused the same SQLite database containing about 2.036 million events. Only Keeper CPU was limited; Keeper memory remained unlimited. Every formal capacity result comes from a five-minute fixed-rate run with ingestion and Dashboard traffic active concurrently.
+## Executive Summary
 
-| Keeper CPU | Five-minute ingestion max | 3-second Dashboard max | Conservative sustained rate | CPU at ingestion max | Keeper cgroup peak memory | Recommended memory |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1C | 150 events/s | 100 events/s | Dashboard 70; ingestion-only 105 events/s | 57.3% | 304.4 MiB | 512 MiB |
-| 2C | 200 events/s | 200 events/s | 140 events/s | 35.9% | 417.0 MiB | 1 GiB |
-| 4C | 650 events/s | 650 events/s | 455 events/s | 29.5% | 1,078.2 MiB | 2 GiB |
+Every formal point reused the same validated SQLite database and changed only the CPU available to Keeper: 1C, 2C, or 4C. The database contains 3,205,740 active events across 90 days; the validation anchor used by this campaign placed 1,201,775 events in the queried 30-day window. Keeper memory was unlimited, and the reported cgroup peak includes Keeper, SQLite pages, and database cache charged to that cgroup.
 
-The default production recommendation is **2C / 1 GiB with sustained traffic no higher than 140 events/s**. On the reference dataset, this profile reached both the 200 events/s ingestion and Dashboard limits while maintaining materially lower page latency than the 4C maximum-capacity point.
+Capacity uses five Core Dashboard endpoints under a three-second aggregate p99 gate. Analysis Latency 30d is measured separately every 30 seconds because it is a heavier diagnostic query. Its latency does not decide Core Dashboard capacity, while errors, OOM, panic, and SQLite failures remain visible.
 
-For higher traffic, use **4C / 2 GiB with sustained traffic no higher than 455 events/s**. At 4C/650, overall p99 was 1970.0ms and therefore met the three-second target, but core p95 reached 1387.6ms. This point should be treated as usable within three seconds, not as a low-latency configuration.
+| Keeper CPU | Five-minute pass / lowest fail | 70% sustained recommendation | Core Dashboard p99 at pass | Analysis Latency p99 at pass | Peak memory at pass | Deployment guidance |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| 1C | 150 / 200 events/s | 105 events/s | 858.4ms | 5109.1ms | 472.9 MiB | 1C / 768 MiB, up to 105 sustained events/s |
+| 2C | 200 / 250 events/s | 140 events/s | 627.1ms | 3075.9ms | 522.2 MiB | 2C / 1 GiB, up to 140 sustained events/s |
+| 4C | 500 / 600 events/s | 350 events/s | 1323.0ms | 3044.6ms | 995.7 MiB | 4C / 2 GiB, up to 350 sustained events/s |
 
-For lightweight deployments, use **1C / 512 MiB**. The Dashboard recommendation is about 70 events/s. If concurrent Dashboard use is not required, an ingestion-only deployment can conservatively use about 105 events/s.
+The strongest verified profile is **4C / 2 GiB at no more than 350 sustained events/s**. The measured 500 events/s point durably stored 149,998 of 150,000 offered events and caught up in 14.63 seconds. At 600 events/s, all 179,998 published events were durable, but 12,266 aggregation checkpoint rows remained after the full 30-second drain window.
 
-Memory recommendations add deployment headroom to the observed peaks; they are not hard-cap validation results. Formal peak memory comes from cgroup v2 `memory.peak` and includes the Keeper process, SQLite mmap/page cache, and database cache charged to the Keeper cgroup.
+The 1C and 2C failure boundaries were durable-throughput failures rather than Dashboard failures. All six formal points kept Core Dashboard p99 below 1.6 seconds, including the failing ingestion boundaries. Additional CPU therefore improves capacity, but SQLite ingestion and derived-state catch-up limit scaling before the assigned CPU quota is saturated.
+
+These are five-minute sustained measurements, not instantaneous peaks or exact absolute maxima. The recommendation is 70% of the highest verified full-stack pass.
 
 ## Test Machine
 
-| Item | Configuration |
+| Item | Specification |
 | --- | --- |
 | Operating system | Debian GNU/Linux 13 |
-| Platform | Linux amd64 |
-| Virtualization | KVM |
-| CPU | Intel Xeon Gold 6138 |
+| Kernel | 6.12.90+deb13.1-cloud-amd64 |
+| Architecture | Linux amd64 |
+| Virtualization | KVM, full virtualization |
+| CPU | Intel Xeon Gold 6138 @ 2.00GHz |
+| Topology | 1 socket, 4 cores, 1 thread per core |
 | Online logical CPUs | 4 vCPU |
-| Available physical memory | About 9.5 GiB |
+| Visible memory | 9,948,040 KiB (about 9.49 GiB) |
 | Go | 1.26.2 |
 | GCC | 14.2.0 |
 | SQLite CLI | 3.46.1 |
 | Redis | 8.0.2 |
 
-The 1C, 2C, and 4C Keeper profiles used cgroup `cpu.max=100000/200000/400000 100000` and `AllowedCPUs=0/0-1/0-3`. All profiles used `memory.max=max` and `memory.swap.max=0`. Dataset generation, cloning, load generation, and result aggregation were outside the Keeper cgroup.
+Keeper received a cgroup quota equivalent to 1, 2, or 4 cores and was bound to CPU `0`, `0-1`, or `0-3`. Every profile used `memory.max=max` and `memory.swap.max=0`.
 
-For 1C and 2C, the load driver used the remaining CPUs. At 4C, Keeper and the load driver shared all four vCPUs. Raw results mark this as `shared_driver=true`, so the 4C figures should be treated as conservative whole-machine results.
+Dataset preparation was unrestricted. Database cloning, Redis publishing, and result collection ran outside the Keeper cgroup. The 1C and 2C drivers used CPUs outside Keeper's binding; the 4C profile shared all four vCPUs with the load driver and is therefore a conservative whole-machine measurement.
 
-## Dataset
+CPU utilization is normalized to Keeper's assigned quota. The passing profiles averaged 49.3% of 1C, 35.7% of 2C, and 27.2% of 4C, equivalent to approximately 0.49, 0.71, and 1.09 logical cores.
 
-| Item | Measured value |
+## Reference Dataset
+
+| Item | Validated value |
 | --- | ---: |
-| Dataset ID | `reference-2m` |
-| Database size | 1,171,144,704 bytes (about 1.09 GiB) |
-| Total events | 2,035,740 |
-| Events in the latest 30 days | 1,226,326 |
-| Hot events in the latest 90 days | 1,946,550 |
-| Archived events | 89,190 |
-| Identities | 323 |
-| Models | 52 |
-| API keys | 27 |
+| Database size | 2,044,776,448 bytes (about 1.90 GiB) |
+| Active 90-day events | 3,205,740 |
+| Events in the formal 30-day query window | 1,201,775 |
+| Archived events | 0 |
+| Failed events | 31,831 (0.993%) |
+| Identities | 500 used / 500 total |
+| Models | 50 used / 50 total |
+| API keys | 50 used / 50 total |
+| Orphan identity/model/API-key references | 0 / 0 / 0 |
 | `PRAGMA quick_check` | `ok` |
-| Semantic fingerprint | `eb9dc034942bd6fd16477e037452cb64324158cdf8b48d2671647e409d4ca8d2` |
+| Semantic fingerprint | `4b2b14e41bf7aaf91455fc1c3d9a2fe95ca45403d5448e2de17f08d969316f0b` |
 
-The dataset contains 1,226,326 events in the latest 30 days, 1,946,550 active events in the latest 90 days, and 89,190 archived events. This represents the storage, page-cache, rollup, and query load of a continuously running deployment.
+The active table covers a complete 90-day history. The archive is intentionally empty because the production Dashboard paths in this suite do not query cold events. Every identity, model, and API key is referenced by events.
 
-The 27 API keys are deterministically assigned to high-, medium-, and low-usage tiers in a 30%/50%/20% split. Per-key weights are 10:3:1, and events are normalized across those weights. All 323 identities, 52 models, and 27 API keys are referenced by events. The dataset also passed orphan-reference, token-semantics, derived rollup/checkpoint, and semantic-fingerprint validation.
+| API-key tier | API keys | Key share | Events | Event share |
+| --- | ---: | ---: | ---: | ---: |
+| High usage | 15 | 30% | 2,051,847 | 64.01% |
+| Medium usage | 25 | 50% | 1,018,187 | 31.76% |
+| Low usage | 10 | 20% | 135,706 | 4.23% |
+
+Per-key generation weights are 10:3:1. The intentionally skewed distribution represents a minority of high-usage keys rather than concentrating traffic on one key.
+
+Before every point, the suite created a new byte-for-byte clone of the canonical database, synced it, and evicted it from the controller page cache. Failed points could not carry backlog, WAL, or warmed SQLite pages into the next run.
 
 ## Method and Pass Criteria
 
-- Each formal point created an independent working copy from the same canonical database, restarted Keeper, warmed six Dashboard endpoints sequentially, and then ran at a fixed rate for 300 seconds.
-- Offered load was published through Redis `usage`. Dashboard replay ran at 1 request/s and rotated through six real page endpoints.
-- An ingestion hard pass required at least 99.9% of target events to publish successfully, a final durable ratio of at least 99%, no backlog growth, caught-up Overview/Activity/Latency checkpoints and Identity aggregation, and no OOM, panic, SQLite busy, HTTP, or publish errors.
-- A Dashboard pass first required the hard pass and then required aggregate p99 across the six endpoints to remain within 3000ms.
-- Core p95 was retained as an experience indicator but was not a formal pass gate.
-- Capacity points were measured for five minutes. The 20-second search selected candidates only and did not become a final capacity limit.
-- Adjacent boundaries converged to a 25 events/s interval or an interval of approximately 10% or less.
+- Each formal point started a fresh Keeper process against an independent database clone, warmed all Dashboard paths, and sustained the selected rate for 300 seconds.
+- Events were published through Redis. Core Dashboard replay ran at 1 request/s across Realtime Overview 60m, Overview 30d, Activity 30d, Analysis 30d, and Request Events 30d.
+- Analysis Latency 30d was warmed once and then requested every 30 seconds. Each formal point produced nine successful diagnostic samples.
+- An ingestion hard pass required at least 99.9% successful publication, at least 99% final durable throughput, no growing backlog, caught-up Overview/Activity/Latency checkpoints and Identity aggregation, no OOM, panic, or publisher error, and catch-up within 15 seconds.
+- A Core Dashboard pass first required the ingestion hard pass, then required zero Core HTTP errors and aggregate p99 at or below 3000ms.
+- Analysis Latency errors and percentiles were evaluated separately. A diagnostic error did not relabel ingestion or Core Dashboard capacity.
+- Short probes selected candidates only. Only the six five-minute boundary points below contribute to capacity conclusions.
+- The sustained recommendation is 70% of the highest verified full-stack pass, rounded down to an integer events/s.
 
-Every result table uses the ingestion hard pass and Dashboard overall p99 <=3000ms criteria above.
+## Capacity Boundaries
 
-## All Five-Minute Formal Points
+| CPU | Highest pass | Lowest fail | Durable at pass | Catch-up at pass | CPU at pass | Peak memory at pass | Failure evidence |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 1C | 150 | 200 | 45,000 / 45,000 | 5.37s | 49.3% | 472.9 MiB | 200 stored 53,969 / 60,000 |
+| 2C | 200 | 250 | 60,000 / 60,000 | 3.24s | 35.7% | 522.2 MiB | 250 stored 71,597 / 75,000 |
+| 4C | 500 | 600 | 149,998 / 150,000 | 14.63s | 27.2% | 995.7 MiB | 600 retained 12,266 checkpoint lag after 30.07s |
 
-Each of the following 24 points independently restored the canonical database, restarted Keeper, and ran for 300 seconds. `Hard` covers ingestion, durability, checkpoint, and aggregation integrity. `Dashboard` additionally requires the three-second SLA.
+No formal point OOMed. Increasing memory alone would not resolve these observed boundaries: 1C/2C failures came from durable throughput, while the 4C failure came from derived-state catch-up.
 
-### 1C / Unlimited Memory
+## Core Dashboard Assessment
 
-| Rate | Hard | Dashboard | Durable / Offered | Durable | CPU | Peak memory | Core p95 | Overall p99 | Failure reason |
-| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| 25 | Pass | Pass | 7,500 / 7,500 | 100% | 47.4% | 174.0 MiB | 274.8ms | 2,586.7ms | — |
-| 50 | Pass | Pass | 15,000 / 15,000 | 100% | 49.4% | 193.1 MiB | 316.3ms | 2,602.0ms | — |
-| 75 | Pass | Pass | 22,500 / 22,500 | 100% | 50.0% | 248.0 MiB | 376.3ms | 2,717.1ms | — |
-| 100 | Pass | Pass | 30,000 / 30,000 | 100% | 53.0% | 290.7 MiB | 465.7ms | 2,892.5ms | — |
-| 150 | Pass | Fail | 45,000 / 45,000 | 100% | 57.3% | 304.4 MiB | 593.0ms | 3,917.1ms | overall p99 >3s |
-| 200 | Fail | Fail | 53,972 / 60,000 | 89.95% | 58.2% | 328.7 MiB | 613.6ms | 3,549.3ms | durable, overall p99 |
-| 250 | Fail | Fail | 59,894 / 75,000 | 79.86% | 59.8% | 417.2 MiB | 718.1ms | 3,751.1ms | durable, overall p99 |
-| 500 | Fail | Fail | 74,441 / 150,000 | 49.63% | 63.1% | 453.0 MiB | 891.0ms | 5,061.7ms | durable, overall p99 |
-| 1,000 | Fail | Fail | 117,279 / 300,000 | 39.09% | 79.8% | 756.5 MiB | 2,187.7ms | 6,200.1ms | durable, overall p99 |
-| 3,000 | Fail | Fail | 264,819 / 900,000 | 29.42% | 86.2% | 1,705.7 MiB | 4,834.3ms | 8,793.5ms | errors, durable, backlog, checkpoint, Identity, overall p99 |
+| CPU | Pass rate | Samples | Aggregate p50 | Aggregate p95 | Aggregate p99 | Slowest endpoint p99 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1C | 150 events/s | 299 | 299.9ms | 639.4ms | 858.4ms | Overview 30d: 961.8ms |
+| 2C | 200 events/s | 299 | 297.9ms | 532.1ms | 627.1ms | Analysis 30d: 649.7ms |
+| 4C | 500 events/s | 299 | 339.6ms | 938.2ms | 1323.0ms | Overview 30d: 1469.6ms |
 
-At 1C, 25, 50, 75, and 100 events/s all met the three-second target. The highest Dashboard pass was 100 events/s. At 150 events/s, all events were durable, but overall p99 increased to 3917.1ms.
+### Endpoint latency at each passing boundary
 
-### 2C / Unlimited Memory
-
-| Rate | Hard | Dashboard | Durable / Offered | Durable | CPU | Peak memory | Core p95 | Overall p99 | Failure reason |
-| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| 200 | Pass | Pass | 60,000 / 60,000 | 100% | 35.9% | 417.0 MiB | 449.3ms | 2,085.8ms | — |
-| 225 | Fail | Fail | 60,741 / 67,500 | 89.99% | 35.6% | 378.2 MiB | 447.8ms | 2,065.0ms | durable |
-| 250 | Fail | Fail | 72,522 / 75,000 | 96.70% | 37.9% | 479.1 MiB | 548.3ms | 2,102.9ms | durable |
-| 300 | Fail | Fail | 80,969 / 90,000 | 89.97% | 39.2% | 454.2 MiB | 589.2ms | 2,196.9ms | durable |
-
-The 2C boundary was clear: 200 events/s passed all criteria, while 225 events/s already failed durable throughput. The failed points did not OOM, so additional memory alone would not move this boundary.
-
-### 4C / Unlimited Memory
-
-| Rate | Hard | Dashboard | Durable / Offered | Durable | CPU | Peak memory | Core p95 | Overall p99 | Failure reason |
-| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| 200 | Pass | Pass | 60,000 / 60,000 | 100% | 18.9% | 326.4 MiB | 434.6ms | 1,947.4ms | — |
-| 250 | Pass | Pass | 74,999 / 75,000 | 99.999% | 20.2% | 383.5 MiB | 498.8ms | 1,947.8ms | — |
-| 275 | Pass | Pass | 82,500 / 82,500 | 100% | 20.7% | 435.2 MiB | 556.7ms | 1,973.6ms | — |
-| 300 | Pass | Pass | 90,000 / 90,000 | 100% | 21.4% | 499.8 MiB | 588.4ms | 1,953.7ms | — |
-| 400 | Pass | Pass | 120,000 / 120,000 | 100% | 24.1% | 654.3 MiB | 744.7ms | 1,945.0ms | — |
-| 500 | Pass | Pass | 150,000 / 150,000 | 100% | 25.2% | 661.5 MiB | 978.3ms | 1,974.7ms | — |
-| 600 | Pass | Pass | 180,000 / 180,000 | 100% | 28.4% | 985.9 MiB | 1,130.8ms | 1,964.7ms | — |
-| 650 | Pass | Pass | 195,000 / 195,000 | 100% | 29.5% | 1,078.2 MiB | 1,387.6ms | 1,970.0ms | — |
-| 675 | Fail | Fail | 182,212 / 202,500 | 89.98% | 30.1% | 979.5 MiB | 1,229.5ms | 1,991.5ms | durable |
-| 750 | Fail | Fail | 225,000 / 225,000 | 100% | 30.0% | 1,321.2 MiB | 1,527.8ms | 1,987.1ms | checkpoint lag=39,762 |
-
-The 4C/750 result shows why counting durable `usage_events` alone overstates capacity: all 225,000 events were durable, but the rollup checkpoint still lagged by 39,762 events, so the hard pass failed.
-
-## Ingestion Boundary
-
-| CPU | Highest pass | First adjacent failure | Durable at pass | Failure reason | CPU at pass | Keeper cgroup peak memory |
-| --- | ---: | ---: | ---: | --- | ---: | ---: |
-| 1C | 150 | 200 | 45,000 / 45,000 | 200 persisted only 53,972 / 60,000 | 57.3% | 304.4 MiB |
-| 2C | 200 | 225 | 60,000 / 60,000 | 225 persisted only 60,741 / 67,500 | 35.9% | 417.0 MiB |
-| 4C | 650 | 675 | 195,000 / 195,000 | 675 persisted only 182,212 / 202,500 | 29.5% | 1,078.2 MiB |
-
-CPU utilization is normalized by the CPUs assigned to Keeper. Therefore, 29.5% at 4C/650 corresponds to approximately 1.18 logical CPUs of total CPU time. Every formal point used unlimited memory. The failed points did not OOM; the primary limits were durable/rollup throughput and Dashboard latency under higher traffic.
-
-## Dashboard Assessment
-
-| CPU | Evaluated rate | Hard | Keeper cgroup peak memory | Core p95 | Overall p99 | Slowest endpoint p99 | Conclusion |
-| --- | ---: | --- | ---: | ---: | ---: | ---: | --- |
-| 1C | 100 events/s | Pass | 290.7 MiB | 465.7ms | 2,892.5ms | Analysis Latency 2,946.8ms | Pass; p99 at 150 was 3,917.1ms |
-| 2C | 200 events/s | Pass | 417.0 MiB | 449.3ms | 2,085.8ms | Analysis Latency 2,114.9ms | Pass; ingestion already failed at 225 |
-| 4C | 650 events/s | Pass | 1,078.2 MiB | 1,387.6ms | 1,970.0ms | Analysis Latency 2,008.3ms | Passes within three seconds, but is not a low-latency point |
-
-Steady-state per-endpoint latency at 4C/650:
-
-| Endpoint | p50 | p95 | p99 |
+| Endpoint | 1C/150 p50 / p95 / p99 | 2C/200 p50 / p95 / p99 | 4C/500 p50 / p95 / p99 |
 | --- | ---: | ---: | ---: |
-| Analysis | 1.6ms | 1.8ms | 1.8ms |
-| Request Events | 147.1ms | 171.5ms | 193.8ms |
-| Activity | 171.0ms | 209.0ms | 245.9ms |
-| Realtime Overview | 589.5ms | 1,447.2ms | 1,729.2ms |
-| Overview 30d | 717.0ms | 1,498.4ms | 1,550.7ms |
-| Analysis Latency 30d | 1,902.8ms | 1,970.0ms | 2,008.3ms |
+| Realtime Overview 60m | 204.5 / 585.3 / 668.9ms | 202.6 / 389.0 / 438.5ms | 422.0 / 895.9 / 1160.1ms |
+| Overview 30d | 353.7 / 710.3 / 961.8ms | 338.0 / 565.5 / 592.8ms | 604.8 / 1165.5 / 1469.6ms |
+| Activity 30d | 262.9 / 523.4 / 582.2ms | 309.0 / 345.4 / 364.7ms | 309.9 / 348.6 / 393.3ms |
+| Analysis 30d | 454.5 / 771.9 / 889.3ms | 497.5 / 623.0 / 649.7ms | 504.7 / 578.0 / 593.3ms |
+| Request Events 30d | 148.2 / 333.2 / 444.5ms | 146.6 / 173.2 / 247.4ms | 152.8 / 182.7 / 190.1ms |
 
-If the deployment goal is faster pages rather than merely staying within three seconds, retain more headroom below the capacity limit and continue monitoring core p95.
+Core Dashboard was not the limiting gate in this campaign. Every passing and failing ingestion boundary stayed well below the three-second Core p99 threshold.
 
-## Scale-up Gains
+## Analysis Latency Diagnostics
 
-- 1C → 2C: ingestion max increased from 150 to 200 (+33%), and the three-second Dashboard max increased from 100 to 200. Peak memory increased from 304.4 MiB to 417.0 MiB.
-- 2C → 4C: ingestion and Dashboard max increased from 200 to 650 (3.25x). Peak memory increased to about 1.05 GiB.
-- Increasing available memory alone does not automatically increase capacity. The formal points already used unlimited memory; failures came from durable throughput, checkpoint lag, or the Dashboard SLA.
-- For the reference dataset, 2C is the default balance between throughput, latency, and memory. 4C provides higher throughput but materially increases core page p95.
+| CPU / pass rate | Successful samples | Errors | Status | p50 | p95 | p99 | Max |
+| --- | ---: | ---: | --- | ---: | ---: | ---: | ---: |
+| 1C / 150 | 9 | 0 | Passed | 4453.6ms | 5109.1ms | 5109.1ms | 5109.1ms |
+| 2C / 200 | 9 | 0 | Passed | 2706.1ms | 3075.9ms | 3075.9ms | 3075.9ms |
+| 4C / 500 | 9 | 0 | Passed | 2802.1ms | 3044.6ms | 3044.6ms | 3044.6ms |
+
+Analysis Latency is intentionally outside the Core Dashboard three-second gate. It merges retained latency sketches and sample points across the selected 30-day range, so it is materially heavier than the other Dashboard paths at this dataset size.
+
+Only nine diagnostic requests complete in a five-minute point at a 30-second interval. Nearest-rank p95 and p99 therefore equal the maximum observation and should be read as bounded run evidence, not as a statistically precise production SLO.
+
+## Identity Cardinality Direction (Exploratory)
+
+A separate five-minute 1C comparison used 3,205,740 active events, 50 models, 50 API keys, unlimited memory, and 1 event/s while reducing identities from 500 to 50. The queried 30-day windows differed by about 1% because the runs used different time anchors. It predates the formal diagnostic cadence and is directional evidence, not a new capacity boundary.
+
+| Metric | 500 identities | 50 identities | Observed change |
+| --- | ---: | ---: | ---: |
+| Core Dashboard aggregate p99 | 521.3ms | 277.4ms | -46.8% |
+| Analysis 30d p99 | 557.6ms | 223.0ms | -60.0% |
+| Analysis Latency 30d p99 | 3384.8ms | 3225.9ms | -4.7% |
+| CPU utilization, normalized to 1C | 64.4% | 56.0% | -8.5 percentage points |
+| Peak memory | 310.8 MiB | 251.3 MiB | -59.5 MiB |
+
+Lower identity cardinality can materially reduce Core Dashboard work and memory for lighter installations. Analysis Latency changes much less because its retained statistics are keyed by API group rather than identity. This direction does not change the formal capacity or hardware recommendations above.
+
+## Boundary Evidence
+
+| CPU | Rate | Hard pass | Core Dashboard pass | Diagnostic status | Durable / offered | Catch-up | Peak memory | Core p99 | Reason |
+| --- | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+| 1C | 150 | Yes | Yes | Passed | 45,000 / 45,000 | 5.37s | 472.9 MiB | 858.4ms | — |
+| 1C | 200 | No | No | Passed | 53,969 / 60,000 | 3.37s | 471.9 MiB | 786.7ms | `durable_throughput` |
+| 2C | 200 | Yes | Yes | Passed | 60,000 / 60,000 | 3.24s | 522.2 MiB | 627.1ms | — |
+| 2C | 250 | No | No | Passed | 71,597 / 75,000 | 0.00s | 589.6 MiB | 708.8ms | `durable_throughput` |
+| 4C | 500 | Yes | Yes | Passed | 149,998 / 150,000 | 14.63s | 995.7 MiB | 1323.0ms | — |
+| 4C | 600 | No | No | Passed | 179,998 / 180,000 | 30.07s | 1044.3 MiB | 1415.4ms | `drain_lag`, `checkpoint_lag` |
+
+## Capacity Planning Guidance
+
+- **Light deployment:** 1C / 768 MiB, no more than 105 sustained events/s.
+- **Medium deployment:** 2C / 1 GiB, no more than 140 sustained events/s.
+- **Higher-throughput deployment:** 4C / 2 GiB, no more than 350 sustained events/s.
+- Size memory from the observed cgroup peak plus deployment headroom. These are not finite hard-cap startup tests.
+- Do not treat additional memory alone as a throughput upgrade; no capacity failure was caused by OOM.
+- Do not linearly extrapolate beyond 4C or 500 events/s. SQLite writes, Redis-to-SQLite durability, derived-state catch-up, and shared-driver contention limit scaling first.
 
 ## Limitations
 
-- Each final boundary has one five-minute formal run. The suite did not repeat each point or run a 24-hour soak. These results support capacity planning but do not prove a long-term SLO.
-- At 4C, Keeper shared the host CPUs with the load driver, making the result conservative.
-- No 256/512/768/1024 MiB hard cap was applied. The report can provide observed peak memory and recommendations with headroom, but it cannot claim a verified minimum startup memory.
-- events/s represents five-minute sustained traffic on a database preloaded with about 2.036 million historical events. It cannot be multiplied directly by 30 days as a safe monthly capacity because query and aggregation costs will change as the database grows.
-- Conclusions apply only to the recorded hardware specification, dataset fingerprint, binary, and method.
+- Each reported boundary point has one five-minute formal run; the campaign did not repeat every boundary or perform a 24-hour soak.
+- Analysis Latency has nine successful samples per formal point, so its high percentiles are observational.
+- The 4C profile shares host CPUs with the load driver and is conservative but more host-dependent.
+- No 256/512/768/1024 MiB memory hard cap was applied. Memory guidance is observed peak plus headroom, not a verified minimum.
+- The generated database covers 90 active days. The Dashboard workload queries production 30-day and realtime paths; archive/cold-table performance is outside scope.
+- Five-minute sustained events/s on a preloaded history cannot be multiplied by time to claim a contractual monthly capacity.
+- A prior campaign that replayed Analysis Latency as frequently as Core Dashboard endpoints is retained as stress evidence but is superseded for production capacity recommendations.
+- The identity-cardinality comparison is exploratory and does not revise the formal capacity boundaries.
 
 ## Reproducibility
 
-- Keeper binary SHA-256: `4782fc7bfacc1c72667436e4d4471cd26755ed2ae192173beff77bcae4bd27d6`
-- Dataset semantic fingerprint: `eb9dc034942bd6fd16477e037452cb64324158cdf8b48d2671647e409d4ca8d2`
+- Canonical database SHA-256: `55805c8644d2a1dc9a2fc2fffb400e3ba74cbb7b777f1c3098516071add070af`
+- Dataset semantic fingerprint: `4b2b14e41bf7aaf91455fc1c3d9a2fe95ca45403d5448e2de17f08d969316f0b`
+- Dataset validation SHA-256: `d0a90239ef1590b30c36b5be51bb61a25b1fc00eda3f7e5cbd9a870ad3a9b557`
+- Keeper binary SHA-256: `75ae2e29e0a4edd8ec7d29954cc9f037721c8c9173d2ff8e2f337f0ea5a68b0e`
+- `benchctl` binary SHA-256: `9b2b8bb5bfcbd57d78ef4bdf95f714203718a5a84d495428ced3757896d89c6c`
+- Manifest SHA-256: `e6513ff3cb50d352a2b1c325daec2d5cec57ea862af3837cdf75789e0419afa2`
+- Expanded plan SHA-256: `0976acf6a94518f536ac84f1b6d7fb0502a1e2c8344966ec11c8241755117323`

--- a/internal/benchmark/REPORT.zh.md
+++ b/internal/benchmark/REPORT.zh.md
@@ -1,0 +1,180 @@
+<p align="center">
+  <a href="./REPORT.md">English</a> ｜ <a href="./REPORT.zh.md"><strong>简体中文</strong></a>
+</p>
+
+# CPA Usage Keeper 容量 Benchmark 报告
+
+测试日期：2026-08-07（Asia/Shanghai）
+
+套件：`capacity-v1`
+
+数据集：`reference-2m`
+
+## 结论
+
+本轮固定复用同一份约 203.6 万 events 的 SQLite 数据库，只限制 Keeper CPU，不限制 Keeper 内存。所有正式容量均来自 ingestion 与 Dashboard 并发运行的五分钟固定速率测试。
+
+| Keeper CPU | 五分钟 ingestion 上限 | 3 秒 Dashboard 上限 | 保守持续流量建议 | ingestion 上限 CPU | Keeper cgroup 峰值内存 | 建议内存 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1C | 150 events/s | 100 events/s | Dashboard 70；ingestion-only 105 events/s | 57.3% | 304.4 MiB | 512 MiB |
+| 2C | 200 events/s | 200 events/s | 140 events/s | 35.9% | 417.0 MiB | 1 GiB |
+| 4C | 650 events/s | 650 events/s | 455 events/s | 29.5% | 1,078.2 MiB | 2 GiB |
+
+默认生产建议为 **2C / 1 GiB、持续流量不超过 140 events/s**。它在当前参考数据集上同时达到 200 events/s ingestion 与 Dashboard 上限，页面延迟明显优于 4C 的极限容量点。
+
+高流量部署可选 **4C / 2 GiB、持续流量不超过 455 events/s**。4C/650 的 overall p99 为 1970.0ms，满足 3 秒口径，但 core p95 已达到 1387.6ms，因此应理解为“3 秒内可用”，不是低延迟配置。
+
+轻量部署可选 **1C / 512 MiB**。Dashboard 建议约 70 events/s；若不要求同时使用 Dashboard，ingestion-only 可保守使用约 105 events/s。
+
+内存建议来自实测峰值加部署余量，不是 hard-cap 验证结果。正式峰值采用 Keeper cgroup v2 的 `memory.peak`，包含 Keeper 进程、SQLite mmap/page cache 以及归属于该 cgroup 的数据库缓存，没有从结果中扣除数据库占用。
+
+## 测试机器
+
+| 项目 | 配置 |
+| --- | --- |
+| 操作系统 | Debian GNU/Linux 13 |
+| 平台 | Linux amd64 |
+| 虚拟化 | KVM |
+| CPU | Intel Xeon Gold 6138 |
+| 在线逻辑 CPU | 4 vCPU |
+| 可用物理内存 | 约 9.5 GiB |
+| Go | 1.26.2 |
+| GCC | 14.2.0 |
+| SQLite CLI | 3.46.1 |
+| Redis | 8.0.2 |
+
+Keeper 的 1C/2C/4C 分别使用 cgroup `cpu.max=100000/200000/400000 100000`，并绑定 `AllowedCPUs=0/0-1/0-3`。三档均为 `memory.max=max`、`memory.swap.max=0`。合成、clone、负载器和结果汇总不计入 Keeper cgroup。
+
+1C 和 2C 时负载器使用剩余 CPU；4C 时 Keeper 与负载器共享四个 vCPU，原始结果标记 `shared_driver=true`，因此 4C 数字可视为偏保守的整机结果。
+
+## 数据集
+
+| 项目 | 实测值 |
+| --- | ---: |
+| 数据集 ID | `reference-2m` |
+| 数据库大小 | 1,171,144,704 bytes（约 1.09 GiB） |
+| 全库 events | 2,035,740 |
+| 最近 30 天 events | 1,226,326 |
+| 最近 90 天 hot events | 1,946,550 |
+| archive events | 89,190 |
+| identities | 323 |
+| models | 52 |
+| API keys | 27 |
+| `PRAGMA quick_check` | `ok` |
+| semantic fingerprint | `eb9dc034942bd6fd16477e037452cb64324158cdf8b48d2671647e409d4ca8d2` |
+
+数据集包含最近 30 天的 1,226,326 条事件、最近 90 天的 1,946,550 条活跃事件，以及 89,190 条归档事件，用于模拟持续运行后的存储、page cache、rollup 和查询负载。
+
+27 个 API keys 按 30%/50%/20% 确定性分入高、中、低用量档，每 Key 权重为 10:3:1，events 根据权重归一化分配。323 identities、52 models 和 27 API keys 均被事件实际引用。数据集同时通过孤儿引用、token 语义、派生 rollup/checkpoint 与 semantic fingerprint 检查。
+
+## 测试方法与通过条件
+
+- 每个正式点从同一份 canonical 创建独立工作副本，重启 Keeper，顺序预热六个 Dashboard 接口，再固定运行 300 秒。
+- offered load 通过 Redis `usage` 发布；Dashboard replay 为 1 req/s，在六个真实页面接口之间轮转。
+- ingestion hard pass：至少 99.9% 目标事件成功发布、最终 durable ratio 至少 99%、backlog 不增长、Overview/Activity/Latency checkpoint 和 Identity 聚合追平、无 OOM、panic、SQLite busy、HTTP 或 publish error。
+- Dashboard pass：先满足 hard pass，再要求六接口整体 p99 不超过 3000ms。
+- core p95 作为体验指标保留，但不参与正式通过判定。
+- 容量点均为五分钟实测；20 秒搜索只用于选择候选，不作为最终上限。
+- 相邻边界收敛到 25 events/s，或不超过约 10% 的间隔。
+
+所有结果表格统一按上述 ingestion hard pass 和 Dashboard overall p99 <=3000ms 标准判定。
+
+## 全部五分钟正式点
+
+以下 24 个点均独立恢复 canonical、重启 Keeper 并运行 300 秒。`Hard` 表示 ingestion、durable、checkpoint 等完整性；`Dashboard` 表示在 Hard 基础上满足 3 秒 SLA。
+
+### 1C / 不限制内存
+
+| Rate | Hard | Dashboard | Durable / Offered | Durable | CPU | Peak memory | Core p95 | Overall p99 | 失败原因 |
+| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 25 | 通过 | 通过 | 7,500 / 7,500 | 100% | 47.4% | 174.0 MiB | 274.8ms | 2,586.7ms | — |
+| 50 | 通过 | 通过 | 15,000 / 15,000 | 100% | 49.4% | 193.1 MiB | 316.3ms | 2,602.0ms | — |
+| 75 | 通过 | 通过 | 22,500 / 22,500 | 100% | 50.0% | 248.0 MiB | 376.3ms | 2,717.1ms | — |
+| 100 | 通过 | 通过 | 30,000 / 30,000 | 100% | 53.0% | 290.7 MiB | 465.7ms | 2,892.5ms | — |
+| 150 | 通过 | 失败 | 45,000 / 45,000 | 100% | 57.3% | 304.4 MiB | 593.0ms | 3,917.1ms | overall p99 >3s |
+| 200 | 失败 | 失败 | 53,972 / 60,000 | 89.95% | 58.2% | 328.7 MiB | 613.6ms | 3,549.3ms | durable、overall p99 |
+| 250 | 失败 | 失败 | 59,894 / 75,000 | 79.86% | 59.8% | 417.2 MiB | 718.1ms | 3,751.1ms | durable、overall p99 |
+| 500 | 失败 | 失败 | 74,441 / 150,000 | 49.63% | 63.1% | 453.0 MiB | 891.0ms | 5,061.7ms | durable、overall p99 |
+| 1,000 | 失败 | 失败 | 117,279 / 300,000 | 39.09% | 79.8% | 756.5 MiB | 2,187.7ms | 6,200.1ms | durable、overall p99 |
+| 3,000 | 失败 | 失败 | 264,819 / 900,000 | 29.42% | 86.2% | 1,705.7 MiB | 4,834.3ms | 8,793.5ms | errors、durable、backlog、checkpoint、Identity、overall p99 |
+
+1C 的 25、50、75、100 events/s 均满足 3 秒口径；100 是最高 Dashboard 通过点。150 虽完整落盘，但 overall p99 已升至 3917.1ms。
+
+### 2C / 不限制内存
+
+| Rate | Hard | Dashboard | Durable / Offered | Durable | CPU | Peak memory | Core p95 | Overall p99 | 失败原因 |
+| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 200 | 通过 | 通过 | 60,000 / 60,000 | 100% | 35.9% | 417.0 MiB | 449.3ms | 2,085.8ms | — |
+| 225 | 失败 | 失败 | 60,741 / 67,500 | 89.99% | 35.6% | 378.2 MiB | 447.8ms | 2,065.0ms | durable |
+| 250 | 失败 | 失败 | 72,522 / 75,000 | 96.70% | 37.9% | 479.1 MiB | 548.3ms | 2,102.9ms | durable |
+| 300 | 失败 | 失败 | 80,969 / 90,000 | 89.97% | 39.2% | 454.2 MiB | 589.2ms | 2,196.9ms | durable |
+
+2C 的边界清晰：200 全部通过，225 已因 durable throughput 失败。失败点没有 OOM，单独增加内存不能改变这条边界。
+
+### 4C / 不限制内存
+
+| Rate | Hard | Dashboard | Durable / Offered | Durable | CPU | Peak memory | Core p95 | Overall p99 | 失败原因 |
+| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 200 | 通过 | 通过 | 60,000 / 60,000 | 100% | 18.9% | 326.4 MiB | 434.6ms | 1,947.4ms | — |
+| 250 | 通过 | 通过 | 74,999 / 75,000 | 99.999% | 20.2% | 383.5 MiB | 498.8ms | 1,947.8ms | — |
+| 275 | 通过 | 通过 | 82,500 / 82,500 | 100% | 20.7% | 435.2 MiB | 556.7ms | 1,973.6ms | — |
+| 300 | 通过 | 通过 | 90,000 / 90,000 | 100% | 21.4% | 499.8 MiB | 588.4ms | 1,953.7ms | — |
+| 400 | 通过 | 通过 | 120,000 / 120,000 | 100% | 24.1% | 654.3 MiB | 744.7ms | 1,945.0ms | — |
+| 500 | 通过 | 通过 | 150,000 / 150,000 | 100% | 25.2% | 661.5 MiB | 978.3ms | 1,974.7ms | — |
+| 600 | 通过 | 通过 | 180,000 / 180,000 | 100% | 28.4% | 985.9 MiB | 1,130.8ms | 1,964.7ms | — |
+| 650 | 通过 | 通过 | 195,000 / 195,000 | 100% | 29.5% | 1,078.2 MiB | 1,387.6ms | 1,970.0ms | — |
+| 675 | 失败 | 失败 | 182,212 / 202,500 | 89.98% | 30.1% | 979.5 MiB | 1,229.5ms | 1,991.5ms | durable |
+| 750 | 失败 | 失败 | 225,000 / 225,000 | 100% | 30.0% | 1,321.2 MiB | 1,527.8ms | 1,987.1ms | checkpoint lag=39,762 |
+
+4C/750 证明只看 `usage_events` 落盘数会高估容量：225,000 条全部 durable，但 rollup checkpoint 仍落后 39,762 条，因此 Hard 必须失败。
+
+## Ingestion 边界
+
+| CPU | 最高通过 | 首个相邻失败 | 通过点 durable | 失败原因 | 通过点 CPU | Keeper cgroup 峰值内存 |
+| --- | ---: | ---: | ---: | --- | ---: | ---: |
+| 1C | 150 | 200 | 45,000 / 45,000 | 200 仅落盘 53,972 / 60,000 | 57.3% | 304.4 MiB |
+| 2C | 200 | 225 | 60,000 / 60,000 | 225 仅落盘 60,741 / 67,500 | 35.9% | 417.0 MiB |
+| 4C | 650 | 675 | 195,000 / 195,000 | 675 仅落盘 182,212 / 202,500 | 29.5% | 1,078.2 MiB |
+
+CPU 利用率按分配给 Keeper 的 CPU 数量归一化，因此 4C/650 的 29.5% 约等于 1.18 个逻辑核心的总 CPU 时间。所有正式点均为 unlimited memory；失败点没有 OOM，主要边界来自 durable/rollup 路径以及高流量下的 Dashboard 延迟。
+
+## Dashboard 评估
+
+| CPU | 评估速率 | Hard | Keeper cgroup 峰值内存 | Core p95 | Overall p99 | 最慢接口 p99 | 结论 |
+| --- | ---: | --- | ---: | ---: | ---: | ---: | --- |
+| 1C | 100 events/s | 通过 | 290.7 MiB | 465.7ms | 2,892.5ms | Analysis Latency 2,946.8ms | 通过；150 的 p99=3,917.1ms |
+| 2C | 200 events/s | 通过 | 417.0 MiB | 449.3ms | 2,085.8ms | Analysis Latency 2,114.9ms | 通过；225 的 ingestion 已失败 |
+| 4C | 650 events/s | 通过 | 1,078.2 MiB | 1,387.6ms | 1,970.0ms | Analysis Latency 2,008.3ms | 3 秒内通过，但不是低延迟点 |
+
+4C/650 的逐接口稳态延迟：
+
+| Endpoint | p50 | p95 | p99 |
+| --- | ---: | ---: | ---: |
+| Analysis | 1.6ms | 1.8ms | 1.8ms |
+| Request Events | 147.1ms | 171.5ms | 193.8ms |
+| Activity | 171.0ms | 209.0ms | 245.9ms |
+| Realtime Overview | 589.5ms | 1,447.2ms | 1,729.2ms |
+| Overview 30d | 717.0ms | 1,498.4ms | 1,550.7ms |
+| Analysis Latency 30d | 1,902.8ms | 1,970.0ms | 2,008.3ms |
+
+若部署目标是“页面尽量快”而不仅是“3 秒内可用”，应在容量上限之外保留更大流量余量，并持续观察 core p95。
+
+## 扩容收益
+
+- 1C → 2C：ingestion 上限从 150 提升到 200（+33%），3 秒 Dashboard 上限从 100 提升到 200；峰值内存从 304.4 MiB 增至 417.0 MiB。
+- 2C → 4C：ingestion 与 Dashboard 上限从 200 提升到 650（3.25x）；峰值内存增至约 1.05 GiB。
+- 单独提高可用内存不会自动提高容量：正式点本来就是 unlimited memory，失败原因是 durable throughput、checkpoint lag 或 Dashboard SLA。
+- 当前参考数据集下，2C 是吞吐、延迟和内存之间的默认平衡点；4C 提供更高吞吐，但核心页面 p95 明显上升。
+
+## 限制
+
+- 每个最终边界只有一次五分钟正式运行，没有多次重复或 24 小时 soak；结果适合容量规划，不等同于长期 SLO 证明。
+- 4C Keeper 与负载器共享宿主 CPU，结果偏保守。
+- 本轮没有施加 256/512/768/1024 MiB hard cap，只能给出 observed peak 和带余量建议，不能声称验证了最低可启动内存。
+- events/s 是在预装约 203.6 万条全库历史上的五分钟持续流量，不能直接乘以 30 天当作长期安全月容量；数据库继续增长后，查询与聚合成本也会变化。
+- 结论只适用于本报告记录的硬件规格、数据集指纹、二进制和测试方法。
+
+## 可复现信息
+
+- Keeper binary SHA-256：`4782fc7bfacc1c72667436e4d4471cd26755ed2ae192173beff77bcae4bd27d6`
+- Dataset semantic fingerprint：`eb9dc034942bd6fd16477e037452cb64324158cdf8b48d2671647e409d4ca8d2`

--- a/internal/benchmark/REPORT.zh.md
+++ b/internal/benchmark/REPORT.zh.md
@@ -4,177 +4,187 @@
 
 # CPA Usage Keeper 容量 Benchmark 报告
 
-测试日期：2026-08-07（Asia/Shanghai）
+测试日期：2026-08-10（Asia/Shanghai）
 
 套件：`capacity-v1`
 
-数据集：`reference-2m`
+数据集：`reference-3m`
 
-## 结论
+平台：Linux amd64
 
-本轮固定复用同一份约 203.6 万 events 的 SQLite 数据库，只限制 Keeper CPU，不限制 Keeper 内存。所有正式容量均来自 ingestion 与 Dashboard 并发运行的五分钟固定速率测试。
+## 结论摘要
 
-| Keeper CPU | 五分钟 ingestion 上限 | 3 秒 Dashboard 上限 | 保守持续流量建议 | ingestion 上限 CPU | Keeper cgroup 峰值内存 | 建议内存 |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1C | 150 events/s | 100 events/s | Dashboard 70；ingestion-only 105 events/s | 57.3% | 304.4 MiB | 512 MiB |
-| 2C | 200 events/s | 200 events/s | 140 events/s | 35.9% | 417.0 MiB | 1 GiB |
-| 4C | 650 events/s | 650 events/s | 455 events/s | 29.5% | 1,078.2 MiB | 2 GiB |
+每个正式点均复用同一份已验证 SQLite 数据库，只改变 Keeper 可用 CPU：1C、2C 或 4C。数据库包含最近 90 天的 3,205,740 条活跃 events；本轮数据校验锚点对应的 30 天查询窗口包含 1,201,775 条 events。Keeper 内存不设上限，报告中的 cgroup 峰值包含 Keeper、SQLite 页面以及归入该 cgroup 的数据库缓存。
 
-默认生产建议为 **2C / 1 GiB、持续流量不超过 140 events/s**。它在当前参考数据集上同时达到 200 events/s ingestion 与 Dashboard 上限，页面延迟明显优于 4C 的极限容量点。
+容量门槛只覆盖五个核心 Dashboard 接口，整体 p99 上限为 3 秒。Analysis Latency 30d 属于更重的诊断查询，每 30 秒独立测量一次；其延迟不决定核心 Dashboard 容量，但错误、OOM、panic 与 SQLite 故障仍会明确记录。
 
-高流量部署可选 **4C / 2 GiB、持续流量不超过 455 events/s**。4C/650 的 overall p99 为 1970.0ms，满足 3 秒口径，但 core p95 已达到 1387.6ms，因此应理解为“3 秒内可用”，不是低延迟配置。
+| Keeper CPU | 五分钟通过 / 最低失败 | 70% 持续流量建议 | 通过点核心 Dashboard p99 | 通过点 Analysis Latency p99 | 通过点峰值内存 | 部署建议 |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| 1C | 150 / 200 events/s | 105 events/s | 858.4ms | 5109.1ms | 472.9 MiB | 1C / 768 MiB，持续流量不超过 105 events/s |
+| 2C | 200 / 250 events/s | 140 events/s | 627.1ms | 3075.9ms | 522.2 MiB | 2C / 1 GiB，持续流量不超过 140 events/s |
+| 4C | 500 / 600 events/s | 350 events/s | 1323.0ms | 3044.6ms | 995.7 MiB | 4C / 2 GiB，持续流量不超过 350 events/s |
 
-轻量部署可选 **1C / 512 MiB**。Dashboard 建议约 70 events/s；若不要求同时使用 Dashboard，ingestion-only 可保守使用约 105 events/s。
+本轮最强的已验证档位为 **4C / 2 GiB，持续流量不超过 350 events/s**。实测 500 events/s 在 150,000 条目标 events 中发布并持久化 149,998 条，14.63 秒内完成追平。600 events/s 虽然 179,998 条已发布 events 全部持久化，但完整 30 秒 drain 后仍有 12,266 条聚合 checkpoint lag。
 
-内存建议来自实测峰值加部署余量，不是 hard-cap 验证结果。正式峰值采用 Keeper cgroup v2 的 `memory.peak`，包含 Keeper 进程、SQLite mmap/page cache 以及归属于该 cgroup 的数据库缓存，没有从结果中扣除数据库占用。
+1C 与 2C 的失败边界均来自 durable throughput，而不是 Dashboard。六个正式点的核心 Dashboard p99 全部低于 1.6 秒，包括 ingestion 失败点。因此增加 CPU 能提升容量，但 SQLite ingestion 与派生聚合追平会在分配的 CPU quota 饱和前限制扩展。
+
+这些数值是五分钟持续测量，不是瞬时峰值或绝对精确上限。持续流量建议取最高完整通过点的 70%。
 
 ## 测试机器
 
 | 项目 | 配置 |
 | --- | --- |
 | 操作系统 | Debian GNU/Linux 13 |
-| 平台 | Linux amd64 |
-| 虚拟化 | KVM |
-| CPU | Intel Xeon Gold 6138 |
+| Kernel | 6.12.90+deb13.1-cloud-amd64 |
+| 架构 | Linux amd64 |
+| 虚拟化 | KVM，全虚拟化 |
+| CPU | Intel Xeon Gold 6138 @ 2.00GHz |
+| 拓扑 | 1 socket、4 cores、每 core 1 thread |
 | 在线逻辑 CPU | 4 vCPU |
-| 可用物理内存 | 约 9.5 GiB |
+| 虚拟机可见内存 | 9,948,040 KiB（约 9.49 GiB） |
 | Go | 1.26.2 |
 | GCC | 14.2.0 |
 | SQLite CLI | 3.46.1 |
 | Redis | 8.0.2 |
 
-Keeper 的 1C/2C/4C 分别使用 cgroup `cpu.max=100000/200000/400000 100000`，并绑定 `AllowedCPUs=0/0-1/0-3`。三档均为 `memory.max=max`、`memory.swap.max=0`。合成、clone、负载器和结果汇总不计入 Keeper cgroup。
+Keeper 分别使用等价于 1、2、4 cores 的 cgroup CPU quota，并绑定到 CPU `0`、`0-1`、`0-3`。三档均为 `memory.max=max`、`memory.swap.max=0`。
 
-1C 和 2C 时负载器使用剩余 CPU；4C 时 Keeper 与负载器共享四个 vCPU，原始结果标记 `shared_driver=true`，因此 4C 数字可视为偏保守的整机结果。
+数据准备阶段不限制资源。数据库 clone、Redis 发布器与结果采集位于 Keeper cgroup 外；1C、2C 的负载器使用 Keeper 绑定范围之外的 CPU，4C 与负载器共享全部四个 vCPU，因此4C属于偏保守的整机测量。
 
-## 数据集
+CPU 利用率按 Keeper 分配的 quota 归一化。通过点平均分别为1C的49.3%、2C的35.7%、4C的27.2%，约等于实际使用0.49、0.71、1.09个逻辑核心。
 
-| 项目 | 实测值 |
+## 参考数据集
+
+| 项目 | 验证值 |
 | --- | ---: |
-| 数据集 ID | `reference-2m` |
-| 数据库大小 | 1,171,144,704 bytes（约 1.09 GiB） |
-| 全库 events | 2,035,740 |
-| 最近 30 天 events | 1,226,326 |
-| 最近 90 天 hot events | 1,946,550 |
-| archive events | 89,190 |
-| identities | 323 |
-| models | 52 |
-| API keys | 27 |
+| 数据库大小 | 2,044,776,448 bytes（约 1.90 GiB） |
+| 90 天活跃 events | 3,205,740 |
+| 正式运行 30 天查询窗口 events | 1,201,775 |
+| Archive events | 0 |
+| Failed events | 31,831（0.993%） |
+| Identities | 使用 500 / 总计 500 |
+| Models | 使用 50 / 总计 50 |
+| API keys | 使用 50 / 总计 50 |
+| 孤儿 identity/model/API-key 引用 | 0 / 0 / 0 |
 | `PRAGMA quick_check` | `ok` |
-| semantic fingerprint | `eb9dc034942bd6fd16477e037452cb64324158cdf8b48d2671647e409d4ca8d2` |
+| Semantic fingerprint | `4b2b14e41bf7aaf91455fc1c3d9a2fe95ca45403d5448e2de17f08d969316f0b` |
 
-数据集包含最近 30 天的 1,226,326 条事件、最近 90 天的 1,946,550 条活跃事件，以及 89,190 条归档事件，用于模拟持续运行后的存储、page cache、rollup 和查询负载。
+活跃表覆盖完整 90 天历史。archive 刻意保持为空，因为本套件覆盖的生产 Dashboard 路径不会查询冷数据。所有 identities、models 和 API keys 都被 events 实际引用。
 
-27 个 API keys 按 30%/50%/20% 确定性分入高、中、低用量档，每 Key 权重为 10:3:1，events 根据权重归一化分配。323 identities、52 models 和 27 API keys 均被事件实际引用。数据集同时通过孤儿引用、token 语义、派生 rollup/checkpoint 与 semantic fingerprint 检查。
+| API-key 档位 | API keys | Key 数量占比 | Events | Events 占比 |
+| --- | ---: | ---: | ---: | ---: |
+| 大用量 | 15 | 30% | 2,051,847 | 64.01% |
+| 中用量 | 25 | 50% | 1,018,187 | 31.76% |
+| 小用量 | 10 | 20% | 135,706 | 4.23% |
+
+每 Key 生成权重为 10:3:1。最终流量刻意保持不均衡，用于模拟少量高用量 Key，而不是把 events 集中到单一 Key。
+
+每个测试点开始前，套件都会从 canonical 创建新的字节级 clone，完成落盘并从 controller page cache 中清除。失败点不会把 backlog、WAL 或已预热 SQLite 页面带入下一轮。
 
 ## 测试方法与通过条件
 
-- 每个正式点从同一份 canonical 创建独立工作副本，重启 Keeper，顺序预热六个 Dashboard 接口，再固定运行 300 秒。
-- offered load 通过 Redis `usage` 发布；Dashboard replay 为 1 req/s，在六个真实页面接口之间轮转。
-- ingestion hard pass：至少 99.9% 目标事件成功发布、最终 durable ratio 至少 99%、backlog 不增长、Overview/Activity/Latency checkpoint 和 Identity 聚合追平、无 OOM、panic、SQLite busy、HTTP 或 publish error。
-- Dashboard pass：先满足 hard pass，再要求六接口整体 p99 不超过 3000ms。
-- core p95 作为体验指标保留，但不参与正式通过判定。
-- 容量点均为五分钟实测；20 秒搜索只用于选择候选，不作为最终上限。
-- 相邻边界收敛到 25 events/s，或不超过约 10% 的间隔。
+- 每个正式点都使用独立数据库 clone 启动全新 Keeper，预热全部 Dashboard 路径后，以选定速率持续运行 300 秒。
+- Events 通过 Redis 发布。核心 Dashboard replay 为 1 req/s，轮询 Realtime Overview 60m、Overview 30d、Activity 30d、Analysis 30d 和 Request Events 30d。
+- Analysis Latency 30d 先预热一次，随后每 30 秒请求一次；每个正式点得到9个成功诊断样本。
+- Ingestion hard pass 要求：发布成功率至少99.9%、最终 durable ratio 至少99%、backlog不增长、Overview/Activity/Latency checkpoint与Identity聚合追平、无OOM、panic或发布器错误，并在15秒内完成追平。
+- 核心 Dashboard pass 先要求 ingestion hard pass，再要求核心HTTP错误为0且整体p99不超过3000ms。
+- Analysis Latency 的错误和分位数独立判定；诊断错误不会把 ingestion 或核心 Dashboard 容量重新标记为失败。
+- 短测只用于选择候选。容量结论仅使用下方六个五分钟正式边界点。
+- 持续流量建议取最高完整通过点的70%，向下取整到整数 events/s。
 
-所有结果表格统一按上述 ingestion hard pass 和 Dashboard overall p99 <=3000ms 标准判定。
+## 容量边界
 
-## 全部五分钟正式点
+| CPU | 最高通过 | 最低失败 | 通过点 durable | 通过点追平 | 通过点 CPU | 通过点峰值内存 | 失败证据 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 1C | 150 | 200 | 45,000 / 45,000 | 5.37s | 49.3% | 472.9 MiB | 200 仅落库 53,969 / 60,000 |
+| 2C | 200 | 250 | 60,000 / 60,000 | 3.24s | 35.7% | 522.2 MiB | 250 仅落库 71,597 / 75,000 |
+| 4C | 500 | 600 | 149,998 / 150,000 | 14.63s | 27.2% | 995.7 MiB | 600 在 30.07s 后仍有 12,266 checkpoint lag |
 
-以下 24 个点均独立恢复 canonical、重启 Keeper 并运行 300 秒。`Hard` 表示 ingestion、durable、checkpoint 等完整性；`Dashboard` 表示在 Hard 基础上满足 3 秒 SLA。
+所有正式点均未 OOM。单独增加内存不能解决这些实测边界：1C/2C失败来自durable throughput，4C失败来自派生状态追平。
 
-### 1C / 不限制内存
+## 核心 Dashboard 评估
 
-| Rate | Hard | Dashboard | Durable / Offered | Durable | CPU | Peak memory | Core p95 | Overall p99 | 失败原因 |
-| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| 25 | 通过 | 通过 | 7,500 / 7,500 | 100% | 47.4% | 174.0 MiB | 274.8ms | 2,586.7ms | — |
-| 50 | 通过 | 通过 | 15,000 / 15,000 | 100% | 49.4% | 193.1 MiB | 316.3ms | 2,602.0ms | — |
-| 75 | 通过 | 通过 | 22,500 / 22,500 | 100% | 50.0% | 248.0 MiB | 376.3ms | 2,717.1ms | — |
-| 100 | 通过 | 通过 | 30,000 / 30,000 | 100% | 53.0% | 290.7 MiB | 465.7ms | 2,892.5ms | — |
-| 150 | 通过 | 失败 | 45,000 / 45,000 | 100% | 57.3% | 304.4 MiB | 593.0ms | 3,917.1ms | overall p99 >3s |
-| 200 | 失败 | 失败 | 53,972 / 60,000 | 89.95% | 58.2% | 328.7 MiB | 613.6ms | 3,549.3ms | durable、overall p99 |
-| 250 | 失败 | 失败 | 59,894 / 75,000 | 79.86% | 59.8% | 417.2 MiB | 718.1ms | 3,751.1ms | durable、overall p99 |
-| 500 | 失败 | 失败 | 74,441 / 150,000 | 49.63% | 63.1% | 453.0 MiB | 891.0ms | 5,061.7ms | durable、overall p99 |
-| 1,000 | 失败 | 失败 | 117,279 / 300,000 | 39.09% | 79.8% | 756.5 MiB | 2,187.7ms | 6,200.1ms | durable、overall p99 |
-| 3,000 | 失败 | 失败 | 264,819 / 900,000 | 29.42% | 86.2% | 1,705.7 MiB | 4,834.3ms | 8,793.5ms | errors、durable、backlog、checkpoint、Identity、overall p99 |
+| CPU | 通过速率 | 样本数 | 整体 p50 | 整体 p95 | 整体 p99 | 最慢接口 p99 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1C | 150 events/s | 299 | 299.9ms | 639.4ms | 858.4ms | Overview 30d：961.8ms |
+| 2C | 200 events/s | 299 | 297.9ms | 532.1ms | 627.1ms | Analysis 30d：649.7ms |
+| 4C | 500 events/s | 299 | 339.6ms | 938.2ms | 1323.0ms | Overview 30d：1469.6ms |
 
-1C 的 25、50、75、100 events/s 均满足 3 秒口径；100 是最高 Dashboard 通过点。150 虽完整落盘，但 overall p99 已升至 3917.1ms。
+### 各通过边界的接口延迟
 
-### 2C / 不限制内存
-
-| Rate | Hard | Dashboard | Durable / Offered | Durable | CPU | Peak memory | Core p95 | Overall p99 | 失败原因 |
-| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| 200 | 通过 | 通过 | 60,000 / 60,000 | 100% | 35.9% | 417.0 MiB | 449.3ms | 2,085.8ms | — |
-| 225 | 失败 | 失败 | 60,741 / 67,500 | 89.99% | 35.6% | 378.2 MiB | 447.8ms | 2,065.0ms | durable |
-| 250 | 失败 | 失败 | 72,522 / 75,000 | 96.70% | 37.9% | 479.1 MiB | 548.3ms | 2,102.9ms | durable |
-| 300 | 失败 | 失败 | 80,969 / 90,000 | 89.97% | 39.2% | 454.2 MiB | 589.2ms | 2,196.9ms | durable |
-
-2C 的边界清晰：200 全部通过，225 已因 durable throughput 失败。失败点没有 OOM，单独增加内存不能改变这条边界。
-
-### 4C / 不限制内存
-
-| Rate | Hard | Dashboard | Durable / Offered | Durable | CPU | Peak memory | Core p95 | Overall p99 | 失败原因 |
-| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| 200 | 通过 | 通过 | 60,000 / 60,000 | 100% | 18.9% | 326.4 MiB | 434.6ms | 1,947.4ms | — |
-| 250 | 通过 | 通过 | 74,999 / 75,000 | 99.999% | 20.2% | 383.5 MiB | 498.8ms | 1,947.8ms | — |
-| 275 | 通过 | 通过 | 82,500 / 82,500 | 100% | 20.7% | 435.2 MiB | 556.7ms | 1,973.6ms | — |
-| 300 | 通过 | 通过 | 90,000 / 90,000 | 100% | 21.4% | 499.8 MiB | 588.4ms | 1,953.7ms | — |
-| 400 | 通过 | 通过 | 120,000 / 120,000 | 100% | 24.1% | 654.3 MiB | 744.7ms | 1,945.0ms | — |
-| 500 | 通过 | 通过 | 150,000 / 150,000 | 100% | 25.2% | 661.5 MiB | 978.3ms | 1,974.7ms | — |
-| 600 | 通过 | 通过 | 180,000 / 180,000 | 100% | 28.4% | 985.9 MiB | 1,130.8ms | 1,964.7ms | — |
-| 650 | 通过 | 通过 | 195,000 / 195,000 | 100% | 29.5% | 1,078.2 MiB | 1,387.6ms | 1,970.0ms | — |
-| 675 | 失败 | 失败 | 182,212 / 202,500 | 89.98% | 30.1% | 979.5 MiB | 1,229.5ms | 1,991.5ms | durable |
-| 750 | 失败 | 失败 | 225,000 / 225,000 | 100% | 30.0% | 1,321.2 MiB | 1,527.8ms | 1,987.1ms | checkpoint lag=39,762 |
-
-4C/750 证明只看 `usage_events` 落盘数会高估容量：225,000 条全部 durable，但 rollup checkpoint 仍落后 39,762 条，因此 Hard 必须失败。
-
-## Ingestion 边界
-
-| CPU | 最高通过 | 首个相邻失败 | 通过点 durable | 失败原因 | 通过点 CPU | Keeper cgroup 峰值内存 |
-| --- | ---: | ---: | ---: | --- | ---: | ---: |
-| 1C | 150 | 200 | 45,000 / 45,000 | 200 仅落盘 53,972 / 60,000 | 57.3% | 304.4 MiB |
-| 2C | 200 | 225 | 60,000 / 60,000 | 225 仅落盘 60,741 / 67,500 | 35.9% | 417.0 MiB |
-| 4C | 650 | 675 | 195,000 / 195,000 | 675 仅落盘 182,212 / 202,500 | 29.5% | 1,078.2 MiB |
-
-CPU 利用率按分配给 Keeper 的 CPU 数量归一化，因此 4C/650 的 29.5% 约等于 1.18 个逻辑核心的总 CPU 时间。所有正式点均为 unlimited memory；失败点没有 OOM，主要边界来自 durable/rollup 路径以及高流量下的 Dashboard 延迟。
-
-## Dashboard 评估
-
-| CPU | 评估速率 | Hard | Keeper cgroup 峰值内存 | Core p95 | Overall p99 | 最慢接口 p99 | 结论 |
-| --- | ---: | --- | ---: | ---: | ---: | ---: | --- |
-| 1C | 100 events/s | 通过 | 290.7 MiB | 465.7ms | 2,892.5ms | Analysis Latency 2,946.8ms | 通过；150 的 p99=3,917.1ms |
-| 2C | 200 events/s | 通过 | 417.0 MiB | 449.3ms | 2,085.8ms | Analysis Latency 2,114.9ms | 通过；225 的 ingestion 已失败 |
-| 4C | 650 events/s | 通过 | 1,078.2 MiB | 1,387.6ms | 1,970.0ms | Analysis Latency 2,008.3ms | 3 秒内通过，但不是低延迟点 |
-
-4C/650 的逐接口稳态延迟：
-
-| Endpoint | p50 | p95 | p99 |
+| 接口 | 1C/150 p50 / p95 / p99 | 2C/200 p50 / p95 / p99 | 4C/500 p50 / p95 / p99 |
 | --- | ---: | ---: | ---: |
-| Analysis | 1.6ms | 1.8ms | 1.8ms |
-| Request Events | 147.1ms | 171.5ms | 193.8ms |
-| Activity | 171.0ms | 209.0ms | 245.9ms |
-| Realtime Overview | 589.5ms | 1,447.2ms | 1,729.2ms |
-| Overview 30d | 717.0ms | 1,498.4ms | 1,550.7ms |
-| Analysis Latency 30d | 1,902.8ms | 1,970.0ms | 2,008.3ms |
+| Realtime Overview 60m | 204.5 / 585.3 / 668.9ms | 202.6 / 389.0 / 438.5ms | 422.0 / 895.9 / 1160.1ms |
+| Overview 30d | 353.7 / 710.3 / 961.8ms | 338.0 / 565.5 / 592.8ms | 604.8 / 1165.5 / 1469.6ms |
+| Activity 30d | 262.9 / 523.4 / 582.2ms | 309.0 / 345.4 / 364.7ms | 309.9 / 348.6 / 393.3ms |
+| Analysis 30d | 454.5 / 771.9 / 889.3ms | 497.5 / 623.0 / 649.7ms | 504.7 / 578.0 / 593.3ms |
+| Request Events 30d | 148.2 / 333.2 / 444.5ms | 146.6 / 173.2 / 247.4ms | 152.8 / 182.7 / 190.1ms |
 
-若部署目标是“页面尽量快”而不仅是“3 秒内可用”，应在容量上限之外保留更大流量余量，并持续观察 core p95。
+本轮核心 Dashboard 不是限制门槛。所有通过和失败 ingestion 边界的核心 p99 都明显低于3秒。
 
-## 扩容收益
+## Analysis Latency 诊断
 
-- 1C → 2C：ingestion 上限从 150 提升到 200（+33%），3 秒 Dashboard 上限从 100 提升到 200；峰值内存从 304.4 MiB 增至 417.0 MiB。
-- 2C → 4C：ingestion 与 Dashboard 上限从 200 提升到 650（3.25x）；峰值内存增至约 1.05 GiB。
-- 单独提高可用内存不会自动提高容量：正式点本来就是 unlimited memory，失败原因是 durable throughput、checkpoint lag 或 Dashboard SLA。
-- 当前参考数据集下，2C 是吞吐、延迟和内存之间的默认平衡点；4C 提供更高吞吐，但核心页面 p95 明显上升。
+| CPU / 通过速率 | 成功样本 | 错误 | 状态 | p50 | p95 | p99 | Max |
+| --- | ---: | ---: | --- | ---: | ---: | ---: | ---: |
+| 1C / 150 | 9 | 0 | 通过 | 4453.6ms | 5109.1ms | 5109.1ms | 5109.1ms |
+| 2C / 200 | 9 | 0 | 通过 | 2706.1ms | 3075.9ms | 3075.9ms | 3075.9ms |
+| 4C / 500 | 9 | 0 | 通过 | 2802.1ms | 3044.6ms | 3044.6ms | 3044.6ms |
+
+Analysis Latency 刻意不参与核心 Dashboard 的3秒门槛。该接口会在所选30天范围内合并已保留的Latency sketches与抽样点，因此在当前数据规模下明显重于其它 Dashboard 路径。
+
+每个五分钟点按30秒间隔只能完成9个诊断请求。nearest-rank p95与p99因此等于最大观测值，应作为本轮有界证据理解，而不是统计上精确的生产SLO。
+
+## Identity 基数方向（探索性）
+
+另一次五分钟1C对照使用3,205,740条活跃events、50个models、50个API keys、内存不设上限及1 event/s，并将identities从500降至50。两次运行因时间锚点不同，30天查询窗口的数据量相差约1%。该测试早于当前正式诊断查询频率，因此只作为方向性证据，不构成新的容量边界。
+
+| 指标 | 500 identities | 50 identities | 观测变化 |
+| --- | ---: | ---: | ---: |
+| 核心 Dashboard 整体 p99 | 521.3ms | 277.4ms | -46.8% |
+| Analysis 30d p99 | 557.6ms | 223.0ms | -60.0% |
+| Analysis Latency 30d p99 | 3384.8ms | 3225.9ms | -4.7% |
+| CPU 利用率（按1C归一化） | 64.4% | 56.0% | -8.5个百分点 |
+| 峰值内存 | 310.8 MiB | 251.3 MiB | -59.5 MiB |
+
+较低的identity基数可以明显减少轻量部署的核心Dashboard开销与内存占用。Analysis Latency改善较小，因为其保留统计按API group而非identity分桶。这个方向不改变上方正式容量边界与硬件建议。
+
+## 边界证据
+
+| CPU | 速率 | Hard pass | 核心 Dashboard pass | 诊断状态 | Durable / offered | 追平 | 峰值内存 | 核心 p99 | 原因 |
+| --- | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+| 1C | 150 | 是 | 是 | 通过 | 45,000 / 45,000 | 5.37s | 472.9 MiB | 858.4ms | — |
+| 1C | 200 | 否 | 否 | 通过 | 53,969 / 60,000 | 3.37s | 471.9 MiB | 786.7ms | `durable_throughput` |
+| 2C | 200 | 是 | 是 | 通过 | 60,000 / 60,000 | 3.24s | 522.2 MiB | 627.1ms | — |
+| 2C | 250 | 否 | 否 | 通过 | 71,597 / 75,000 | 0.00s | 589.6 MiB | 708.8ms | `durable_throughput` |
+| 4C | 500 | 是 | 是 | 通过 | 149,998 / 150,000 | 14.63s | 995.7 MiB | 1323.0ms | — |
+| 4C | 600 | 否 | 否 | 通过 | 179,998 / 180,000 | 30.07s | 1044.3 MiB | 1415.4ms | `drain_lag`、`checkpoint_lag` |
+
+## 容量规划建议
+
+- **轻量部署：**1C / 768 MiB，持续流量不超过 105 events/s。
+- **中等部署：**2C / 1 GiB，持续流量不超过 140 events/s。
+- **较高吞吐部署：**4C / 2 GiB，持续流量不超过 350 events/s。
+- 内存按实测cgroup峰值加部署余量配置；这些不是有限hard-cap启动测试。
+- 不要把单独增加内存视为吞吐升级；本轮没有容量失败来自OOM。
+- 不要从4C或500 events/s继续线性外推；SQLite写入、Redis到SQLite的持久化、派生状态追平和共享负载器会先限制扩展。
 
 ## 限制
 
-- 每个最终边界只有一次五分钟正式运行，没有多次重复或 24 小时 soak；结果适合容量规划，不等同于长期 SLO 证明。
-- 4C Keeper 与负载器共享宿主 CPU，结果偏保守。
-- 本轮没有施加 256/512/768/1024 MiB hard cap，只能给出 observed peak 和带余量建议，不能声称验证了最低可启动内存。
-- events/s 是在预装约 203.6 万条全库历史上的五分钟持续流量，不能直接乘以 30 天当作长期安全月容量；数据库继续增长后，查询与聚合成本也会变化。
-- 结论只适用于本报告记录的硬件规格、数据集指纹、二进制和测试方法。
+- 每个报告边界点只有一次五分钟正式运行；本轮没有重复全部边界或执行24小时soak。
+- 每个正式点只有9个Analysis Latency成功样本，其高分位数属于观测值。
+- 4C与负载器共享宿主CPU，因此结果偏保守，也更依赖当前主机。
+- 本轮没有施加256/512/768/1024 MiB内存hard cap；内存建议是observed peak加余量，不是已验证最低限制。
+- 生成数据库覆盖90天活跃数据；Dashboard负载查询生产使用的30天和realtime路径，archive/冷表性能不在范围内。
+- 预装历史数据库上的五分钟 sustained events/s 不能直接乘以时间，作为契约型月容量。
+- 早期把Analysis Latency按核心接口频率回放的测试仍保留为压力证据，但不再用于生产容量建议。
+- Identity基数对照属于探索性测试，不修改正式容量边界。
 
 ## 可复现信息
 
-- Keeper binary SHA-256：`4782fc7bfacc1c72667436e4d4471cd26755ed2ae192173beff77bcae4bd27d6`
-- Dataset semantic fingerprint：`eb9dc034942bd6fd16477e037452cb64324158cdf8b48d2671647e409d4ca8d2`
+- Canonical database SHA-256：`55805c8644d2a1dc9a2fc2fffb400e3ba74cbb7b777f1c3098516071add070af`
+- Dataset semantic fingerprint：`4b2b14e41bf7aaf91455fc1c3d9a2fe95ca45403d5448e2de17f08d969316f0b`
+- Dataset validation SHA-256：`d0a90239ef1590b30c36b5be51bb61a25b1fc00eda3f7e5cbd9a870ad3a9b557`
+- Keeper binary SHA-256：`75ae2e29e0a4edd8ec7d29954cc9f037721c8c9173d2ff8e2f337f0ea5a68b0e`
+- `benchctl` binary SHA-256：`9b2b8bb5bfcbd57d78ef4bdf95f714203718a5a84d495428ced3757896d89c6c`
+- Manifest SHA-256：`e6513ff3cb50d352a2b1c325daec2d5cec57ea862af3837cdf75789e0419afa2`
+- Expanded plan SHA-256：`0976acf6a94518f536ac84f1b6d7fb0502a1e2c8344966ec11c8241755117323`

--- a/internal/benchmark/capacity/capacity.go
+++ b/internal/benchmark/capacity/capacity.go
@@ -1,0 +1,165 @@
+package capacity
+
+import (
+	"fmt"
+)
+
+type CapacitySearch struct {
+	rates         []int
+	lowPassIndex  int
+	highFailIndex int
+	pendingIndex  int
+	pending       int
+	done          bool
+}
+
+func NewCapacitySearch(rates []int) (*CapacitySearch, error) {
+	if len(rates) == 0 {
+		return nil, fmt.Errorf("capacity rates are required")
+	}
+	copyRates := append([]int(nil), rates...)
+	for index, rate := range copyRates {
+		if rate <= 0 || (index > 0 && rate <= copyRates[index-1]) {
+			return nil, fmt.Errorf("capacity rates must be positive and increasing")
+		}
+	}
+	return &CapacitySearch{
+		rates: copyRates, lowPassIndex: -1, highFailIndex: len(copyRates), pendingIndex: -1,
+	}, nil
+}
+
+func (search *CapacitySearch) Next() (int, bool) {
+	if search == nil || search.done || search.pending != 0 {
+		return 0, false
+	}
+	if search.highFailIndex-search.lowPassIndex <= 1 {
+		search.done = true
+		return 0, false
+	}
+	search.pendingIndex = search.lowPassIndex + (search.highFailIndex-search.lowPassIndex)/2
+	search.pending = search.rates[search.pendingIndex]
+	return search.pending, true
+}
+
+func (search *CapacitySearch) Record(rate int, passed bool) {
+	if search == nil || search.done || search.pending == 0 || rate != search.pending {
+		return
+	}
+	search.pending = 0
+	if passed {
+		search.lowPassIndex = search.pendingIndex
+	} else {
+		search.highFailIndex = search.pendingIndex
+	}
+	search.pendingIndex = -1
+	if search.highFailIndex-search.lowPassIndex <= 1 {
+		search.done = true
+	}
+}
+
+func (search *CapacitySearch) HardCapacity() int {
+	if search == nil {
+		return 0
+	}
+	if search.lowPassIndex < 0 {
+		return 0
+	}
+	return search.rates[search.lowPassIndex]
+}
+
+type ProbeMetrics struct {
+	OfferedEvents   int64   `json:"offered_events"`
+	PublishedEvents int64   `json:"published_events"`
+	DurableEvents   int64   `json:"durable_events"`
+	BacklogStart    int64   `json:"backlog_start"`
+	BacklogEnd      int64   `json:"backlog_end"`
+	Errors          int64   `json:"errors"`
+	HTTPRequests    int64   `json:"http_requests"`
+	HTTPP95MS       float64 `json:"http_p95_ms"`
+	HTTPP99MS       float64 `json:"http_p99_ms"`
+	OOM             bool    `json:"oom"`
+	Panic           bool    `json:"panic"`
+	SQLiteBusy      int64   `json:"sqlite_busy"`
+	CheckpointLag   int64   `json:"checkpoint_lag"`
+	IdentityPending int64   `json:"identity_pending"`
+}
+
+type ProbeThresholds struct {
+	MinPublishedRatio float64 `json:"min_published_ratio"`
+	MinDurableRatio   float64 `json:"min_durable_ratio"`
+	MaxBacklogGrowth  int64   `json:"max_backlog_growth"`
+	InteractiveP95MS  float64 `json:"interactive_p95_ms"`
+	InteractiveP99MS  float64 `json:"interactive_p99_ms"`
+}
+
+type ProbeEvaluation struct {
+	HardPass        bool     `json:"hard_pass"`
+	InteractivePass bool     `json:"interactive_pass"`
+	Reasons         []string `json:"reasons,omitempty"`
+}
+
+func EvaluateProbe(metrics ProbeMetrics, thresholds ProbeThresholds) ProbeEvaluation {
+	if thresholds.MinPublishedRatio <= 0 {
+		thresholds.MinPublishedRatio = 0.999
+	}
+	if thresholds.MinDurableRatio <= 0 {
+		thresholds.MinDurableRatio = 0.99
+	}
+	evaluation := ProbeEvaluation{HardPass: true}
+	if metrics.OOM {
+		evaluation.HardPass = false
+		evaluation.Reasons = append(evaluation.Reasons, "oom")
+	}
+	if metrics.Panic {
+		evaluation.HardPass = false
+		evaluation.Reasons = append(evaluation.Reasons, "panic")
+	}
+	if metrics.Errors > 0 {
+		evaluation.HardPass = false
+		evaluation.Reasons = append(evaluation.Reasons, "errors")
+	}
+	if metrics.OfferedEvents > 0 && float64(metrics.PublishedEvents)/float64(metrics.OfferedEvents) < thresholds.MinPublishedRatio {
+		evaluation.HardPass = false
+		evaluation.Reasons = append(evaluation.Reasons, "driver_lag")
+	}
+	if metrics.SQLiteBusy > 0 {
+		evaluation.HardPass = false
+		evaluation.Reasons = append(evaluation.Reasons, "sqlite_busy")
+	}
+	durableTailAllowed := metrics.OfferedEvents >= 10 &&
+		metrics.PublishedEvents == metrics.OfferedEvents &&
+		metrics.OfferedEvents-metrics.DurableEvents == 1 &&
+		metrics.BacklogEnd <= metrics.BacklogStart &&
+		metrics.CheckpointLag == 0 &&
+		metrics.IdentityPending == 0
+	if metrics.OfferedEvents > 0 &&
+		float64(metrics.DurableEvents)/float64(metrics.OfferedEvents) < thresholds.MinDurableRatio &&
+		!durableTailAllowed {
+		evaluation.HardPass = false
+		evaluation.Reasons = append(evaluation.Reasons, "durable_throughput")
+	}
+	if metrics.BacklogEnd-metrics.BacklogStart > thresholds.MaxBacklogGrowth {
+		evaluation.HardPass = false
+		evaluation.Reasons = append(evaluation.Reasons, "backlog_growth")
+	}
+	if metrics.CheckpointLag > 0 {
+		evaluation.HardPass = false
+		evaluation.Reasons = append(evaluation.Reasons, "checkpoint_lag")
+	}
+	if metrics.IdentityPending > 0 {
+		evaluation.HardPass = false
+		evaluation.Reasons = append(evaluation.Reasons, "identity_pending")
+	}
+	evaluation.InteractivePass = evaluation.HardPass
+	if metrics.HTTPRequests > 0 {
+		if thresholds.InteractiveP95MS > 0 && metrics.HTTPP95MS > thresholds.InteractiveP95MS {
+			evaluation.InteractivePass = false
+			evaluation.Reasons = append(evaluation.Reasons, "http_p95")
+		}
+		if thresholds.InteractiveP99MS > 0 && metrics.HTTPP99MS > thresholds.InteractiveP99MS {
+			evaluation.InteractivePass = false
+			evaluation.Reasons = append(evaluation.Reasons, "http_p99")
+		}
+	}
+	return evaluation
+}

--- a/internal/benchmark/capacity/capacity.go
+++ b/internal/benchmark/capacity/capacity.go
@@ -10,6 +10,9 @@ type CapacitySearch struct {
 	highFailIndex int
 	pendingIndex  int
 	pending       int
+	startIndex    int
+	started       bool
+	ramping       bool
 	done          bool
 }
 
@@ -17,14 +20,25 @@ func NewCapacitySearch(rates []int) (*CapacitySearch, error) {
 	if len(rates) == 0 {
 		return nil, fmt.Errorf("capacity rates are required")
 	}
+	return NewCapacitySearchAt(rates, rates[0])
+}
+
+func NewCapacitySearchAt(rates []int, initialRate int) (*CapacitySearch, error) {
 	copyRates := append([]int(nil), rates...)
+	startIndex := -1
 	for index, rate := range copyRates {
 		if rate <= 0 || (index > 0 && rate <= copyRates[index-1]) {
 			return nil, fmt.Errorf("capacity rates must be positive and increasing")
 		}
+		if rate == initialRate {
+			startIndex = index
+		}
+	}
+	if startIndex < 0 {
+		return nil, fmt.Errorf("initial capacity rate %d is not configured", initialRate)
 	}
 	return &CapacitySearch{
-		rates: copyRates, lowPassIndex: -1, highFailIndex: len(copyRates), pendingIndex: -1,
+		rates: copyRates, lowPassIndex: -1, highFailIndex: len(copyRates), pendingIndex: -1, startIndex: startIndex, ramping: true,
 	}, nil
 }
 
@@ -36,7 +50,25 @@ func (search *CapacitySearch) Next() (int, bool) {
 		search.done = true
 		return 0, false
 	}
-	search.pendingIndex = search.lowPassIndex + (search.highFailIndex-search.lowPassIndex)/2
+	if !search.started {
+		search.pendingIndex = search.startIndex
+		search.started = true
+	} else if search.ramping && search.highFailIndex == len(search.rates) {
+		if search.lowPassIndex < 0 {
+			search.pendingIndex = 0
+		} else {
+			search.pendingIndex = len(search.rates) - 1
+			current := search.rates[search.lowPassIndex]
+			for index := search.lowPassIndex + 1; index < len(search.rates); index++ {
+				if current <= search.rates[len(search.rates)-1]/2 && search.rates[index] >= current*2 {
+					search.pendingIndex = index
+					break
+				}
+			}
+		}
+	} else {
+		search.pendingIndex = search.lowPassIndex + (search.highFailIndex-search.lowPassIndex)/2
+	}
 	search.pending = search.rates[search.pendingIndex]
 	return search.pending, true
 }
@@ -50,6 +82,7 @@ func (search *CapacitySearch) Record(rate int, passed bool) {
 		search.lowPassIndex = search.pendingIndex
 	} else {
 		search.highFailIndex = search.pendingIndex
+		search.ramping = false
 	}
 	search.pendingIndex = -1
 	if search.highFailIndex-search.lowPassIndex <= 1 {
@@ -67,21 +100,46 @@ func (search *CapacitySearch) HardCapacity() int {
 	return search.rates[search.lowPassIndex]
 }
 
+func (search *CapacitySearch) FailureBoundary() int {
+	if search == nil || search.highFailIndex < 0 || search.highFailIndex >= len(search.rates) {
+		return 0
+	}
+	return search.rates[search.highFailIndex]
+}
+
+// PromoteFailure resumes the upward ramp when a longer boundary probe proves
+// that the prior short-probe failure was transient.
+func (search *CapacitySearch) PromoteFailure(rate int) error {
+	if search == nil || search.pending != 0 || search.FailureBoundary() != rate {
+		return fmt.Errorf("capacity failure boundary %d cannot be promoted", rate)
+	}
+	search.lowPassIndex = search.highFailIndex
+	search.highFailIndex = len(search.rates)
+	search.pendingIndex = -1
+	search.ramping = true
+	search.done = search.lowPassIndex == len(search.rates)-1
+	return nil
+}
+
 type ProbeMetrics struct {
-	OfferedEvents   int64   `json:"offered_events"`
-	PublishedEvents int64   `json:"published_events"`
-	DurableEvents   int64   `json:"durable_events"`
-	BacklogStart    int64   `json:"backlog_start"`
-	BacklogEnd      int64   `json:"backlog_end"`
-	Errors          int64   `json:"errors"`
-	HTTPRequests    int64   `json:"http_requests"`
-	HTTPP95MS       float64 `json:"http_p95_ms"`
-	HTTPP99MS       float64 `json:"http_p99_ms"`
-	OOM             bool    `json:"oom"`
-	Panic           bool    `json:"panic"`
-	SQLiteBusy      int64   `json:"sqlite_busy"`
-	CheckpointLag   int64   `json:"checkpoint_lag"`
-	IdentityPending int64   `json:"identity_pending"`
+	OfferedEvents           int64   `json:"offered_events"`
+	PublishedEvents         int64   `json:"published_events"`
+	DurableEvents           int64   `json:"durable_events"`
+	BacklogStart            int64   `json:"backlog_start"`
+	BacklogEnd              int64   `json:"backlog_end"`
+	Errors                  int64   `json:"errors"`
+	HTTPRequests            int64   `json:"http_requests"`
+	CoreHTTPRequests        int64   `json:"core_http_requests"`
+	CoreHTTPErrors          int64   `json:"core_http_errors"`
+	AnalysisLatencyRequests int64   `json:"analysis_latency_requests"`
+	AnalysisLatencyErrors   int64   `json:"analysis_latency_errors"`
+	HTTPP95MS               float64 `json:"http_p95_ms"`
+	HTTPP99MS               float64 `json:"http_p99_ms"`
+	OOM                     bool    `json:"oom"`
+	Panic                   bool    `json:"panic"`
+	CheckpointLag           int64   `json:"checkpoint_lag"`
+	IdentityPending         int64   `json:"identity_pending"`
+	DrainSeconds            float64 `json:"drain_seconds"`
 }
 
 type ProbeThresholds struct {
@@ -90,12 +148,14 @@ type ProbeThresholds struct {
 	MaxBacklogGrowth  int64   `json:"max_backlog_growth"`
 	InteractiveP95MS  float64 `json:"interactive_p95_ms"`
 	InteractiveP99MS  float64 `json:"interactive_p99_ms"`
+	MaxDrainSeconds   float64 `json:"max_drain_seconds"`
 }
 
 type ProbeEvaluation struct {
-	HardPass        bool     `json:"hard_pass"`
-	InteractivePass bool     `json:"interactive_pass"`
-	Reasons         []string `json:"reasons,omitempty"`
+	HardPass            bool     `json:"hard_pass"`
+	InteractivePass     bool     `json:"interactive_pass"`
+	AnalysisLatencyPass bool     `json:"analysis_latency_pass"`
+	Reasons             []string `json:"reasons,omitempty"`
 }
 
 func EvaluateProbe(metrics ProbeMetrics, thresholds ProbeThresholds) ProbeEvaluation {
@@ -105,7 +165,7 @@ func EvaluateProbe(metrics ProbeMetrics, thresholds ProbeThresholds) ProbeEvalua
 	if thresholds.MinDurableRatio <= 0 {
 		thresholds.MinDurableRatio = 0.99
 	}
-	evaluation := ProbeEvaluation{HardPass: true}
+	evaluation := ProbeEvaluation{HardPass: true, AnalysisLatencyPass: true}
 	if metrics.OOM {
 		evaluation.HardPass = false
 		evaluation.Reasons = append(evaluation.Reasons, "oom")
@@ -118,13 +178,13 @@ func EvaluateProbe(metrics ProbeMetrics, thresholds ProbeThresholds) ProbeEvalua
 		evaluation.HardPass = false
 		evaluation.Reasons = append(evaluation.Reasons, "errors")
 	}
+	if thresholds.MaxDrainSeconds > 0 && metrics.DrainSeconds > thresholds.MaxDrainSeconds {
+		evaluation.HardPass = false
+		evaluation.Reasons = append(evaluation.Reasons, "drain_lag")
+	}
 	if metrics.OfferedEvents > 0 && float64(metrics.PublishedEvents)/float64(metrics.OfferedEvents) < thresholds.MinPublishedRatio {
 		evaluation.HardPass = false
 		evaluation.Reasons = append(evaluation.Reasons, "driver_lag")
-	}
-	if metrics.SQLiteBusy > 0 {
-		evaluation.HardPass = false
-		evaluation.Reasons = append(evaluation.Reasons, "sqlite_busy")
 	}
 	durableTailAllowed := metrics.OfferedEvents >= 10 &&
 		metrics.PublishedEvents == metrics.OfferedEvents &&
@@ -151,6 +211,16 @@ func EvaluateProbe(metrics ProbeMetrics, thresholds ProbeThresholds) ProbeEvalua
 		evaluation.Reasons = append(evaluation.Reasons, "identity_pending")
 	}
 	evaluation.InteractivePass = evaluation.HardPass
+	// 诊断状态只反映自身请求与会使整个 Keeper 失效的运行时故障，不继承 ingestion 容量失败。
+	evaluation.AnalysisLatencyPass = !metrics.OOM && !metrics.Panic
+	if metrics.CoreHTTPErrors > 0 {
+		evaluation.InteractivePass = false
+		evaluation.Reasons = append(evaluation.Reasons, "core_http_errors")
+	}
+	if metrics.AnalysisLatencyErrors > 0 {
+		evaluation.AnalysisLatencyPass = false
+		evaluation.Reasons = append(evaluation.Reasons, "analysis_latency_errors")
+	}
 	if metrics.HTTPRequests > 0 {
 		if thresholds.InteractiveP95MS > 0 && metrics.HTTPP95MS > thresholds.InteractiveP95MS {
 			evaluation.InteractivePass = false

--- a/internal/benchmark/capacity/dataset.go
+++ b/internal/benchmark/capacity/dataset.go
@@ -1,0 +1,813 @@
+package capacity
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"cpa-usage-keeper/internal/activity"
+	"cpa-usage-keeper/internal/config"
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/latency"
+	"cpa-usage-keeper/internal/overview"
+	"cpa-usage-keeper/internal/repository"
+	"cpa-usage-keeper/internal/timeutil"
+	"gorm.io/gorm"
+)
+
+const usageEventInsertColumns = entities.UsageEventStorageColumns
+
+const DatasetGeneratorVersion = "production-v6-token-canonical"
+
+type GenerateOptions struct {
+	Path            string
+	HotEvents       int64
+	ArchiveEvents   int64
+	HotDays         int
+	ArchiveDays     int
+	FailureRate     float64
+	Seed            uint64
+	Now             time.Time
+	Cardinality     Cardinality
+	TrafficTiers    []TrafficTier
+	InsertBatchSize int
+	AggregatePage   int
+	Vacuum          bool
+}
+
+type DatasetResult struct {
+	Path                    string    `json:"-"`
+	GeneratorVersion        string    `json:"generator_version,omitempty"`
+	Seed                    uint64    `json:"seed,omitempty"`
+	BenchmarkNow            time.Time `json:"benchmark_now,omitempty"`
+	HotEvents               int64     `json:"hot_events"`
+	ArchiveEvents           int64     `json:"archive_events"`
+	TotalEvents             int64     `json:"total_events"`
+	FailedEvents            int64     `json:"failed_events"`
+	Identities              int64     `json:"identities"`
+	Models                  int64     `json:"models"`
+	APIKeys                 int64     `json:"api_keys"`
+	UsedIdentities          int64     `json:"used_identities"`
+	UsedModels              int64     `json:"used_models"`
+	UsedAPIKeys             int64     `json:"used_api_keys"`
+	OrphanIdentities        int64     `json:"orphan_identities"`
+	OrphanModels            int64     `json:"orphan_models"`
+	OrphanAPIKeys           int64     `json:"orphan_api_keys"`
+	DuplicateEventKeys      int64     `json:"duplicate_event_keys"`
+	TokenSemanticViolations int64     `json:"token_semantic_violations"`
+	OverviewHourlyRequests  int64     `json:"overview_hourly_requests"`
+	OverviewDailyRequests   int64     `json:"overview_daily_requests"`
+	IdentityRequests        int64     `json:"identity_requests"`
+	OverviewHourlyRows      int64     `json:"overview_hourly_rows"`
+	OverviewDailyRows       int64     `json:"overview_daily_rows"`
+	ActivityRows            int64     `json:"activity_rows"`
+	LatencyRows             int64     `json:"latency_rows"`
+	InputTokens             int64     `json:"input_tokens"`
+	OutputTokens            int64     `json:"output_tokens"`
+	TotalLatencyMS          int64     `json:"total_latency_ms"`
+	CheckpointMin           int64     `json:"checkpoint_min"`
+	CheckpointMax           int64     `json:"checkpoint_max"`
+	QuickCheck              string    `json:"quick_check"`
+	DatabaseBytes           int64     `json:"database_bytes"`
+	SemanticFingerprint     string    `json:"semantic_fingerprint"`
+}
+
+type storedIndex struct {
+	Name string
+	SQL  string
+}
+
+type generatedEvent struct {
+	ID                  int64
+	EventKey            string
+	APIGroupKey         string
+	Provider            string
+	Endpoint            string
+	AuthType            string
+	RequestID           string
+	Model               string
+	ModelAlias          string
+	ReasoningEffort     string
+	ServiceTier         string
+	ResponseServiceTier string
+	ExecutorType        string
+	Timestamp           time.Time
+	Source              string
+	AuthIndex           string
+	Failed              bool
+	LatencyMS           int64
+	TTFTMS              int64
+	InputTokens         int64
+	OutputTokens        int64
+	ReasoningTokens     int64
+	CachedTokens        int64
+	CacheReadTokens     int64
+	CacheCreationTokens int64
+	TotalTokens         int64
+}
+
+type identityProfile struct {
+	Identity string
+	AuthType entities.UsageIdentityAuthType
+}
+
+type weightedSelector struct {
+	cumulative []float64
+	total      float64
+}
+
+type timeBucket struct {
+	start time.Time
+	count int64
+}
+
+type eventTimeline struct {
+	buckets     []timeBucket
+	bucketIndex int
+	inside      int64
+}
+
+func GenerateDataset(ctx context.Context, options GenerateOptions) (DatasetResult, error) {
+	if err := validateGenerateOptions(options); err != nil {
+		return DatasetResult{}, err
+	}
+	if _, err := os.Stat(options.Path); err == nil {
+		return DatasetResult{}, fmt.Errorf("benchmark dataset already exists: %s", filepath.Clean(options.Path))
+	} else if !os.IsNotExist(err) {
+		return DatasetResult{}, fmt.Errorf("inspect benchmark dataset path: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(options.Path), 0o755); err != nil {
+		return DatasetResult{}, fmt.Errorf("create benchmark dataset directory: %w", err)
+	}
+
+	db, err := repository.OpenDatabase(config.Config{SQLitePath: options.Path})
+	if err != nil {
+		return DatasetResult{}, fmt.Errorf("open benchmark dataset: %w", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		return DatasetResult{}, fmt.Errorf("resolve benchmark database: %w", err)
+	}
+	defer sqlDB.Close()
+
+	// 数据准备可重建且不计入容量，使用 NORMAL 和较大页缓存减少 10M 行合成时间。
+	if err := db.Exec("PRAGMA synchronous=NORMAL").Error; err != nil {
+		return DatasetResult{}, fmt.Errorf("configure benchmark synchronous mode: %w", err)
+	}
+	if err := db.Exec("PRAGMA temp_store=MEMORY").Error; err != nil {
+		return DatasetResult{}, fmt.Errorf("configure benchmark temp store: %w", err)
+	}
+	if err := db.Exec("PRAGMA cache_size=-524288").Error; err != nil {
+		return DatasetResult{}, fmt.Errorf("configure benchmark page cache: %w", err)
+	}
+
+	indexes, err := dropSecondaryIndexes(ctx, sqlDB, "usage_events")
+	if err != nil {
+		return DatasetResult{}, err
+	}
+	identities, err := seedDatasetMetadata(db, options)
+	if err != nil {
+		return DatasetResult{}, err
+	}
+	if err := insertGeneratedEvents(ctx, sqlDB, options, identities); err != nil {
+		return DatasetResult{}, err
+	}
+	if err := restoreIndexes(ctx, sqlDB, indexes); err != nil {
+		return DatasetResult{}, err
+	}
+	if err := buildDerivedDataset(ctx, db, options); err != nil {
+		return DatasetResult{}, err
+	}
+	if err := moveArchiveRows(db, options.ArchiveEvents); err != nil {
+		return DatasetResult{}, err
+	}
+	if options.Vacuum {
+		if err := repository.Vacuum(db); err != nil {
+			return DatasetResult{}, fmt.Errorf("vacuum benchmark dataset: %w", err)
+		}
+	}
+	if err := db.Exec("PRAGMA wal_checkpoint(TRUNCATE)").Error; err != nil {
+		return DatasetResult{}, fmt.Errorf("checkpoint benchmark WAL: %w", err)
+	}
+	result, err := ValidateDataset(db, options.Path)
+	if err != nil {
+		return DatasetResult{}, err
+	}
+	result.GeneratorVersion = DatasetGeneratorVersion
+	result.Seed = options.Seed
+	result.BenchmarkNow = options.Now
+	return result, nil
+}
+
+func validateGenerateOptions(options GenerateOptions) error {
+	if strings.TrimSpace(options.Path) == "" {
+		return fmt.Errorf("benchmark dataset path is required")
+	}
+	if options.HotEvents <= 0 || options.ArchiveEvents < 0 || options.HotDays <= 0 || options.ArchiveDays < 0 {
+		return fmt.Errorf("benchmark event counts and day windows are invalid")
+	}
+	if options.FailureRate < 0 || options.FailureRate > 1 {
+		return fmt.Errorf("benchmark failure rate must be between zero and one")
+	}
+	if options.Now.IsZero() {
+		return fmt.Errorf("benchmark now is required")
+	}
+	if err := validateCardinality("dataset", options.Cardinality); err != nil {
+		return err
+	}
+	if len(options.TrafficTiers) == 0 {
+		return fmt.Errorf("benchmark traffic tiers are required")
+	}
+	if options.InsertBatchSize <= 0 {
+		options.InsertBatchSize = 10_000
+	}
+	if options.AggregatePage <= 0 {
+		options.AggregatePage = 1_000
+	}
+	return nil
+}
+
+func seedDatasetMetadata(db *gorm.DB, options GenerateOptions) ([]identityProfile, error) {
+	now := timeutil.NormalizeStorageTime(options.Now)
+	apiProfiles, err := BuildAPIKeyProfiles(options.Cardinality.APIKeys, options.TrafficTiers, options.Seed)
+	if err != nil {
+		return nil, err
+	}
+	apiKeys := make([]entities.CPAAPIKey, 0, len(apiProfiles))
+	for _, profile := range apiProfiles {
+		apiKeys = append(apiKeys, entities.CPAAPIKey{
+			ID: int64(profile.Index), APIKey: fmt.Sprintf("bench-key-%03d", profile.Index),
+			DisplayKey: fmt.Sprintf("bench-***-%03d", profile.Index), KeyAlias: fmt.Sprintf("bench-%s-%03d", profile.Tier, profile.Index),
+			IsDeleted: false, LastSyncedAt: &now, CreatedAt: now, UpdatedAt: now,
+		})
+	}
+	if err := db.CreateInBatches(apiKeys, 100).Error; err != nil {
+		return nil, fmt.Errorf("seed benchmark API keys: %w", err)
+	}
+
+	identityRows := make([]entities.UsageIdentity, 0, options.Cardinality.Identities)
+	identityProfiles := make([]identityProfile, 0, options.Cardinality.Identities)
+	for index := 1; index <= options.Cardinality.Identities; index++ {
+		authType := entities.UsageIdentityAuthTypeAuthFile
+		authTypeName := "auth_file"
+		provider := "codex"
+		eventAuthType := "oauth"
+		if index%4 == 0 {
+			authType = entities.UsageIdentityAuthTypeAIProvider
+			authTypeName = "ai_provider"
+			provider = "openai"
+			eventAuthType = "apikey"
+		}
+		identity := fmt.Sprintf("bench-auth-%04d", index)
+		identityRows = append(identityRows, entities.UsageIdentity{
+			ID: int64(index), Name: identity, AuthType: authType, AuthTypeName: authTypeName,
+			Identity: identity, Type: provider, Provider: provider, LookupKey: identity,
+			ActiveStart: &now, IsDeleted: false, CreatedAt: now, UpdatedAt: now,
+		})
+		identityProfiles = append(identityProfiles, identityProfile{Identity: identity, AuthType: authType})
+		_ = eventAuthType
+	}
+	if err := db.CreateInBatches(identityRows, 100).Error; err != nil {
+		return nil, fmt.Errorf("seed benchmark identities: %w", err)
+	}
+
+	prices := make([]entities.ModelPriceSetting, 0, options.Cardinality.Models)
+	for index := 1; index <= options.Cardinality.Models; index++ {
+		multiplier := 1.0
+		prices = append(prices, entities.ModelPriceSetting{
+			ID: int64(index), Model: fmt.Sprintf("bench-model-%03d", index), PricingStyle: entities.ModelPricingStyleOpenAI,
+			PromptPricePer1M: 1 + float64(index%7)/10, CompletionPricePer1M: 4 + float64(index%11)/10,
+			CacheReadPricePer1M: 0.1, CacheWritePricePer1M: 1.25, PriceMultiplier: &multiplier,
+			CreatedAt: now, UpdatedAt: now,
+		})
+	}
+	if err := db.CreateInBatches(prices, 100).Error; err != nil {
+		return nil, fmt.Errorf("seed benchmark pricing: %w", err)
+	}
+	return identityProfiles, nil
+}
+
+func insertGeneratedEvents(ctx context.Context, sqlDB *sql.DB, options GenerateOptions, identities []identityProfile) error {
+	total := options.HotEvents + options.ArchiveEvents
+	apiProfiles, err := BuildAPIKeyProfiles(options.Cardinality.APIKeys, options.TrafficTiers, options.Seed)
+	if err != nil {
+		return err
+	}
+	apiTraffic, err := newAPITrafficTopology(apiProfiles)
+	if err != nil {
+		return err
+	}
+	random := splitMix64{state: options.Seed ^ 0x6a09e667f3bcc909}
+	timeline := buildEventTimeline(options)
+	batchSize := options.InsertBatchSize
+	if batchSize <= 0 {
+		batchSize = 10_000
+	}
+
+	for startID := int64(1); startID <= total; startID += int64(batchSize) {
+		endID := min(startID+int64(batchSize)-1, total)
+		tx, err := sqlDB.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin benchmark event batch: %w", err)
+		}
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", 31), ",")
+		statement, err := tx.PrepareContext(ctx, "INSERT INTO usage_events ("+usageEventInsertColumns+") VALUES ("+placeholders+")")
+		if err != nil {
+			tx.Rollback()
+			return fmt.Errorf("prepare benchmark event insert: %w", err)
+		}
+		for eventID := startID; eventID <= endID; eventID++ {
+			timestamp, ok := timeline.next()
+			if !ok {
+				statement.Close()
+				tx.Rollback()
+				return fmt.Errorf("benchmark timeline ended before event %d", eventID)
+			}
+			event := makeGeneratedEvent(eventID, timestamp, options, identities, apiTraffic, &random)
+			if _, err := statement.ExecContext(ctx, eventInsertArgs(event)...); err != nil {
+				statement.Close()
+				tx.Rollback()
+				return fmt.Errorf("insert benchmark event %d: %w", eventID, err)
+			}
+		}
+		if err := statement.Close(); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("close benchmark event statement: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit benchmark event batch: %w", err)
+		}
+	}
+	return nil
+}
+
+func makeGeneratedEvent(eventID int64, timestamp time.Time, options GenerateOptions, identities []identityProfile, apiTraffic apiTrafficTopology, random *splitMix64) generatedEvent {
+	apiIndex := apiTraffic.choose(timestamp, random)
+	identityIndex := chooseCorrelatedIdentity(apiIndex, options.Cardinality, timestamp, random)
+	modelIndex := chooseCorrelatedModel(identityIndex, options.Cardinality, random)
+	// 开头的覆盖段保证全部 metadata 至少被一条事件引用，后续仍完全遵循权重。
+	if eventID <= int64(options.Cardinality.APIKeys) {
+		apiIndex = int(eventID - 1)
+		identityIndex = chooseCorrelatedIdentity(apiIndex, options.Cardinality, timestamp, random)
+	}
+	if eventID <= int64(options.Cardinality.Identities) {
+		identityIndex = int(eventID - 1)
+		apiIndex = identityIndex % options.Cardinality.APIKeys
+	}
+	if eventID <= int64(options.Cardinality.Models) {
+		modelIndex = int(eventID - 1)
+	}
+	identity := identities[identityIndex]
+	authType := "oauth"
+	provider := "codex"
+	if identity.AuthType == entities.UsageIdentityAuthTypeAIProvider {
+		authType = "apikey"
+		provider = "openai"
+	}
+	input := int64(80 + random.next()%4000)
+	output := int64(20 + random.next()%1200)
+	reasoning := int64(random.next() % uint64(output+1))
+	cacheRead := int64(random.next() % uint64(max(input/2, 1)))
+	cacheCreation := int64(random.next() % uint64(max(input/5, 1)))
+	cached := cacheRead
+	total := input + output
+	failed := random.float64() < options.FailureRate
+	latencyMS := int64(250 + random.next()%45_000)
+	ttftMS := int64(50 + random.next()%min(uint64(latencyMS), uint64(8_000)))
+	eventKeyIndex := eventID
+	if eventID%100 == 0 {
+		eventKeyIndex = eventID - 1
+	}
+	requestIDIndex := eventID
+	if eventID%250 == 0 {
+		requestIDIndex = eventID - 1
+	}
+	endpoint, serviceTier, responseTier, reasoningEffort, executorType := correlatedDimensions(modelIndex, identityIndex, provider, random)
+	return generatedEvent{
+		ID: eventID, EventKey: fmt.Sprintf("bench-event-%012d", eventKeyIndex), APIGroupKey: fmt.Sprint(apiIndex + 1),
+		Provider: provider, Endpoint: endpoint, AuthType: authType,
+		RequestID: fmt.Sprintf("bench-request-%012d", requestIDIndex), Model: fmt.Sprintf("bench-model-%03d", modelIndex+1),
+		ModelAlias: fmt.Sprintf("bench-alias-%03d", modelIndex+1), ReasoningEffort: reasoningEffort,
+		ServiceTier: serviceTier, ResponseServiceTier: responseTier, ExecutorType: executorType,
+		Timestamp: timestamp, Source: provider, AuthIndex: identity.Identity, Failed: failed,
+		LatencyMS: latencyMS, TTFTMS: ttftMS, InputTokens: input, OutputTokens: output, ReasoningTokens: reasoning,
+		CachedTokens: cached, CacheReadTokens: cacheRead, CacheCreationTokens: cacheCreation, TotalTokens: total,
+	}
+}
+
+func chooseCorrelatedIdentity(apiIndex int, cardinality Cardinality, timestamp time.Time, random *splitMix64) int {
+	poolAPI := apiIndex
+	// 一部分事件从相邻 Key 的身份池中选择，复刻真实场景中同一身份被多个 Key 使用，但不形成全交叉。
+	if cardinality.APIKeys > 1 && random.float64() < 0.20 {
+		poolAPI = (apiIndex + 1) % cardinality.APIKeys
+	}
+	if poolAPI >= cardinality.Identities {
+		return poolAPI % cardinality.Identities
+	}
+	poolSize := (cardinality.Identities-1-poolAPI)/cardinality.APIKeys + 1
+	unit := random.float64()
+	// 十次方长尾接近样本的“小时内少量身份活跃、全周期仍覆盖全部有效身份”。
+	skewed := unit
+	for index := 1; index < 10; index++ {
+		skewed *= unit
+	}
+	rank := int(skewed * float64(poolSize))
+	if rank >= poolSize {
+		rank = poolSize - 1
+	}
+	if rank > 0 && poolSize > 2 {
+		tailSize := poolSize - 1
+		activeTail := max(1, int(math.Ceil(float64(tailSize)*0.15)))
+		week := timestamp.Unix() / int64((7 * 24 * time.Hour).Seconds())
+		rotator := splitMix64{state: uint64(week) ^ uint64(poolAPI+1)*0xbf58476d1ce4e5b9}
+		rotation := int(rotator.next() % uint64(tailSize))
+		rank = 1 + (rotation+(rank-1)%activeTail)%tailSize
+	}
+	return poolAPI + rank*cardinality.APIKeys
+}
+
+func chooseCorrelatedModel(identityIndex int, cardinality Cardinality, random *splitMix64) int {
+	modelCount := cardinality.Models
+	clusterSize := min(modelCount, max(4, int(math.Ceil(math.Sqrt(float64(modelCount))*2))))
+	primaryAPI := identityIndex % cardinality.APIKeys
+	clusterStart := (primaryAPI * 7) % modelCount
+	localRank := identityIndex / cardinality.APIKeys
+	primaryOffset := localRank % clusterSize
+	roll := random.next() % 1000
+	switch {
+	case roll < 850:
+		return (clusterStart + primaryOffset) % modelCount
+	case roll < 990:
+		return (clusterStart + (primaryOffset+1+localRank%3)%clusterSize) % modelCount
+	default:
+		return (clusterStart + (primaryOffset+3+localRank%5)%clusterSize) % modelCount
+	}
+}
+
+func correlatedDimensions(modelIndex, identityIndex int, provider string, random *splitMix64) (string, string, string, string, string) {
+	endpoints := []string{"responses", "chat/completions", "messages"}
+	reasoning := []string{"", "low", "medium", "high"}
+	endpoint := endpoints[modelIndex%len(endpoints)]
+	serviceTier := "default"
+	if modelIndex%10 < 2 {
+		serviceTier = ""
+	} else if modelIndex%10 >= 8 {
+		serviceTier = "priority"
+	}
+	responseTier := serviceTier
+	if identityIndex%7 == 0 {
+		responseTier = ""
+	}
+	reasoningEffort := reasoning[modelIndex%len(reasoning)]
+	executorType := "native"
+	if provider == "openai" {
+		executorType = "compat"
+	} else if identityIndex%6 == 0 {
+		executorType = ""
+	}
+	// 仅 0.5% 事件使用同一个相关替代 tuple，避免五个维度独立随机产生笛卡尔爆炸。
+	if random.next()%1000 >= 995 {
+		endpoint = endpoints[(modelIndex+1)%len(endpoints)]
+		if serviceTier == "priority" {
+			serviceTier = "default"
+		} else {
+			serviceTier = "priority"
+		}
+		responseTier = serviceTier
+		reasoningEffort = reasoning[(modelIndex+1)%len(reasoning)]
+		if executorType == "native" {
+			executorType = "compat"
+		} else {
+			executorType = "native"
+		}
+	}
+	return endpoint, serviceTier, responseTier, reasoningEffort, executorType
+}
+
+func eventInsertArgs(event generatedEvent) []any {
+	timestamp := timeutil.FormatStorageTime(event.Timestamp)
+	return []any{
+		event.ID, event.EventKey, event.APIGroupKey, event.Provider, event.Endpoint, event.AuthType, event.RequestID,
+		nil, nil, nil, event.Model, event.ModelAlias, event.ReasoningEffort, event.ServiceTier, event.ResponseServiceTier,
+		event.ExecutorType, timestamp, event.Source, event.AuthIndex, event.Failed, true, event.LatencyMS, event.TTFTMS,
+		event.InputTokens, event.OutputTokens, event.ReasoningTokens, event.CachedTokens, event.CacheReadTokens,
+		event.CacheCreationTokens, event.TotalTokens, timestamp,
+	}
+}
+
+func buildEventTimeline(options GenerateOptions) *eventTimeline {
+	now := timeutil.NormalizeStorageTime(options.Now)
+	hotStart := now.AddDate(0, 0, -options.HotDays)
+	archiveStart := hotStart.AddDate(0, 0, -options.ArchiveDays)
+	buckets := make([]timeBucket, 0, (options.HotDays+options.ArchiveDays)*24)
+	if options.ArchiveEvents > 0 && options.ArchiveDays > 0 {
+		buckets = append(buckets, weightedTimeBuckets(archiveStart, options.ArchiveDays*24, options.ArchiveEvents, options.Seed^1)...)
+	}
+	recentDays := min(options.HotDays, 30)
+	olderDays := options.HotDays - recentDays
+	recentEvents := options.HotEvents
+	olderEvents := int64(0)
+	if olderDays > 0 {
+		olderEvents = int64(math.Round(float64(options.HotEvents) * 0.37))
+		recentEvents = options.HotEvents - olderEvents
+		buckets = append(buckets, weightedTimeBuckets(hotStart, olderDays*24, olderEvents, options.Seed^2)...)
+	}
+	recentStart := hotStart.AddDate(0, 0, olderDays)
+	buckets = append(buckets, weightedTimeBuckets(recentStart, recentDays*24, recentEvents, options.Seed^3)...)
+	return &eventTimeline{buckets: buckets}
+}
+
+func weightedTimeBuckets(start time.Time, hours int, total int64, seed uint64) []timeBucket {
+	if hours <= 0 || total <= 0 {
+		return nil
+	}
+	hourWeights := [...]float64{0.35, 0.28, 0.25, 0.25, 0.35, 0.60, 0.90, 1.20, 1.50, 1.70, 1.80, 1.70, 1.60, 1.50, 1.50, 1.60, 1.80, 2.00, 2.20, 2.00, 1.60, 1.20, 0.80, 0.50}
+	weights := make([]float64, hours)
+	random := splitMix64{state: seed}
+	for index := range weights {
+		timestamp := start.Add(time.Duration(index) * time.Hour)
+		weekday := 1.0
+		if timestamp.Weekday() == time.Saturday || timestamp.Weekday() == time.Sunday {
+			weekday = 0.78
+		}
+		burst := 1.0
+		if random.next()%97 == 0 {
+			burst = 3.5
+		}
+		weights[index] = hourWeights[timestamp.Hour()] * weekday * burst
+	}
+	counts := allocateWeightedInteger(total, weights)
+	buckets := make([]timeBucket, 0, hours)
+	for index, count := range counts {
+		if count > 0 {
+			buckets = append(buckets, timeBucket{start: start.Add(time.Duration(index) * time.Hour), count: count})
+		}
+	}
+	return buckets
+}
+
+func allocateWeightedInteger(total int64, weights []float64) []int64 {
+	counts := make([]int64, len(weights))
+	remainders := make([]fractionalShare, len(weights))
+	weightTotal := 0.0
+	for _, weight := range weights {
+		weightTotal += weight
+	}
+	allocated := int64(0)
+	for index, weight := range weights {
+		exact := float64(total) * weight / weightTotal
+		counts[index] = int64(math.Floor(exact))
+		allocated += counts[index]
+		remainders[index] = fractionalShare{index: index, fraction: exact - float64(counts[index])}
+	}
+	sort.SliceStable(remainders, func(left, right int) bool { return remainders[left].fraction > remainders[right].fraction })
+	for index := int64(0); index < total-allocated; index++ {
+		counts[remainders[index%int64(len(remainders))].index]++
+	}
+	return counts
+}
+
+func (timeline *eventTimeline) next() (time.Time, bool) {
+	for timeline.bucketIndex < len(timeline.buckets) {
+		bucket := timeline.buckets[timeline.bucketIndex]
+		if timeline.inside >= bucket.count {
+			timeline.bucketIndex++
+			timeline.inside = 0
+			continue
+		}
+		position := timeline.inside
+		timeline.inside++
+		offset := time.Duration((float64(position) + 0.5) / float64(bucket.count) * float64(time.Hour))
+		return bucket.start.Add(offset), true
+	}
+	return time.Time{}, false
+}
+
+func newWeightedSelector(weights []float64) weightedSelector {
+	selector := weightedSelector{cumulative: make([]float64, len(weights))}
+	for index, weight := range weights {
+		selector.total += weight
+		selector.cumulative[index] = selector.total
+	}
+	return selector
+}
+
+func (selector weightedSelector) choose(unit float64) int {
+	target := unit * selector.total
+	index := sort.Search(len(selector.cumulative), func(index int) bool { return selector.cumulative[index] >= target })
+	if index >= len(selector.cumulative) {
+		return len(selector.cumulative) - 1
+	}
+	return index
+}
+
+func dropSecondaryIndexes(ctx context.Context, sqlDB *sql.DB, table string) ([]storedIndex, error) {
+	rows, err := sqlDB.QueryContext(ctx, "SELECT name, sql FROM sqlite_master WHERE type = 'index' AND tbl_name = ? AND sql IS NOT NULL ORDER BY name", table)
+	if err != nil {
+		return nil, fmt.Errorf("list benchmark indexes: %w", err)
+	}
+	defer rows.Close()
+	var indexes []storedIndex
+	for rows.Next() {
+		var index storedIndex
+		if err := rows.Scan(&index.Name, &index.SQL); err != nil {
+			return nil, fmt.Errorf("scan benchmark index: %w", err)
+		}
+		indexes = append(indexes, index)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate benchmark indexes: %w", err)
+	}
+	for _, index := range indexes {
+		if _, err := sqlDB.ExecContext(ctx, "DROP INDEX "+quoteSQLiteIdentifier(index.Name)); err != nil {
+			return nil, fmt.Errorf("drop benchmark index %s: %w", index.Name, err)
+		}
+	}
+	return indexes, nil
+}
+
+func restoreIndexes(ctx context.Context, sqlDB *sql.DB, indexes []storedIndex) error {
+	for _, index := range indexes {
+		if _, err := sqlDB.ExecContext(ctx, index.SQL); err != nil {
+			return fmt.Errorf("restore benchmark index %s: %w", index.Name, err)
+		}
+	}
+	return nil
+}
+
+func quoteSQLiteIdentifier(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
+}
+
+func buildDerivedDataset(ctx context.Context, db *gorm.DB, options GenerateOptions) error {
+	target := options.HotEvents + options.ArchiveEvents
+	pageSize := options.AggregatePage
+	if pageSize <= 0 {
+		pageSize = 1_000
+	}
+	for _, kind := range []entities.UsageAggregationCheckpointName{
+		entities.UsageAggregationCheckpointOverview,
+		entities.UsageAggregationCheckpointActivity,
+		entities.UsageAggregationCheckpointLatency,
+	} {
+		cursor := int64(0)
+		for cursor < target {
+			var events []entities.UsageEvent
+			if err := db.WithContext(ctx).Model(&entities.UsageEvent{}).
+				Select(entities.UsageAggregationEventProjectionColumns).
+				Where("id > ? AND id <= ?", cursor, target).
+				Order("id asc").Limit(pageSize).Find(&events).Error; err != nil {
+				return fmt.Errorf("load %s benchmark aggregation page: %w", kind, err)
+			}
+			if len(events) == 0 {
+				return fmt.Errorf("%s benchmark aggregation stopped at %d before %d", kind, cursor, target)
+			}
+			nextCursor := events[len(events)-1].ID
+			switch kind {
+			case entities.UsageAggregationCheckpointOverview:
+				hourly, daily, _ := overview.BuildRows(events)
+				if err := repository.ApplyUsageOverviewAggregationPage(ctx, db, cursor, nextCursor, hourly, daily, options.Now); err != nil {
+					return fmt.Errorf("apply overview benchmark aggregation: %w", err)
+				}
+			case entities.UsageAggregationCheckpointActivity:
+				rows, err := activity.BuildRows(events, options.Now)
+				if err != nil {
+					return err
+				}
+				if err := repository.ApplyUsageActivityAggregationPage(ctx, db, cursor, nextCursor, rows, options.Now); err != nil {
+					return fmt.Errorf("apply activity benchmark aggregation: %w", err)
+				}
+			case entities.UsageAggregationCheckpointLatency:
+				rows, err := latency.BuildRows(events, options.Now)
+				if err != nil {
+					return err
+				}
+				if err := repository.ApplyUsageLatencyAggregationPage(ctx, db, cursor, nextCursor, rows, options.Now); err != nil {
+					return fmt.Errorf("apply latency benchmark aggregation: %w", err)
+				}
+			}
+			cursor = nextCursor
+		}
+	}
+	if err := repository.AggregateUsageIdentityStats(ctx, db, options.Now); err != nil {
+		return fmt.Errorf("aggregate benchmark identities: %w", err)
+	}
+	return nil
+}
+
+func moveArchiveRows(db *gorm.DB, archiveEvents int64) error {
+	if archiveEvents == 0 {
+		return nil
+	}
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("INSERT INTO usage_events_archive ("+entities.UsageEventStorageColumns+") SELECT "+entities.UsageEventStorageColumns+" FROM usage_events WHERE id <= ? ORDER BY id", archiveEvents).Error; err != nil {
+			return fmt.Errorf("copy benchmark archive rows: %w", err)
+		}
+		if err := tx.Where("id <= ?", archiveEvents).Delete(&entities.UsageEvent{}).Error; err != nil {
+			return fmt.Errorf("delete benchmark archived hot rows: %w", err)
+		}
+		return nil
+	})
+}
+
+func ValidateDataset(db *gorm.DB, path string) (DatasetResult, error) {
+	result := DatasetResult{Path: filepath.Clean(path)}
+	queries := []struct {
+		name   string
+		query  string
+		target *int64
+	}{
+		{"hot events", "SELECT COUNT(*) FROM usage_events", &result.HotEvents},
+		{"archive events", "SELECT COUNT(*) FROM usage_events_archive", &result.ArchiveEvents},
+		{"failed events", "SELECT COUNT(*) FROM (SELECT failed FROM usage_events UNION ALL SELECT failed FROM usage_events_archive) WHERE failed", &result.FailedEvents},
+		{"identities", "SELECT COUNT(*) FROM usage_identities WHERE is_deleted = 0 AND COALESCE(disabled, 0) = 0", &result.Identities},
+		{"models", "SELECT COUNT(*) FROM model_price_settings", &result.Models},
+		{"API keys", "SELECT COUNT(*) FROM cpa_api_keys WHERE is_deleted = 0", &result.APIKeys},
+		{"used identities", "SELECT COUNT(DISTINCT auth_index) FROM (SELECT auth_index FROM usage_events UNION ALL SELECT auth_index FROM usage_events_archive)", &result.UsedIdentities},
+		{"used models", "SELECT COUNT(DISTINCT model) FROM (SELECT model FROM usage_events UNION ALL SELECT model FROM usage_events_archive)", &result.UsedModels},
+		{"used API keys", "SELECT COUNT(DISTINCT api_group_key) FROM (SELECT api_group_key FROM usage_events UNION ALL SELECT api_group_key FROM usage_events_archive)", &result.UsedAPIKeys},
+		{"orphan identities", "SELECT COUNT(*) FROM (SELECT auth_index, auth_type FROM usage_events UNION ALL SELECT auth_index, auth_type FROM usage_events_archive) e LEFT JOIN usage_identities i ON i.identity = e.auth_index AND ((i.auth_type = 1 AND e.auth_type = 'oauth') OR (i.auth_type = 2 AND e.auth_type = 'apikey')) AND i.is_deleted = 0 WHERE i.id IS NULL", &result.OrphanIdentities},
+		{"orphan models", "SELECT COUNT(*) FROM (SELECT model FROM usage_events UNION ALL SELECT model FROM usage_events_archive) e LEFT JOIN model_price_settings p ON p.model = e.model WHERE p.id IS NULL", &result.OrphanModels},
+		{"orphan API keys", "SELECT COUNT(*) FROM (SELECT api_group_key FROM usage_events UNION ALL SELECT api_group_key FROM usage_events_archive) e LEFT JOIN cpa_api_keys k ON CAST(k.id AS TEXT) = e.api_group_key AND k.is_deleted = 0 WHERE k.id IS NULL", &result.OrphanAPIKeys},
+		{"duplicate event keys", "SELECT COUNT(*) - COUNT(DISTINCT event_key) FROM (SELECT event_key FROM usage_events UNION ALL SELECT event_key FROM usage_events_archive)", &result.DuplicateEventKeys},
+		{"overview hourly requests", "SELECT COALESCE(SUM(request_count), 0) FROM usage_overview_hourly_stats", &result.OverviewHourlyRequests},
+		{"overview daily requests", "SELECT COALESCE(SUM(request_count), 0) FROM usage_overview_daily_stats", &result.OverviewDailyRequests},
+		{"identity requests", "SELECT COALESCE(SUM(total_requests), 0) FROM usage_identities", &result.IdentityRequests},
+		{"overview hourly rows", "SELECT COUNT(*) FROM usage_overview_hourly_stats", &result.OverviewHourlyRows},
+		{"overview daily rows", "SELECT COUNT(*) FROM usage_overview_daily_stats", &result.OverviewDailyRows},
+		{"activity rows", "SELECT COUNT(*) FROM usage_activity_stats", &result.ActivityRows},
+		{"latency rows", "SELECT COUNT(*) FROM usage_latency_stats", &result.LatencyRows},
+		{"checkpoint minimum", "SELECT COALESCE(MIN(last_aggregated_usage_event_id), 0) FROM usage_aggregation_checkpoints", &result.CheckpointMin},
+		{"checkpoint maximum", "SELECT COALESCE(MAX(last_aggregated_usage_event_id), 0) FROM usage_aggregation_checkpoints", &result.CheckpointMax},
+	}
+	for _, item := range queries {
+		if err := db.Raw(item.query).Scan(item.target).Error; err != nil {
+			return DatasetResult{}, fmt.Errorf("validate benchmark %s: %w", item.name, err)
+		}
+	}
+	result.TotalEvents = result.HotEvents + result.ArchiveEvents
+	var totals struct {
+		InputTokens             int64
+		OutputTokens            int64
+		TotalLatencyMS          int64
+		TokenSemanticViolations int64
+	}
+	if err := db.Raw(`
+		SELECT COALESCE(SUM(input_tokens), 0) AS input_tokens,
+		       COALESCE(SUM(output_tokens), 0) AS output_tokens,
+		       COALESCE(SUM(latency_ms), 0) AS total_latency_ms,
+		       COALESCE(SUM(CASE WHEN reasoning_tokens > output_tokens
+		                              OR cache_read_tokens + cache_creation_tokens > input_tokens
+		                              OR cached_tokens != cache_read_tokens
+		                              OR total_tokens != input_tokens + output_tokens
+		                         THEN 1 ELSE 0 END), 0) AS token_semantic_violations
+		FROM (
+			SELECT input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens, latency_ms FROM usage_events
+			UNION ALL
+			SELECT input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens, latency_ms FROM usage_events_archive
+		)`).Scan(&totals).Error; err != nil {
+		return DatasetResult{}, fmt.Errorf("validate benchmark numeric totals: %w", err)
+	}
+	result.InputTokens = totals.InputTokens
+	result.OutputTokens = totals.OutputTokens
+	result.TotalLatencyMS = totals.TotalLatencyMS
+	result.TokenSemanticViolations = totals.TokenSemanticViolations
+	if err := db.Raw("PRAGMA quick_check").Scan(&result.QuickCheck).Error; err != nil {
+		return DatasetResult{}, fmt.Errorf("quick check benchmark database: %w", err)
+	}
+	if info, err := os.Stat(path); err == nil {
+		result.DatabaseBytes = info.Size()
+	} else {
+		return DatasetResult{}, fmt.Errorf("stat benchmark database: %w", err)
+	}
+	semantic := struct {
+		Hot, Archive, Total, Failed, Identities, Models, APIKeys, UsedIdentities, UsedModels, UsedAPIKeys, DuplicateKeys  int64
+		TokenSemanticViolations                                                                                           int64
+		OverviewHourly, OverviewDaily, IdentityRequests, OverviewHourlyRows, OverviewDailyRows, ActivityRows, LatencyRows int64
+		InputTokens, OutputTokens, TotalLatencyMS, CheckpointMin, CheckpointMax                                           int64
+	}{
+		result.HotEvents, result.ArchiveEvents, result.TotalEvents, result.FailedEvents,
+		result.Identities, result.Models, result.APIKeys, result.UsedIdentities, result.UsedModels, result.UsedAPIKeys, result.DuplicateEventKeys,
+		result.TokenSemanticViolations,
+		result.OverviewHourlyRequests, result.OverviewDailyRequests, result.IdentityRequests,
+		result.OverviewHourlyRows, result.OverviewDailyRows, result.ActivityRows, result.LatencyRows,
+		result.InputTokens, result.OutputTokens, result.TotalLatencyMS,
+		result.CheckpointMin, result.CheckpointMax,
+	}
+	data, err := json.Marshal(semantic)
+	if err != nil {
+		return DatasetResult{}, fmt.Errorf("encode benchmark semantic fingerprint: %w", err)
+	}
+	digest := sha256.Sum256(data)
+	result.SemanticFingerprint = hex.EncodeToString(digest[:])
+	return result, nil
+}

--- a/internal/benchmark/capacity/dataset.go
+++ b/internal/benchmark/capacity/dataset.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -26,59 +27,67 @@ import (
 
 const usageEventInsertColumns = entities.UsageEventStorageColumns
 
-const DatasetGeneratorVersion = "production-v6-token-canonical"
+const DatasetGeneratorVersion = "production-v8-month-window-canonical"
 
 type GenerateOptions struct {
-	Path            string
-	HotEvents       int64
-	ArchiveEvents   int64
-	HotDays         int
-	ArchiveDays     int
-	FailureRate     float64
-	Seed            uint64
-	Now             time.Time
-	Cardinality     Cardinality
-	TrafficTiers    []TrafficTier
-	InsertBatchSize int
-	AggregatePage   int
-	Vacuum          bool
+	Path              string
+	HotEvents         int64
+	Recent30DayEvents int64
+	ArchiveEvents     int64
+	HotDays           int
+	ArchiveDays       int
+	FailureRate       float64
+	Seed              uint64
+	Now               time.Time
+	Cardinality       Cardinality
+	TrafficTiers      []TrafficTier
+	InsertBatchSize   int
+	AggregatePage     int
+	Vacuum            bool
 }
 
 type DatasetResult struct {
-	Path                    string    `json:"-"`
-	GeneratorVersion        string    `json:"generator_version,omitempty"`
-	Seed                    uint64    `json:"seed,omitempty"`
-	BenchmarkNow            time.Time `json:"benchmark_now,omitempty"`
-	HotEvents               int64     `json:"hot_events"`
-	ArchiveEvents           int64     `json:"archive_events"`
-	TotalEvents             int64     `json:"total_events"`
-	FailedEvents            int64     `json:"failed_events"`
-	Identities              int64     `json:"identities"`
-	Models                  int64     `json:"models"`
-	APIKeys                 int64     `json:"api_keys"`
-	UsedIdentities          int64     `json:"used_identities"`
-	UsedModels              int64     `json:"used_models"`
-	UsedAPIKeys             int64     `json:"used_api_keys"`
-	OrphanIdentities        int64     `json:"orphan_identities"`
-	OrphanModels            int64     `json:"orphan_models"`
-	OrphanAPIKeys           int64     `json:"orphan_api_keys"`
-	DuplicateEventKeys      int64     `json:"duplicate_event_keys"`
-	TokenSemanticViolations int64     `json:"token_semantic_violations"`
-	OverviewHourlyRequests  int64     `json:"overview_hourly_requests"`
-	OverviewDailyRequests   int64     `json:"overview_daily_requests"`
-	IdentityRequests        int64     `json:"identity_requests"`
-	OverviewHourlyRows      int64     `json:"overview_hourly_rows"`
-	OverviewDailyRows       int64     `json:"overview_daily_rows"`
-	ActivityRows            int64     `json:"activity_rows"`
-	LatencyRows             int64     `json:"latency_rows"`
-	InputTokens             int64     `json:"input_tokens"`
-	OutputTokens            int64     `json:"output_tokens"`
-	TotalLatencyMS          int64     `json:"total_latency_ms"`
-	CheckpointMin           int64     `json:"checkpoint_min"`
-	CheckpointMax           int64     `json:"checkpoint_max"`
-	QuickCheck              string    `json:"quick_check"`
-	DatabaseBytes           int64     `json:"database_bytes"`
-	SemanticFingerprint     string    `json:"semantic_fingerprint"`
+	Path                    string        `json:"-"`
+	GeneratorVersion        string        `json:"generator_version,omitempty"`
+	Seed                    uint64        `json:"seed,omitempty"`
+	BenchmarkNow            time.Time     `json:"benchmark_now,omitempty"`
+	FailureRate             float64       `json:"failure_rate"`
+	TrafficTiers            []TrafficTier `json:"traffic_tiers"`
+	QueryAnchor             time.Time     `json:"query_anchor,omitempty"`
+	EventTimeMin            time.Time     `json:"event_time_min,omitempty"`
+	EventTimeMax            time.Time     `json:"event_time_max,omitempty"`
+	Recent30DayEvents       int64         `json:"recent_30_day_events"`
+	HotEvents               int64         `json:"hot_events"`
+	ArchiveEvents           int64         `json:"archive_events"`
+	TotalEvents             int64         `json:"total_events"`
+	FailedEvents            int64         `json:"failed_events"`
+	Identities              int64         `json:"identities"`
+	Models                  int64         `json:"models"`
+	APIKeys                 int64         `json:"api_keys"`
+	UsedIdentities          int64         `json:"used_identities"`
+	UsedModels              int64         `json:"used_models"`
+	UsedAPIKeys             int64         `json:"used_api_keys"`
+	OrphanIdentities        int64         `json:"orphan_identities"`
+	OrphanModels            int64         `json:"orphan_models"`
+	OrphanAPIKeys           int64         `json:"orphan_api_keys"`
+	DuplicateEventKeys      int64         `json:"duplicate_event_keys"`
+	TokenSemanticViolations int64         `json:"token_semantic_violations"`
+	OverviewHourlyRequests  int64         `json:"overview_hourly_requests"`
+	OverviewDailyRequests   int64         `json:"overview_daily_requests"`
+	IdentityRequests        int64         `json:"identity_requests"`
+	OverviewHourlyRows      int64         `json:"overview_hourly_rows"`
+	OverviewDailyRows       int64         `json:"overview_daily_rows"`
+	ActivityRows            int64         `json:"activity_rows"`
+	LatencyRows             int64         `json:"latency_rows"`
+	InputTokens             int64         `json:"input_tokens"`
+	OutputTokens            int64         `json:"output_tokens"`
+	TotalLatencyMS          int64         `json:"total_latency_ms"`
+	CheckpointMin           int64         `json:"checkpoint_min"`
+	CheckpointMax           int64         `json:"checkpoint_max"`
+	QuickCheck              string        `json:"quick_check"`
+	DatabaseBytes           int64         `json:"database_bytes"`
+	DimensionFingerprint    string        `json:"dimension_fingerprint"`
+	SemanticFingerprint     string        `json:"semantic_fingerprint"`
 }
 
 type storedIndex struct {
@@ -118,6 +127,10 @@ type generatedEvent struct {
 type identityProfile struct {
 	Identity string
 	AuthType entities.UsageIdentityAuthType
+}
+
+func benchmarkAPIKey(index int) string {
+	return fmt.Sprintf("bench-key-%03d", index)
 }
 
 type weightedSelector struct {
@@ -198,13 +211,15 @@ func GenerateDataset(ctx context.Context, options GenerateOptions) (DatasetResul
 	if err := db.Exec("PRAGMA wal_checkpoint(TRUNCATE)").Error; err != nil {
 		return DatasetResult{}, fmt.Errorf("checkpoint benchmark WAL: %w", err)
 	}
-	result, err := ValidateDataset(db, options.Path)
+	result, err := ValidateDatasetAt(db, options.Path, options.Now)
 	if err != nil {
 		return DatasetResult{}, err
 	}
 	result.GeneratorVersion = DatasetGeneratorVersion
 	result.Seed = options.Seed
 	result.BenchmarkNow = options.Now
+	result.FailureRate = options.FailureRate
+	result.TrafficTiers = append([]TrafficTier(nil), options.TrafficTiers...)
 	return result, nil
 }
 
@@ -212,8 +227,11 @@ func validateGenerateOptions(options GenerateOptions) error {
 	if strings.TrimSpace(options.Path) == "" {
 		return fmt.Errorf("benchmark dataset path is required")
 	}
-	if options.HotEvents <= 0 || options.ArchiveEvents < 0 || options.HotDays <= 0 || options.ArchiveDays < 0 {
+	if options.HotEvents <= 0 || options.Recent30DayEvents <= 0 || options.Recent30DayEvents > options.HotEvents || options.ArchiveEvents < 0 || options.HotDays <= 0 || options.ArchiveDays < 0 {
 		return fmt.Errorf("benchmark event counts and day windows are invalid")
+	}
+	if (options.HotDays <= 30 && options.Recent30DayEvents != options.HotEvents) || (options.HotDays > 30 && options.Recent30DayEvents >= options.HotEvents) {
+		return fmt.Errorf("benchmark recent 30-day count is inconsistent with the hot window")
 	}
 	if options.FailureRate < 0 || options.FailureRate > 1 {
 		return fmt.Errorf("benchmark failure rate must be between zero and one")
@@ -245,7 +263,7 @@ func seedDatasetMetadata(db *gorm.DB, options GenerateOptions) ([]identityProfil
 	apiKeys := make([]entities.CPAAPIKey, 0, len(apiProfiles))
 	for _, profile := range apiProfiles {
 		apiKeys = append(apiKeys, entities.CPAAPIKey{
-			ID: int64(profile.Index), APIKey: fmt.Sprintf("bench-key-%03d", profile.Index),
+			ID: int64(profile.Index), APIKey: benchmarkAPIKey(profile.Index),
 			DisplayKey: fmt.Sprintf("bench-***-%03d", profile.Index), KeyAlias: fmt.Sprintf("bench-%s-%03d", profile.Tier, profile.Index),
 			IsDeleted: false, LastSyncedAt: &now, CreatedAt: now, UpdatedAt: now,
 		})
@@ -393,7 +411,7 @@ func makeGeneratedEvent(eventID int64, timestamp time.Time, options GenerateOpti
 	}
 	endpoint, serviceTier, responseTier, reasoningEffort, executorType := correlatedDimensions(modelIndex, identityIndex, provider, random)
 	return generatedEvent{
-		ID: eventID, EventKey: fmt.Sprintf("bench-event-%012d", eventKeyIndex), APIGroupKey: fmt.Sprint(apiIndex + 1),
+		ID: eventID, EventKey: fmt.Sprintf("bench-event-%012d", eventKeyIndex), APIGroupKey: benchmarkAPIKey(apiIndex + 1),
 		Provider: provider, Endpoint: endpoint, AuthType: authType,
 		RequestID: fmt.Sprintf("bench-request-%012d", requestIDIndex), Model: fmt.Sprintf("bench-model-%03d", modelIndex+1),
 		ModelAlias: fmt.Sprintf("bench-alias-%03d", modelIndex+1), ReasoningEffort: reasoningEffort,
@@ -514,11 +532,9 @@ func buildEventTimeline(options GenerateOptions) *eventTimeline {
 	}
 	recentDays := min(options.HotDays, 30)
 	olderDays := options.HotDays - recentDays
-	recentEvents := options.HotEvents
-	olderEvents := int64(0)
+	recentEvents := options.Recent30DayEvents
+	olderEvents := options.HotEvents - recentEvents
 	if olderDays > 0 {
-		olderEvents = int64(math.Round(float64(options.HotEvents) * 0.37))
-		recentEvents = options.HotEvents - olderEvents
 		buckets = append(buckets, weightedTimeBuckets(hotStart, olderDays*24, olderEvents, options.Seed^2)...)
 	}
 	recentStart := hotStart.AddDate(0, 0, olderDays)
@@ -719,8 +735,43 @@ func moveArchiveRows(db *gorm.DB, archiveEvents int64) error {
 	})
 }
 
+const MaxReusableDatasetAge = 7 * 24 * time.Hour
+
 func ValidateDataset(db *gorm.DB, path string) (DatasetResult, error) {
-	result := DatasetResult{Path: filepath.Clean(path)}
+	return ValidateDatasetAt(db, path, time.Now())
+}
+
+func ValidateDatasetPath(ctx context.Context, sourcePath string, queryAnchor time.Time) (DatasetResult, error) {
+	validationPath := sourcePath
+	if strings.HasSuffix(sourcePath, ".zst") {
+		temporaryDir, err := os.MkdirTemp(filepath.Dir(sourcePath), ".benchmark-validate-*")
+		if err != nil {
+			return DatasetResult{}, fmt.Errorf("create compressed dataset validation directory: %w", err)
+		}
+		defer os.RemoveAll(temporaryDir)
+		validationPath = filepath.Join(temporaryDir, "app.db")
+		if err := RestoreDataset(ctx, sourcePath, validationPath); err != nil {
+			return DatasetResult{}, err
+		}
+	}
+	db, err := repository.OpenReadDatabase(config.Config{SQLitePath: validationPath})
+	if err != nil {
+		return DatasetResult{}, err
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		return DatasetResult{}, err
+	}
+	defer sqlDB.Close()
+	return ValidateDatasetAt(db, validationPath, queryAnchor)
+}
+
+func ValidateDatasetAt(db *gorm.DB, path string, queryAnchor time.Time) (DatasetResult, error) {
+	if queryAnchor.IsZero() {
+		return DatasetResult{}, fmt.Errorf("benchmark dataset query anchor is required")
+	}
+	queryAnchor = timeutil.NormalizeStorageTime(queryAnchor)
+	result := DatasetResult{Path: filepath.Clean(path), QueryAnchor: queryAnchor}
 	queries := []struct {
 		name   string
 		query  string
@@ -737,7 +788,7 @@ func ValidateDataset(db *gorm.DB, path string) (DatasetResult, error) {
 		{"used API keys", "SELECT COUNT(DISTINCT api_group_key) FROM (SELECT api_group_key FROM usage_events UNION ALL SELECT api_group_key FROM usage_events_archive)", &result.UsedAPIKeys},
 		{"orphan identities", "SELECT COUNT(*) FROM (SELECT auth_index, auth_type FROM usage_events UNION ALL SELECT auth_index, auth_type FROM usage_events_archive) e LEFT JOIN usage_identities i ON i.identity = e.auth_index AND ((i.auth_type = 1 AND e.auth_type = 'oauth') OR (i.auth_type = 2 AND e.auth_type = 'apikey')) AND i.is_deleted = 0 WHERE i.id IS NULL", &result.OrphanIdentities},
 		{"orphan models", "SELECT COUNT(*) FROM (SELECT model FROM usage_events UNION ALL SELECT model FROM usage_events_archive) e LEFT JOIN model_price_settings p ON p.model = e.model WHERE p.id IS NULL", &result.OrphanModels},
-		{"orphan API keys", "SELECT COUNT(*) FROM (SELECT api_group_key FROM usage_events UNION ALL SELECT api_group_key FROM usage_events_archive) e LEFT JOIN cpa_api_keys k ON CAST(k.id AS TEXT) = e.api_group_key AND k.is_deleted = 0 WHERE k.id IS NULL", &result.OrphanAPIKeys},
+		{"orphan API keys", "SELECT COUNT(*) FROM (SELECT api_group_key FROM usage_events UNION ALL SELECT api_group_key FROM usage_events_archive) e LEFT JOIN cpa_api_keys k ON k.api_key = e.api_group_key AND k.is_deleted = 0 WHERE k.id IS NULL", &result.OrphanAPIKeys},
 		{"duplicate event keys", "SELECT COUNT(*) - COUNT(DISTINCT event_key) FROM (SELECT event_key FROM usage_events UNION ALL SELECT event_key FROM usage_events_archive)", &result.DuplicateEventKeys},
 		{"overview hourly requests", "SELECT COALESCE(SUM(request_count), 0) FROM usage_overview_hourly_stats", &result.OverviewHourlyRequests},
 		{"overview daily requests", "SELECT COALESCE(SUM(request_count), 0) FROM usage_overview_daily_stats", &result.OverviewDailyRequests},
@@ -755,6 +806,37 @@ func ValidateDataset(db *gorm.DB, path string) (DatasetResult, error) {
 		}
 	}
 	result.TotalEvents = result.HotEvents + result.ArchiveEvents
+	var bounds struct {
+		Minimum sql.NullString `gorm:"column:minimum"`
+		Maximum sql.NullString `gorm:"column:maximum"`
+	}
+	if err := db.Raw(`
+		SELECT MIN(timestamp) AS minimum, MAX(timestamp) AS maximum
+		FROM (SELECT timestamp FROM usage_events UNION ALL SELECT timestamp FROM usage_events_archive)
+	`).Scan(&bounds).Error; err != nil {
+		return DatasetResult{}, fmt.Errorf("validate benchmark event bounds: %w", err)
+	}
+	if !bounds.Minimum.Valid || !bounds.Maximum.Valid {
+		return DatasetResult{}, fmt.Errorf("benchmark event bounds are empty")
+	}
+	var err error
+	if result.EventTimeMin, err = timeutil.ParseStorageTime(bounds.Minimum.String); err != nil {
+		return DatasetResult{}, fmt.Errorf("parse benchmark minimum event time: %w", err)
+	}
+	if result.EventTimeMax, err = timeutil.ParseStorageTime(bounds.Maximum.String); err != nil {
+		return DatasetResult{}, fmt.Errorf("parse benchmark maximum event time: %w", err)
+	}
+	recentStart := timeutil.FormatStorageTime(queryAnchor.Add(-30 * 24 * time.Hour))
+	recentEnd := timeutil.FormatStorageTime(queryAnchor)
+	if err := db.Raw(`
+		SELECT COUNT(*) FROM (
+			SELECT timestamp FROM usage_events
+			UNION ALL
+			SELECT timestamp FROM usage_events_archive
+		) WHERE timestamp >= ? AND timestamp <= ?
+	`, recentStart, recentEnd).Scan(&result.Recent30DayEvents).Error; err != nil {
+		return DatasetResult{}, fmt.Errorf("validate benchmark recent 30-day events: %w", err)
+	}
 	var totals struct {
 		InputTokens             int64
 		OutputTokens            int64
@@ -781,6 +863,11 @@ func ValidateDataset(db *gorm.DB, path string) (DatasetResult, error) {
 	result.OutputTokens = totals.OutputTokens
 	result.TotalLatencyMS = totals.TotalLatencyMS
 	result.TokenSemanticViolations = totals.TokenSemanticViolations
+	dimensionFingerprint, err := benchmarkDimensionFingerprint(db)
+	if err != nil {
+		return DatasetResult{}, err
+	}
+	result.DimensionFingerprint = dimensionFingerprint
 	if err := db.Raw("PRAGMA quick_check").Scan(&result.QuickCheck).Error; err != nil {
 		return DatasetResult{}, fmt.Errorf("quick check benchmark database: %w", err)
 	}
@@ -790,18 +877,22 @@ func ValidateDataset(db *gorm.DB, path string) (DatasetResult, error) {
 		return DatasetResult{}, fmt.Errorf("stat benchmark database: %w", err)
 	}
 	semantic := struct {
-		Hot, Archive, Total, Failed, Identities, Models, APIKeys, UsedIdentities, UsedModels, UsedAPIKeys, DuplicateKeys  int64
+		Hot, Archive, Total, Failed, Identities, Models, APIKeys, UsedIdentities, UsedModels, UsedAPIKeys                 int64
+		OrphanIdentities, OrphanModels, OrphanAPIKeys, DuplicateKeys                                                      int64
 		TokenSemanticViolations                                                                                           int64
 		OverviewHourly, OverviewDaily, IdentityRequests, OverviewHourlyRows, OverviewDailyRows, ActivityRows, LatencyRows int64
 		InputTokens, OutputTokens, TotalLatencyMS, CheckpointMin, CheckpointMax                                           int64
+		EventTimeMin, EventTimeMax, DimensionFingerprint                                                                  string
 	}{
 		result.HotEvents, result.ArchiveEvents, result.TotalEvents, result.FailedEvents,
-		result.Identities, result.Models, result.APIKeys, result.UsedIdentities, result.UsedModels, result.UsedAPIKeys, result.DuplicateEventKeys,
+		result.Identities, result.Models, result.APIKeys, result.UsedIdentities, result.UsedModels, result.UsedAPIKeys,
+		result.OrphanIdentities, result.OrphanModels, result.OrphanAPIKeys, result.DuplicateEventKeys,
 		result.TokenSemanticViolations,
 		result.OverviewHourlyRequests, result.OverviewDailyRequests, result.IdentityRequests,
 		result.OverviewHourlyRows, result.OverviewDailyRows, result.ActivityRows, result.LatencyRows,
 		result.InputTokens, result.OutputTokens, result.TotalLatencyMS,
 		result.CheckpointMin, result.CheckpointMax,
+		result.EventTimeMin.UTC().Format(time.RFC3339Nano), result.EventTimeMax.UTC().Format(time.RFC3339Nano), result.DimensionFingerprint,
 	}
 	data, err := json.Marshal(semantic)
 	if err != nil {
@@ -810,4 +901,146 @@ func ValidateDataset(db *gorm.DB, path string) (DatasetResult, error) {
 	digest := sha256.Sum256(data)
 	result.SemanticFingerprint = hex.EncodeToString(digest[:])
 	return result, nil
+}
+
+func benchmarkDimensionFingerprint(db *gorm.DB) (string, error) {
+	hash := sha256.New()
+	queries := []struct {
+		name  string
+		value string
+	}{
+		{"api_key", "api_group_key"},
+		{"identity", "auth_index"},
+		{"model", "model"},
+	}
+	for _, item := range queries {
+		query := fmt.Sprintf(`
+			SELECT %s AS value, COUNT(*) AS count
+			FROM (SELECT %s FROM usage_events UNION ALL SELECT %s FROM usage_events_archive)
+			GROUP BY %s ORDER BY %s
+		`, item.value, item.value, item.value, item.value, item.value)
+		rows, err := db.Raw(query).Rows()
+		if err != nil {
+			return "", fmt.Errorf("validate benchmark %s distribution: %w", item.name, err)
+		}
+		for rows.Next() {
+			var value string
+			var count int64
+			if err := rows.Scan(&value, &count); err != nil {
+				rows.Close()
+				return "", fmt.Errorf("scan benchmark %s distribution: %w", item.name, err)
+			}
+			_, _ = fmt.Fprintf(hash, "%s\x00%s\x00%d\n", item.name, value, count)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return "", fmt.Errorf("iterate benchmark %s distribution: %w", item.name, err)
+		}
+		rows.Close()
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func ValidateDatasetAgainstManifest(actual, metadata DatasetResult, manifest Manifest) error {
+	if metadata.GeneratorVersion != DatasetGeneratorVersion {
+		return fmt.Errorf("dataset generator=%q, want %q", metadata.GeneratorVersion, DatasetGeneratorVersion)
+	}
+	if metadata.Seed != manifest.Dataset.Seed {
+		return fmt.Errorf("dataset seed=%d, want %d", metadata.Seed, manifest.Dataset.Seed)
+	}
+	if metadata.FailureRate != manifest.Dataset.FailureRate {
+		return fmt.Errorf("dataset failure_rate=%g, want %g", metadata.FailureRate, manifest.Dataset.FailureRate)
+	}
+	if !slices.Equal(metadata.TrafficTiers, manifest.TrafficTiers) {
+		return fmt.Errorf("dataset traffic_tiers do not match the manifest")
+	}
+	if metadata.BenchmarkNow.IsZero() {
+		return fmt.Errorf("dataset benchmark_now is missing")
+	}
+	if strings.TrimSpace(manifest.Dataset.BenchmarkNow) != "generation-time" {
+		benchmarkNow, err := ResolveDatasetBenchmarkNow(manifest.Dataset.BenchmarkNow, time.Time{})
+		if err != nil {
+			return err
+		}
+		if !metadata.BenchmarkNow.Equal(benchmarkNow) {
+			return fmt.Errorf("dataset benchmark_now=%s, want %s", metadata.BenchmarkNow.Format(time.RFC3339), benchmarkNow.Format(time.RFC3339))
+		}
+	}
+	if actual.HotEvents != manifest.Dataset.HotEvents || actual.ArchiveEvents != manifest.Dataset.ArchiveEvents {
+		return fmt.Errorf("dataset rows hot=%d archive=%d, want %d/%d", actual.HotEvents, actual.ArchiveEvents, manifest.Dataset.HotEvents, manifest.Dataset.ArchiveEvents)
+	}
+	if metadata.Recent30DayEvents != manifest.Dataset.Recent30DayEvents {
+		return fmt.Errorf("dataset generation-time recent 30-day events=%d, want %d", metadata.Recent30DayEvents, manifest.Dataset.Recent30DayEvents)
+	}
+	cardinality := manifest.Dataset.Cardinality
+	if actual.Identities != int64(cardinality.Identities) || actual.Models != int64(cardinality.Models) || actual.APIKeys != int64(cardinality.APIKeys) {
+		return fmt.Errorf("dataset cardinality=%d/%d/%d, want %d/%d/%d", actual.Identities, actual.Models, actual.APIKeys, cardinality.Identities, cardinality.Models, cardinality.APIKeys)
+	}
+	if actual.UsedIdentities != actual.Identities || actual.UsedModels != actual.Models || actual.UsedAPIKeys != actual.APIKeys {
+		return fmt.Errorf("dataset does not exercise every identity/model/API key")
+	}
+	if actual.QuickCheck != "ok" {
+		return fmt.Errorf("dataset quick_check=%q, want ok", actual.QuickCheck)
+	}
+	if actual.OrphanIdentities != 0 || actual.OrphanModels != 0 || actual.OrphanAPIKeys != 0 {
+		return fmt.Errorf("dataset has orphan references identities=%d models=%d API keys=%d", actual.OrphanIdentities, actual.OrphanModels, actual.OrphanAPIKeys)
+	}
+	if actual.TokenSemanticViolations != 0 {
+		return fmt.Errorf("dataset has %d token semantic violations", actual.TokenSemanticViolations)
+	}
+	if actual.OverviewHourlyRequests != actual.TotalEvents || actual.OverviewDailyRequests != actual.TotalEvents || actual.IdentityRequests != actual.TotalEvents {
+		return fmt.Errorf("dataset derived totals hourly=%d daily=%d identity=%d, want %d", actual.OverviewHourlyRequests, actual.OverviewDailyRequests, actual.IdentityRequests, actual.TotalEvents)
+	}
+	if actual.CheckpointMin != actual.TotalEvents || actual.CheckpointMax != actual.TotalEvents {
+		return fmt.Errorf("dataset checkpoints=%d..%d, want %d", actual.CheckpointMin, actual.CheckpointMax, actual.TotalEvents)
+	}
+	if datasetStaticMetadata(actual) != datasetStaticMetadata(metadata) {
+		return fmt.Errorf("dataset statistics do not match dataset.json metadata")
+	}
+	if actual.SemanticFingerprint == "" || actual.SemanticFingerprint != metadata.SemanticFingerprint {
+		return fmt.Errorf("dataset semantic fingerprint=%q does not match metadata %q", actual.SemanticFingerprint, metadata.SemanticFingerprint)
+	}
+	if actual.Recent30DayEvents <= 0 {
+		return fmt.Errorf("dataset has no events in the effective 30-day Dashboard window")
+	}
+	if actual.QueryAnchor.IsZero() || actual.EventTimeMax.IsZero() {
+		return fmt.Errorf("dataset freshness timestamps are missing")
+	}
+	age := actual.QueryAnchor.Sub(actual.EventTimeMax)
+	if age < -time.Hour {
+		return fmt.Errorf("dataset contains future events: latest=%s query_anchor=%s", actual.EventTimeMax.Format(time.RFC3339), actual.QueryAnchor.Format(time.RFC3339))
+	}
+	if age > MaxReusableDatasetAge {
+		return fmt.Errorf("dataset is stale by %s; regenerate it within %s of the formal run", age.Round(time.Minute), MaxReusableDatasetAge)
+	}
+	return nil
+}
+
+type datasetStaticSnapshot struct {
+	EventTimeMin, EventTimeMax, QuickCheck, DimensionFingerprint            string
+	HotEvents, ArchiveEvents, TotalEvents, FailedEvents                     int64
+	Identities, Models, APIKeys                                             int64
+	UsedIdentities, UsedModels, UsedAPIKeys                                 int64
+	OrphanIdentities, OrphanModels, OrphanAPIKeys                           int64
+	DuplicateEventKeys, TokenSemanticViolations                             int64
+	OverviewHourlyRequests, OverviewDailyRequests, IdentityRequests         int64
+	OverviewHourlyRows, OverviewDailyRows, ActivityRows, LatencyRows        int64
+	InputTokens, OutputTokens, TotalLatencyMS, CheckpointMin, CheckpointMax int64
+}
+
+func datasetStaticMetadata(result DatasetResult) datasetStaticSnapshot {
+	return datasetStaticSnapshot{
+		EventTimeMin: result.EventTimeMin.UTC().Format(time.RFC3339Nano), EventTimeMax: result.EventTimeMax.UTC().Format(time.RFC3339Nano),
+		QuickCheck: result.QuickCheck, DimensionFingerprint: result.DimensionFingerprint,
+		HotEvents: result.HotEvents, ArchiveEvents: result.ArchiveEvents, TotalEvents: result.TotalEvents, FailedEvents: result.FailedEvents,
+		Identities: result.Identities, Models: result.Models, APIKeys: result.APIKeys,
+		UsedIdentities: result.UsedIdentities, UsedModels: result.UsedModels, UsedAPIKeys: result.UsedAPIKeys,
+		OrphanIdentities: result.OrphanIdentities, OrphanModels: result.OrphanModels, OrphanAPIKeys: result.OrphanAPIKeys,
+		DuplicateEventKeys: result.DuplicateEventKeys, TokenSemanticViolations: result.TokenSemanticViolations,
+		OverviewHourlyRequests: result.OverviewHourlyRequests, OverviewDailyRequests: result.OverviewDailyRequests, IdentityRequests: result.IdentityRequests,
+		OverviewHourlyRows: result.OverviewHourlyRows, OverviewDailyRows: result.OverviewDailyRows,
+		ActivityRows: result.ActivityRows, LatencyRows: result.LatencyRows,
+		InputTokens: result.InputTokens, OutputTokens: result.OutputTokens, TotalLatencyMS: result.TotalLatencyMS,
+		CheckpointMin: result.CheckpointMin, CheckpointMax: result.CheckpointMax,
+	}
 }

--- a/internal/benchmark/capacity/filelock_linux.go
+++ b/internal/benchmark/capacity/filelock_linux.go
@@ -1,0 +1,40 @@
+//go:build linux
+
+package capacity
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+type FileLock struct {
+	file *os.File
+}
+
+func AcquireFileLock(path string) (*FileLock, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create benchmark lock directory: %w", err)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open benchmark lock: %w", err)
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		file.Close()
+		return nil, fmt.Errorf("another benchmark owns %s: %w", filepath.Clean(path), err)
+	}
+	return &FileLock{file: file}, nil
+}
+
+func (lock *FileLock) Close() error {
+	if lock == nil || lock.file == nil {
+		return nil
+	}
+	err := syscall.Flock(int(lock.file.Fd()), syscall.LOCK_UN)
+	err = errors.Join(err, lock.file.Close())
+	lock.file = nil
+	return err
+}

--- a/internal/benchmark/capacity/filelock_unsupported.go
+++ b/internal/benchmark/capacity/filelock_unsupported.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package capacity
+
+import "fmt"
+
+type FileLock struct{}
+
+func AcquireFileLock(path string) (*FileLock, error) {
+	return nil, fmt.Errorf("benchmark file locking is unavailable for %s: capacity benchmark requires linux/amd64", path)
+}
+
+func (lock *FileLock) Close() error {
+	return nil
+}

--- a/internal/benchmark/capacity/manifest.go
+++ b/internal/benchmark/capacity/manifest.go
@@ -1,0 +1,253 @@
+package capacity
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	maxIdentities = 1000
+	maxModels     = 100
+	maxAPIKeys    = 100
+)
+
+type Manifest struct {
+	Version      string        `json:"version"`
+	Target       Target        `json:"target"`
+	Dataset      DatasetSpec   `json:"dataset"`
+	TrafficTiers []TrafficTier `json:"traffic_tiers"`
+	Resources    []Resource    `json:"resources"`
+	Search       Search        `json:"search"`
+	SourceSHA256 string        `json:"-"`
+}
+
+type Target struct {
+	OS   string `json:"os"`
+	Arch string `json:"arch"`
+}
+
+type DatasetSpec struct {
+	ID            string      `json:"id"`
+	HotEvents     int64       `json:"hot_events"`
+	ArchiveEvents int64       `json:"archive_events"`
+	FailureRate   float64     `json:"failure_rate"`
+	Seed          uint64      `json:"seed"`
+	HotDays       int         `json:"hot_days"`
+	ArchiveDays   int         `json:"archive_days"`
+	BenchmarkNow  string      `json:"benchmark_now"`
+	Cardinality   Cardinality `json:"cardinality"`
+}
+
+type Cardinality struct {
+	Identities int `json:"identities"`
+	Models     int `json:"models"`
+	APIKeys    int `json:"api_keys"`
+}
+
+type TrafficTier struct {
+	Name         string  `json:"name"`
+	KeyShare     float64 `json:"key_share"`
+	PerKeyWeight float64 `json:"per_key_weight"`
+}
+
+type Resource struct {
+	ID        string  `json:"id"`
+	CPU       float64 `json:"cpu"`
+	MemoryMiB int     `json:"memory_mib"`
+}
+
+type Search struct {
+	RatesPerSecond             []int   `json:"rates_per_second"`
+	ProbeSeconds               int     `json:"probe_seconds"`
+	BoundarySeconds            int     `json:"boundary_seconds"`
+	BoundaryRepetitions        int     `json:"boundary_repetitions"`
+	SkipBoundary               bool    `json:"skip_boundary,omitempty"`
+	SoakSeconds                int     `json:"soak_seconds"`
+	MaxRunSeconds              int     `json:"max_run_seconds"`
+	DashboardCoreP95MS         int     `json:"dashboard_core_p95_ms"`
+	DashboardOverallP99MS      int     `json:"dashboard_overall_p99_ms"`
+	DashboardRequestsPerSecond int     `json:"dashboard_requests_per_second"`
+	SearchDashboardCapacity    bool    `json:"search_dashboard_capacity,omitempty"`
+	RecommendedCapacityRate    float64 `json:"recommended_capacity_ratio"`
+}
+
+type Plan struct {
+	Version        string `json:"version"`
+	ManifestSHA256 string `json:"manifest_sha256"`
+	Cells          []Cell `json:"cells"`
+}
+
+type Cell struct {
+	ID             string      `json:"id"`
+	Kind           string      `json:"kind"`
+	DatasetID      string      `json:"dataset_id"`
+	HotEvents      int64       `json:"hot_events"`
+	ArchiveEvents  int64       `json:"archive_events"`
+	Cardinality    Cardinality `json:"cardinality"`
+	Resource       Resource    `json:"resource"`
+	RatesPerSecond []int       `json:"rates_per_second"`
+}
+
+func LoadManifest(path string) (Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("read benchmark manifest: %w", err)
+	}
+	var manifest Manifest
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&manifest); err != nil {
+		return Manifest{}, fmt.Errorf("decode benchmark manifest: %w", err)
+	}
+	digest := sha256.Sum256(data)
+	manifest.SourceSHA256 = hex.EncodeToString(digest[:])
+	return manifest, nil
+}
+
+func (m Manifest) Validate() error {
+	if m.Version != "capacity-v1" {
+		return fmt.Errorf("unsupported benchmark manifest version %q", m.Version)
+	}
+	if m.Target.OS != "linux" || m.Target.Arch != "amd64" {
+		return fmt.Errorf("capacity benchmark requires linux/amd64")
+	}
+	if !validPublicID(m.Dataset.ID) {
+		return fmt.Errorf("invalid dataset ID %q", m.Dataset.ID)
+	}
+	if m.Dataset.HotEvents <= 0 || m.Dataset.ArchiveEvents < 0 || m.Dataset.HotDays <= 0 || m.Dataset.ArchiveDays < 0 {
+		return fmt.Errorf("dataset counts and day windows must be positive")
+	}
+	if m.Dataset.FailureRate < 0 || m.Dataset.FailureRate > 1 {
+		return fmt.Errorf("failure rate must be between zero and one")
+	}
+	if _, err := time.Parse(time.RFC3339, m.Dataset.BenchmarkNow); err != nil {
+		return fmt.Errorf("dataset benchmark_now must be RFC3339: %w", err)
+	}
+	if err := validateCardinality(m.Dataset.ID, m.Dataset.Cardinality); err != nil {
+		return err
+	}
+	if len(m.TrafficTiers) == 0 {
+		return fmt.Errorf("traffic tiers are required")
+	}
+	shareTotal := 0.0
+	seenTierNames := map[string]bool{}
+	for _, tier := range m.TrafficTiers {
+		if !validPublicID(tier.Name) || seenTierNames[tier.Name] || tier.KeyShare <= 0 || tier.PerKeyWeight <= 0 {
+			return fmt.Errorf("invalid traffic tier %q", tier.Name)
+		}
+		seenTierNames[tier.Name] = true
+		shareTotal += tier.KeyShare
+	}
+	if math.Abs(shareTotal-1) > 1e-9 {
+		return fmt.Errorf("traffic tier key shares sum to %.12f, want 1", shareTotal)
+	}
+	if len(m.Resources) == 0 {
+		return fmt.Errorf("at least one resource profile is required")
+	}
+	seenResources := map[string]bool{}
+	for _, resource := range m.Resources {
+		if !validPublicID(resource.ID) || seenResources[resource.ID] || resource.CPU <= 0 || resource.CPU > 4 || math.Trunc(resource.CPU) != resource.CPU || (resource.MemoryMiB != 0 && resource.MemoryMiB < 100) || resource.MemoryMiB > 4096 {
+			return fmt.Errorf("invalid resource profile %q", resource.ID)
+		}
+		seenResources[resource.ID] = true
+	}
+	if len(m.Search.RatesPerSecond) == 0 || m.Search.ProbeSeconds <= 0 || m.Search.BoundarySeconds <= 0 || m.Search.BoundaryRepetitions <= 0 || m.Search.SoakSeconds <= 0 || m.Search.MaxRunSeconds <= 0 || m.Search.DashboardRequestsPerSecond <= 0 {
+		return fmt.Errorf("capacity search durations and rates must be positive")
+	}
+	for index, rate := range m.Search.RatesPerSecond {
+		if rate <= 0 || (index > 0 && rate <= m.Search.RatesPerSecond[index-1]) {
+			return fmt.Errorf("capacity search rates must be positive and increasing")
+		}
+	}
+	if m.Search.DashboardCoreP95MS < 0 || m.Search.DashboardOverallP99MS <= 0 {
+		return fmt.Errorf("dashboard latency thresholds are invalid")
+	}
+	if m.Search.RecommendedCapacityRate <= 0 || m.Search.RecommendedCapacityRate > 1 {
+		return fmt.Errorf("recommended capacity ratio must be in (0,1]")
+	}
+	return nil
+}
+
+func LoadPlan(path string) (Plan, string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Plan{}, "", fmt.Errorf("read benchmark plan: %w", err)
+	}
+	var plan Plan
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&plan); err != nil {
+		return Plan{}, "", fmt.Errorf("decode benchmark plan: %w", err)
+	}
+	if strings.TrimSpace(plan.Version) == "" || strings.TrimSpace(plan.ManifestSHA256) == "" || len(plan.Cells) == 0 {
+		return Plan{}, "", fmt.Errorf("benchmark plan is incomplete")
+	}
+	seen := map[string]bool{}
+	for _, cell := range plan.Cells {
+		if strings.TrimSpace(cell.ID) == "" || !validPublicID(cell.DatasetID) || seen[cell.ID] {
+			return Plan{}, "", fmt.Errorf("benchmark plan contains invalid or duplicate cell %q", cell.ID)
+		}
+		seen[cell.ID] = true
+	}
+	digest := sha256.Sum256(data)
+	return plan, hex.EncodeToString(digest[:]), nil
+}
+
+func validateCardinality(name string, cardinality Cardinality) error {
+	if cardinality.Identities <= 0 || cardinality.Identities > maxIdentities || cardinality.Models <= 0 || cardinality.Models > maxModels || cardinality.APIKeys <= 0 || cardinality.APIKeys > maxAPIKeys {
+		return fmt.Errorf("cardinality %q exceeds benchmark bounds: %+v", name, cardinality)
+	}
+	return nil
+}
+
+func validPublicID(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.HasPrefix(value, "-") || strings.HasSuffix(value, "-") || strings.Contains(value, "--") {
+		return false
+	}
+	for _, character := range value {
+		if (character < 'a' || character > 'z') && (character < '0' || character > '9') && character != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+func ExpandPlan(manifest Manifest) (Plan, error) {
+	if err := manifest.Validate(); err != nil {
+		return Plan{}, err
+	}
+	plan := Plan{Version: manifest.Version, ManifestSHA256: manifest.SourceSHA256}
+	for _, resource := range manifest.Resources {
+		plan.Cells = append(plan.Cells, Cell{
+			ID:             fmt.Sprintf("capacity-%s-%s", manifest.Dataset.ID, resource.ID),
+			Kind:           "capacity",
+			DatasetID:      manifest.Dataset.ID,
+			HotEvents:      manifest.Dataset.HotEvents,
+			ArchiveEvents:  manifest.Dataset.ArchiveEvents,
+			Cardinality:    manifest.Dataset.Cardinality,
+			Resource:       resource,
+			RatesPerSecond: append([]int(nil), manifest.Search.RatesPerSecond...),
+		})
+	}
+	return plan, nil
+}
+
+func MarshalPlan(plan Plan) ([]byte, error) {
+	data, err := json.MarshalIndent(plan, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode benchmark plan: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func SortCellsByID(cells []Cell) {
+	sort.Slice(cells, func(left, right int) bool { return cells[left].ID < cells[right].ID })
+}

--- a/internal/benchmark/capacity/manifest.go
+++ b/internal/benchmark/capacity/manifest.go
@@ -34,15 +34,16 @@ type Target struct {
 }
 
 type DatasetSpec struct {
-	ID            string      `json:"id"`
-	HotEvents     int64       `json:"hot_events"`
-	ArchiveEvents int64       `json:"archive_events"`
-	FailureRate   float64     `json:"failure_rate"`
-	Seed          uint64      `json:"seed"`
-	HotDays       int         `json:"hot_days"`
-	ArchiveDays   int         `json:"archive_days"`
-	BenchmarkNow  string      `json:"benchmark_now"`
-	Cardinality   Cardinality `json:"cardinality"`
+	ID                string      `json:"id"`
+	HotEvents         int64       `json:"hot_events"`
+	Recent30DayEvents int64       `json:"recent_30_day_events"`
+	ArchiveEvents     int64       `json:"archive_events"`
+	FailureRate       float64     `json:"failure_rate"`
+	Seed              uint64      `json:"seed"`
+	HotDays           int         `json:"hot_days"`
+	ArchiveDays       int         `json:"archive_days"`
+	BenchmarkNow      string      `json:"benchmark_now"`
+	Cardinality       Cardinality `json:"cardinality"`
 }
 
 type Cardinality struct {
@@ -64,18 +65,21 @@ type Resource struct {
 }
 
 type Search struct {
-	RatesPerSecond             []int   `json:"rates_per_second"`
-	ProbeSeconds               int     `json:"probe_seconds"`
-	BoundarySeconds            int     `json:"boundary_seconds"`
-	BoundaryRepetitions        int     `json:"boundary_repetitions"`
-	SkipBoundary               bool    `json:"skip_boundary,omitempty"`
-	SoakSeconds                int     `json:"soak_seconds"`
-	MaxRunSeconds              int     `json:"max_run_seconds"`
-	DashboardCoreP95MS         int     `json:"dashboard_core_p95_ms"`
-	DashboardOverallP99MS      int     `json:"dashboard_overall_p99_ms"`
-	DashboardRequestsPerSecond int     `json:"dashboard_requests_per_second"`
-	SearchDashboardCapacity    bool    `json:"search_dashboard_capacity,omitempty"`
-	RecommendedCapacityRate    float64 `json:"recommended_capacity_ratio"`
+	RatesPerSecond                 []int   `json:"rates_per_second"`
+	InitialRatePerSecond           int     `json:"initial_rate_per_second"`
+	ProbeSeconds                   int     `json:"probe_seconds"`
+	BoundarySeconds                int     `json:"boundary_seconds"`
+	BoundaryRepetitions            int     `json:"boundary_repetitions"`
+	SkipBoundary                   bool    `json:"skip_boundary,omitempty"`
+	SoakSeconds                    int     `json:"soak_seconds"`
+	MaxPassDrainSeconds            int     `json:"max_pass_drain_seconds"`
+	MaxRunSeconds                  int     `json:"max_run_seconds"`
+	DashboardCoreP95MS             int     `json:"dashboard_core_p95_ms"`
+	DashboardCoreP99MS             int     `json:"dashboard_core_p99_ms"`
+	DashboardRequestsPerSecond     int     `json:"dashboard_requests_per_second"`
+	AnalysisLatencyIntervalSeconds int     `json:"analysis_latency_interval_seconds"`
+	SearchDashboardCapacity        bool    `json:"search_dashboard_capacity,omitempty"`
+	RecommendedCapacityRate        float64 `json:"recommended_capacity_ratio"`
 }
 
 type Plan struct {
@@ -85,14 +89,15 @@ type Plan struct {
 }
 
 type Cell struct {
-	ID             string      `json:"id"`
-	Kind           string      `json:"kind"`
-	DatasetID      string      `json:"dataset_id"`
-	HotEvents      int64       `json:"hot_events"`
-	ArchiveEvents  int64       `json:"archive_events"`
-	Cardinality    Cardinality `json:"cardinality"`
-	Resource       Resource    `json:"resource"`
-	RatesPerSecond []int       `json:"rates_per_second"`
+	ID                string      `json:"id"`
+	Kind              string      `json:"kind"`
+	DatasetID         string      `json:"dataset_id"`
+	HotEvents         int64       `json:"hot_events"`
+	Recent30DayEvents int64       `json:"recent_30_day_events"`
+	ArchiveEvents     int64       `json:"archive_events"`
+	Cardinality       Cardinality `json:"cardinality"`
+	Resource          Resource    `json:"resource"`
+	RatesPerSecond    []int       `json:"rates_per_second"`
 }
 
 func LoadManifest(path string) (Manifest, error) {
@@ -121,14 +126,17 @@ func (m Manifest) Validate() error {
 	if !validPublicID(m.Dataset.ID) {
 		return fmt.Errorf("invalid dataset ID %q", m.Dataset.ID)
 	}
-	if m.Dataset.HotEvents <= 0 || m.Dataset.ArchiveEvents < 0 || m.Dataset.HotDays <= 0 || m.Dataset.ArchiveDays < 0 {
+	if m.Dataset.HotEvents <= 0 || m.Dataset.Recent30DayEvents <= 0 || m.Dataset.Recent30DayEvents > m.Dataset.HotEvents || m.Dataset.ArchiveEvents < 0 || m.Dataset.HotDays <= 0 || m.Dataset.ArchiveDays < 0 {
 		return fmt.Errorf("dataset counts and day windows must be positive")
+	}
+	if (m.Dataset.HotDays <= 30 && m.Dataset.Recent30DayEvents != m.Dataset.HotEvents) || (m.Dataset.HotDays > 30 && m.Dataset.Recent30DayEvents >= m.Dataset.HotEvents) {
+		return fmt.Errorf("dataset recent 30-day count is inconsistent with the hot window")
 	}
 	if m.Dataset.FailureRate < 0 || m.Dataset.FailureRate > 1 {
 		return fmt.Errorf("failure rate must be between zero and one")
 	}
-	if _, err := time.Parse(time.RFC3339, m.Dataset.BenchmarkNow); err != nil {
-		return fmt.Errorf("dataset benchmark_now must be RFC3339: %w", err)
+	if _, err := ResolveDatasetBenchmarkNow(m.Dataset.BenchmarkNow, time.Now()); err != nil {
+		return err
 	}
 	if err := validateCardinality(m.Dataset.ID, m.Dataset.Cardinality); err != nil {
 		return err
@@ -158,7 +166,7 @@ func (m Manifest) Validate() error {
 		}
 		seenResources[resource.ID] = true
 	}
-	if len(m.Search.RatesPerSecond) == 0 || m.Search.ProbeSeconds <= 0 || m.Search.BoundarySeconds <= 0 || m.Search.BoundaryRepetitions <= 0 || m.Search.SoakSeconds <= 0 || m.Search.MaxRunSeconds <= 0 || m.Search.DashboardRequestsPerSecond <= 0 {
+	if len(m.Search.RatesPerSecond) == 0 || m.Search.InitialRatePerSecond <= 0 || m.Search.ProbeSeconds <= 0 || m.Search.BoundarySeconds <= 0 || m.Search.BoundaryRepetitions <= 0 || m.Search.SoakSeconds <= 0 || m.Search.MaxPassDrainSeconds <= 0 || m.Search.MaxPassDrainSeconds > 30 || m.Search.MaxRunSeconds <= 0 || m.Search.DashboardRequestsPerSecond <= 0 || m.Search.AnalysisLatencyIntervalSeconds <= 0 {
 		return fmt.Errorf("capacity search durations and rates must be positive")
 	}
 	for index, rate := range m.Search.RatesPerSecond {
@@ -166,13 +174,32 @@ func (m Manifest) Validate() error {
 			return fmt.Errorf("capacity search rates must be positive and increasing")
 		}
 	}
-	if m.Search.DashboardCoreP95MS < 0 || m.Search.DashboardOverallP99MS <= 0 {
+	initialIndex := sort.SearchInts(m.Search.RatesPerSecond, m.Search.InitialRatePerSecond)
+	if initialIndex >= len(m.Search.RatesPerSecond) || m.Search.RatesPerSecond[initialIndex] != m.Search.InitialRatePerSecond {
+		return fmt.Errorf("initial capacity rate %d is not configured", m.Search.InitialRatePerSecond)
+	}
+	if m.Search.DashboardCoreP95MS < 0 || m.Search.DashboardCoreP99MS <= 0 {
 		return fmt.Errorf("dashboard latency thresholds are invalid")
 	}
 	if m.Search.RecommendedCapacityRate <= 0 || m.Search.RecommendedCapacityRate > 1 {
 		return fmt.Errorf("recommended capacity ratio must be in (0,1]")
 	}
 	return nil
+}
+
+func ResolveDatasetBenchmarkNow(value string, generationTime time.Time) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "generation-time" {
+		if generationTime.IsZero() {
+			return time.Time{}, fmt.Errorf("dataset generation time is required")
+		}
+		return generationTime, nil
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("dataset benchmark_now must be RFC3339 or generation-time: %w", err)
+	}
+	return parsed, nil
 }
 
 func LoadPlan(path string) (Plan, string, error) {
@@ -191,7 +218,7 @@ func LoadPlan(path string) (Plan, string, error) {
 	}
 	seen := map[string]bool{}
 	for _, cell := range plan.Cells {
-		if strings.TrimSpace(cell.ID) == "" || !validPublicID(cell.DatasetID) || seen[cell.ID] {
+		if !validPublicID(cell.ID) || !validPublicID(cell.DatasetID) || seen[cell.ID] {
 			return Plan{}, "", fmt.Errorf("benchmark plan contains invalid or duplicate cell %q", cell.ID)
 		}
 		seen[cell.ID] = true
@@ -227,14 +254,15 @@ func ExpandPlan(manifest Manifest) (Plan, error) {
 	plan := Plan{Version: manifest.Version, ManifestSHA256: manifest.SourceSHA256}
 	for _, resource := range manifest.Resources {
 		plan.Cells = append(plan.Cells, Cell{
-			ID:             fmt.Sprintf("capacity-%s-%s", manifest.Dataset.ID, resource.ID),
-			Kind:           "capacity",
-			DatasetID:      manifest.Dataset.ID,
-			HotEvents:      manifest.Dataset.HotEvents,
-			ArchiveEvents:  manifest.Dataset.ArchiveEvents,
-			Cardinality:    manifest.Dataset.Cardinality,
-			Resource:       resource,
-			RatesPerSecond: append([]int(nil), manifest.Search.RatesPerSecond...),
+			ID:                fmt.Sprintf("capacity-%s-%s", manifest.Dataset.ID, resource.ID),
+			Kind:              "capacity",
+			DatasetID:         manifest.Dataset.ID,
+			HotEvents:         manifest.Dataset.HotEvents,
+			Recent30DayEvents: manifest.Dataset.Recent30DayEvents,
+			ArchiveEvents:     manifest.Dataset.ArchiveEvents,
+			Cardinality:       manifest.Dataset.Cardinality,
+			Resource:          resource,
+			RatesPerSecond:    append([]int(nil), manifest.Search.RatesPerSecond...),
 		})
 	}
 	return plan, nil

--- a/internal/benchmark/capacity/orchestrator.go
+++ b/internal/benchmark/capacity/orchestrator.go
@@ -1,0 +1,1053 @@
+package capacity
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type RunOptions struct {
+	ManifestPath   string
+	PlanPath       string
+	Root           string
+	RunID          string
+	KeeperBinary   string
+	RedisBinary    string
+	RedisPort      int
+	AppPort        int
+	CellIDs        []string
+	Resume         bool
+	MaxDuration    time.Duration
+	FixedRate      int
+	FixedDuration  time.Duration
+	FixedPass      string
+	SearchDuration time.Duration
+}
+
+type RunMetadata struct {
+	Version               string    `json:"version"`
+	RunID                 string    `json:"run_id"`
+	State                 string    `json:"state"`
+	StartedAt             time.Time `json:"started_at"`
+	UpdatedAt             time.Time `json:"updated_at"`
+	FinishedAt            time.Time `json:"finished_at,omitempty"`
+	OS                    string    `json:"os"`
+	Arch                  string    `json:"arch"`
+	ManifestSHA256        string    `json:"manifest_sha256"`
+	PlanSHA256            string    `json:"plan_sha256"`
+	KeeperBinarySHA256    string    `json:"keeper_binary_sha256"`
+	BenchctlBinarySHA256  string    `json:"benchctl_binary_sha256"`
+	RedisPort             int       `json:"redis_port"`
+	AppPort               int       `json:"app_port"`
+	SelectedCells         []string  `json:"selected_cells"`
+	CompletedCells        int       `json:"completed_cells"`
+	FailedCells           int       `json:"failed_cells"`
+	SkippedCells          int       `json:"skipped_cells"`
+	FixedRate             int       `json:"fixed_rate,omitempty"`
+	FixedDurationSeconds  int       `json:"fixed_duration_seconds,omitempty"`
+	FixedPass             string    `json:"fixed_pass,omitempty"`
+	SearchDurationSeconds int       `json:"search_duration_seconds,omitempty"`
+	Error                 string    `json:"error,omitempty"`
+}
+
+type AttemptResource struct {
+	MeasuredSeconds       float64 `json:"measured_seconds"`
+	CPUUsageUsecDelta     int64   `json:"cpu_usage_usec_delta"`
+	CPUUtilizationPercent float64 `json:"cpu_utilization_percent"`
+	CPUThrottledUsecDelta int64   `json:"cpu_throttled_usec_delta"`
+	IOReadBytesDelta      int64   `json:"io_read_bytes_delta"`
+	IOWriteBytesDelta     int64   `json:"io_write_bytes_delta"`
+	MemoryPeakBytes       int64   `json:"memory_peak_bytes"`
+	MemoryOOMDelta        int64   `json:"memory_oom_delta"`
+	MemoryOOMKillDelta    int64   `json:"memory_oom_kill_delta"`
+}
+
+type ProbeAttempt struct {
+	Phase           string          `json:"phase"`
+	Repetition      int             `json:"repetition"`
+	RatePerSecond   int             `json:"rate_per_second"`
+	DurationSeconds int             `json:"duration_seconds"`
+	StartedAt       time.Time       `json:"started_at"`
+	FinishedAt      time.Time       `json:"finished_at"`
+	StartupSeconds  float64         `json:"startup_seconds"`
+	WarmupSeconds   float64         `json:"warmup_seconds"`
+	UnitName        string          `json:"unit_name"`
+	EffectiveLimits CgroupLimits    `json:"effective_limits"`
+	Report          ProbeReport     `json:"report"`
+	Resource        AttemptResource `json:"resource"`
+	LastResource    CgroupSample    `json:"last_resource"`
+	PeakResource    CgroupSample    `json:"peak_resource"`
+	FinalUnitState  UnitState       `json:"final_unit_state"`
+	Error           string          `json:"error,omitempty"`
+}
+
+type CapacityResult struct {
+	HardEventsPerSecond        int `json:"hard_events_per_second"`
+	InteractiveEventsPerSecond int `json:"interactive_events_per_second"`
+	RecommendedEventsPerSecond int `json:"recommended_events_per_second"`
+}
+
+type CellResult struct {
+	Version              string         `json:"version"`
+	RunID                string         `json:"run_id"`
+	Cell                 Cell           `json:"cell"`
+	Status               string         `json:"status"`
+	StartedAt            time.Time      `json:"started_at"`
+	FinishedAt           time.Time      `json:"finished_at"`
+	StartupSeconds       float64        `json:"startup_seconds"`
+	WarmupSeconds        float64        `json:"warmup_seconds"`
+	DatasetFingerprint   string         `json:"dataset_fingerprint"`
+	ManifestSHA256       string         `json:"manifest_sha256"`
+	KeeperBinarySHA256   string         `json:"keeper_binary_sha256"`
+	BenchctlBinarySHA256 string         `json:"benchctl_binary_sha256"`
+	UnitName             string         `json:"unit_name"`
+	AllowedCPUs          string         `json:"allowed_cpus"`
+	DriverCPUs           string         `json:"driver_cpus"`
+	SharedDriver         bool           `json:"shared_driver"`
+	EffectiveLimits      CgroupLimits   `json:"effective_limits"`
+	Attempts             []ProbeAttempt `json:"attempts"`
+	Capacity             CapacityResult `json:"capacity"`
+	LastResource         CgroupSample   `json:"last_resource"`
+	PeakResource         CgroupSample   `json:"peak_resource"`
+	FinalUnitState       UnitState      `json:"final_unit_state"`
+	DatabaseBytesBefore  int64          `json:"database_bytes_before"`
+	DatabaseBytesAfter   int64          `json:"database_bytes_after"`
+	WALBytesAfter        int64          `json:"wal_bytes_after"`
+	WorkDatabaseRetained bool           `json:"work_database_retained"`
+	Error                string         `json:"error,omitempty"`
+}
+
+type runContext struct {
+	options        RunOptions
+	manifest       Manifest
+	plan           Plan
+	metadata       RunMetadata
+	runDir         string
+	datasetsDir    string
+	binaryDigest   string
+	benchctlDigest string
+	redis          SystemdRuntime
+	redisPass      string
+	onlineCPUs     int
+}
+
+func ExecuteRun(parent context.Context, options RunOptions) (metadata RunMetadata, returnErr error) {
+	if options.RedisPort == 0 {
+		options.RedisPort = 16379
+	}
+	if options.AppPort == 0 {
+		options.AppPort = 18080
+	}
+	if options.MaxDuration <= 0 {
+		options.MaxDuration = 8 * time.Hour
+	}
+	if options.FixedPass == "" {
+		options.FixedPass = "interactive"
+	}
+	if strings.TrimSpace(options.Root) == "" || strings.TrimSpace(options.RunID) == "" || strings.TrimSpace(options.KeeperBinary) == "" {
+		return metadata, fmt.Errorf("run root, run ID, and Keeper binary are required")
+	}
+	cleanRoot := filepath.Clean(options.Root)
+	if cleanRoot == "." || cleanRoot == string(os.PathSeparator) {
+		return metadata, fmt.Errorf("benchmark root is unsafe: %q", options.Root)
+	}
+	if !validRunID(options.RunID) {
+		return metadata, fmt.Errorf("invalid benchmark run ID %q", options.RunID)
+	}
+	if options.FixedRate < 0 || (options.FixedDuration > 0 && options.FixedRate == 0) {
+		return metadata, fmt.Errorf("fixed duration requires a positive fixed rate")
+	}
+	if options.SearchDuration < 0 {
+		return metadata, fmt.Errorf("search duration cannot be negative")
+	}
+	if _, err := FixedRateSoakPassed(options.FixedPass, ProbeEvaluation{}); err != nil {
+		return metadata, err
+	}
+	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
+		return metadata, fmt.Errorf("capacity benchmark requires linux/amd64, got %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+	ctx, cancel := context.WithTimeout(parent, options.MaxDuration)
+	defer cancel()
+	lock, err := AcquireFileLock(filepath.Join(options.Root, "benchmark.lock"))
+	if err != nil {
+		return metadata, err
+	}
+	defer lock.Close()
+
+	manifest, err := LoadManifest(options.ManifestPath)
+	if err != nil {
+		return metadata, err
+	}
+	if err := manifest.Validate(); err != nil {
+		return metadata, err
+	}
+	plan, planDigest, err := LoadPlan(options.PlanPath)
+	if err != nil {
+		return metadata, err
+	}
+	if plan.ManifestSHA256 != manifest.SourceSHA256 {
+		return metadata, fmt.Errorf("plan manifest hash %s does not match %s", plan.ManifestSHA256, manifest.SourceSHA256)
+	}
+	selected, err := selectCells(plan.Cells, options.CellIDs)
+	if err != nil {
+		return metadata, err
+	}
+	binaryDigest, err := FileSHA256(options.KeeperBinary)
+	if err != nil {
+		return metadata, fmt.Errorf("hash Keeper binary: %w", err)
+	}
+	benchctlPath, err := os.Executable()
+	if err != nil {
+		return metadata, fmt.Errorf("resolve benchctl executable: %w", err)
+	}
+	benchctlDigest, err := FileSHA256(benchctlPath)
+	if err != nil {
+		return metadata, fmt.Errorf("hash benchctl binary: %w", err)
+	}
+	runDir := filepath.Join(options.Root, "runs", options.RunID)
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		return metadata, fmt.Errorf("create benchmark run directory: %w", err)
+	}
+	metadata = RunMetadata{
+		Version: manifest.Version, RunID: options.RunID, State: "preparing", StartedAt: time.Now(), UpdatedAt: time.Now(),
+		OS: runtime.GOOS, Arch: runtime.GOARCH, ManifestSHA256: manifest.SourceSHA256, PlanSHA256: planDigest,
+		KeeperBinarySHA256: binaryDigest, BenchctlBinarySHA256: benchctlDigest, RedisPort: options.RedisPort, AppPort: options.AppPort,
+		FixedRate: options.FixedRate, FixedDurationSeconds: int(options.FixedDuration.Seconds()), FixedPass: options.FixedPass,
+		SearchDurationSeconds: int(options.SearchDuration.Seconds()),
+	}
+	for _, cell := range selected {
+		metadata.SelectedCells = append(metadata.SelectedCells, cell.ID)
+	}
+	metadataPath := filepath.Join(runDir, "run.json")
+	if err := WriteJSONAtomic(metadataPath, metadata); err != nil {
+		return metadata, err
+	}
+	defer func() {
+		if returnErr != nil {
+			metadata.State = "failed"
+			metadata.Error = returnErr.Error()
+		}
+		metadata.UpdatedAt = time.Now()
+		metadata.FinishedAt = time.Now()
+		_ = WriteJSONAtomic(metadataPath, metadata)
+	}()
+
+	for _, command := range []string{"systemd-run", "systemctl", "sqlite3", "taskset"} {
+		if _, err := exec.LookPath(command); err != nil {
+			return metadata, fmt.Errorf("required benchmark command %s is unavailable: %w", command, err)
+		}
+	}
+	onlineCPUs, err := OnlineCPUCount()
+	if err != nil {
+		return metadata, err
+	}
+	if onlineCPUs < 4 {
+		return metadata, fmt.Errorf("capacity benchmark requires 4 online CPUs, found %d", onlineCPUs)
+	}
+	context := &runContext{
+		options: options, manifest: manifest, plan: plan, metadata: metadata, runDir: runDir,
+		datasetsDir: filepath.Join(options.Root, "datasets"), binaryDigest: binaryDigest, benchctlDigest: benchctlDigest,
+		redisPass: "benchmark-only", onlineCPUs: onlineCPUs,
+	}
+	redisUnit := unitName(options.RunID, "redis")
+	context.redis, err = StartRedisUnit(ctx, RedisStartOptions{
+		UnitName: redisUnit, Root: runDir, Port: options.RedisPort, Password: context.redisPass, BinaryPath: options.RedisBinary,
+	})
+	if err != nil {
+		return metadata, err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, stopUnitWithTimeout(context.redis.UnitName, 20*time.Second))
+	}()
+
+	metadata.State = "running"
+	metadata.UpdatedAt = time.Now()
+	if err := WriteJSONAtomic(metadataPath, metadata); err != nil {
+		return metadata, err
+	}
+	for _, cell := range selected {
+		if err := ctx.Err(); err != nil {
+			return metadata, err
+		}
+		result, skipped, cellErr := context.executeCell(ctx, cell)
+		if skipped {
+			metadata.SkippedCells++
+		} else if cellErr != nil || result.Status != "completed" {
+			metadata.FailedCells++
+		} else {
+			metadata.CompletedCells++
+		}
+		metadata.UpdatedAt = time.Now()
+		if err := WriteJSONAtomic(metadataPath, metadata); err != nil {
+			return metadata, err
+		}
+		if err := RebuildResultsJSONL(runDir); err != nil {
+			return metadata, err
+		}
+	}
+	metadata.State = "completed"
+	metadata.UpdatedAt = time.Now()
+	if _, err := SummarizeRun(runDir); err != nil {
+		return metadata, err
+	}
+	return metadata, nil
+}
+
+func validRunID(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" || value == "." || value == ".." || strings.HasPrefix(value, ".") || strings.HasSuffix(value, ".") {
+		return false
+	}
+	for _, character := range value {
+		if (character < 'a' || character > 'z') && (character < 'A' || character > 'Z') && (character < '0' || character > '9') && character != '-' && character != '_' && character != '.' {
+			return false
+		}
+	}
+	return true
+}
+
+func (run *runContext) executeCell(ctx context.Context, cell Cell) (result CellResult, skipped bool, returnErr error) {
+	datasetDir := filepath.Join(run.datasetsDir, cell.DatasetID)
+	datasetPath, err := resolveDatasetPath(datasetDir)
+	if err != nil {
+		return result, false, fmt.Errorf("cell %s dataset: %w", cell.ID, err)
+	}
+	datasetResultPath := filepath.Join(datasetDir, "dataset.json")
+	dataset, err := LoadDatasetResult(datasetResultPath)
+	if err != nil {
+		return result, false, fmt.Errorf("cell %s dataset metadata: %w", cell.ID, err)
+	}
+	if err := validateCellDataset(cell, dataset, datasetPath); err != nil {
+		return result, false, err
+	}
+	cellDir := filepath.Join(run.runDir, "cells", cell.ID)
+	if run.options.Resume {
+		matched, matchErr := ResumeCellMatches(filepath.Join(cellDir, "result.json"), run.manifest.SourceSHA256, run.binaryDigest, run.benchctlDigest, dataset.SemanticFingerprint)
+		if matchErr != nil {
+			return result, false, matchErr
+		}
+		if matched {
+			return result, true, nil
+		}
+	}
+	attemptDir, err := nextAttemptDirectory(cellDir)
+	if err != nil {
+		return result, false, err
+	}
+	workDir := filepath.Join(attemptDir, "work")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		return result, false, err
+	}
+	result = CellResult{
+		Version: run.manifest.Version, RunID: run.options.RunID, Cell: cell, Status: "preparing", StartedAt: time.Now(),
+		DatasetFingerprint: dataset.SemanticFingerprint, ManifestSHA256: run.manifest.SourceSHA256,
+		KeeperBinarySHA256: run.binaryDigest, BenchctlBinarySHA256: run.benchctlDigest, DatabaseBytesBefore: dataset.DatabaseBytes,
+	}
+	resultPath := filepath.Join(cellDir, "result.json")
+	defer func() {
+		result.FinishedAt = time.Now()
+		// Keeper 与采样器的 defer 后注册、会先停止；只有完整成功的可重建 clone 才在结果落盘前精确裁剪。
+		if returnErr == nil && result.Status == "completed" {
+			if pruneErr := PruneCompletedWorkDatabase(workDir); pruneErr != nil {
+				returnErr = pruneErr
+			} else {
+				result.WorkDatabaseRetained = false
+			}
+		}
+		if returnErr != nil {
+			result.Error = returnErr.Error()
+			if result.Status != "oom" && result.Status != "timeout" {
+				result.Status = "failed"
+			}
+		}
+		_ = WriteJSONAtomic(filepath.Join(attemptDir, "result.json"), result)
+		_ = WriteJSONAtomic(resultPath, result)
+		if result.Status == "completed" {
+			_ = WriteJSONAtomic(filepath.Join(cellDir, "done.marker"), map[string]string{
+				"manifest_sha256": result.ManifestSHA256, "keeper_binary_sha256": result.KeeperBinarySHA256,
+				"benchctl_binary_sha256": result.BenchctlBinarySHA256, "dataset_fingerprint": result.DatasetFingerprint,
+			})
+		}
+	}()
+
+	activeDB := filepath.Join(workDir, "app.db")
+	result.WorkDatabaseRetained = true
+	envPath := filepath.Join(attemptDir, "keeper.env")
+	if err := writeKeeperEnvironment(envPath, workDir, run.options.AppPort, run.options.RedisPort, run.redisPass); err != nil {
+		return result, false, err
+	}
+	cpu := int(cell.Resource.CPU)
+	allowedCPUs := cpuSet(0, cpu)
+	driverCPUs := cpuSet(cpu, run.onlineCPUs)
+	sharedDriver := false
+	if driverCPUs == "" {
+		driverCPUs = cpuSet(0, run.onlineCPUs)
+		sharedDriver = true
+	}
+	result.AllowedCPUs = allowedCPUs
+	result.DriverCPUs = driverCPUs
+	result.SharedDriver = sharedDriver
+	if err := SetProcessAffinity(driverCPUs); err != nil {
+		return result, false, err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, SetProcessAffinity(cpuSet(0, run.onlineCPUs)))
+	}()
+	probeSequence := 0
+	runAttempt := func(phase string, repetition, rate int, duration time.Duration) ProbeAttempt {
+		probeSequence++
+		attempt := run.runIsolatedProbeAttempt(ctx, cell, datasetPath, activeDB, envPath, attemptDir, allowedCPUs, probeSequence, phase, repetition, rate, duration)
+		mergeProbeAttemptRuntime(&result, attempt)
+		return attempt
+	}
+	result.Status = "running"
+	if run.options.FixedRate > 0 {
+		duration := run.options.FixedDuration
+		if duration <= 0 {
+			duration = time.Duration(run.manifest.Search.SoakSeconds) * time.Second
+		}
+		attempt := runAttempt("soak", 1, run.options.FixedRate, duration)
+		result.Attempts = append(result.Attempts, attempt)
+		if attempt.Report.Evaluation.HardPass {
+			result.Capacity.HardEventsPerSecond = run.options.FixedRate
+		}
+		if attempt.Report.Evaluation.InteractivePass {
+			result.Capacity.InteractiveEventsPerSecond = run.options.FixedRate
+			result.Capacity.RecommendedEventsPerSecond = run.options.FixedRate
+		}
+		passed, _ := FixedRateSoakPassed(run.options.FixedPass, attempt.Report.Evaluation)
+		if !passed {
+			if attempt.Report.Metrics.OOM {
+				result.Status = "oom"
+			}
+			return result, false, fmt.Errorf("%s soak failed at %d events/s: %s", run.options.FixedPass, run.options.FixedRate, strings.Join(attempt.Report.Evaluation.Reasons, ","))
+		}
+		if stat, statErr := os.Stat(activeDB); statErr == nil {
+			result.DatabaseBytesAfter = stat.Size()
+		}
+		if stat, statErr := os.Stat(activeDB + "-wal"); statErr == nil {
+			result.WALBytesAfter = stat.Size()
+		}
+		result.Status = "completed"
+		return result, false, nil
+	}
+	search, err := NewCapacitySearch(cell.RatesPerSecond)
+	if err != nil {
+		return result, false, err
+	}
+	searchAttempts := map[int]ProbeAttempt{}
+	runSearchAttempt := func(rate int) ProbeAttempt {
+		if attempt, ok := searchAttempts[rate]; ok {
+			return attempt
+		}
+		searchDuration := run.options.SearchDuration
+		if searchDuration <= 0 {
+			searchDuration = time.Duration(run.manifest.Search.ProbeSeconds) * time.Second
+		}
+		attempt := runAttempt("search", 1, rate, searchDuration)
+		result.Attempts = append(result.Attempts, attempt)
+		searchAttempts[rate] = attempt
+		return attempt
+	}
+	for {
+		rate, ok := search.Next()
+		if !ok {
+			break
+		}
+		attempt := runSearchAttempt(rate)
+		search.Record(rate, attempt.Report.Evaluation.HardPass)
+		if IsCapacityAttemptInfrastructureFailure(attempt) {
+			break
+		}
+	}
+	hardCandidate := search.HardCapacity()
+	interactiveCandidate := 0
+	if run.manifest.Search.SearchDashboardCapacity && hardCandidate > 0 {
+		interactiveRates := ratesAtOrBelow(cell.RatesPerSecond, hardCandidate)
+		interactiveSearch, searchErr := NewCapacitySearch(interactiveRates)
+		if searchErr != nil {
+			return result, false, searchErr
+		}
+		for {
+			rate, ok := interactiveSearch.Next()
+			if !ok {
+				break
+			}
+			attempt := runSearchAttempt(rate)
+			interactiveSearch.Record(rate, attempt.Report.Evaluation.InteractivePass)
+			if IsCapacityAttemptInfrastructureFailure(attempt) {
+				break
+			}
+		}
+		interactiveCandidate = interactiveSearch.HardCapacity()
+	}
+	verifiedHard := hardCandidate
+	if !run.manifest.Search.SkipBoundary {
+		verifiedHard = 0
+		for _, candidate := range SelectBoundaryCandidates(result.Attempts, hardCandidate, 2) {
+			passed := true
+			for repetition := 1; repetition <= run.manifest.Search.BoundaryRepetitions; repetition++ {
+				attempt := runAttempt("boundary", repetition, candidate, time.Duration(run.manifest.Search.BoundarySeconds)*time.Second)
+				result.Attempts = append(result.Attempts, attempt)
+				if !attempt.Report.Evaluation.HardPass {
+					passed = false
+					break
+				}
+			}
+			if passed {
+				verifiedHard = candidate
+				break
+			}
+		}
+	}
+	interactive := min(interactiveCandidate, verifiedHard)
+	if !run.manifest.Search.SearchDashboardCapacity {
+		for _, attempt := range result.Attempts {
+			if attempt.RatePerSecond <= verifiedHard && attempt.Report.Evaluation.InteractivePass && attempt.RatePerSecond > interactive {
+				interactive = attempt.RatePerSecond
+			}
+		}
+	}
+	recommended := int(math.Floor(float64(interactive) * run.manifest.Search.RecommendedCapacityRate))
+	if interactive > 0 && recommended < 1 {
+		recommended = 1
+	}
+	result.Capacity = CapacityResult{HardEventsPerSecond: verifiedHard, InteractiveEventsPerSecond: interactive, RecommendedEventsPerSecond: recommended}
+	for _, attempt := range result.Attempts {
+		if IsCapacityAttemptInfrastructureFailure(attempt) {
+			return result, false, fmt.Errorf("benchmark probe failed during %s at %d events/s: %s", attempt.Phase, attempt.RatePerSecond, attempt.Error)
+		}
+	}
+	if stat, statErr := os.Stat(activeDB); statErr == nil {
+		result.DatabaseBytesAfter = stat.Size()
+	}
+	if stat, statErr := os.Stat(activeDB + "-wal"); statErr == nil {
+		result.WALBytesAfter = stat.Size()
+	}
+	result.Status = "completed"
+	return result, false, nil
+}
+
+func FixedRateSoakPassed(mode string, evaluation ProbeEvaluation) (bool, error) {
+	switch strings.TrimSpace(mode) {
+	case "hard":
+		return evaluation.HardPass, nil
+	case "interactive":
+		return evaluation.InteractivePass, nil
+	default:
+		return false, fmt.Errorf("fixed pass mode must be hard or interactive")
+	}
+}
+
+// IsCapacityAttemptInfrastructureFailure separates an expected capacity OOM
+// from a broken probe. The OOM rate remains in the result as the upper failure
+// boundary; panic, sampler/runtime errors, and other probe errors still fail
+// the cell.
+func IsCapacityAttemptInfrastructureFailure(attempt ProbeAttempt) bool {
+	if attempt.Report.Metrics.OOM {
+		return false
+	}
+	return attempt.Report.Metrics.Panic || attempt.Error != ""
+}
+
+// PruneCompletedWorkDatabase 只裁剪成功 cell 的可重建 SQLite clone；日志、结果和其它诊断文件保持不动。
+func PruneCompletedWorkDatabase(workDir string) error {
+	cleaned := filepath.Clean(strings.TrimSpace(workDir))
+	if cleaned == "." || cleaned == string(os.PathSeparator) || cleaned == "" {
+		return fmt.Errorf("completed work directory is unsafe: %q", workDir)
+	}
+	databasePath := filepath.Join(cleaned, "app.db")
+	var result error
+	for _, path := range []string{databasePath + "-shm", databasePath + "-wal", databasePath} {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			result = errors.Join(result, fmt.Errorf("remove completed benchmark clone %s: %w", filepath.Clean(path), err))
+		}
+	}
+	return result
+}
+
+func (run *runContext) runIsolatedProbeAttempt(ctx context.Context, cell Cell, datasetPath, databasePath, envPath, attemptDir, allowedCPUs string, sequence int, phase string, repetition, rate int, duration time.Duration) (attempt ProbeAttempt) {
+	attempt = ProbeAttempt{Phase: phase, Repetition: repetition, RatePerSecond: rate, DurationSeconds: int(duration.Seconds()), StartedAt: time.Now()}
+	thresholds := ProbeThresholds{MinDurableRatio: 0.99, MaxBacklogGrowth: 0,
+		InteractiveP95MS: float64(run.manifest.Search.DashboardCoreP95MS), InteractiveP99MS: float64(run.manifest.Search.DashboardOverallP99MS)}
+	if err := ResetDatasetClone(ctx, datasetPath, databasePath); err != nil {
+		markProbeAttemptError(&attempt, thresholds, err)
+		attempt.FinishedAt = time.Now()
+		return attempt
+	}
+	unit := unitName(run.options.RunID, cell.ID, filepath.Base(attemptDir), fmt.Sprintf("probe-%03d", sequence))
+	attempt.UnitName = unit
+	runtimeUnit, err := StartKeeperUnit(ctx, KeeperStartOptions{
+		UnitName: unit, BinaryPath: run.options.KeeperBinary, Environment: envPath, WorkingDir: attemptDir,
+		StdoutPath: filepath.Join(attemptDir, "stdout.log"), StderrPath: filepath.Join(attemptDir, "stderr.log"),
+		CPU: int(cell.Resource.CPU), MemoryMiB: cell.Resource.MemoryMiB, AllowedCPUs: allowedCPUs,
+	})
+	if err != nil {
+		markProbeAttemptError(&attempt, thresholds, err)
+		attempt.FinishedAt = time.Now()
+		return attempt
+	}
+	attempt.EffectiveLimits = runtimeUnit.Limits
+	var sampler *CgroupSampler
+	defer func() {
+		if attempt.FinalUnitState.ActiveState == "" {
+			attempt.FinalUnitState, _ = readUnitStateWithTimeout(runtimeUnit.UnitName, 3*time.Second)
+		}
+		if sampler != nil {
+			last, peak, sampleErr := sampler.Stop()
+			attempt.LastResource = last
+			attempt.PeakResource = peak
+			if sampleErr != nil {
+				markProbeAttemptError(&attempt, thresholds, sampleErr)
+			}
+		}
+		if stopErr := stopUnitWithTimeout(runtimeUnit.UnitName, 20*time.Second); stopErr != nil {
+			markProbeAttemptError(&attempt, thresholds, stopErr)
+		}
+		attempt.FinishedAt = time.Now()
+	}()
+
+	sampler, err = StartCgroupSampler(ctx, runtimeUnit.CgroupPath, filepath.Join(attemptDir, fmt.Sprintf("cgroup-samples-%03d.jsonl", sequence)), 200*time.Millisecond)
+	if err != nil {
+		markProbeAttemptError(&attempt, thresholds, err)
+		return attempt
+	}
+	startupDuration, err := WaitHTTPHealth(ctx, fmt.Sprintf("http://127.0.0.1:%d", run.options.AppPort), unit, 90*time.Second)
+	attempt.StartupSeconds = startupDuration.Seconds()
+	if err != nil {
+		last, _ := ReadCgroupSample(runtimeUnit.CgroupPath)
+		state, _ := readUnitStateWithTimeout(unit, 3*time.Second)
+		attempt.FinalUnitState = state
+		if last.MemoryOOMKill > 0 || state.Result == "oom-kill" {
+			attempt.Report.Metrics.OOM = true
+		} else if state.ActiveState != "active" {
+			attempt.Report.Metrics.Panic = true
+		}
+		markProbeAttemptError(&attempt, thresholds, err)
+		return attempt
+	}
+	warmupDuration, err := WarmDashboard(ctx, fmt.Sprintf("http://127.0.0.1:%d", run.options.AppPort))
+	attempt.WarmupSeconds = warmupDuration.Seconds()
+	if err != nil {
+		last, _ := ReadCgroupSample(runtimeUnit.CgroupPath)
+		state, _ := readUnitStateWithTimeout(unit, 3*time.Second)
+		attempt.FinalUnitState = state
+		if last.MemoryOOMKill > 0 || state.Result == "oom-kill" {
+			attempt.Report.Metrics.OOM = true
+		} else if state.ActiveState != "active" {
+			attempt.Report.Metrics.Panic = true
+		}
+		markProbeAttemptError(&attempt, thresholds, err)
+		return attempt
+	}
+	select {
+	case <-ctx.Done():
+		markProbeAttemptError(&attempt, thresholds, ctx.Err())
+		return attempt
+	case <-time.After(time.Second):
+	}
+
+	before, _ := ReadCgroupSample(runtimeUnit.CgroupPath)
+	measuredAt := time.Now()
+	apiProfiles, err := BuildAPIKeyProfiles(cell.Cardinality.APIKeys, run.manifest.TrafficTiers, run.manifest.Dataset.Seed)
+	if err == nil {
+		attempt.Report, err = RunProbe(ctx, ProbeOptions{
+			RedisAddress: netAddress(run.options.RedisPort), RedisPassword: run.redisPass, RedisChannel: "usage",
+			ApplicationURL: fmt.Sprintf("http://127.0.0.1:%d", run.options.AppPort), DatabasePath: databasePath,
+			RatePerSecond: rate, Duration: duration, DrainTimeout: 30 * time.Second, HTTPRatePerSecond: run.manifest.Search.DashboardRequestsPerSecond,
+			Cardinality: cell.Cardinality, APIKeyProfiles: apiProfiles, Seed: run.manifest.Dataset.Seed,
+			Thresholds: thresholds,
+		})
+	}
+	after, _ := ReadCgroupSample(runtimeUnit.CgroupPath)
+	attempt.Resource = resourceDelta(before, after, time.Since(measuredAt), int(cell.Resource.CPU))
+	attempt.LastResource = after
+	if after.MemoryOOMKill > before.MemoryOOMKill {
+		attempt.Report.Metrics.OOM = true
+		attempt.Report.Evaluation = EvaluateProbe(attempt.Report.Metrics, thresholds)
+	}
+	if state, stateErr := readUnitStateWithTimeout(runtimeUnit.UnitName, 3*time.Second); stateErr == nil {
+		attempt.FinalUnitState = state
+		if state.ActiveState == "active" {
+			// 正常 probe 在 defer 停止 unit；这里仅记录运行末端状态。
+		} else if state.Result == "oom-kill" || after.MemoryOOMKill > before.MemoryOOMKill {
+			attempt.Report.Metrics.OOM = true
+		} else {
+			attempt.Report.Metrics.Panic = true
+		}
+		attempt.Report.Evaluation = EvaluateProbe(attempt.Report.Metrics, thresholds)
+	}
+	if err != nil {
+		markProbeAttemptError(&attempt, thresholds, err)
+	}
+	return attempt
+}
+
+func markProbeAttemptError(attempt *ProbeAttempt, thresholds ProbeThresholds, err error) {
+	if attempt == nil || err == nil {
+		return
+	}
+	if attempt.Error == "" {
+		attempt.Error = err.Error()
+	} else {
+		attempt.Error += "; " + err.Error()
+	}
+	attempt.Report.Metrics.Errors++
+	attempt.Report.Evaluation = EvaluateProbe(attempt.Report.Metrics, thresholds)
+	if !slices.Contains(attempt.Report.Evaluation.Reasons, "probe_error") {
+		attempt.Report.Evaluation.Reasons = append(attempt.Report.Evaluation.Reasons, "probe_error")
+	}
+}
+
+func mergeProbeAttemptRuntime(result *CellResult, attempt ProbeAttempt) {
+	if result == nil {
+		return
+	}
+	if result.UnitName == "" {
+		result.UnitName = attempt.UnitName
+		result.EffectiveLimits = attempt.EffectiveLimits
+		result.StartupSeconds = attempt.StartupSeconds
+		result.WarmupSeconds = attempt.WarmupSeconds
+	}
+	result.LastResource = attempt.LastResource
+	result.FinalUnitState = attempt.FinalUnitState
+	if attempt.PeakResource.MemoryPeakBytes > result.PeakResource.MemoryPeakBytes {
+		result.PeakResource = attempt.PeakResource
+	}
+}
+
+func validateCellDataset(cell Cell, dataset DatasetResult, path string) error {
+	if dataset.GeneratorVersion != DatasetGeneratorVersion {
+		return fmt.Errorf("cell %s dataset generator=%q, want %q", cell.ID, dataset.GeneratorVersion, DatasetGeneratorVersion)
+	}
+	if dataset.HotEvents != cell.HotEvents || dataset.ArchiveEvents != cell.ArchiveEvents {
+		return fmt.Errorf("cell %s dataset rows hot=%d archive=%d, want %d/%d", cell.ID, dataset.HotEvents, dataset.ArchiveEvents, cell.HotEvents, cell.ArchiveEvents)
+	}
+	if dataset.Identities != int64(cell.Cardinality.Identities) || dataset.Models != int64(cell.Cardinality.Models) || dataset.APIKeys != int64(cell.Cardinality.APIKeys) {
+		return fmt.Errorf("cell %s dataset cardinality does not match plan", cell.ID)
+	}
+	if dataset.UsedIdentities != dataset.Identities || dataset.UsedModels != dataset.Models || dataset.UsedAPIKeys != dataset.APIKeys {
+		return fmt.Errorf("cell %s dataset does not exercise every identity/model/API key", cell.ID)
+	}
+	if dataset.QuickCheck != "ok" || dataset.OrphanIdentities != 0 || dataset.OrphanModels != 0 || dataset.OrphanAPIKeys != 0 || dataset.TokenSemanticViolations != 0 || dataset.SemanticFingerprint == "" {
+		return fmt.Errorf("cell %s dataset validation is not reusable", cell.ID)
+	}
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("cell %s dataset file: %w", cell.ID, err)
+	}
+	return nil
+}
+
+func resolveDatasetPath(datasetDir string) (string, error) {
+	for _, name := range []string{"app.db", "app.db.zst"} {
+		path := filepath.Join(datasetDir, name)
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		} else if !os.IsNotExist(err) {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("neither app.db nor app.db.zst exists in %s", filepath.Clean(datasetDir))
+}
+
+func selectCells(cells []Cell, ids []string) ([]Cell, error) {
+	if len(ids) == 0 {
+		return append([]Cell(nil), cells...), nil
+	}
+	wanted := map[string]bool{}
+	for _, id := range ids {
+		wanted[id] = true
+	}
+	var selected []Cell
+	for _, cell := range cells {
+		if wanted[cell.ID] {
+			selected = append(selected, cell)
+			delete(wanted, cell.ID)
+		}
+	}
+	if len(wanted) > 0 {
+		missing := make([]string, 0, len(wanted))
+		for id := range wanted {
+			missing = append(missing, id)
+		}
+		sort.Strings(missing)
+		return nil, fmt.Errorf("unknown benchmark cells: %s", strings.Join(missing, ", "))
+	}
+	return selected, nil
+}
+
+func descendingPassingRates(attempts []ProbeAttempt, upper int) []int {
+	seen := map[int]bool{}
+	var rates []int
+	for _, attempt := range attempts {
+		if attempt.Phase == "search" && attempt.RatePerSecond <= upper && attempt.Report.Evaluation.HardPass && !seen[attempt.RatePerSecond] {
+			seen[attempt.RatePerSecond] = true
+			rates = append(rates, attempt.RatePerSecond)
+		}
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(rates)))
+	return rates
+}
+
+// SelectBoundaryCandidates limits ordinary matrix validation to the highest
+// short-probe capacity and one conservative fallback at roughly half that
+// rate. Final deployment recommendations are still verified by dedicated
+// soaks, so testing every intermediate passing rate only adds runtime.
+func SelectBoundaryCandidates(attempts []ProbeAttempt, upper, maximum int) []int {
+	rates := descendingPassingRates(attempts, upper)
+	if maximum <= 0 || len(rates) <= maximum {
+		return rates
+	}
+	selected := []int{rates[0]}
+	for len(selected) < maximum {
+		target := selected[len(selected)-1] / 2
+		candidate := 0
+		for _, rate := range rates {
+			if rate < selected[len(selected)-1] && rate <= target {
+				candidate = rate
+				break
+			}
+		}
+		if candidate == 0 {
+			candidate = rates[len(rates)-1]
+		}
+		if slices.Contains(selected, candidate) {
+			break
+		}
+		selected = append(selected, candidate)
+	}
+	return selected
+}
+
+func resourceDelta(before, after CgroupSample, measured time.Duration, cpu int) AttemptResource {
+	usageDelta := after.CPUUsageUsec - before.CPUUsageUsec
+	utilization := 0.0
+	if measured > 0 && cpu > 0 {
+		utilization = float64(usageDelta) / (measured.Seconds() * 1_000_000 * float64(cpu)) * 100
+	}
+	return AttemptResource{
+		MeasuredSeconds:       measured.Seconds(),
+		CPUUsageUsecDelta:     usageDelta,
+		CPUUtilizationPercent: utilization,
+		CPUThrottledUsecDelta: after.CPUThrottledUsec - before.CPUThrottledUsec,
+		IOReadBytesDelta:      after.IOReadBytes - before.IOReadBytes,
+		IOWriteBytesDelta:     after.IOWriteBytes - before.IOWriteBytes,
+		MemoryPeakBytes:       after.MemoryPeakBytes,
+		MemoryOOMDelta:        after.MemoryOOM - before.MemoryOOM,
+		MemoryOOMKillDelta:    after.MemoryOOMKill - before.MemoryOOMKill,
+	}
+}
+
+func ratesAtOrBelow(rates []int, upper int) []int {
+	selected := make([]int, 0, len(rates))
+	for _, rate := range rates {
+		if rate > upper {
+			break
+		}
+		selected = append(selected, rate)
+	}
+	return selected
+}
+
+func ResumeCellMatches(path, manifestDigest, keeperDigest, benchctlDigest, datasetFingerprint string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	var result CellResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		return false, fmt.Errorf("decode existing cell result: %w", err)
+	}
+	return result.Status == "completed" && result.ManifestSHA256 == manifestDigest && result.KeeperBinarySHA256 == keeperDigest && result.BenchctlBinarySHA256 == benchctlDigest && result.DatasetFingerprint == datasetFingerprint, nil
+}
+
+func nextAttemptDirectory(cellDir string) (string, error) {
+	if err := os.MkdirAll(cellDir, 0o755); err != nil {
+		return "", err
+	}
+	entries, err := os.ReadDir(cellDir)
+	if err != nil {
+		return "", err
+	}
+	maximum := 0
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "attempt-") {
+			continue
+		}
+		value, _ := strconv.Atoi(strings.TrimPrefix(entry.Name(), "attempt-"))
+		maximum = max(maximum, value)
+	}
+	path := filepath.Join(cellDir, fmt.Sprintf("attempt-%03d", maximum+1))
+	return path, os.MkdirAll(path, 0o755)
+}
+
+func writeKeeperEnvironment(path, workDir string, appPort, redisPort int, password string) error {
+	content := strings.Join([]string{
+		"APP_HOST=127.0.0.1",
+		"APP_PORT=" + strconv.Itoa(appPort),
+		"WORK_DIR=" + workDir,
+		"CPA_BASE_URL=http://127.0.0.1:1",
+		"CPA_MANAGEMENT_KEY=" + password,
+		"REDIS_QUEUE_ADDR=127.0.0.1:" + strconv.Itoa(redisPort),
+		"REDIS_QUEUE_TLS=false",
+		"REDIS_QUEUE_BATCH_SIZE=10000",
+		"REDIS_QUEUE_IDLE_INTERVAL=100ms",
+		"REQUEST_TIMEOUT=2s",
+		"AUTH_ENABLED=false",
+		"BACKUP_ENABLED=false",
+		"LOG_FILE_ENABLED=false",
+		"LOG_LEVEL=warn",
+		"TZ=Asia/Shanghai",
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		return fmt.Errorf("write Keeper benchmark environment: %w", err)
+	}
+	return nil
+}
+
+func cpuSet(start, end int) string {
+	if start >= end {
+		return ""
+	}
+	if end-start == 1 {
+		return strconv.Itoa(start)
+	}
+	return fmt.Sprintf("%d-%d", start, end-1)
+}
+
+func OnlineCPUCount() (int, error) {
+	data, err := os.ReadFile("/sys/devices/system/cpu/online")
+	if err != nil {
+		return 0, fmt.Errorf("read online CPUs: %w", err)
+	}
+	value := strings.TrimSpace(string(data))
+	parts := strings.Split(value, "-")
+	if len(parts) == 1 {
+		last, err := strconv.Atoi(parts[0])
+		return last + 1, err
+	}
+	if len(parts) == 2 && parts[0] == "0" {
+		last, err := strconv.Atoi(parts[1])
+		if err == nil {
+			return last + 1, nil
+		}
+	}
+	return 0, fmt.Errorf("benchmark requires contiguous online CPUs, got %q", value)
+}
+
+func SetProcessAffinity(cpus string) error {
+	if cpus == "" {
+		return fmt.Errorf("process affinity CPU set is empty")
+	}
+	output, err := exec.Command("taskset", "-apc", cpus, strconv.Itoa(os.Getpid())).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("set benchmark driver affinity to %s: %w: %s", cpus, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func unitName(parts ...string) string {
+	joined := strings.Join(parts, "-")
+	var builder strings.Builder
+	for _, character := range strings.ToLower(joined) {
+		if (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9') || character == '-' {
+			builder.WriteRune(character)
+		} else {
+			builder.WriteByte('-')
+		}
+	}
+	name := strings.Trim(builder.String(), "-")
+	if len(name) > 180 {
+		digest := sha256.Sum256([]byte(name))
+		name = name[:160] + "-" + hex.EncodeToString(digest[:6])
+	}
+	return "cpa-keeper-bench-" + name
+}
+
+func netAddress(port int) string {
+	return "127.0.0.1:" + strconv.Itoa(port)
+}
+
+func stopUnitWithTimeout(unitName string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return StopUnit(ctx, unitName)
+}
+
+func readUnitStateWithTimeout(unitName string, timeout time.Duration) (UnitState, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return ReadUnitState(ctx, unitName)
+}
+
+func FileSHA256(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := file.WriteTo(hash); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func WriteJSONAtomic(path string, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode %s: %w", filepath.Base(path), err)
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".benchmark-*.tmp")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if _, err := temporary.Write(data); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, path)
+}
+
+func LoadDatasetResult(path string) (DatasetResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return DatasetResult{}, err
+	}
+	var result DatasetResult
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&result); err != nil {
+		return DatasetResult{}, err
+	}
+	return result, nil
+}

--- a/internal/benchmark/capacity/orchestrator.go
+++ b/internal/benchmark/capacity/orchestrator.go
@@ -20,47 +20,52 @@ import (
 )
 
 type RunOptions struct {
-	ManifestPath   string
-	PlanPath       string
-	Root           string
-	RunID          string
-	KeeperBinary   string
-	RedisBinary    string
-	RedisPort      int
-	AppPort        int
-	CellIDs        []string
-	Resume         bool
-	MaxDuration    time.Duration
-	FixedRate      int
-	FixedDuration  time.Duration
-	FixedPass      string
-	SearchDuration time.Duration
+	ManifestPath          string
+	PlanPath              string
+	Root                  string
+	RunID                 string
+	KeeperBinary          string
+	RedisBinary           string
+	RedisPort             int
+	AppPort               int
+	CellIDs               []string
+	Resume                bool
+	MaxDuration           time.Duration
+	FixedRate             int
+	FixedDuration         time.Duration
+	FixedPass             string
+	SearchDuration        time.Duration
+	DatasetValidationPath string
 }
 
 type RunMetadata struct {
-	Version               string    `json:"version"`
-	RunID                 string    `json:"run_id"`
-	State                 string    `json:"state"`
-	StartedAt             time.Time `json:"started_at"`
-	UpdatedAt             time.Time `json:"updated_at"`
-	FinishedAt            time.Time `json:"finished_at,omitempty"`
-	OS                    string    `json:"os"`
-	Arch                  string    `json:"arch"`
-	ManifestSHA256        string    `json:"manifest_sha256"`
-	PlanSHA256            string    `json:"plan_sha256"`
-	KeeperBinarySHA256    string    `json:"keeper_binary_sha256"`
-	BenchctlBinarySHA256  string    `json:"benchctl_binary_sha256"`
-	RedisPort             int       `json:"redis_port"`
-	AppPort               int       `json:"app_port"`
-	SelectedCells         []string  `json:"selected_cells"`
-	CompletedCells        int       `json:"completed_cells"`
-	FailedCells           int       `json:"failed_cells"`
-	SkippedCells          int       `json:"skipped_cells"`
-	FixedRate             int       `json:"fixed_rate,omitempty"`
-	FixedDurationSeconds  int       `json:"fixed_duration_seconds,omitempty"`
-	FixedPass             string    `json:"fixed_pass,omitempty"`
-	SearchDurationSeconds int       `json:"search_duration_seconds,omitempty"`
-	Error                 string    `json:"error,omitempty"`
+	Version                  string    `json:"version"`
+	RunID                    string    `json:"run_id"`
+	State                    string    `json:"state"`
+	StartedAt                time.Time `json:"started_at"`
+	UpdatedAt                time.Time `json:"updated_at"`
+	FinishedAt               time.Time `json:"finished_at,omitempty"`
+	OS                       string    `json:"os"`
+	Arch                     string    `json:"arch"`
+	ManifestSHA256           string    `json:"manifest_sha256"`
+	PlanSHA256               string    `json:"plan_sha256"`
+	KeeperBinarySHA256       string    `json:"keeper_binary_sha256"`
+	BenchctlBinarySHA256     string    `json:"benchctl_binary_sha256"`
+	RedisPort                int       `json:"redis_port"`
+	RedisCPUs                string    `json:"redis_cpus"`
+	AppPort                  int       `json:"app_port"`
+	SelectedCells            []string  `json:"selected_cells"`
+	CompletedCells           int       `json:"completed_cells"`
+	FailedCells              int       `json:"failed_cells"`
+	SkippedCells             int       `json:"skipped_cells"`
+	FixedRate                int       `json:"fixed_rate,omitempty"`
+	FixedDurationSeconds     int       `json:"fixed_duration_seconds,omitempty"`
+	FixedPass                string    `json:"fixed_pass,omitempty"`
+	SearchDurationSeconds    int       `json:"search_duration_seconds,omitempty"`
+	DatasetValidationSHA256  string    `json:"dataset_validation_sha256"`
+	DatasetQueryAnchor       time.Time `json:"dataset_query_anchor"`
+	DatasetRecent30DayEvents int64     `json:"dataset_recent_30_day_events"`
+	Error                    string    `json:"error,omitempty"`
 }
 
 type AttemptResource struct {
@@ -95,53 +100,78 @@ type ProbeAttempt struct {
 }
 
 type CapacityResult struct {
-	HardEventsPerSecond        int `json:"hard_events_per_second"`
-	InteractiveEventsPerSecond int `json:"interactive_events_per_second"`
-	RecommendedEventsPerSecond int `json:"recommended_events_per_second"`
+	HardEventsPerSecond                     int `json:"hard_events_per_second"`
+	LowestHardFailureEventsPerSecond        int `json:"lowest_hard_failure_events_per_second,omitempty"`
+	InteractiveEventsPerSecond              int `json:"interactive_events_per_second"`
+	LowestInteractiveFailureEventsPerSecond int `json:"lowest_interactive_failure_events_per_second,omitempty"`
+	RecommendedEventsPerSecond              int `json:"recommended_events_per_second"`
 }
 
 type CellResult struct {
-	Version              string         `json:"version"`
-	RunID                string         `json:"run_id"`
-	Cell                 Cell           `json:"cell"`
-	Status               string         `json:"status"`
-	StartedAt            time.Time      `json:"started_at"`
-	FinishedAt           time.Time      `json:"finished_at"`
-	StartupSeconds       float64        `json:"startup_seconds"`
-	WarmupSeconds        float64        `json:"warmup_seconds"`
-	DatasetFingerprint   string         `json:"dataset_fingerprint"`
-	ManifestSHA256       string         `json:"manifest_sha256"`
-	KeeperBinarySHA256   string         `json:"keeper_binary_sha256"`
-	BenchctlBinarySHA256 string         `json:"benchctl_binary_sha256"`
-	UnitName             string         `json:"unit_name"`
-	AllowedCPUs          string         `json:"allowed_cpus"`
-	DriverCPUs           string         `json:"driver_cpus"`
-	SharedDriver         bool           `json:"shared_driver"`
-	EffectiveLimits      CgroupLimits   `json:"effective_limits"`
-	Attempts             []ProbeAttempt `json:"attempts"`
-	Capacity             CapacityResult `json:"capacity"`
-	LastResource         CgroupSample   `json:"last_resource"`
-	PeakResource         CgroupSample   `json:"peak_resource"`
-	FinalUnitState       UnitState      `json:"final_unit_state"`
-	DatabaseBytesBefore  int64          `json:"database_bytes_before"`
-	DatabaseBytesAfter   int64          `json:"database_bytes_after"`
-	WALBytesAfter        int64          `json:"wal_bytes_after"`
-	WorkDatabaseRetained bool           `json:"work_database_retained"`
-	Error                string         `json:"error,omitempty"`
+	Version                  string         `json:"version"`
+	RunID                    string         `json:"run_id"`
+	Cell                     Cell           `json:"cell"`
+	Status                   string         `json:"status"`
+	StartedAt                time.Time      `json:"started_at"`
+	FinishedAt               time.Time      `json:"finished_at"`
+	StartupSeconds           float64        `json:"startup_seconds"`
+	WarmupSeconds            float64        `json:"warmup_seconds"`
+	DatasetFingerprint       string         `json:"dataset_fingerprint"`
+	DatasetValidationSHA256  string         `json:"dataset_validation_sha256"`
+	DatasetQueryAnchor       time.Time      `json:"dataset_query_anchor"`
+	DatasetRecent30DayEvents int64          `json:"dataset_recent_30_day_events"`
+	ManifestSHA256           string         `json:"manifest_sha256"`
+	PlanSHA256               string         `json:"plan_sha256"`
+	KeeperBinarySHA256       string         `json:"keeper_binary_sha256"`
+	BenchctlBinarySHA256     string         `json:"benchctl_binary_sha256"`
+	FixedRate                int            `json:"fixed_rate,omitempty"`
+	FixedDurationSeconds     int            `json:"fixed_duration_seconds,omitempty"`
+	FixedPass                string         `json:"fixed_pass,omitempty"`
+	SearchDurationSeconds    int            `json:"search_duration_seconds,omitempty"`
+	UnitName                 string         `json:"unit_name"`
+	AllowedCPUs              string         `json:"allowed_cpus"`
+	DriverCPUs               string         `json:"driver_cpus"`
+	SharedDriver             bool           `json:"shared_driver"`
+	EffectiveLimits          CgroupLimits   `json:"effective_limits"`
+	Attempts                 []ProbeAttempt `json:"attempts"`
+	Capacity                 CapacityResult `json:"capacity"`
+	LastResource             CgroupSample   `json:"last_resource"`
+	PeakResource             CgroupSample   `json:"peak_resource"`
+	FinalUnitState           UnitState      `json:"final_unit_state"`
+	DatabaseBytesBefore      int64          `json:"database_bytes_before"`
+	DatabaseBytesAfter       int64          `json:"database_bytes_after"`
+	WALBytesAfter            int64          `json:"wal_bytes_after"`
+	WorkDatabaseRetained     bool           `json:"work_database_retained"`
+	Error                    string         `json:"error,omitempty"`
+}
+
+type ExecutionProvenance struct {
+	ManifestSHA256          string
+	PlanSHA256              string
+	KeeperBinarySHA256      string
+	BenchctlBinarySHA256    string
+	DatasetFingerprint      string
+	DatasetValidationSHA256 string
+	FixedRate               int
+	FixedDurationSeconds    int
+	FixedPass               string
+	SearchDurationSeconds   int
 }
 
 type runContext struct {
-	options        RunOptions
-	manifest       Manifest
-	plan           Plan
-	metadata       RunMetadata
-	runDir         string
-	datasetsDir    string
-	binaryDigest   string
-	benchctlDigest string
-	redis          SystemdRuntime
-	redisPass      string
-	onlineCPUs     int
+	options                 RunOptions
+	manifest                Manifest
+	plan                    Plan
+	metadata                RunMetadata
+	runDir                  string
+	datasetsDir             string
+	binaryDigest            string
+	benchctlDigest          string
+	datasetValidation       DatasetResult
+	datasetValidationDigest string
+	redis                   SystemdRuntime
+	redisPass               string
+	onlineCPUs              int
 }
 
 func ExecuteRun(parent context.Context, options RunOptions) (metadata RunMetadata, returnErr error) {
@@ -217,6 +247,10 @@ func ExecuteRun(parent context.Context, options RunOptions) (metadata RunMetadat
 	if err != nil {
 		return metadata, fmt.Errorf("hash benchctl binary: %w", err)
 	}
+	datasetValidation, datasetValidationDigest, err := prepareDatasetValidation(ctx, options, manifest, selected)
+	if err != nil {
+		return metadata, err
+	}
 	runDir := filepath.Join(options.Root, "runs", options.RunID)
 	if err := os.MkdirAll(runDir, 0o755); err != nil {
 		return metadata, fmt.Errorf("create benchmark run directory: %w", err)
@@ -226,7 +260,9 @@ func ExecuteRun(parent context.Context, options RunOptions) (metadata RunMetadat
 		OS: runtime.GOOS, Arch: runtime.GOARCH, ManifestSHA256: manifest.SourceSHA256, PlanSHA256: planDigest,
 		KeeperBinarySHA256: binaryDigest, BenchctlBinarySHA256: benchctlDigest, RedisPort: options.RedisPort, AppPort: options.AppPort,
 		FixedRate: options.FixedRate, FixedDurationSeconds: int(options.FixedDuration.Seconds()), FixedPass: options.FixedPass,
-		SearchDurationSeconds: int(options.SearchDuration.Seconds()),
+		SearchDurationSeconds:   int(options.SearchDuration.Seconds()),
+		DatasetValidationSHA256: datasetValidationDigest, DatasetQueryAnchor: datasetValidation.QueryAnchor,
+		DatasetRecent30DayEvents: datasetValidation.Recent30DayEvents,
 	}
 	for _, cell := range selected {
 		metadata.SelectedCells = append(metadata.SelectedCells, cell.ID)
@@ -250,6 +286,9 @@ func ExecuteRun(parent context.Context, options RunOptions) (metadata RunMetadat
 			return metadata, fmt.Errorf("required benchmark command %s is unavailable: %w", command, err)
 		}
 	}
+	if err := PreflightDatasetDependencies(options.Root, selected); err != nil {
+		return metadata, err
+	}
 	onlineCPUs, err := OnlineCPUCount()
 	if err != nil {
 		return metadata, err
@@ -257,14 +296,18 @@ func ExecuteRun(parent context.Context, options RunOptions) (metadata RunMetadat
 	if onlineCPUs < 4 {
 		return metadata, fmt.Errorf("capacity benchmark requires 4 online CPUs, found %d", onlineCPUs)
 	}
+	redisCPUs := RedisCPUSet(onlineCPUs)
+	metadata.RedisCPUs = redisCPUs
 	context := &runContext{
 		options: options, manifest: manifest, plan: plan, metadata: metadata, runDir: runDir,
 		datasetsDir: filepath.Join(options.Root, "datasets"), binaryDigest: binaryDigest, benchctlDigest: benchctlDigest,
+		datasetValidation: datasetValidation, datasetValidationDigest: datasetValidationDigest,
 		redisPass: "benchmark-only", onlineCPUs: onlineCPUs,
 	}
 	redisUnit := unitName(options.RunID, "redis")
 	context.redis, err = StartRedisUnit(ctx, RedisStartOptions{
 		UnitName: redisUnit, Root: runDir, Port: options.RedisPort, Password: context.redisPass, BinaryPath: options.RedisBinary,
+		AllowedCPUs: redisCPUs,
 	})
 	if err != nil {
 		return metadata, err
@@ -278,6 +321,7 @@ func ExecuteRun(parent context.Context, options RunOptions) (metadata RunMetadat
 	if err := WriteJSONAtomic(metadataPath, metadata); err != nil {
 		return metadata, err
 	}
+	var cellFailures []error
 	for _, cell := range selected {
 		if err := ctx.Err(); err != nil {
 			return metadata, err
@@ -287,6 +331,11 @@ func ExecuteRun(parent context.Context, options RunOptions) (metadata RunMetadat
 			metadata.SkippedCells++
 		} else if cellErr != nil || result.Status != "completed" {
 			metadata.FailedCells++
+			if cellErr != nil {
+				cellFailures = append(cellFailures, fmt.Errorf("cell %s: %w", cell.ID, cellErr))
+			} else {
+				cellFailures = append(cellFailures, fmt.Errorf("cell %s ended with status %s", cell.ID, result.Status))
+			}
 		} else {
 			metadata.CompletedCells++
 		}
@@ -297,6 +346,9 @@ func ExecuteRun(parent context.Context, options RunOptions) (metadata RunMetadat
 		if err := RebuildResultsJSONL(runDir); err != nil {
 			return metadata, err
 		}
+	}
+	if len(cellFailures) > 0 {
+		return metadata, errors.Join(cellFailures...)
 	}
 	metadata.State = "completed"
 	metadata.UpdatedAt = time.Now()
@@ -333,9 +385,12 @@ func (run *runContext) executeCell(ctx context.Context, cell Cell) (result CellR
 	if err := validateCellDataset(cell, dataset, datasetPath); err != nil {
 		return result, false, err
 	}
+	if err := ValidateDatasetAgainstManifest(run.datasetValidation, dataset, run.manifest); err != nil {
+		return result, false, fmt.Errorf("cell %s strict dataset validation: %w", cell.ID, err)
+	}
 	cellDir := filepath.Join(run.runDir, "cells", cell.ID)
 	if run.options.Resume {
-		matched, matchErr := ResumeCellMatches(filepath.Join(cellDir, "result.json"), run.manifest.SourceSHA256, run.binaryDigest, run.benchctlDigest, dataset.SemanticFingerprint)
+		matched, matchErr := ResumeCellMatches(filepath.Join(cellDir, "result.json"), run.executionProvenance(dataset.SemanticFingerprint))
 		if matchErr != nil {
 			return result, false, matchErr
 		}
@@ -353,8 +408,12 @@ func (run *runContext) executeCell(ctx context.Context, cell Cell) (result CellR
 	}
 	result = CellResult{
 		Version: run.manifest.Version, RunID: run.options.RunID, Cell: cell, Status: "preparing", StartedAt: time.Now(),
-		DatasetFingerprint: dataset.SemanticFingerprint, ManifestSHA256: run.manifest.SourceSHA256,
-		KeeperBinarySHA256: run.binaryDigest, BenchctlBinarySHA256: run.benchctlDigest, DatabaseBytesBefore: dataset.DatabaseBytes,
+		DatasetFingerprint: dataset.SemanticFingerprint, DatasetValidationSHA256: run.datasetValidationDigest,
+		DatasetQueryAnchor: run.datasetValidation.QueryAnchor, DatasetRecent30DayEvents: run.datasetValidation.Recent30DayEvents,
+		ManifestSHA256: run.manifest.SourceSHA256, PlanSHA256: run.metadata.PlanSHA256,
+		KeeperBinarySHA256: run.binaryDigest, BenchctlBinarySHA256: run.benchctlDigest,
+		FixedRate: run.options.FixedRate, FixedDurationSeconds: int(run.options.FixedDuration.Seconds()), FixedPass: run.options.FixedPass,
+		SearchDurationSeconds: int(run.options.SearchDuration.Seconds()), DatabaseBytesBefore: dataset.DatabaseBytes,
 	}
 	resultPath := filepath.Join(cellDir, "result.json")
 	defer func() {
@@ -378,7 +437,7 @@ func (run *runContext) executeCell(ctx context.Context, cell Cell) (result CellR
 		if result.Status == "completed" {
 			_ = WriteJSONAtomic(filepath.Join(cellDir, "done.marker"), map[string]string{
 				"manifest_sha256": result.ManifestSHA256, "keeper_binary_sha256": result.KeeperBinarySHA256,
-				"benchctl_binary_sha256": result.BenchctlBinarySHA256, "dataset_fingerprint": result.DatasetFingerprint,
+				"plan_sha256": result.PlanSHA256, "benchctl_binary_sha256": result.BenchctlBinarySHA256, "dataset_fingerprint": result.DatasetFingerprint,
 			})
 		}
 	}()
@@ -423,10 +482,14 @@ func (run *runContext) executeCell(ctx context.Context, cell Cell) (result CellR
 		result.Attempts = append(result.Attempts, attempt)
 		if attempt.Report.Evaluation.HardPass {
 			result.Capacity.HardEventsPerSecond = run.options.FixedRate
+		} else {
+			result.Capacity.LowestHardFailureEventsPerSecond = run.options.FixedRate
 		}
 		if attempt.Report.Evaluation.InteractivePass {
 			result.Capacity.InteractiveEventsPerSecond = run.options.FixedRate
-			result.Capacity.RecommendedEventsPerSecond = run.options.FixedRate
+			result.Capacity.RecommendedEventsPerSecond = RecommendedEventsPerSecond(run.options.FixedRate, run.manifest.Search.RecommendedCapacityRate)
+		} else {
+			result.Capacity.LowestInteractiveFailureEventsPerSecond = run.options.FixedRate
 		}
 		passed, _ := FixedRateSoakPassed(run.options.FixedPass, attempt.Report.Evaluation)
 		if !passed {
@@ -444,7 +507,7 @@ func (run *runContext) executeCell(ctx context.Context, cell Cell) (result CellR
 		result.Status = "completed"
 		return result, false, nil
 	}
-	search, err := NewCapacitySearch(cell.RatesPerSecond)
+	search, err := NewCapacitySearchAt(cell.RatesPerSecond, run.manifest.Search.InitialRatePerSecond)
 	if err != nil {
 		return result, false, err
 	}
@@ -462,22 +525,96 @@ func (run *runContext) executeCell(ctx context.Context, cell Cell) (result CellR
 		searchAttempts[rate] = attempt
 		return attempt
 	}
-	for {
-		rate, ok := search.Next()
-		if !ok {
-			break
-		}
-		attempt := runSearchAttempt(rate)
-		search.Record(rate, attempt.Report.Evaluation.HardPass)
-		if IsCapacityAttemptInfrastructureFailure(attempt) {
-			break
+	runHardSearch := func() {
+		for {
+			rate, ok := search.Next()
+			if !ok {
+				return
+			}
+			attempt := runSearchAttempt(rate)
+			search.Record(rate, attempt.Report.Evaluation.HardPass)
+			if IsCapacityAttemptInfrastructureFailure(attempt) {
+				return
+			}
 		}
 	}
-	hardCandidate := search.HardCapacity()
+	runHardSearch()
+	verifiedHard := search.HardCapacity()
+	lowestHardFailure := search.FailureBoundary()
+	if !run.manifest.Search.SkipBoundary && verifiedHard > 0 {
+		confirmedPasses := map[int]bool{}
+		for verifiedHard > 0 {
+			if !confirmedPasses[verifiedHard] {
+				passed := true
+				for repetition := 1; repetition <= run.manifest.Search.BoundaryRepetitions; repetition++ {
+					attempt := runAttempt("boundary-pass", repetition, verifiedHard, time.Duration(run.manifest.Search.BoundarySeconds)*time.Second)
+					result.Attempts = append(result.Attempts, attempt)
+					if !attempt.Report.Evaluation.HardPass {
+						passed = false
+						lowestHardFailure = lowestPositiveRate(lowestHardFailure, verifiedHard)
+						break
+					}
+				}
+				if !passed {
+					verifiedHard = 0
+					for _, fallback := range SelectBoundaryCandidates(result.Attempts, search.HardCapacity()-1, 3) {
+						fallbackPassed := true
+						for repetition := 1; repetition <= run.manifest.Search.BoundaryRepetitions; repetition++ {
+							attempt := runAttempt("boundary-pass", repetition, fallback, time.Duration(run.manifest.Search.BoundarySeconds)*time.Second)
+							result.Attempts = append(result.Attempts, attempt)
+							if !attempt.Report.Evaluation.HardPass {
+								fallbackPassed = false
+								lowestHardFailure = lowestPositiveRate(lowestHardFailure, fallback)
+								break
+							}
+						}
+						if fallbackPassed {
+							verifiedHard = fallback
+							break
+						}
+					}
+					break
+				}
+				confirmedPasses[verifiedHard] = true
+			}
+
+			upper := search.FailureBoundary()
+			if upper == 0 {
+				break
+			}
+			upperPassed := true
+			var passingAttempt ProbeAttempt
+			for repetition := 1; repetition <= run.manifest.Search.BoundaryRepetitions; repetition++ {
+				attempt := runAttempt("boundary-fail", repetition, upper, time.Duration(run.manifest.Search.BoundarySeconds)*time.Second)
+				result.Attempts = append(result.Attempts, attempt)
+				if !attempt.Report.Evaluation.HardPass {
+					upperPassed = false
+					lowestHardFailure = lowestPositiveRate(lowestHardFailure, upper)
+					break
+				}
+				passingAttempt = attempt
+			}
+			if !upperPassed {
+				break
+			}
+			confirmedPasses[upper] = true
+			searchAttempts[upper] = passingAttempt
+			if err := search.PromoteFailure(upper); err != nil {
+				return result, false, err
+			}
+			lowestHardFailure = 0
+			runHardSearch()
+			verifiedHard = search.HardCapacity()
+			lowestHardFailure = search.FailureBoundary()
+		}
+	}
+
 	interactiveCandidate := 0
-	if run.manifest.Search.SearchDashboardCapacity && hardCandidate > 0 {
-		interactiveRates := ratesAtOrBelow(cell.RatesPerSecond, hardCandidate)
-		interactiveSearch, searchErr := NewCapacitySearch(interactiveRates)
+	lowestInteractiveFailure := 0
+	if run.manifest.Search.SearchDashboardCapacity && verifiedHard > 0 {
+		interactiveRates := ratesAtOrBelow(cell.RatesPerSecond, verifiedHard)
+		interactiveInitialRate := min(run.manifest.Search.InitialRatePerSecond, interactiveRates[len(interactiveRates)-1])
+		interactiveSearch, searchErr := NewCapacitySearchAt(interactiveRates, interactiveInitialRate)
 		if searchErr != nil {
 			return result, false, searchErr
 		}
@@ -493,25 +630,7 @@ func (run *runContext) executeCell(ctx context.Context, cell Cell) (result CellR
 			}
 		}
 		interactiveCandidate = interactiveSearch.HardCapacity()
-	}
-	verifiedHard := hardCandidate
-	if !run.manifest.Search.SkipBoundary {
-		verifiedHard = 0
-		for _, candidate := range SelectBoundaryCandidates(result.Attempts, hardCandidate, 2) {
-			passed := true
-			for repetition := 1; repetition <= run.manifest.Search.BoundaryRepetitions; repetition++ {
-				attempt := runAttempt("boundary", repetition, candidate, time.Duration(run.manifest.Search.BoundarySeconds)*time.Second)
-				result.Attempts = append(result.Attempts, attempt)
-				if !attempt.Report.Evaluation.HardPass {
-					passed = false
-					break
-				}
-			}
-			if passed {
-				verifiedHard = candidate
-				break
-			}
-		}
+		lowestInteractiveFailure = lowestPositiveRate(interactiveSearch.FailureBoundary(), lowestHardFailure)
 	}
 	interactive := min(interactiveCandidate, verifiedHard)
 	if !run.manifest.Search.SearchDashboardCapacity {
@@ -521,11 +640,12 @@ func (run *runContext) executeCell(ctx context.Context, cell Cell) (result CellR
 			}
 		}
 	}
-	recommended := int(math.Floor(float64(interactive) * run.manifest.Search.RecommendedCapacityRate))
-	if interactive > 0 && recommended < 1 {
-		recommended = 1
+	recommended := RecommendedEventsPerSecond(interactive, run.manifest.Search.RecommendedCapacityRate)
+	result.Capacity = CapacityResult{
+		HardEventsPerSecond: verifiedHard, LowestHardFailureEventsPerSecond: NormalizeFailureBoundary(verifiedHard, lowestHardFailure),
+		InteractiveEventsPerSecond: interactive, LowestInteractiveFailureEventsPerSecond: NormalizeFailureBoundary(interactive, lowestInteractiveFailure),
+		RecommendedEventsPerSecond: recommended,
 	}
-	result.Capacity = CapacityResult{HardEventsPerSecond: verifiedHard, InteractiveEventsPerSecond: interactive, RecommendedEventsPerSecond: recommended}
 	for _, attempt := range result.Attempts {
 		if IsCapacityAttemptInfrastructureFailure(attempt) {
 			return result, false, fmt.Errorf("benchmark probe failed during %s at %d events/s: %s", attempt.Phase, attempt.RatePerSecond, attempt.Error)
@@ -539,6 +659,24 @@ func (run *runContext) executeCell(ctx context.Context, cell Cell) (result CellR
 	}
 	result.Status = "completed"
 	return result, false, nil
+}
+
+func RecommendedEventsPerSecond(rate int, ratio float64) int {
+	if rate <= 0 || ratio <= 0 {
+		return 0
+	}
+	recommended := int(math.Floor(float64(rate) * ratio))
+	if recommended < 1 {
+		return 1
+	}
+	return recommended
+}
+
+func NormalizeFailureBoundary(passingRate, failureRate int) int {
+	if failureRate > passingRate {
+		return failureRate
+	}
+	return 0
 }
 
 func FixedRateSoakPassed(mode string, evaluation ProbeEvaluation) (bool, error) {
@@ -582,7 +720,8 @@ func PruneCompletedWorkDatabase(workDir string) error {
 func (run *runContext) runIsolatedProbeAttempt(ctx context.Context, cell Cell, datasetPath, databasePath, envPath, attemptDir, allowedCPUs string, sequence int, phase string, repetition, rate int, duration time.Duration) (attempt ProbeAttempt) {
 	attempt = ProbeAttempt{Phase: phase, Repetition: repetition, RatePerSecond: rate, DurationSeconds: int(duration.Seconds()), StartedAt: time.Now()}
 	thresholds := ProbeThresholds{MinDurableRatio: 0.99, MaxBacklogGrowth: 0,
-		InteractiveP95MS: float64(run.manifest.Search.DashboardCoreP95MS), InteractiveP99MS: float64(run.manifest.Search.DashboardOverallP99MS)}
+		InteractiveP95MS: float64(run.manifest.Search.DashboardCoreP95MS), InteractiveP99MS: float64(run.manifest.Search.DashboardCoreP99MS),
+		MaxDrainSeconds: float64(run.manifest.Search.MaxPassDrainSeconds)}
 	if err := ResetDatasetClone(ctx, datasetPath, databasePath); err != nil {
 		markProbeAttemptError(&attempt, thresholds, err)
 		attempt.FinishedAt = time.Now()
@@ -668,7 +807,8 @@ func (run *runContext) runIsolatedProbeAttempt(ctx context.Context, cell Cell, d
 			RedisAddress: netAddress(run.options.RedisPort), RedisPassword: run.redisPass, RedisChannel: "usage",
 			ApplicationURL: fmt.Sprintf("http://127.0.0.1:%d", run.options.AppPort), DatabasePath: databasePath,
 			RatePerSecond: rate, Duration: duration, DrainTimeout: 30 * time.Second, HTTPRatePerSecond: run.manifest.Search.DashboardRequestsPerSecond,
-			Cardinality: cell.Cardinality, APIKeyProfiles: apiProfiles, Seed: run.manifest.Dataset.Seed,
+			AnalysisLatencyInterval: time.Duration(run.manifest.Search.AnalysisLatencyIntervalSeconds) * time.Second,
+			Cardinality:             cell.Cardinality, APIKeyProfiles: apiProfiles, Seed: run.manifest.Dataset.Seed,
 			Thresholds: thresholds,
 		})
 	}
@@ -733,8 +873,8 @@ func validateCellDataset(cell Cell, dataset DatasetResult, path string) error {
 	if dataset.GeneratorVersion != DatasetGeneratorVersion {
 		return fmt.Errorf("cell %s dataset generator=%q, want %q", cell.ID, dataset.GeneratorVersion, DatasetGeneratorVersion)
 	}
-	if dataset.HotEvents != cell.HotEvents || dataset.ArchiveEvents != cell.ArchiveEvents {
-		return fmt.Errorf("cell %s dataset rows hot=%d archive=%d, want %d/%d", cell.ID, dataset.HotEvents, dataset.ArchiveEvents, cell.HotEvents, cell.ArchiveEvents)
+	if dataset.HotEvents != cell.HotEvents || dataset.Recent30DayEvents != cell.Recent30DayEvents || dataset.ArchiveEvents != cell.ArchiveEvents {
+		return fmt.Errorf("cell %s dataset rows hot=%d recent30=%d archive=%d, want %d/%d/%d", cell.ID, dataset.HotEvents, dataset.Recent30DayEvents, dataset.ArchiveEvents, cell.HotEvents, cell.Recent30DayEvents, cell.ArchiveEvents)
 	}
 	if dataset.Identities != int64(cell.Cardinality.Identities) || dataset.Models != int64(cell.Cardinality.Models) || dataset.APIKeys != int64(cell.Cardinality.APIKeys) {
 		return fmt.Errorf("cell %s dataset cardinality does not match plan", cell.ID)
@@ -761,6 +901,74 @@ func resolveDatasetPath(datasetDir string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("neither app.db nor app.db.zst exists in %s", filepath.Clean(datasetDir))
+}
+
+func PreflightDatasetDependencies(root string, cells []Cell) error {
+	for _, cell := range cells {
+		path, err := resolveDatasetPath(filepath.Join(root, "datasets", cell.DatasetID))
+		if err != nil {
+			return fmt.Errorf("preflight cell %s dataset: %w", cell.ID, err)
+		}
+		if strings.HasSuffix(path, ".zst") {
+			if _, err := exec.LookPath("zstd"); err != nil {
+				return fmt.Errorf("compressed canonical dataset requires zstd: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+const maxDatasetValidationProofAge = 12 * time.Hour
+
+func prepareDatasetValidation(ctx context.Context, options RunOptions, manifest Manifest, cells []Cell) (DatasetResult, string, error) {
+	if len(cells) == 0 {
+		return DatasetResult{}, "", fmt.Errorf("benchmark run has no selected cells")
+	}
+	for _, cell := range cells {
+		if cell.DatasetID != manifest.Dataset.ID {
+			return DatasetResult{}, "", fmt.Errorf("cell %s dataset %q does not match manifest dataset %q", cell.ID, cell.DatasetID, manifest.Dataset.ID)
+		}
+	}
+	datasetDir := filepath.Join(options.Root, "datasets", manifest.Dataset.ID)
+	metadata, err := LoadDatasetResult(filepath.Join(datasetDir, "dataset.json"))
+	if err != nil {
+		return DatasetResult{}, "", fmt.Errorf("load dataset validation metadata: %w", err)
+	}
+	var validation DatasetResult
+	var digest string
+	if strings.TrimSpace(options.DatasetValidationPath) != "" {
+		validation, err = LoadDatasetResult(options.DatasetValidationPath)
+		if err != nil {
+			return DatasetResult{}, "", fmt.Errorf("load dataset validation proof: %w", err)
+		}
+		digest, err = FileSHA256(options.DatasetValidationPath)
+		if err != nil {
+			return DatasetResult{}, "", fmt.Errorf("hash dataset validation proof: %w", err)
+		}
+	} else {
+		datasetPath, resolveErr := resolveDatasetPath(datasetDir)
+		if resolveErr != nil {
+			return DatasetResult{}, "", resolveErr
+		}
+		validation, err = ValidateDatasetPath(ctx, datasetPath, time.Now())
+		if err != nil {
+			return DatasetResult{}, "", err
+		}
+		data, marshalErr := json.Marshal(validation)
+		if marshalErr != nil {
+			return DatasetResult{}, "", fmt.Errorf("encode dataset validation proof: %w", marshalErr)
+		}
+		hash := sha256.Sum256(data)
+		digest = hex.EncodeToString(hash[:])
+	}
+	if err := ValidateDatasetAgainstManifest(validation, metadata, manifest); err != nil {
+		return DatasetResult{}, "", err
+	}
+	proofAge := time.Since(validation.QueryAnchor)
+	if proofAge < -time.Minute || proofAge > maxDatasetValidationProofAge {
+		return DatasetResult{}, "", fmt.Errorf("dataset validation proof age %s is outside the allowed %s", proofAge.Round(time.Minute), maxDatasetValidationProofAge)
+	}
+	return validation, digest, nil
 }
 
 func selectCells(cells []Cell, ids []string) ([]Cell, error) {
@@ -803,8 +1011,8 @@ func descendingPassingRates(attempts []ProbeAttempt, upper int) []int {
 }
 
 // SelectBoundaryCandidates limits ordinary matrix validation to the highest
-// short-probe capacity and one conservative fallback at roughly half that
-// rate. Final deployment recommendations are still verified by dedicated
+// short-probe capacity, conservative halving points, and the lowest passing
+// rate as a final guard. Final recommendations are still verified by dedicated
 // soaks, so testing every intermediate passing rate only adds runtime.
 func SelectBoundaryCandidates(attempts []ProbeAttempt, upper, maximum int) []int {
 	rates := descendingPassingRates(attempts, upper)
@@ -812,7 +1020,12 @@ func SelectBoundaryCandidates(attempts []ProbeAttempt, upper, maximum int) []int
 		return rates
 	}
 	selected := []int{rates[0]}
-	for len(selected) < maximum {
+	reserveLowest := maximum >= 3
+	intermediateLimit := maximum
+	if reserveLowest {
+		intermediateLimit--
+	}
+	for len(selected) < intermediateLimit {
 		target := selected[len(selected)-1] / 2
 		candidate := 0
 		for _, rate := range rates {
@@ -824,10 +1037,14 @@ func SelectBoundaryCandidates(attempts []ProbeAttempt, upper, maximum int) []int
 		if candidate == 0 {
 			candidate = rates[len(rates)-1]
 		}
-		if slices.Contains(selected, candidate) {
+		if slices.Contains(selected, candidate) || (reserveLowest && candidate == rates[len(rates)-1]) {
 			break
 		}
 		selected = append(selected, candidate)
+	}
+	lowest := rates[len(rates)-1]
+	if reserveLowest && len(selected) < maximum && !slices.Contains(selected, lowest) {
+		selected = append(selected, lowest)
 	}
 	return selected
 }
@@ -862,7 +1079,27 @@ func ratesAtOrBelow(rates []int, upper int) []int {
 	return selected
 }
 
-func ResumeCellMatches(path, manifestDigest, keeperDigest, benchctlDigest, datasetFingerprint string) (bool, error) {
+func lowestPositiveRate(left, right int) int {
+	if left <= 0 {
+		return max(right, 0)
+	}
+	if right <= 0 {
+		return left
+	}
+	return min(left, right)
+}
+
+func (run *runContext) executionProvenance(datasetFingerprint string) ExecutionProvenance {
+	return ExecutionProvenance{
+		ManifestSHA256: run.manifest.SourceSHA256, PlanSHA256: run.metadata.PlanSHA256,
+		KeeperBinarySHA256: run.binaryDigest, BenchctlBinarySHA256: run.benchctlDigest, DatasetFingerprint: datasetFingerprint,
+		DatasetValidationSHA256: run.datasetValidationDigest,
+		FixedRate:               run.options.FixedRate, FixedDurationSeconds: int(run.options.FixedDuration.Seconds()), FixedPass: run.options.FixedPass,
+		SearchDurationSeconds: int(run.options.SearchDuration.Seconds()),
+	}
+}
+
+func ResumeCellMatches(path string, expected ExecutionProvenance) (bool, error) {
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return false, nil
@@ -874,7 +1111,19 @@ func ResumeCellMatches(path, manifestDigest, keeperDigest, benchctlDigest, datas
 	if err := json.Unmarshal(data, &result); err != nil {
 		return false, fmt.Errorf("decode existing cell result: %w", err)
 	}
-	return result.Status == "completed" && result.ManifestSHA256 == manifestDigest && result.KeeperBinarySHA256 == keeperDigest && result.BenchctlBinarySHA256 == benchctlDigest && result.DatasetFingerprint == datasetFingerprint, nil
+	terminal := result.Status == "completed"
+	if !terminal && result.FixedRate > 0 && len(result.Attempts) > 0 {
+		lastAttempt := result.Attempts[len(result.Attempts)-1]
+		expectedFailure := fmt.Sprintf("%s soak failed at %d events/s:", result.FixedPass, result.FixedRate)
+		terminal = lastAttempt.RatePerSecond == result.FixedRate && strings.HasPrefix(result.Error, expectedFailure)
+	}
+	return terminal &&
+		result.ManifestSHA256 == expected.ManifestSHA256 && result.PlanSHA256 == expected.PlanSHA256 &&
+		result.KeeperBinarySHA256 == expected.KeeperBinarySHA256 && result.BenchctlBinarySHA256 == expected.BenchctlBinarySHA256 &&
+		result.DatasetFingerprint == expected.DatasetFingerprint && result.DatasetValidationSHA256 == expected.DatasetValidationSHA256 &&
+		result.FixedRate == expected.FixedRate &&
+		result.FixedDurationSeconds == expected.FixedDurationSeconds && result.FixedPass == expected.FixedPass &&
+		result.SearchDurationSeconds == expected.SearchDurationSeconds, nil
 }
 
 func nextAttemptDirectory(cellDir string) (string, error) {
@@ -929,6 +1178,13 @@ func cpuSet(start, end int) string {
 		return strconv.Itoa(start)
 	}
 	return fmt.Sprintf("%d-%d", start, end-1)
+}
+
+func RedisCPUSet(onlineCPUs int) string {
+	if onlineCPUs <= 0 {
+		return ""
+	}
+	return cpuSet(onlineCPUs-1, onlineCPUs)
 }
 
 func OnlineCPUCount() (int, error) {

--- a/internal/benchmark/capacity/pagecache_linux.go
+++ b/internal/benchmark/capacity/pagecache_linux.go
@@ -1,0 +1,22 @@
+//go:build linux
+
+package capacity
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func DropFilePageCache(path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	if err := unix.Fadvise(int(file.Fd()), 0, 0, unix.FADV_DONTNEED); err != nil {
+		return fmt.Errorf("fadvise DONTNEED %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/benchmark/capacity/pagecache_unsupported.go
+++ b/internal/benchmark/capacity/pagecache_unsupported.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package capacity
+
+func DropFilePageCache(string) error {
+	return nil
+}

--- a/internal/benchmark/capacity/probe.go
+++ b/internal/benchmark/capacity/probe.go
@@ -1,0 +1,581 @@
+package capacity
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"cpa-usage-keeper/internal/repository"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+type UsagePayloadMetadata struct {
+	APIKeyIndex   int    `json:"api_key_index"`
+	ModelIndex    int    `json:"model_index"`
+	IdentityIndex int    `json:"identity_index"`
+	APIGroupKey   string `json:"api_group_key"`
+	Model         string `json:"model"`
+	AuthIndex     string `json:"auth_index"`
+}
+
+type usagePayload struct {
+	Timestamp string             `json:"timestamp"`
+	LatencyMS int64              `json:"latency_ms"`
+	TTFTMS    int64              `json:"ttft_ms"`
+	Source    string             `json:"source"`
+	AuthIndex string             `json:"auth_index"`
+	Tokens    usagePayloadTokens `json:"tokens"`
+	Provider  string             `json:"provider"`
+	Model     string             `json:"model"`
+	AuthType  string             `json:"auth_type"`
+	APIKey    string             `json:"api_key"`
+	RequestID string             `json:"request_id"`
+	Endpoint  string             `json:"endpoint"`
+}
+
+type usagePayloadTokens struct {
+	InputTokens         int64 `json:"input_tokens"`
+	OutputTokens        int64 `json:"output_tokens"`
+	ReasoningTokens     int64 `json:"reasoning_tokens"`
+	CachedTokens        int64 `json:"cached_tokens"`
+	CacheReadTokens     int64 `json:"cache_read_tokens"`
+	CacheCreationTokens int64 `json:"cache_creation_tokens"`
+	TotalTokens         int64 `json:"total_tokens"`
+}
+
+type LatencySummary struct {
+	P50MS float64 `json:"p50_ms"`
+	P95MS float64 `json:"p95_ms"`
+	P99MS float64 `json:"p99_ms"`
+	MaxMS float64 `json:"max_ms"`
+}
+
+type DashboardLatencySample struct {
+	Path     string
+	Duration time.Duration
+}
+
+const heavyDashboardLatencyPath = "/api/v1/usage/analysis/latency?range=30d"
+
+var dashboardReplayPaths = []string{
+	"/api/v1/usage/overview?range=30d",
+	"/api/v1/usage/overview/realtime?range=1h",
+	"/api/v1/usage/activity?range=30d",
+	"/api/v1/usage/analysis?range=30d",
+	"/api/v1/usage/analysis/latency?range=30d",
+	"/api/v1/usage/events?range=30d&page=1&page_size=50",
+}
+
+type ProbeOptions struct {
+	RedisAddress      string
+	RedisPassword     string
+	RedisChannel      string
+	ApplicationURL    string
+	DatabasePath      string
+	RatePerSecond     int
+	Duration          time.Duration
+	DrainTimeout      time.Duration
+	HTTPRatePerSecond int
+	Cardinality       Cardinality
+	APIKeyProfiles    []APIKeyProfile
+	Seed              uint64
+	Thresholds        ProbeThresholds
+}
+
+type ProbeReport struct {
+	StartedAt            time.Time                 `json:"started_at"`
+	FinishedAt           time.Time                 `json:"finished_at"`
+	RatePerSecond        int                       `json:"rate_per_second"`
+	Metrics              ProbeMetrics              `json:"metrics"`
+	Evaluation           ProbeEvaluation           `json:"evaluation"`
+	Latency              LatencySummary            `json:"latency"`
+	CoreLatency          LatencySummary            `json:"core_latency"`
+	LatencyByPath        map[string]LatencySummary `json:"latency_by_path"`
+	DrainSeconds         float64                   `json:"drain_seconds"`
+	FinalBacklog         int64                     `json:"final_backlog"`
+	FinalCheckpointLag   int64                     `json:"final_checkpoint_lag"`
+	FinalIdentityPending int64                     `json:"final_identity_pending"`
+	PublishedByTier      map[string]int64          `json:"published_by_tier"`
+	PublishError         string                    `json:"publish_error,omitempty"`
+}
+
+type databaseProbeState struct {
+	Backlog         int64
+	MaxEventID      int64
+	CheckpointMin   int64
+	IdentityPending int64
+}
+
+func BuildUsagePayload(sequence int64, timestamp time.Time, cardinality Cardinality, apiProfiles []APIKeyProfile, seed uint64) ([]byte, UsagePayloadMetadata, error) {
+	if sequence <= 0 {
+		return nil, UsagePayloadMetadata{}, fmt.Errorf("usage payload sequence must be positive")
+	}
+	if err := validateCardinality("probe", cardinality); err != nil {
+		return nil, UsagePayloadMetadata{}, err
+	}
+	if len(apiProfiles) != cardinality.APIKeys {
+		return nil, UsagePayloadMetadata{}, fmt.Errorf("API key profile count=%d, want %d", len(apiProfiles), cardinality.APIKeys)
+	}
+	traffic, err := newAPITrafficTopology(apiProfiles)
+	if err != nil {
+		return nil, UsagePayloadMetadata{}, err
+	}
+	return buildUsagePayload(sequence, timestamp, cardinality, traffic, seed)
+}
+
+func buildUsagePayload(sequence int64, timestamp time.Time, cardinality Cardinality, traffic apiTrafficTopology, seed uint64) ([]byte, UsagePayloadMetadata, error) {
+	random := splitMix64{state: seed ^ uint64(sequence)*0x9e3779b97f4a7c15}
+	apiIndex := traffic.choose(timestamp, &random)
+	identityIndex := chooseCorrelatedIdentity(apiIndex, cardinality, timestamp, &random)
+	modelIndex := chooseCorrelatedModel(identityIndex, cardinality, &random)
+	authType := "oauth"
+	provider := "codex"
+	if (identityIndex+1)%4 == 0 {
+		authType = "apikey"
+		provider = "openai"
+	}
+	input := int64(100 + random.next()%3000)
+	output := int64(20 + random.next()%900)
+	reasoning := int64(random.next() % uint64(output+1))
+	cacheRead := int64(random.next() % uint64(max(input/3, 1)))
+	cacheCreation := int64(random.next() % uint64(max(input/8, 1)))
+	total := input + output
+	metadata := UsagePayloadMetadata{
+		APIKeyIndex: apiIndex + 1, ModelIndex: modelIndex + 1, IdentityIndex: identityIndex + 1,
+		APIGroupKey: strconv.Itoa(apiIndex + 1), Model: fmt.Sprintf("bench-model-%03d", modelIndex+1),
+		AuthIndex: fmt.Sprintf("bench-auth-%04d", identityIndex+1),
+	}
+	payload := usagePayload{
+		Timestamp: timestamp.Format(time.RFC3339Nano), LatencyMS: int64(300 + random.next()%30_000),
+		TTFTMS: int64(50 + random.next()%5_000), Source: provider, AuthIndex: metadata.AuthIndex,
+		Tokens: usagePayloadTokens{
+			InputTokens: input, OutputTokens: output, ReasoningTokens: reasoning,
+			CachedTokens: cacheRead, CacheReadTokens: cacheRead,
+			CacheCreationTokens: cacheCreation, TotalTokens: total,
+		},
+		Provider: provider, Model: metadata.Model, AuthType: authType, APIKey: metadata.APIGroupKey,
+		RequestID: fmt.Sprintf("bench-live-%012d", sequence), Endpoint: []string{"responses", "chat/completions", "messages"}[modelIndex%3],
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, UsagePayloadMetadata{}, fmt.Errorf("encode usage payload: %w", err)
+	}
+	return data, metadata, nil
+}
+
+func LatencyPercentiles(values []time.Duration) LatencySummary {
+	if len(values) == 0 {
+		return LatencySummary{}
+	}
+	ordered := append([]time.Duration(nil), values...)
+	sort.Slice(ordered, func(left, right int) bool { return ordered[left] < ordered[right] })
+	nearest := func(percentile float64) time.Duration {
+		index := int(mathCeil(percentile*float64(len(ordered)))) - 1
+		if index < 0 {
+			index = 0
+		}
+		if index >= len(ordered) {
+			index = len(ordered) - 1
+		}
+		return ordered[index]
+	}
+	toMS := func(value time.Duration) float64 { return float64(value) / float64(time.Millisecond) }
+	return LatencySummary{P50MS: toMS(nearest(0.50)), P95MS: toMS(nearest(0.95)), P99MS: toMS(nearest(0.99)), MaxMS: toMS(ordered[len(ordered)-1])}
+}
+
+func mathCeil(value float64) float64 {
+	integer := int64(value)
+	if float64(integer) == value {
+		return float64(integer)
+	}
+	return float64(integer + 1)
+}
+
+func RunProbe(ctx context.Context, options ProbeOptions) (ProbeReport, error) {
+	if options.RatePerSecond <= 0 || options.Duration <= 0 || strings.TrimSpace(options.DatabasePath) == "" {
+		return ProbeReport{}, fmt.Errorf("probe rate, duration, and database are required")
+	}
+	if err := validateCardinality("probe", options.Cardinality); err != nil {
+		return ProbeReport{}, err
+	}
+	if len(options.APIKeyProfiles) != options.Cardinality.APIKeys {
+		return ProbeReport{}, fmt.Errorf("API key profile count=%d, want %d", len(options.APIKeyProfiles), options.Cardinality.APIKeys)
+	}
+	if options.RedisChannel == "" {
+		options.RedisChannel = "usage"
+	}
+	if options.DrainTimeout <= 0 {
+		options.DrainTimeout = 15 * time.Second
+	}
+	database, err := openProbeDatabase(options.DatabasePath)
+	if err != nil {
+		return ProbeReport{}, err
+	}
+	defer database.Close()
+	startState, err := loadDatabaseProbeState(ctx, database, -1)
+	if err != nil {
+		return ProbeReport{}, err
+	}
+	publisher, err := newRedisPublisher(ctx, options.RedisAddress, options.RedisPassword)
+	if err != nil {
+		return ProbeReport{}, err
+	}
+	defer publisher.Close()
+	traffic, err := newAPITrafficTopology(options.APIKeyProfiles)
+	if err != nil {
+		return ProbeReport{}, err
+	}
+
+	report := ProbeReport{StartedAt: time.Now(), RatePerSecond: options.RatePerSecond, PublishedByTier: map[string]int64{}}
+	probeContext, cancel := context.WithTimeout(ctx, options.Duration)
+	defer cancel()
+	var httpErrors atomic.Int64
+	latencyDone := make(chan []DashboardLatencySample, 1)
+	go func() {
+		latencyDone <- runHTTPReplay(probeContext, options.ApplicationURL, options.HTTPRatePerSecond, &httpErrors)
+	}()
+
+	sequence := int64(0)
+	start := time.Now()
+	targetTotal := int64(options.Duration.Seconds() * float64(options.RatePerSecond))
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	publishErrors := int64(0)
+	for {
+		select {
+		case <-probeContext.Done():
+			goto finishedPublishing
+		case now := <-ticker.C:
+			// 第一个事件在窗口起点发送，最后一个目标事件会在 duration 结束前一个频率间隔进入队列。
+			target := min(1+int64(now.Sub(start).Seconds()*float64(options.RatePerSecond)), targetTotal)
+			if target <= sequence {
+				continue
+			}
+			batchSize := min(target-sequence, int64(1000))
+			payloads := make([][]byte, 0, batchSize)
+			metadata := make([]UsagePayloadMetadata, 0, batchSize)
+			for index := int64(0); index < batchSize; index++ {
+				payload, item, err := buildUsagePayload(sequence+index+1, now, options.Cardinality, traffic, options.Seed)
+				if err != nil {
+					return ProbeReport{}, err
+				}
+				payloads = append(payloads, payload)
+				metadata = append(metadata, item)
+			}
+			published, publishErr := publisher.PublishBatch(probeContext, options.RedisChannel, payloads)
+			for index := 0; index < published; index++ {
+				report.PublishedByTier[options.APIKeyProfiles[metadata[index].APIKeyIndex-1].Tier]++
+			}
+			sequence += int64(published)
+			if publishErr != nil {
+				// Redis 写超时属于该 offered rate 的有效容量失败；保留已发布数量并进入 drain，不能把整个 cell 误判为基础设施失败。
+				publishErrors++
+				report.PublishError = publishErr.Error()
+				cancel()
+				goto finishedPublishing
+			}
+		}
+	}
+
+finishedPublishing:
+	latencySamples := <-latencyDone
+	immediateState, err := loadDatabaseProbeState(ctx, database, startState.MaxEventID)
+	if err != nil {
+		return ProbeReport{}, err
+	}
+	drainStart := time.Now()
+	finalState := immediateState
+	for time.Since(drainStart) < options.DrainTimeout {
+		if finalState.Backlog == 0 && finalState.CheckpointMin >= finalState.MaxEventID && finalState.IdentityPending == 0 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+		finalState, err = loadDatabaseProbeState(ctx, database, startState.MaxEventID)
+		if err != nil {
+			return ProbeReport{}, err
+		}
+	}
+	report.FinishedAt = time.Now()
+	report.DrainSeconds = time.Since(drainStart).Seconds()
+	report.FinalBacklog = finalState.Backlog
+	report.FinalCheckpointLag = max(finalState.MaxEventID-finalState.CheckpointMin, 0)
+	report.FinalIdentityPending = finalState.IdentityPending
+	durableEvents, err := countNewDurableEvents(ctx, database, startState.MaxEventID)
+	if err != nil {
+		return ProbeReport{}, err
+	}
+	expectedEvents := targetTotal
+	report.Metrics = ProbeMetrics{
+		OfferedEvents: expectedEvents, PublishedEvents: sequence, DurableEvents: durableEvents,
+		BacklogStart: startState.Backlog, BacklogEnd: finalState.Backlog,
+		Errors: publishErrors + httpErrors.Load(), HTTPRequests: int64(len(latencySamples)),
+		CheckpointLag: report.FinalCheckpointLag, IdentityPending: report.FinalIdentityPending,
+	}
+	report.Latency, report.CoreLatency, report.LatencyByPath = SummarizeDashboardLatencies(latencySamples)
+	report.Metrics.HTTPP95MS = report.CoreLatency.P95MS
+	report.Metrics.HTTPP99MS = report.Latency.P99MS
+	report.Evaluation = EvaluateProbe(report.Metrics, options.Thresholds)
+	return report, nil
+}
+
+func openProbeDatabase(path string) (*sql.DB, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve probe database path: %w", err)
+	}
+	dsn := repository.BuildSQLiteFileURI(absolute) + "?mode=ro&_query_only=on&_busy_timeout=5000"
+	database, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open probe database: %w", err)
+	}
+	if err := database.Ping(); err != nil {
+		database.Close()
+		return nil, fmt.Errorf("ping probe database: %w", err)
+	}
+	return database, nil
+}
+
+func loadDatabaseProbeState(ctx context.Context, database *sql.DB, identityFloor int64) (databaseProbeState, error) {
+	state := databaseProbeState{}
+	if err := database.QueryRowContext(ctx, "SELECT COALESCE(MAX(id), 0) FROM usage_events").Scan(&state.MaxEventID); err != nil {
+		return state, fmt.Errorf("load probe event state: %w", err)
+	}
+	if identityFloor < 0 {
+		identityFloor = state.MaxEventID
+	}
+	if err := database.QueryRowContext(ctx, "SELECT COUNT(*) FROM redis_usage_inboxes WHERE status IN ('pending', 'process_failed')").Scan(&state.Backlog); err != nil {
+		return state, fmt.Errorf("load probe inbox state: %w", err)
+	}
+	if err := database.QueryRowContext(ctx, "SELECT COALESCE(MIN(last_aggregated_usage_event_id), 0) FROM usage_aggregation_checkpoints").Scan(&state.CheckpointMin); err != nil {
+		return state, fmt.Errorf("load probe checkpoint state: %w", err)
+	}
+	if err := database.QueryRowContext(ctx, `
+		SELECT EXISTS(
+			SELECT 1
+			FROM usage_events AS event
+			JOIN usage_identities AS identity ON identity.identity = event.auth_index
+			WHERE event.id > ?
+			  AND event.id > identity.last_aggregated_usage_event_id
+			LIMIT 1
+		)`, identityFloor).Scan(&state.IdentityPending); err != nil {
+		return state, fmt.Errorf("load probe identity state: %w", err)
+	}
+	return state, nil
+}
+
+func countNewDurableEvents(ctx context.Context, database *sql.DB, afterID int64) (int64, error) {
+	var count int64
+	if err := database.QueryRowContext(ctx, "SELECT COUNT(*) FROM usage_events WHERE id > ?", afterID).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count durable probe events: %w", err)
+	}
+	return count, nil
+}
+
+func runHTTPReplay(ctx context.Context, baseURL string, rate int, errors *atomic.Int64) []DashboardLatencySample {
+	if strings.TrimSpace(baseURL) == "" || rate <= 0 {
+		return nil
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	latencies := make(chan DashboardLatencySample, rate*2+16)
+	var wait sync.WaitGroup
+	go func() {
+		defer close(latencies)
+		interval := time.Second / time.Duration(rate)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		semaphore := make(chan struct{}, 16)
+		sequence := 0
+		for {
+			select {
+			case <-ctx.Done():
+				wait.Wait()
+				return
+			case <-ticker.C:
+				path := dashboardReplayPaths[sequence%len(dashboardReplayPaths)]
+				sequence++
+				semaphore <- struct{}{}
+				wait.Add(1)
+				go func() {
+					defer wait.Done()
+					defer func() { <-semaphore }()
+					started := time.Now()
+					request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+path, nil)
+					if err != nil {
+						errors.Add(1)
+						return
+					}
+					response, err := client.Do(request)
+					if err != nil {
+						if ctx.Err() == nil {
+							errors.Add(1)
+						}
+						return
+					}
+					_, _ = io.Copy(io.Discard, response.Body)
+					_ = response.Body.Close()
+					if response.StatusCode < 200 || response.StatusCode >= 300 {
+						errors.Add(1)
+						return
+					}
+					latencies <- DashboardLatencySample{Path: path, Duration: time.Since(started)}
+				}()
+			}
+		}
+	}()
+	var values []DashboardLatencySample
+	for value := range latencies {
+		values = append(values, value)
+	}
+	return values
+}
+
+func SummarizeDashboardLatencies(samples []DashboardLatencySample) (LatencySummary, LatencySummary, map[string]LatencySummary) {
+	overallValues := make([]time.Duration, 0, len(samples))
+	coreValues := make([]time.Duration, 0, len(samples))
+	grouped := make(map[string][]time.Duration)
+	for _, sample := range samples {
+		overallValues = append(overallValues, sample.Duration)
+		grouped[sample.Path] = append(grouped[sample.Path], sample.Duration)
+		if sample.Path != heavyDashboardLatencyPath {
+			coreValues = append(coreValues, sample.Duration)
+		}
+	}
+	byPath := make(map[string]LatencySummary, len(grouped))
+	for path, values := range grouped {
+		byPath[path] = LatencyPercentiles(values)
+	}
+	return LatencyPercentiles(overallValues), LatencyPercentiles(coreValues), byPath
+}
+
+func WarmDashboard(ctx context.Context, baseURL string) (time.Duration, error) {
+	started := time.Now()
+	client := &http.Client{Timeout: 30 * time.Second}
+	for _, path := range dashboardReplayPaths {
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+path, nil)
+		if err != nil {
+			return time.Since(started), err
+		}
+		response, err := client.Do(request)
+		if err != nil {
+			return time.Since(started), fmt.Errorf("warm dashboard %s: %w", path, err)
+		}
+		_, _ = io.Copy(io.Discard, response.Body)
+		_ = response.Body.Close()
+		if response.StatusCode < 200 || response.StatusCode >= 300 {
+			return time.Since(started), fmt.Errorf("warm dashboard %s returned %s", path, response.Status)
+		}
+	}
+	return time.Since(started), nil
+}
+
+type redisPublisher struct {
+	connection net.Conn
+	reader     *bufio.Reader
+	writer     *bufio.Writer
+}
+
+func newRedisPublisher(ctx context.Context, address, password string) (*redisPublisher, error) {
+	dialer := net.Dialer{Timeout: 5 * time.Second}
+	connection, err := dialer.DialContext(ctx, "tcp", address)
+	if err != nil {
+		return nil, fmt.Errorf("connect Redis publisher: %w", err)
+	}
+	publisher := &redisPublisher{connection: connection, reader: bufio.NewReader(connection), writer: bufio.NewWriter(connection)}
+	if password != "" {
+		if err := publisher.writeCommand("AUTH", password); err != nil {
+			publisher.Close()
+			return nil, err
+		}
+		if err := publisher.writer.Flush(); err != nil {
+			publisher.Close()
+			return nil, err
+		}
+		if err := publisher.readReply(); err != nil {
+			publisher.Close()
+			return nil, fmt.Errorf("authenticate Redis publisher: %w", err)
+		}
+	}
+	return publisher, nil
+}
+
+func (publisher *redisPublisher) PublishBatch(_ context.Context, channel string, payloads [][]byte) (int, error) {
+	// 单批 Redis I/O 使用独立上限，避免 30 秒 probe 结束前最后一个 tick 继承即将过期的整体 deadline。
+	if err := publisher.connection.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return 0, err
+	}
+	for _, payload := range payloads {
+		if err := publisher.writeCommand("PUBLISH", channel, string(payload)); err != nil {
+			return 0, err
+		}
+	}
+	if err := publisher.writer.Flush(); err != nil {
+		return 0, err
+	}
+	for index := range payloads {
+		if err := publisher.readReply(); err != nil {
+			return index, err
+		}
+	}
+	return len(payloads), nil
+}
+
+func (publisher *redisPublisher) writeCommand(parts ...string) error {
+	if _, err := fmt.Fprintf(publisher.writer, "*%d\r\n", len(parts)); err != nil {
+		return err
+	}
+	for _, part := range parts {
+		if _, err := fmt.Fprintf(publisher.writer, "$%d\r\n%s\r\n", len(part), part); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (publisher *redisPublisher) readReply() error {
+	prefix, err := publisher.reader.ReadByte()
+	if err != nil {
+		return err
+	}
+	line, err := publisher.reader.ReadString('\n')
+	if err != nil {
+		return err
+	}
+	line = strings.TrimSpace(line)
+	if prefix == '-' {
+		return fmt.Errorf("Redis error: %s", line)
+	}
+	if prefix != '+' && prefix != ':' {
+		return fmt.Errorf("unexpected Redis response prefix %q", prefix)
+	}
+	return nil
+}
+
+func (publisher *redisPublisher) Close() error {
+	if publisher == nil || publisher.connection == nil {
+		return nil
+	}
+	return publisher.connection.Close()
+}
+
+func marshalProbeReport(report ProbeReport) ([]byte, error) {
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(report); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}

--- a/internal/benchmark/capacity/probe.go
+++ b/internal/benchmark/capacity/probe.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -57,10 +56,11 @@ type usagePayloadTokens struct {
 }
 
 type LatencySummary struct {
-	P50MS float64 `json:"p50_ms"`
-	P95MS float64 `json:"p95_ms"`
-	P99MS float64 `json:"p99_ms"`
-	MaxMS float64 `json:"max_ms"`
+	Samples int64   `json:"samples"`
+	P50MS   float64 `json:"p50_ms"`
+	P95MS   float64 `json:"p95_ms"`
+	P99MS   float64 `json:"p99_ms"`
+	MaxMS   float64 `json:"max_ms"`
 }
 
 type DashboardLatencySample struct {
@@ -68,31 +68,40 @@ type DashboardLatencySample struct {
 	Duration time.Duration
 }
 
-const heavyDashboardLatencyPath = "/api/v1/usage/analysis/latency?range=30d"
+const analysisLatencyDashboardPath = "/api/v1/usage/analysis/latency?range=30d"
 
-var dashboardReplayPaths = []string{
+var coreDashboardReplayPaths = []string{
 	"/api/v1/usage/overview?range=30d",
-	"/api/v1/usage/overview/realtime?range=1h",
+	"/api/v1/usage/overview/realtime?window=60m",
 	"/api/v1/usage/activity?range=30d",
 	"/api/v1/usage/analysis?range=30d",
-	"/api/v1/usage/analysis/latency?range=30d",
 	"/api/v1/usage/events?range=30d&page=1&page_size=50",
 }
 
+func DashboardReplayPaths() []string {
+	paths := append([]string(nil), coreDashboardReplayPaths...)
+	return append(paths, analysisLatencyDashboardPath)
+}
+
+func CoreDashboardReplayPaths() []string {
+	return append([]string(nil), coreDashboardReplayPaths...)
+}
+
 type ProbeOptions struct {
-	RedisAddress      string
-	RedisPassword     string
-	RedisChannel      string
-	ApplicationURL    string
-	DatabasePath      string
-	RatePerSecond     int
-	Duration          time.Duration
-	DrainTimeout      time.Duration
-	HTTPRatePerSecond int
-	Cardinality       Cardinality
-	APIKeyProfiles    []APIKeyProfile
-	Seed              uint64
-	Thresholds        ProbeThresholds
+	RedisAddress            string
+	RedisPassword           string
+	RedisChannel            string
+	ApplicationURL          string
+	DatabasePath            string
+	RatePerSecond           int
+	Duration                time.Duration
+	DrainTimeout            time.Duration
+	HTTPRatePerSecond       int
+	AnalysisLatencyInterval time.Duration
+	Cardinality             Cardinality
+	APIKeyProfiles          []APIKeyProfile
+	Seed                    uint64
+	Thresholds              ProbeThresholds
 }
 
 type ProbeReport struct {
@@ -101,8 +110,8 @@ type ProbeReport struct {
 	RatePerSecond        int                       `json:"rate_per_second"`
 	Metrics              ProbeMetrics              `json:"metrics"`
 	Evaluation           ProbeEvaluation           `json:"evaluation"`
-	Latency              LatencySummary            `json:"latency"`
 	CoreLatency          LatencySummary            `json:"core_latency"`
+	AnalysisLatency      LatencySummary            `json:"analysis_latency"`
 	LatencyByPath        map[string]LatencySummary `json:"latency_by_path"`
 	DrainSeconds         float64                   `json:"drain_seconds"`
 	FinalBacklog         int64                     `json:"final_backlog"`
@@ -155,7 +164,7 @@ func buildUsagePayload(sequence int64, timestamp time.Time, cardinality Cardinal
 	total := input + output
 	metadata := UsagePayloadMetadata{
 		APIKeyIndex: apiIndex + 1, ModelIndex: modelIndex + 1, IdentityIndex: identityIndex + 1,
-		APIGroupKey: strconv.Itoa(apiIndex + 1), Model: fmt.Sprintf("bench-model-%03d", modelIndex+1),
+		APIGroupKey: benchmarkAPIKey(apiIndex + 1), Model: fmt.Sprintf("bench-model-%03d", modelIndex+1),
 		AuthIndex: fmt.Sprintf("bench-auth-%04d", identityIndex+1),
 	}
 	payload := usagePayload{
@@ -193,7 +202,7 @@ func LatencyPercentiles(values []time.Duration) LatencySummary {
 		return ordered[index]
 	}
 	toMS := func(value time.Duration) float64 { return float64(value) / float64(time.Millisecond) }
-	return LatencySummary{P50MS: toMS(nearest(0.50)), P95MS: toMS(nearest(0.95)), P99MS: toMS(nearest(0.99)), MaxMS: toMS(ordered[len(ordered)-1])}
+	return LatencySummary{Samples: int64(len(ordered)), P50MS: toMS(nearest(0.50)), P95MS: toMS(nearest(0.95)), P99MS: toMS(nearest(0.99)), MaxMS: toMS(ordered[len(ordered)-1])}
 }
 
 func mathCeil(value float64) float64 {
@@ -220,6 +229,9 @@ func RunProbe(ctx context.Context, options ProbeOptions) (ProbeReport, error) {
 	if options.DrainTimeout <= 0 {
 		options.DrainTimeout = 15 * time.Second
 	}
+	if options.AnalysisLatencyInterval <= 0 {
+		options.AnalysisLatencyInterval = 30 * time.Second
+	}
 	database, err := openProbeDatabase(options.DatabasePath)
 	if err != nil {
 		return ProbeReport{}, err
@@ -242,10 +254,11 @@ func RunProbe(ctx context.Context, options ProbeOptions) (ProbeReport, error) {
 	report := ProbeReport{StartedAt: time.Now(), RatePerSecond: options.RatePerSecond, PublishedByTier: map[string]int64{}}
 	probeContext, cancel := context.WithTimeout(ctx, options.Duration)
 	defer cancel()
-	var httpErrors atomic.Int64
+	var coreHTTPErrors atomic.Int64
+	var analysisLatencyErrors atomic.Int64
 	latencyDone := make(chan []DashboardLatencySample, 1)
 	go func() {
-		latencyDone <- runHTTPReplay(probeContext, options.ApplicationURL, options.HTTPRatePerSecond, &httpErrors)
+		latencyDone <- runHTTPReplay(probeContext, options.ApplicationURL, options.HTTPRatePerSecond, options.AnalysisLatencyInterval, &coreHTTPErrors, &analysisLatencyErrors)
 	}()
 
 	sequence := int64(0)
@@ -318,15 +331,18 @@ finishedPublishing:
 		return ProbeReport{}, err
 	}
 	expectedEvents := targetTotal
+	report.CoreLatency, report.AnalysisLatency, report.LatencyByPath = SummarizeDashboardLatencies(latencySamples)
 	report.Metrics = ProbeMetrics{
 		OfferedEvents: expectedEvents, PublishedEvents: sequence, DurableEvents: durableEvents,
 		BacklogStart: startState.Backlog, BacklogEnd: finalState.Backlog,
-		Errors: publishErrors + httpErrors.Load(), HTTPRequests: int64(len(latencySamples)),
-		CheckpointLag: report.FinalCheckpointLag, IdentityPending: report.FinalIdentityPending,
+		Errors:           publishErrors,
+		HTTPRequests:     report.CoreLatency.Samples + report.AnalysisLatency.Samples + coreHTTPErrors.Load() + analysisLatencyErrors.Load(),
+		CoreHTTPRequests: report.CoreLatency.Samples + coreHTTPErrors.Load(), CoreHTTPErrors: coreHTTPErrors.Load(),
+		AnalysisLatencyRequests: report.AnalysisLatency.Samples + analysisLatencyErrors.Load(), AnalysisLatencyErrors: analysisLatencyErrors.Load(),
+		CheckpointLag: report.FinalCheckpointLag, IdentityPending: report.FinalIdentityPending, DrainSeconds: report.DrainSeconds,
 	}
-	report.Latency, report.CoreLatency, report.LatencyByPath = SummarizeDashboardLatencies(latencySamples)
 	report.Metrics.HTTPP95MS = report.CoreLatency.P95MS
-	report.Metrics.HTTPP99MS = report.Latency.P99MS
+	report.Metrics.HTTPP99MS = report.CoreLatency.P99MS
 	report.Evaluation = EvaluateProbe(report.Metrics, options.Thresholds)
 	return report, nil
 }
@@ -384,7 +400,7 @@ func countNewDurableEvents(ctx context.Context, database *sql.DB, afterID int64)
 	return count, nil
 }
 
-func runHTTPReplay(ctx context.Context, baseURL string, rate int, errors *atomic.Int64) []DashboardLatencySample {
+func runHTTPReplay(ctx context.Context, baseURL string, rate int, analysisLatencyInterval time.Duration, coreErrors, analysisErrors *atomic.Int64) []DashboardLatencySample {
 	if strings.TrimSpace(baseURL) == "" || rate <= 0 {
 		return nil
 	}
@@ -393,45 +409,74 @@ func runHTTPReplay(ctx context.Context, baseURL string, rate int, errors *atomic
 	var wait sync.WaitGroup
 	go func() {
 		defer close(latencies)
-		interval := time.Second / time.Duration(rate)
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
+		coreTicker := time.NewTicker(time.Second / time.Duration(rate))
+		defer coreTicker.Stop()
+		var analysisTicker *time.Ticker
+		var analysisTick <-chan time.Time
+		if analysisLatencyInterval > 0 {
+			analysisTicker = time.NewTicker(analysisLatencyInterval)
+			analysisTick = analysisTicker.C
+			defer analysisTicker.Stop()
+		}
 		semaphore := make(chan struct{}, 16)
 		sequence := 0
+		launch := func(path string) bool {
+			recordError := func() {
+				if path == analysisLatencyDashboardPath {
+					analysisErrors.Add(1)
+					return
+				}
+				coreErrors.Add(1)
+			}
+			select {
+			case semaphore <- struct{}{}:
+			case <-ctx.Done():
+				return false
+			}
+			wait.Add(1)
+			go func() {
+				defer wait.Done()
+				defer func() { <-semaphore }()
+				started := time.Now()
+				request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+path, nil)
+				if err != nil {
+					recordError()
+					return
+				}
+				response, err := client.Do(request)
+				if err != nil {
+					if ctx.Err() == nil {
+						recordError()
+					}
+					return
+				}
+				_, _ = io.Copy(io.Discard, response.Body)
+				_ = response.Body.Close()
+				if response.StatusCode < 200 || response.StatusCode >= 300 {
+					recordError()
+					return
+				}
+				latencies <- DashboardLatencySample{Path: path, Duration: time.Since(started)}
+			}()
+			return true
+		}
 		for {
 			select {
 			case <-ctx.Done():
 				wait.Wait()
 				return
-			case <-ticker.C:
-				path := dashboardReplayPaths[sequence%len(dashboardReplayPaths)]
+			case <-coreTicker.C:
+				path := coreDashboardReplayPaths[sequence%len(coreDashboardReplayPaths)]
 				sequence++
-				semaphore <- struct{}{}
-				wait.Add(1)
-				go func() {
-					defer wait.Done()
-					defer func() { <-semaphore }()
-					started := time.Now()
-					request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+path, nil)
-					if err != nil {
-						errors.Add(1)
-						return
-					}
-					response, err := client.Do(request)
-					if err != nil {
-						if ctx.Err() == nil {
-							errors.Add(1)
-						}
-						return
-					}
-					_, _ = io.Copy(io.Discard, response.Body)
-					_ = response.Body.Close()
-					if response.StatusCode < 200 || response.StatusCode >= 300 {
-						errors.Add(1)
-						return
-					}
-					latencies <- DashboardLatencySample{Path: path, Duration: time.Since(started)}
-				}()
+				if !launch(path) {
+					wait.Wait()
+					return
+				}
+			case <-analysisTick:
+				if !launch(analysisLatencyDashboardPath) {
+					wait.Wait()
+					return
+				}
 			}
 		}
 	}()
@@ -443,13 +488,14 @@ func runHTTPReplay(ctx context.Context, baseURL string, rate int, errors *atomic
 }
 
 func SummarizeDashboardLatencies(samples []DashboardLatencySample) (LatencySummary, LatencySummary, map[string]LatencySummary) {
-	overallValues := make([]time.Duration, 0, len(samples))
 	coreValues := make([]time.Duration, 0, len(samples))
+	analysisValues := make([]time.Duration, 0, len(samples))
 	grouped := make(map[string][]time.Duration)
 	for _, sample := range samples {
-		overallValues = append(overallValues, sample.Duration)
 		grouped[sample.Path] = append(grouped[sample.Path], sample.Duration)
-		if sample.Path != heavyDashboardLatencyPath {
+		if sample.Path == analysisLatencyDashboardPath {
+			analysisValues = append(analysisValues, sample.Duration)
+		} else {
 			coreValues = append(coreValues, sample.Duration)
 		}
 	}
@@ -457,13 +503,13 @@ func SummarizeDashboardLatencies(samples []DashboardLatencySample) (LatencySumma
 	for path, values := range grouped {
 		byPath[path] = LatencyPercentiles(values)
 	}
-	return LatencyPercentiles(overallValues), LatencyPercentiles(coreValues), byPath
+	return LatencyPercentiles(coreValues), LatencyPercentiles(analysisValues), byPath
 }
 
 func WarmDashboard(ctx context.Context, baseURL string) (time.Duration, error) {
 	started := time.Now()
 	client := &http.Client{Timeout: 30 * time.Second}
-	for _, path := range dashboardReplayPaths {
+	for _, path := range DashboardReplayPaths() {
 		request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+path, nil)
 		if err != nil {
 			return time.Since(started), err

--- a/internal/benchmark/capacity/runtime.go
+++ b/internal/benchmark/capacity/runtime.go
@@ -1,0 +1,692 @@
+package capacity
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type FileLock struct {
+	file *os.File
+}
+
+func AcquireFileLock(path string) (*FileLock, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create benchmark lock directory: %w", err)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open benchmark lock: %w", err)
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		file.Close()
+		return nil, fmt.Errorf("another benchmark owns %s: %w", filepath.Clean(path), err)
+	}
+	return &FileLock{file: file}, nil
+}
+
+func (lock *FileLock) Close() error {
+	if lock == nil || lock.file == nil {
+		return nil
+	}
+	err := syscall.Flock(int(lock.file.Fd()), syscall.LOCK_UN)
+	err = errors.Join(err, lock.file.Close())
+	lock.file = nil
+	return err
+}
+
+type UnitState struct {
+	ActiveState    string `json:"active_state"`
+	SubState       string `json:"sub_state"`
+	Result         string `json:"result"`
+	ExecMainCode   string `json:"exec_main_code"`
+	ExecMainStatus int    `json:"exec_main_status"`
+	ControlGroup   string `json:"control_group"`
+}
+
+type SystemdRuntime struct {
+	UnitName   string
+	CgroupPath string
+	Limits     CgroupLimits
+}
+
+type CgroupLimits struct {
+	CPUQuotaUsec       int64  `json:"cpu_quota_usec"`
+	CPUPeriodUsec      int64  `json:"cpu_period_usec"`
+	AllowedCPUs        string `json:"allowed_cpus"`
+	MemoryMaxBytes     int64  `json:"memory_max_bytes"`
+	MemoryMaxUnlimited bool   `json:"memory_max_unlimited"`
+	MemorySwapMaxBytes int64  `json:"memory_swap_max_bytes"`
+}
+
+type KeeperStartOptions struct {
+	UnitName     string
+	BinaryPath   string
+	Environment  string
+	WorkingDir   string
+	StdoutPath   string
+	StderrPath   string
+	CPU          int
+	MemoryMiB    int
+	AllowedCPUs  string
+	StartupLimit time.Duration
+}
+
+func StartKeeperUnit(ctx context.Context, options KeeperStartOptions) (SystemdRuntime, error) {
+	if strings.TrimSpace(options.UnitName) == "" || strings.TrimSpace(options.BinaryPath) == "" || strings.TrimSpace(options.Environment) == "" {
+		return SystemdRuntime{}, fmt.Errorf("keeper unit name, binary, and environment are required")
+	}
+	if options.CPU <= 0 || options.MemoryMiB < 0 || strings.TrimSpace(options.AllowedCPUs) == "" {
+		return SystemdRuntime{}, fmt.Errorf("keeper CPU, memory, and affinity are required")
+	}
+	if options.StartupLimit <= 0 {
+		options.StartupLimit = 90 * time.Second
+	}
+	if err := os.MkdirAll(options.WorkingDir, 0o755); err != nil {
+		return SystemdRuntime{}, fmt.Errorf("create keeper working directory: %w", err)
+	}
+	for _, path := range []string{options.StdoutPath, options.StderrPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return SystemdRuntime{}, fmt.Errorf("create keeper log directory: %w", err)
+		}
+	}
+	arguments := []string{
+		"--unit=" + options.UnitName,
+		"--service-type=exec",
+		"--property=Restart=no",
+		"--property=KillMode=mixed",
+		"--property=TimeoutStopSec=15s",
+		"--property=CPUAccounting=yes",
+		"--property=MemoryAccounting=yes",
+		"--property=IOAccounting=yes",
+		fmt.Sprintf("--property=CPUQuota=%d%%", options.CPU*100),
+		"--property=AllowedCPUs=" + options.AllowedCPUs,
+	}
+	if options.MemoryMiB > 0 {
+		arguments = append(arguments, fmt.Sprintf("--property=MemoryMax=%d", int64(options.MemoryMiB)*1024*1024))
+	}
+	arguments = append(arguments,
+		"--property=MemorySwapMax=0",
+		"--property=TasksMax=512",
+		"--property=OOMPolicy=stop",
+		"--property=WorkingDirectory="+options.WorkingDir,
+		"--property=StandardOutput=append:"+options.StdoutPath,
+		"--property=StandardError=append:"+options.StderrPath,
+		fmt.Sprintf("--setenv=GOMAXPROCS=%d", options.CPU),
+		"--setenv=GOTRACEBACK=all",
+		options.BinaryPath,
+		"-env", options.Environment,
+		"-host", "127.0.0.1",
+	)
+	if output, err := exec.CommandContext(ctx, "systemd-run", arguments...).CombinedOutput(); err != nil {
+		return SystemdRuntime{}, fmt.Errorf("start constrained Keeper: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	state, err := ReadUnitState(ctx, options.UnitName)
+	if err != nil {
+		_ = StopUnit(context.Background(), options.UnitName)
+		return SystemdRuntime{}, err
+	}
+	if state.ControlGroup == "" {
+		_ = StopUnit(context.Background(), options.UnitName)
+		return SystemdRuntime{}, fmt.Errorf("Keeper unit %s has no control group", options.UnitName)
+	}
+	cgroupPath := filepath.Join("/sys/fs/cgroup", strings.TrimPrefix(state.ControlGroup, "/"))
+	limits, err := ReadCgroupLimits(cgroupPath)
+	if err != nil {
+		_ = StopUnit(context.Background(), options.UnitName)
+		return SystemdRuntime{}, err
+	}
+	if err := ValidateCgroupLimits(limits, options.CPU, options.MemoryMiB, options.AllowedCPUs); err != nil {
+		_ = StopUnit(context.Background(), options.UnitName)
+		return SystemdRuntime{}, err
+	}
+	return SystemdRuntime{UnitName: options.UnitName, CgroupPath: cgroupPath, Limits: limits}, nil
+}
+
+type RedisStartOptions struct {
+	UnitName   string
+	Root       string
+	Port       int
+	Password   string
+	BinaryPath string
+}
+
+func StartRedisUnit(ctx context.Context, options RedisStartOptions) (SystemdRuntime, error) {
+	if options.Port <= 0 || strings.TrimSpace(options.Password) == "" || strings.TrimSpace(options.Root) == "" {
+		return SystemdRuntime{}, fmt.Errorf("Redis root, port, and password are required")
+	}
+	if options.BinaryPath == "" {
+		options.BinaryPath = "redis-server"
+	}
+	redisDir := filepath.Join(options.Root, "redis")
+	if err := os.MkdirAll(redisDir, 0o700); err != nil {
+		return SystemdRuntime{}, fmt.Errorf("create Redis directory: %w", err)
+	}
+	stdoutPath := filepath.Join(redisDir, "stdout.log")
+	stderrPath := filepath.Join(redisDir, "stderr.log")
+	arguments := []string{
+		"--unit=" + options.UnitName,
+		"--service-type=exec",
+		"--property=Restart=no",
+		"--property=KillMode=mixed",
+		"--property=TimeoutStopSec=10s",
+		"--property=WorkingDirectory=" + redisDir,
+		"--property=StandardOutput=append:" + stdoutPath,
+		"--property=StandardError=append:" + stderrPath,
+		options.BinaryPath,
+		"--port", strconv.Itoa(options.Port),
+		"--bind", "127.0.0.1",
+		"--protected-mode", "yes",
+		"--requirepass", options.Password,
+		"--appendonly", "no",
+		"--save", "",
+		"--dir", redisDir,
+	}
+	if output, err := exec.CommandContext(ctx, "systemd-run", arguments...).CombinedOutput(); err != nil {
+		return SystemdRuntime{}, fmt.Errorf("start benchmark Redis: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := redisPing(ctx, net.JoinHostPort("127.0.0.1", strconv.Itoa(options.Port)), options.Password); err == nil {
+			state, stateErr := ReadUnitState(ctx, options.UnitName)
+			if stateErr != nil {
+				_ = StopUnit(context.Background(), options.UnitName)
+				return SystemdRuntime{}, stateErr
+			}
+			return SystemdRuntime{UnitName: options.UnitName, CgroupPath: filepath.Join("/sys/fs/cgroup", strings.TrimPrefix(state.ControlGroup, "/"))}, nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	state, _ := ReadUnitState(ctx, options.UnitName)
+	_ = StopUnit(context.Background(), options.UnitName)
+	return SystemdRuntime{}, fmt.Errorf("benchmark Redis did not become ready: %+v", state)
+}
+
+func redisPing(ctx context.Context, address, password string) error {
+	publisher, err := newRedisPublisher(ctx, address, password)
+	if err != nil {
+		return err
+	}
+	defer publisher.Close()
+	if err := publisher.writeCommand("PING"); err != nil {
+		return err
+	}
+	if err := publisher.writer.Flush(); err != nil {
+		return err
+	}
+	return publisher.readReply()
+}
+
+func ReadUnitState(ctx context.Context, unitName string) (UnitState, error) {
+	output, err := exec.CommandContext(ctx, "systemctl", "show", "--no-page", unitName,
+		"--property=ActiveState", "--property=SubState", "--property=Result", "--property=ExecMainCode",
+		"--property=ExecMainStatus", "--property=ControlGroup").CombinedOutput()
+	if err != nil {
+		return UnitState{}, fmt.Errorf("inspect unit %s: %w: %s", unitName, err, strings.TrimSpace(string(output)))
+	}
+	values := map[string]string{}
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		key, value, ok := strings.Cut(scanner.Text(), "=")
+		if ok {
+			values[key] = value
+		}
+	}
+	status, _ := strconv.Atoi(values["ExecMainStatus"])
+	return UnitState{
+		ActiveState: values["ActiveState"], SubState: values["SubState"], Result: values["Result"],
+		ExecMainCode: values["ExecMainCode"], ExecMainStatus: status, ControlGroup: values["ControlGroup"],
+	}, nil
+}
+
+func StopUnit(ctx context.Context, unitName string) error {
+	if strings.TrimSpace(unitName) == "" {
+		return nil
+	}
+	output, err := exec.CommandContext(ctx, "systemctl", "stop", unitName).CombinedOutput()
+	if err != nil && !strings.Contains(string(output), "not loaded") {
+		return fmt.Errorf("stop unit %s: %w: %s", unitName, err, strings.TrimSpace(string(output)))
+	}
+	_, _ = exec.CommandContext(ctx, "systemctl", "reset-failed", unitName).CombinedOutput()
+	return nil
+}
+
+func WaitHTTPHealth(ctx context.Context, applicationURL, unitName string, timeout time.Duration) (time.Duration, error) {
+	if timeout <= 0 {
+		timeout = 90 * time.Second
+	}
+	started := time.Now()
+	deadline := started.Add(timeout)
+	client := &http.Client{Timeout: time.Second}
+	for time.Now().Before(deadline) {
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(applicationURL, "/")+"/healthz", nil)
+		if err == nil {
+			response, requestErr := client.Do(request)
+			if requestErr == nil {
+				_, _ = io.Copy(io.Discard, response.Body)
+				_ = response.Body.Close()
+				if response.StatusCode == http.StatusOK {
+					return time.Since(started), nil
+				}
+			}
+		}
+		state, stateErr := ReadUnitState(ctx, unitName)
+		if stateErr == nil && state.ActiveState != "active" && state.ActiveState != "activating" {
+			return time.Since(started), fmt.Errorf("Keeper exited before health check: %+v", state)
+		}
+		select {
+		case <-ctx.Done():
+			return time.Since(started), ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	return time.Since(started), fmt.Errorf("Keeper health check exceeded %s", timeout)
+}
+
+func BackupSQLite(ctx context.Context, sourcePath, destinationPath string) error {
+	if strings.TrimSpace(sourcePath) == "" || strings.TrimSpace(destinationPath) == "" {
+		return fmt.Errorf("SQLite backup source and destination are required")
+	}
+	if err := os.MkdirAll(filepath.Dir(destinationPath), 0o755); err != nil {
+		return fmt.Errorf("create SQLite backup directory: %w", err)
+	}
+	if _, err := os.Stat(destinationPath); err == nil {
+		return fmt.Errorf("SQLite backup destination already exists: %s", filepath.Clean(destinationPath))
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect SQLite backup destination: %w", err)
+	}
+	dotCommand := ".backup '" + strings.ReplaceAll(destinationPath, "'", "''") + "'"
+	output, err := exec.CommandContext(ctx, "sqlite3", sourcePath, dotCommand).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("clone benchmark SQLite database: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func copyStaticDataset(sourcePath, destinationPath string) (returnErr error) {
+	if err := os.MkdirAll(filepath.Dir(destinationPath), 0o755); err != nil {
+		return fmt.Errorf("create static dataset clone directory: %w", err)
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return fmt.Errorf("open static benchmark dataset: %w", err)
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, source.Close())
+	}()
+	destination, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("create static dataset clone: %w", err)
+	}
+	defer func() {
+		if closeErr := destination.Close(); closeErr != nil {
+			returnErr = errors.Join(returnErr, closeErr)
+		}
+		if returnErr != nil {
+			_ = os.Remove(destinationPath)
+		}
+	}()
+	if _, err := io.Copy(destination, source); err != nil {
+		return fmt.Errorf("copy static benchmark dataset: %w", err)
+	}
+	return nil
+}
+
+func RestoreDataset(ctx context.Context, sourcePath, destinationPath string) error {
+	if strings.HasSuffix(sourcePath, ".zst") {
+		if err := os.MkdirAll(filepath.Dir(destinationPath), 0o755); err != nil {
+			return fmt.Errorf("create compressed dataset restore directory: %w", err)
+		}
+		destination, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err != nil {
+			return fmt.Errorf("create restored dataset: %w", err)
+		}
+		command := exec.CommandContext(ctx, "zstd", "-d", "-c", "--no-progress", sourcePath)
+		command.Stdout = destination
+		var stderr bytes.Buffer
+		command.Stderr = &stderr
+		commandErr := command.Run()
+		closeErr := destination.Close()
+		if commandErr != nil || closeErr != nil {
+			_ = os.Remove(destinationPath)
+			return errors.Join(fmt.Errorf("restore compressed benchmark dataset: %w: %s", commandErr, strings.TrimSpace(stderr.String())), closeErr)
+		}
+		return nil
+	}
+	// Canonical 数据库在生成后已 checkpoint、关闭并验证；直接字节复制既保持
+	// SQLite 页布局不变，也避免每个 probe 再调用 sqlite3 backup 的额外开销。
+	return copyStaticDataset(sourcePath, destinationPath)
+}
+
+// ResetDatasetClone gives every probe the same canonical database state. A
+// failed high-rate probe may leave inbox backlog and partially advanced
+// aggregates behind, so reusing its database would bias every later probe.
+func ResetDatasetClone(ctx context.Context, sourcePath, destinationPath string) error {
+	sourcePath = filepath.Clean(strings.TrimSpace(sourcePath))
+	destinationPath = filepath.Clean(strings.TrimSpace(destinationPath))
+	if sourcePath == "." || destinationPath == "." || sourcePath == destinationPath {
+		return fmt.Errorf("dataset reset requires distinct source and destination paths")
+	}
+	for _, path := range []string{destinationPath + "-shm", destinationPath + "-wal", destinationPath} {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove previous probe database %s: %w", path, err)
+		}
+	}
+	return RestoreDataset(ctx, sourcePath, destinationPath)
+}
+
+func CompressDataset(ctx context.Context, sourcePath, destinationPath string, removeSource bool) error {
+	if strings.TrimSpace(sourcePath) == "" || strings.TrimSpace(destinationPath) == "" {
+		return fmt.Errorf("dataset compression source and destination are required")
+	}
+	if _, err := os.Stat(destinationPath); err == nil {
+		return fmt.Errorf("compressed dataset already exists: %s", filepath.Clean(destinationPath))
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	output, err := exec.CommandContext(ctx, "zstd", "-T0", "-6", "--no-progress", "-o", destinationPath, sourcePath).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("compress benchmark dataset: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	output, err = exec.CommandContext(ctx, "zstd", "-t", "--no-progress", destinationPath).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("verify compressed benchmark dataset: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	if removeSource {
+		if err := os.Remove(sourcePath); err != nil {
+			return fmt.Errorf("remove uncompressed dataset after verified compression: %w", err)
+		}
+	}
+	return nil
+}
+
+type CgroupSample struct {
+	At                 time.Time `json:"at"`
+	CPUUsageUsec       int64     `json:"cpu_usage_usec"`
+	CPUUserUsec        int64     `json:"cpu_user_usec"`
+	CPUSystemUsec      int64     `json:"cpu_system_usec"`
+	CPUThrottledUsec   int64     `json:"cpu_throttled_usec"`
+	CPUNrThrottled     int64     `json:"cpu_nr_throttled"`
+	MemoryCurrentBytes int64     `json:"memory_current_bytes"`
+	MemoryPeakBytes    int64     `json:"memory_peak_bytes"`
+	MemorySwapBytes    int64     `json:"memory_swap_bytes"`
+	MemoryOOM          int64     `json:"memory_oom"`
+	MemoryOOMKill      int64     `json:"memory_oom_kill"`
+	IOReadBytes        int64     `json:"io_read_bytes"`
+	IOWriteBytes       int64     `json:"io_write_bytes"`
+	PIDsCurrent        int64     `json:"pids_current"`
+}
+
+func ReadCgroupLimits(path string) (CgroupLimits, error) {
+	limits := CgroupLimits{}
+	cpuMax, err := os.ReadFile(filepath.Join(path, "cpu.max"))
+	if err != nil {
+		return limits, fmt.Errorf("read cgroup cpu.max: %w", err)
+	}
+	fields := strings.Fields(string(cpuMax))
+	if len(fields) != 2 || fields[0] == "max" {
+		return limits, fmt.Errorf("cgroup cpu.max is not a finite quota: %q", strings.TrimSpace(string(cpuMax)))
+	}
+	limits.CPUQuotaUsec, err = strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return limits, fmt.Errorf("parse cgroup CPU quota: %w", err)
+	}
+	limits.CPUPeriodUsec, err = strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return limits, fmt.Errorf("parse cgroup CPU period: %w", err)
+	}
+	allowed, err := os.ReadFile(filepath.Join(path, "cpuset.cpus.effective"))
+	if err != nil {
+		return limits, fmt.Errorf("read cgroup effective CPUs: %w", err)
+	}
+	limits.AllowedCPUs = strings.TrimSpace(string(allowed))
+	if limits.MemoryMaxBytes, limits.MemoryMaxUnlimited, err = readMemoryMaxFile(filepath.Join(path, "memory.max")); err != nil {
+		return limits, err
+	}
+	if limits.MemorySwapMaxBytes, err = readFiniteIntegerFile(filepath.Join(path, "memory.swap.max")); err != nil {
+		return limits, err
+	}
+	return limits, nil
+}
+
+func ValidateCgroupLimits(limits CgroupLimits, cpu, memoryMiB int, allowedCPUs string) error {
+	if limits.CPUPeriodUsec <= 0 || limits.CPUQuotaUsec != int64(cpu)*limits.CPUPeriodUsec {
+		return fmt.Errorf("effective CPU quota=%d/%d, want %d CPUs", limits.CPUQuotaUsec, limits.CPUPeriodUsec, cpu)
+	}
+	if limits.AllowedCPUs != allowedCPUs {
+		return fmt.Errorf("effective AllowedCPUs=%q, want %q", limits.AllowedCPUs, allowedCPUs)
+	}
+	if memoryMiB == 0 {
+		if !limits.MemoryMaxUnlimited {
+			return fmt.Errorf("effective memory.max=%d, want unlimited", limits.MemoryMaxBytes)
+		}
+	} else {
+		wantedMemory := int64(memoryMiB) * 1024 * 1024
+		if limits.MemoryMaxUnlimited || limits.MemoryMaxBytes != wantedMemory {
+			return fmt.Errorf("effective memory.max=%d unlimited=%t, want %d", limits.MemoryMaxBytes, limits.MemoryMaxUnlimited, wantedMemory)
+		}
+	}
+	if limits.MemorySwapMaxBytes != 0 {
+		return fmt.Errorf("effective memory.swap.max=%d, want 0", limits.MemorySwapMaxBytes)
+	}
+	return nil
+}
+
+func ReadCgroupSample(path string) (CgroupSample, error) {
+	sample := CgroupSample{At: time.Now()}
+	cpu, err := readKeyValueFile(filepath.Join(path, "cpu.stat"))
+	if err != nil {
+		return sample, err
+	}
+	sample.CPUUsageUsec = cpu["usage_usec"]
+	sample.CPUUserUsec = cpu["user_usec"]
+	sample.CPUSystemUsec = cpu["system_usec"]
+	sample.CPUThrottledUsec = cpu["throttled_usec"]
+	sample.CPUNrThrottled = cpu["nr_throttled"]
+	if sample.MemoryCurrentBytes, err = readIntegerFile(filepath.Join(path, "memory.current")); err != nil {
+		return sample, err
+	}
+	if sample.MemoryPeakBytes, err = readIntegerFile(filepath.Join(path, "memory.peak")); err != nil {
+		return sample, err
+	}
+	if sample.MemorySwapBytes, err = readIntegerFile(filepath.Join(path, "memory.swap.current")); err != nil {
+		return sample, err
+	}
+	memoryEvents, err := readKeyValueFile(filepath.Join(path, "memory.events"))
+	if err != nil {
+		return sample, err
+	}
+	sample.MemoryOOM = memoryEvents["oom"]
+	sample.MemoryOOMKill = memoryEvents["oom_kill"]
+	if sample.PIDsCurrent, err = readIntegerFile(filepath.Join(path, "pids.current")); err != nil {
+		return sample, err
+	}
+	ioData, err := os.ReadFile(filepath.Join(path, "io.stat"))
+	if err != nil {
+		return sample, fmt.Errorf("read cgroup io.stat: %w", err)
+	}
+	for _, line := range strings.Split(string(ioData), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		for _, field := range fields[1:] {
+			key, value, ok := strings.Cut(field, "=")
+			if !ok {
+				continue
+			}
+			parsed, _ := strconv.ParseInt(value, 10, 64)
+			switch key {
+			case "rbytes":
+				sample.IOReadBytes += parsed
+			case "wbytes":
+				sample.IOWriteBytes += parsed
+			}
+		}
+	}
+	return sample, nil
+}
+
+func readKeyValueFile(path string) (map[string]int64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", filepath.Base(path), err)
+	}
+	values := map[string]int64{}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		value, parseErr := strconv.ParseInt(fields[1], 10, 64)
+		if parseErr == nil {
+			values[fields[0]] = value
+		}
+	}
+	return values, nil
+}
+
+func readIntegerFile(path string) (int64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", filepath.Base(path), err)
+	}
+	value, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", filepath.Base(path), err)
+	}
+	return value, nil
+}
+
+func readFiniteIntegerFile(path string) (int64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", filepath.Base(path), err)
+	}
+	value := strings.TrimSpace(string(data))
+	if value == "max" {
+		return 0, fmt.Errorf("%s is unlimited", filepath.Base(path))
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", filepath.Base(path), err)
+	}
+	return parsed, nil
+}
+
+func readMemoryMaxFile(path string) (int64, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false, fmt.Errorf("read %s: %w", filepath.Base(path), err)
+	}
+	value := strings.TrimSpace(string(data))
+	if value == "max" {
+		return 0, true, nil
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, false, fmt.Errorf("parse %s: %w", filepath.Base(path), err)
+	}
+	return parsed, false, nil
+}
+
+type CgroupSampler struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+	mu     sync.Mutex
+	last   CgroupSample
+	peak   CgroupSample
+	err    error
+}
+
+func StartCgroupSampler(parent context.Context, path, outputPath string, interval time.Duration) (*CgroupSampler, error) {
+	if interval <= 0 {
+		interval = 200 * time.Millisecond
+	}
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return nil, fmt.Errorf("create cgroup sample directory: %w", err)
+	}
+	file, err := os.Create(outputPath)
+	if err != nil {
+		return nil, fmt.Errorf("create cgroup samples: %w", err)
+	}
+	ctx, cancel := context.WithCancel(parent)
+	sampler := &CgroupSampler{cancel: cancel, done: make(chan struct{})}
+	go func() {
+		defer close(sampler.done)
+		defer file.Close()
+		encoder := json.NewEncoder(file)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			sample, sampleErr := ReadCgroupSample(path)
+			if sampleErr == nil {
+				_ = encoder.Encode(sample)
+				sampler.mu.Lock()
+				sampler.last = sample
+				if sample.MemoryCurrentBytes > sampler.peak.MemoryCurrentBytes {
+					sampler.peak.MemoryCurrentBytes = sample.MemoryCurrentBytes
+				}
+				if sample.MemoryPeakBytes > sampler.peak.MemoryPeakBytes {
+					sampler.peak.MemoryPeakBytes = sample.MemoryPeakBytes
+				}
+				sampler.mu.Unlock()
+			} else if !errors.Is(sampleErr, os.ErrNotExist) {
+				sampler.mu.Lock()
+				if sampler.err == nil {
+					sampler.err = sampleErr
+				}
+				sampler.mu.Unlock()
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+	return sampler, nil
+}
+
+func (sampler *CgroupSampler) Stop() (CgroupSample, CgroupSample, error) {
+	if sampler == nil {
+		return CgroupSample{}, CgroupSample{}, nil
+	}
+	sampler.cancel()
+	<-sampler.done
+	sampler.mu.Lock()
+	defer sampler.mu.Unlock()
+	return sampler.last, sampler.peak, sampler.err
+}
+
+func CopyFile(sourcePath, destinationPath string, mode os.FileMode) error {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+	if err := os.MkdirAll(filepath.Dir(destinationPath), 0o755); err != nil {
+		return err
+	}
+	destination, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(destination, source)
+	closeErr := destination.Close()
+	return errors.Join(copyErr, closeErr)
+}

--- a/internal/benchmark/capacity/runtime.go
+++ b/internal/benchmark/capacity/runtime.go
@@ -128,16 +128,17 @@ func StartKeeperUnit(ctx context.Context, options KeeperStartOptions) (SystemdRu
 }
 
 type RedisStartOptions struct {
-	UnitName   string
-	Root       string
-	Port       int
-	Password   string
-	BinaryPath string
+	UnitName    string
+	Root        string
+	Port        int
+	Password    string
+	BinaryPath  string
+	AllowedCPUs string
 }
 
 func StartRedisUnit(ctx context.Context, options RedisStartOptions) (SystemdRuntime, error) {
-	if options.Port <= 0 || strings.TrimSpace(options.Password) == "" || strings.TrimSpace(options.Root) == "" {
-		return SystemdRuntime{}, fmt.Errorf("Redis root, port, and password are required")
+	if options.Port <= 0 || strings.TrimSpace(options.Password) == "" || strings.TrimSpace(options.Root) == "" || strings.TrimSpace(options.AllowedCPUs) == "" {
+		return SystemdRuntime{}, fmt.Errorf("Redis root, port, password, and CPU affinity are required")
 	}
 	if options.BinaryPath == "" {
 		options.BinaryPath = "redis-server"
@@ -154,6 +155,7 @@ func StartRedisUnit(ctx context.Context, options RedisStartOptions) (SystemdRunt
 		"--property=Restart=no",
 		"--property=KillMode=mixed",
 		"--property=TimeoutStopSec=10s",
+		"--property=AllowedCPUs=" + options.AllowedCPUs,
 		"--property=WorkingDirectory=" + redisDir,
 		"--property=StandardOutput=append:" + stdoutPath,
 		"--property=StandardError=append:" + stderrPath,
@@ -177,7 +179,17 @@ func StartRedisUnit(ctx context.Context, options RedisStartOptions) (SystemdRunt
 				_ = StopUnit(context.Background(), options.UnitName)
 				return SystemdRuntime{}, stateErr
 			}
-			return SystemdRuntime{UnitName: options.UnitName, CgroupPath: filepath.Join("/sys/fs/cgroup", strings.TrimPrefix(state.ControlGroup, "/"))}, nil
+			cgroupPath := filepath.Join("/sys/fs/cgroup", strings.TrimPrefix(state.ControlGroup, "/"))
+			allowedCPUs, allowedErr := ReadCgroupAllowedCPUs(cgroupPath)
+			if allowedErr != nil {
+				_ = StopUnit(context.Background(), options.UnitName)
+				return SystemdRuntime{}, allowedErr
+			}
+			if allowedCPUs != options.AllowedCPUs {
+				_ = StopUnit(context.Background(), options.UnitName)
+				return SystemdRuntime{}, fmt.Errorf("Redis effective AllowedCPUs=%q, want %q", allowedCPUs, options.AllowedCPUs)
+			}
+			return SystemdRuntime{UnitName: options.UnitName, CgroupPath: cgroupPath, Limits: CgroupLimits{AllowedCPUs: allowedCPUs}}, nil
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
@@ -313,6 +325,9 @@ func copyStaticDataset(sourcePath, destinationPath string) (returnErr error) {
 	if _, err := io.Copy(destination, source); err != nil {
 		return fmt.Errorf("copy static benchmark dataset: %w", err)
 	}
+	if err := destination.Sync(); err != nil {
+		return fmt.Errorf("sync static benchmark dataset: %w", err)
+	}
 	return nil
 }
 
@@ -330,10 +345,11 @@ func RestoreDataset(ctx context.Context, sourcePath, destinationPath string) err
 		var stderr bytes.Buffer
 		command.Stderr = &stderr
 		commandErr := command.Run()
+		syncErr := destination.Sync()
 		closeErr := destination.Close()
-		if commandErr != nil || closeErr != nil {
+		if commandErr != nil || syncErr != nil || closeErr != nil {
 			_ = os.Remove(destinationPath)
-			return errors.Join(fmt.Errorf("restore compressed benchmark dataset: %w: %s", commandErr, strings.TrimSpace(stderr.String())), closeErr)
+			return errors.Join(fmt.Errorf("restore compressed benchmark dataset: %w: %s", commandErr, strings.TrimSpace(stderr.String())), syncErr, closeErr)
 		}
 		return nil
 	}
@@ -356,7 +372,14 @@ func ResetDatasetClone(ctx context.Context, sourcePath, destinationPath string) 
 			return fmt.Errorf("remove previous probe database %s: %w", path, err)
 		}
 	}
-	return RestoreDataset(ctx, sourcePath, destinationPath)
+	if err := RestoreDataset(ctx, sourcePath, destinationPath); err != nil {
+		return err
+	}
+	if err := DropFilePageCache(destinationPath); err != nil {
+		_ = os.Remove(destinationPath)
+		return fmt.Errorf("evict restored dataset page cache: %w", err)
+	}
+	return nil
 }
 
 func CompressDataset(ctx context.Context, sourcePath, destinationPath string, removeSource bool) error {
@@ -419,11 +442,9 @@ func ReadCgroupLimits(path string) (CgroupLimits, error) {
 	if err != nil {
 		return limits, fmt.Errorf("parse cgroup CPU period: %w", err)
 	}
-	allowed, err := os.ReadFile(filepath.Join(path, "cpuset.cpus.effective"))
-	if err != nil {
-		return limits, fmt.Errorf("read cgroup effective CPUs: %w", err)
+	if limits.AllowedCPUs, err = ReadCgroupAllowedCPUs(path); err != nil {
+		return limits, err
 	}
-	limits.AllowedCPUs = strings.TrimSpace(string(allowed))
 	if limits.MemoryMaxBytes, limits.MemoryMaxUnlimited, err = readMemoryMaxFile(filepath.Join(path, "memory.max")); err != nil {
 		return limits, err
 	}
@@ -431,6 +452,14 @@ func ReadCgroupLimits(path string) (CgroupLimits, error) {
 		return limits, err
 	}
 	return limits, nil
+}
+
+func ReadCgroupAllowedCPUs(path string) (string, error) {
+	allowed, err := os.ReadFile(filepath.Join(path, "cpuset.cpus.effective"))
+	if err != nil {
+		return "", fmt.Errorf("read cgroup effective CPUs: %w", err)
+	}
+	return strings.TrimSpace(string(allowed)), nil
 }
 
 func ValidateCgroupLimits(limits CgroupLimits, cpu, memoryMiB int, allowedCPUs string) error {

--- a/internal/benchmark/capacity/runtime.go
+++ b/internal/benchmark/capacity/runtime.go
@@ -16,38 +16,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 )
-
-type FileLock struct {
-	file *os.File
-}
-
-func AcquireFileLock(path string) (*FileLock, error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return nil, fmt.Errorf("create benchmark lock directory: %w", err)
-	}
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
-	if err != nil {
-		return nil, fmt.Errorf("open benchmark lock: %w", err)
-	}
-	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
-		file.Close()
-		return nil, fmt.Errorf("another benchmark owns %s: %w", filepath.Clean(path), err)
-	}
-	return &FileLock{file: file}, nil
-}
-
-func (lock *FileLock) Close() error {
-	if lock == nil || lock.file == nil {
-		return nil
-	}
-	err := syscall.Flock(int(lock.file.Fd()), syscall.LOCK_UN)
-	err = errors.Join(err, lock.file.Close())
-	lock.file = nil
-	return err
-}
 
 type UnitState struct {
 	ActiveState    string `json:"active_state"`

--- a/internal/benchmark/capacity/summary.go
+++ b/internal/benchmark/capacity/summary.go
@@ -1,0 +1,340 @@
+package capacity
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type SummaryCell struct {
+	CellID                        string  `json:"cell_id"`
+	DatasetID                     string  `json:"dataset_id"`
+	Identities                    int     `json:"identities"`
+	Models                        int     `json:"models"`
+	APIKeys                       int     `json:"api_keys"`
+	ResourceID                    string  `json:"resource_id"`
+	CPU                           float64 `json:"cpu"`
+	MemoryMiB                     int     `json:"memory_mib"`
+	Status                        string  `json:"status"`
+	StartupSeconds                float64 `json:"startup_seconds"`
+	WarmupSeconds                 float64 `json:"warmup_seconds"`
+	HardEventsPerSecond           int     `json:"hard_events_per_second"`
+	InteractiveEventsPerSecond    int     `json:"interactive_events_per_second"`
+	RecommendedEventsPerSecond    int     `json:"recommended_events_per_second"`
+	PeakMemoryBytes               int64   `json:"peak_memory_bytes"`
+	CapacityPeakMemoryBytes       int64   `json:"capacity_peak_memory_bytes"`
+	CapacityCPUUtilizationPercent float64 `json:"capacity_cpu_utilization_percent"`
+	BoundaryHTTPP95MS             float64 `json:"capacity_http_core_p95_ms"`
+	BoundaryHTTPP99MS             float64 `json:"capacity_http_overall_p99_ms"`
+	DashboardStatus               string  `json:"dashboard_status"`
+	SlowestDashboardPath          string  `json:"slowest_dashboard_path,omitempty"`
+	SlowestDashboardP99MS         float64 `json:"slowest_dashboard_p99_ms"`
+	SharedDriver                  bool    `json:"shared_driver"`
+	Error                         string  `json:"error,omitempty"`
+}
+
+type HardwareRecommendation struct {
+	DatasetID                   string  `json:"dataset_id"`
+	ResourceID                  string  `json:"resource_id"`
+	CPU                         float64 `json:"cpu"`
+	MemoryMiB                   int     `json:"memory_mib"`
+	IngestionMaxEventsPerSecond int     `json:"ingestion_max_events_per_second"`
+	DashboardMaxEventsPerSecond int     `json:"dashboard_max_events_per_second"`
+	RecommendedEventsPerSecond  int     `json:"recommended_events_per_second"`
+	CPUUtilizationPercent       float64 `json:"capacity_cpu_utilization_percent"`
+	CoreP95MS                   float64 `json:"capacity_http_core_p95_ms"`
+	OverallP99MS                float64 `json:"capacity_http_overall_p99_ms"`
+	PeakMemoryBytes             int64   `json:"peak_memory_bytes"`
+	SharedDriver                bool    `json:"shared_driver"`
+	Guidance                    string  `json:"guidance"`
+}
+
+type RunSummary struct {
+	GeneratedAt time.Time                `json:"generated_at"`
+	Cells       []SummaryCell            `json:"cells"`
+	Hardware    []HardwareRecommendation `json:"hardware"`
+	Failures    int                      `json:"failures"`
+}
+
+func SummarizeRun(runDir string) (RunSummary, error) {
+	results, err := loadCellResults(runDir)
+	if err != nil {
+		return RunSummary{}, err
+	}
+	summary := BuildSummary(results)
+	if err := WriteJSONAtomic(filepath.Join(runDir, "summary.json"), summary); err != nil {
+		return RunSummary{}, err
+	}
+	if err := writeSummaryCSV(filepath.Join(runDir, "summary.csv"), summary); err != nil {
+		return RunSummary{}, err
+	}
+	if err := writeReportMarkdown(filepath.Join(runDir, "report.md"), summary); err != nil {
+		return RunSummary{}, err
+	}
+	return summary, nil
+}
+
+func BuildSummary(results []CellResult) RunSummary {
+	summary := RunSummary{GeneratedAt: time.Now()}
+	for _, result := range results {
+		p95, p99, slowestPath, slowestP99 := capacityLatency(result.Attempts, result.Capacity.HardEventsPerSecond)
+		cpuUtilization, capacityPeakMemory := capacityTelemetry(result.Attempts, result.Capacity.HardEventsPerSecond)
+		cell := SummaryCell{
+			CellID: result.Cell.ID, DatasetID: result.Cell.DatasetID,
+			Identities: result.Cell.Cardinality.Identities, Models: result.Cell.Cardinality.Models, APIKeys: result.Cell.Cardinality.APIKeys,
+			ResourceID: result.Cell.Resource.ID, CPU: result.Cell.Resource.CPU, MemoryMiB: result.Cell.Resource.MemoryMiB,
+			Status: result.Status, StartupSeconds: result.StartupSeconds, WarmupSeconds: result.WarmupSeconds,
+			HardEventsPerSecond: result.Capacity.HardEventsPerSecond, InteractiveEventsPerSecond: result.Capacity.InteractiveEventsPerSecond,
+			RecommendedEventsPerSecond: result.Capacity.RecommendedEventsPerSecond,
+			PeakMemoryBytes:            max(result.PeakResource.MemoryPeakBytes, result.LastResource.MemoryPeakBytes), CapacityPeakMemoryBytes: capacityPeakMemory,
+			CapacityCPUUtilizationPercent: cpuUtilization, BoundaryHTTPP95MS: p95, BoundaryHTTPP99MS: p99,
+			DashboardStatus:      dashboardStatus(result.Capacity.HardEventsPerSecond, result.Capacity.InteractiveEventsPerSecond),
+			SlowestDashboardPath: slowestPath, SlowestDashboardP99MS: slowestP99,
+			SharedDriver: result.SharedDriver, Error: result.Error,
+		}
+		if result.Status != "completed" {
+			summary.Failures++
+		}
+		summary.Cells = append(summary.Cells, cell)
+	}
+	sort.Slice(summary.Cells, func(left, right int) bool {
+		if summary.Cells[left].CPU != summary.Cells[right].CPU {
+			return summary.Cells[left].CPU < summary.Cells[right].CPU
+		}
+		if summary.Cells[left].MemoryMiB != summary.Cells[right].MemoryMiB {
+			return summary.Cells[left].MemoryMiB < summary.Cells[right].MemoryMiB
+		}
+		return summary.Cells[left].CellID < summary.Cells[right].CellID
+	})
+	summary.Hardware = buildHardwareRecommendations(summary.Cells)
+	return summary
+}
+
+func buildHardwareRecommendations(cells []SummaryCell) []HardwareRecommendation {
+	recommendations := make([]HardwareRecommendation, 0, len(cells))
+	for _, cell := range cells {
+		recommendation := HardwareRecommendation{
+			DatasetID: cell.DatasetID, ResourceID: cell.ResourceID, CPU: cell.CPU, MemoryMiB: cell.MemoryMiB,
+			IngestionMaxEventsPerSecond: cell.HardEventsPerSecond, DashboardMaxEventsPerSecond: cell.InteractiveEventsPerSecond,
+			RecommendedEventsPerSecond: cell.RecommendedEventsPerSecond, CPUUtilizationPercent: cell.CapacityCPUUtilizationPercent,
+			CoreP95MS: cell.BoundaryHTTPP95MS, OverallP99MS: cell.BoundaryHTTPP99MS,
+			PeakMemoryBytes: cell.CapacityPeakMemoryBytes, SharedDriver: cell.SharedDriver,
+		}
+		if recommendation.PeakMemoryBytes == 0 {
+			recommendation.PeakMemoryBytes = cell.PeakMemoryBytes
+		}
+		switch {
+		case cell.Status != "completed":
+			recommendation.Guidance = "该资源档未完成，不能用于容量建议"
+		case cell.HardEventsPerSecond <= 0:
+			recommendation.Guidance = "Keeper 可以启动，但未找到可持续 ingestion 容量"
+		case cell.InteractiveEventsPerSecond <= 0:
+			recommendation.Guidance = fmt.Sprintf("可持续 ingestion 上限为 %d events/s；Dashboard 未通过交互 SLA", cell.HardEventsPerSecond)
+		default:
+			recommendation.Guidance = fmt.Sprintf("持续流量建议不超过 %d events/s", cell.RecommendedEventsPerSecond)
+		}
+		recommendations = append(recommendations, recommendation)
+	}
+	return recommendations
+}
+
+func capacityLatency(attempts []ProbeAttempt, hardCapacity int) (float64, float64, string, float64) {
+	selected := capacityAttempts(attempts, hardCapacity)
+	var p95Values, p99Values []float64
+	slowestPath := ""
+	slowestP99 := 0.0
+	for _, attempt := range selected {
+		p95Values = append(p95Values, attempt.Report.Metrics.HTTPP95MS)
+		p99Values = append(p99Values, attempt.Report.Metrics.HTTPP99MS)
+		for path, latency := range attempt.Report.LatencyByPath {
+			if latency.P99MS > slowestP99 {
+				slowestPath = path
+				slowestP99 = latency.P99MS
+			}
+		}
+	}
+	return medianFloat(p95Values), medianFloat(p99Values), slowestPath, slowestP99
+}
+
+func capacityTelemetry(attempts []ProbeAttempt, hardCapacity int) (float64, int64) {
+	selected := capacityAttempts(attempts, hardCapacity)
+	var utilization []float64
+	var peakMemory int64
+	for _, attempt := range selected {
+		utilization = append(utilization, attempt.Resource.CPUUtilizationPercent)
+		peakMemory = max(peakMemory, attempt.PeakResource.MemoryPeakBytes, attempt.Resource.MemoryPeakBytes)
+	}
+	return medianFloat(utilization), peakMemory
+}
+
+func capacityAttempts(attempts []ProbeAttempt, hardCapacity int) []ProbeAttempt {
+	selected := make([]ProbeAttempt, 0, len(attempts))
+	for _, attempt := range attempts {
+		if attempt.Phase == "boundary" && attempt.RatePerSecond == hardCapacity && attempt.Report.Evaluation.HardPass {
+			selected = append(selected, attempt)
+		}
+	}
+	if len(selected) == 0 {
+		for _, attempt := range attempts {
+			if attempt.RatePerSecond == hardCapacity && attempt.Report.Evaluation.HardPass && (attempt.Phase == "search" || attempt.Phase == "soak") {
+				selected = append(selected, attempt)
+			}
+		}
+	}
+	return selected
+}
+
+func dashboardStatus(hardCapacity, interactiveCapacity int) string {
+	switch {
+	case hardCapacity <= 0:
+		return "no_capacity"
+	case interactiveCapacity >= hardCapacity:
+		return "interactive"
+	case interactiveCapacity > 0:
+		return "interactive_below_ingestion"
+	default:
+		return "ingestion_only"
+	}
+}
+
+func medianFloat(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	ordered := append([]float64(nil), values...)
+	sort.Float64s(ordered)
+	middle := len(ordered) / 2
+	if len(ordered)%2 == 1 {
+		return ordered[middle]
+	}
+	return (ordered[middle-1] + ordered[middle]) / 2
+}
+
+func loadCellResults(runDir string) ([]CellResult, error) {
+	paths, err := filepath.Glob(filepath.Join(runDir, "cells", "*", "result.json"))
+	if err != nil {
+		return nil, err
+	}
+	var results []CellResult
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		var result CellResult
+		if err := json.Unmarshal(data, &result); err != nil {
+			return nil, fmt.Errorf("decode cell result %s: %w", path, err)
+		}
+		results = append(results, result)
+	}
+	sort.Slice(results, func(left, right int) bool { return results[left].Cell.ID < results[right].Cell.ID })
+	return results, nil
+}
+
+func RebuildResultsJSONL(runDir string) error {
+	results, err := loadCellResults(runDir)
+	if err != nil {
+		return err
+	}
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	for _, result := range results {
+		if err := encoder.Encode(result); err != nil {
+			return err
+		}
+	}
+	return writeBytesAtomic(filepath.Join(runDir, "results.jsonl"), buffer.Bytes())
+}
+
+func writeSummaryCSV(path string, summary RunSummary) error {
+	var buffer bytes.Buffer
+	writer := csv.NewWriter(&buffer)
+	_ = writer.Write([]string{
+		"cell_id", "dataset_id", "identities", "models", "api_keys", "resource_id", "cpu", "memory_mib",
+		"status", "startup_seconds", "warmup_seconds", "hard_events_per_second", "interactive_events_per_second", "recommended_events_per_second",
+		"peak_memory_bytes", "capacity_peak_memory_bytes", "capacity_cpu_utilization_percent", "capacity_http_core_p95_ms", "capacity_http_overall_p99_ms",
+		"dashboard_status", "slowest_dashboard_path", "slowest_dashboard_p99_ms", "shared_driver", "error",
+	})
+	for _, cell := range summary.Cells {
+		_ = writer.Write([]string{
+			cell.CellID, cell.DatasetID, strconv.Itoa(cell.Identities), strconv.Itoa(cell.Models), strconv.Itoa(cell.APIKeys),
+			cell.ResourceID, strconv.FormatFloat(cell.CPU, 'f', -1, 64), strconv.Itoa(cell.MemoryMiB), cell.Status,
+			strconv.FormatFloat(cell.StartupSeconds, 'f', 3, 64), strconv.FormatFloat(cell.WarmupSeconds, 'f', 3, 64),
+			strconv.Itoa(cell.HardEventsPerSecond), strconv.Itoa(cell.InteractiveEventsPerSecond), strconv.Itoa(cell.RecommendedEventsPerSecond),
+			strconv.FormatInt(cell.PeakMemoryBytes, 10), strconv.FormatInt(cell.CapacityPeakMemoryBytes, 10), strconv.FormatFloat(cell.CapacityCPUUtilizationPercent, 'f', 3, 64),
+			strconv.FormatFloat(cell.BoundaryHTTPP95MS, 'f', 3, 64), strconv.FormatFloat(cell.BoundaryHTTPP99MS, 'f', 3, 64),
+			cell.DashboardStatus, cell.SlowestDashboardPath, strconv.FormatFloat(cell.SlowestDashboardP99MS, 'f', 3, 64), strconv.FormatBool(cell.SharedDriver), cell.Error,
+		})
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return err
+	}
+	return writeBytesAtomic(path, buffer.Bytes())
+}
+
+func writeReportMarkdown(path string, summary RunSummary) error {
+	var report strings.Builder
+	report.WriteString("# CPA Usage Keeper Capacity Benchmark\n\n")
+	report.WriteString("> 容量结果与建议适用于本次记录的 linux/amd64 硬件规格、数据集指纹和 Keeper 二进制。\n\n")
+	report.WriteString("## Hardware recommendations\n\n")
+	report.WriteString("| Dataset | Resource | Ingestion max | Dashboard max | Recommended | CPU avg | Core p95 / overall p99 | Peak memory | Note |\n")
+	report.WriteString("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n")
+	for _, item := range summary.Hardware {
+		note := item.Guidance
+		if item.SharedDriver {
+			note += "；Keeper 与负载器共享宿主 CPU，结果偏保守"
+		}
+		report.WriteString(fmt.Sprintf("| %s | %s | %d | %d | %d | %.1f%% | %.1f / %.1f ms | %.1f MiB | %s |\n",
+			item.DatasetID, item.ResourceID, item.IngestionMaxEventsPerSecond, item.DashboardMaxEventsPerSecond, item.RecommendedEventsPerSecond,
+			item.CPUUtilizationPercent, item.CoreP95MS, item.OverallP99MS, float64(item.PeakMemoryBytes)/(1024*1024), note))
+	}
+	report.WriteString("\n## Cells\n\n")
+	report.WriteString("| Cell | Cardinality I/M/K | Resource | Status | Ingestion max | Dashboard max | CPU avg / peak memory | Dashboard status | Core p95 / overall p99 | Slowest endpoint p99 |\n")
+	report.WriteString("| --- | ---: | --- | --- | ---: | ---: | ---: | --- | ---: | --- |\n")
+	for _, cell := range summary.Cells {
+		slowest := "-"
+		if cell.SlowestDashboardPath != "" {
+			slowest = fmt.Sprintf("%s %.1f ms", cell.SlowestDashboardPath, cell.SlowestDashboardP99MS)
+		}
+		report.WriteString(fmt.Sprintf("| %s | %d/%d/%d | %s | %s | %d | %d | %.1f%% / %.1f MiB | %s | %.1f / %.1f ms | %s |\n",
+			cell.CellID, cell.Identities, cell.Models, cell.APIKeys, cell.ResourceID, cell.Status,
+			cell.HardEventsPerSecond, cell.InteractiveEventsPerSecond, cell.CapacityCPUUtilizationPercent, float64(cell.CapacityPeakMemoryBytes)/(1024*1024),
+			cell.DashboardStatus, cell.BoundaryHTTPP95MS, cell.BoundaryHTTPP99MS, slowest))
+	}
+	if summary.Failures > 0 {
+		report.WriteString(fmt.Sprintf("\nFailures: %d. Inspect each cell's result and logs before using recommendations.\n", summary.Failures))
+	}
+	return writeBytesAtomic(path, []byte(report.String()))
+}
+
+func writeBytesAtomic(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".benchmark-*.tmp")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if _, err := temporary.Write(data); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, path)
+}

--- a/internal/benchmark/capacity/summary.go
+++ b/internal/benchmark/capacity/summary.go
@@ -26,13 +26,22 @@ type SummaryCell struct {
 	StartupSeconds                float64 `json:"startup_seconds"`
 	WarmupSeconds                 float64 `json:"warmup_seconds"`
 	HardEventsPerSecond           int     `json:"hard_events_per_second"`
+	LowestHardFailurePerSecond    int     `json:"lowest_hard_failure_events_per_second"`
 	InteractiveEventsPerSecond    int     `json:"interactive_events_per_second"`
+	LowestInteractiveFailureRate  int     `json:"lowest_interactive_failure_events_per_second"`
 	RecommendedEventsPerSecond    int     `json:"recommended_events_per_second"`
 	PeakMemoryBytes               int64   `json:"peak_memory_bytes"`
 	CapacityPeakMemoryBytes       int64   `json:"capacity_peak_memory_bytes"`
 	CapacityCPUUtilizationPercent float64 `json:"capacity_cpu_utilization_percent"`
 	BoundaryHTTPP95MS             float64 `json:"capacity_http_core_p95_ms"`
-	BoundaryHTTPP99MS             float64 `json:"capacity_http_overall_p99_ms"`
+	BoundaryHTTPP99MS             float64 `json:"capacity_http_core_p99_ms"`
+	AnalysisLatencyP50MS          float64 `json:"analysis_latency_p50_ms"`
+	AnalysisLatencyP95MS          float64 `json:"analysis_latency_p95_ms"`
+	AnalysisLatencyP99MS          float64 `json:"analysis_latency_p99_ms"`
+	AnalysisLatencyMaxMS          float64 `json:"analysis_latency_max_ms"`
+	AnalysisLatencySamples        int64   `json:"analysis_latency_samples"`
+	AnalysisLatencyErrors         int64   `json:"analysis_latency_errors"`
+	AnalysisLatencyStatus         string  `json:"analysis_latency_status"`
 	DashboardStatus               string  `json:"dashboard_status"`
 	SlowestDashboardPath          string  `json:"slowest_dashboard_path,omitempty"`
 	SlowestDashboardP99MS         float64 `json:"slowest_dashboard_p99_ms"`
@@ -46,11 +55,17 @@ type HardwareRecommendation struct {
 	CPU                         float64 `json:"cpu"`
 	MemoryMiB                   int     `json:"memory_mib"`
 	IngestionMaxEventsPerSecond int     `json:"ingestion_max_events_per_second"`
+	IngestionLowestFailureRate  int     `json:"ingestion_lowest_failure_events_per_second"`
 	DashboardMaxEventsPerSecond int     `json:"dashboard_max_events_per_second"`
+	DashboardLowestFailureRate  int     `json:"dashboard_lowest_failure_events_per_second"`
 	RecommendedEventsPerSecond  int     `json:"recommended_events_per_second"`
 	CPUUtilizationPercent       float64 `json:"capacity_cpu_utilization_percent"`
 	CoreP95MS                   float64 `json:"capacity_http_core_p95_ms"`
-	OverallP99MS                float64 `json:"capacity_http_overall_p99_ms"`
+	CoreP99MS                   float64 `json:"capacity_http_core_p99_ms"`
+	AnalysisLatencyP99MS        float64 `json:"analysis_latency_p99_ms"`
+	AnalysisLatencySamples      int64   `json:"analysis_latency_samples"`
+	AnalysisLatencyErrors       int64   `json:"analysis_latency_errors"`
+	AnalysisLatencyStatus       string  `json:"analysis_latency_status"`
 	PeakMemoryBytes             int64   `json:"peak_memory_bytes"`
 	SharedDriver                bool    `json:"shared_driver"`
 	Guidance                    string  `json:"guidance"`
@@ -84,17 +99,25 @@ func SummarizeRun(runDir string) (RunSummary, error) {
 func BuildSummary(results []CellResult) RunSummary {
 	summary := RunSummary{GeneratedAt: time.Now()}
 	for _, result := range results {
-		p95, p99, slowestPath, slowestP99 := capacityLatency(result.Attempts, result.Capacity.HardEventsPerSecond)
+		dashboardRate := result.Capacity.InteractiveEventsPerSecond
+		if dashboardRate <= 0 {
+			dashboardRate = result.Capacity.HardEventsPerSecond
+		}
+		p95, p99, slowestPath, slowestP99, analysisLatency, analysisErrors, analysisStatus := capacityLatency(result.Attempts, dashboardRate, result.Capacity.InteractiveEventsPerSecond > 0)
 		cpuUtilization, capacityPeakMemory := capacityTelemetry(result.Attempts, result.Capacity.HardEventsPerSecond)
 		cell := SummaryCell{
 			CellID: result.Cell.ID, DatasetID: result.Cell.DatasetID,
 			Identities: result.Cell.Cardinality.Identities, Models: result.Cell.Cardinality.Models, APIKeys: result.Cell.Cardinality.APIKeys,
 			ResourceID: result.Cell.Resource.ID, CPU: result.Cell.Resource.CPU, MemoryMiB: result.Cell.Resource.MemoryMiB,
 			Status: result.Status, StartupSeconds: result.StartupSeconds, WarmupSeconds: result.WarmupSeconds,
-			HardEventsPerSecond: result.Capacity.HardEventsPerSecond, InteractiveEventsPerSecond: result.Capacity.InteractiveEventsPerSecond,
+			HardEventsPerSecond: result.Capacity.HardEventsPerSecond, LowestHardFailurePerSecond: result.Capacity.LowestHardFailureEventsPerSecond,
+			InteractiveEventsPerSecond: result.Capacity.InteractiveEventsPerSecond, LowestInteractiveFailureRate: result.Capacity.LowestInteractiveFailureEventsPerSecond,
 			RecommendedEventsPerSecond: result.Capacity.RecommendedEventsPerSecond,
 			PeakMemoryBytes:            max(result.PeakResource.MemoryPeakBytes, result.LastResource.MemoryPeakBytes), CapacityPeakMemoryBytes: capacityPeakMemory,
 			CapacityCPUUtilizationPercent: cpuUtilization, BoundaryHTTPP95MS: p95, BoundaryHTTPP99MS: p99,
+			AnalysisLatencyP50MS: analysisLatency.P50MS, AnalysisLatencyP95MS: analysisLatency.P95MS,
+			AnalysisLatencyP99MS: analysisLatency.P99MS, AnalysisLatencyMaxMS: analysisLatency.MaxMS,
+			AnalysisLatencySamples: analysisLatency.Samples, AnalysisLatencyErrors: analysisErrors, AnalysisLatencyStatus: analysisStatus,
 			DashboardStatus:      dashboardStatus(result.Capacity.HardEventsPerSecond, result.Capacity.InteractiveEventsPerSecond),
 			SlowestDashboardPath: slowestPath, SlowestDashboardP99MS: slowestP99,
 			SharedDriver: result.SharedDriver, Error: result.Error,
@@ -122,9 +145,11 @@ func buildHardwareRecommendations(cells []SummaryCell) []HardwareRecommendation 
 	for _, cell := range cells {
 		recommendation := HardwareRecommendation{
 			DatasetID: cell.DatasetID, ResourceID: cell.ResourceID, CPU: cell.CPU, MemoryMiB: cell.MemoryMiB,
-			IngestionMaxEventsPerSecond: cell.HardEventsPerSecond, DashboardMaxEventsPerSecond: cell.InteractiveEventsPerSecond,
+			IngestionMaxEventsPerSecond: cell.HardEventsPerSecond, IngestionLowestFailureRate: cell.LowestHardFailurePerSecond,
+			DashboardMaxEventsPerSecond: cell.InteractiveEventsPerSecond, DashboardLowestFailureRate: cell.LowestInteractiveFailureRate,
 			RecommendedEventsPerSecond: cell.RecommendedEventsPerSecond, CPUUtilizationPercent: cell.CapacityCPUUtilizationPercent,
-			CoreP95MS: cell.BoundaryHTTPP95MS, OverallP99MS: cell.BoundaryHTTPP99MS,
+			CoreP95MS: cell.BoundaryHTTPP95MS, CoreP99MS: cell.BoundaryHTTPP99MS, AnalysisLatencyP99MS: cell.AnalysisLatencyP99MS,
+			AnalysisLatencySamples: cell.AnalysisLatencySamples, AnalysisLatencyErrors: cell.AnalysisLatencyErrors, AnalysisLatencyStatus: cell.AnalysisLatencyStatus,
 			PeakMemoryBytes: cell.CapacityPeakMemoryBytes, SharedDriver: cell.SharedDriver,
 		}
 		if recommendation.PeakMemoryBytes == 0 {
@@ -145,22 +170,61 @@ func buildHardwareRecommendations(cells []SummaryCell) []HardwareRecommendation 
 	return recommendations
 }
 
-func capacityLatency(attempts []ProbeAttempt, hardCapacity int) (float64, float64, string, float64) {
-	selected := capacityAttempts(attempts, hardCapacity)
+func capacityLatency(attempts []ProbeAttempt, rate int, requireInteractive bool) (float64, float64, string, float64, LatencySummary, int64, string) {
+	selected := capacityAttempts(attempts, rate)
+	if requireInteractive {
+		selected = selected[:0]
+		for _, attempt := range attempts {
+			if attempt.RatePerSecond == rate && attempt.Report.Evaluation.InteractivePass {
+				selected = append(selected, attempt)
+			}
+		}
+	}
 	var p95Values, p99Values []float64
+	var analysisP50Values, analysisP95Values, analysisP99Values, analysisMaxValues []float64
+	var analysisSampleValues []float64
+	var analysisErrors int64
+	analysisStatus := "not_measured"
 	slowestPath := ""
 	slowestP99 := 0.0
 	for _, attempt := range selected {
 		p95Values = append(p95Values, attempt.Report.Metrics.HTTPP95MS)
 		p99Values = append(p99Values, attempt.Report.Metrics.HTTPP99MS)
 		for path, latency := range attempt.Report.LatencyByPath {
+			if path == analysisLatencyDashboardPath {
+				continue
+			}
 			if latency.P99MS > slowestP99 {
 				slowestPath = path
 				slowestP99 = latency.P99MS
 			}
 		}
+		analysis := attempt.Report.AnalysisLatency
+		if analysis == (LatencySummary{}) {
+			analysis = attempt.Report.LatencyByPath[analysisLatencyDashboardPath]
+		}
+		if analysis != (LatencySummary{}) {
+			analysisSampleValues = append(analysisSampleValues, float64(analysis.Samples))
+			analysisP50Values = append(analysisP50Values, analysis.P50MS)
+			analysisP95Values = append(analysisP95Values, analysis.P95MS)
+			analysisP99Values = append(analysisP99Values, analysis.P99MS)
+			analysisMaxValues = append(analysisMaxValues, analysis.MaxMS)
+		}
+		analysisErrors += attempt.Report.Metrics.AnalysisLatencyErrors
+		if attempt.Report.Metrics.AnalysisLatencyRequests > 0 || attempt.Report.AnalysisLatency.Samples > 0 {
+			if !attempt.Report.Evaluation.AnalysisLatencyPass {
+				analysisStatus = "failed"
+			} else if analysisStatus != "failed" {
+				analysisStatus = "passed"
+			}
+		} else if analysis != (LatencySummary{}) && analysisStatus == "not_measured" {
+			analysisStatus = "legacy_observation"
+		}
 	}
-	return medianFloat(p95Values), medianFloat(p99Values), slowestPath, slowestP99
+	return medianFloat(p95Values), medianFloat(p99Values), slowestPath, slowestP99, LatencySummary{
+		Samples: int64(medianFloat(analysisSampleValues)), P50MS: medianFloat(analysisP50Values), P95MS: medianFloat(analysisP95Values),
+		P99MS: medianFloat(analysisP99Values), MaxMS: medianFloat(analysisMaxValues),
+	}, analysisErrors, analysisStatus
 }
 
 func capacityTelemetry(attempts []ProbeAttempt, hardCapacity int) (float64, int64) {
@@ -177,7 +241,7 @@ func capacityTelemetry(attempts []ProbeAttempt, hardCapacity int) (float64, int6
 func capacityAttempts(attempts []ProbeAttempt, hardCapacity int) []ProbeAttempt {
 	selected := make([]ProbeAttempt, 0, len(attempts))
 	for _, attempt := range attempts {
-		if attempt.Phase == "boundary" && attempt.RatePerSecond == hardCapacity && attempt.Report.Evaluation.HardPass {
+		if (attempt.Phase == "boundary" || strings.HasPrefix(attempt.Phase, "boundary-")) && attempt.RatePerSecond == hardCapacity && attempt.Report.Evaluation.HardPass {
 			selected = append(selected, attempt)
 		}
 	}
@@ -258,8 +322,11 @@ func writeSummaryCSV(path string, summary RunSummary) error {
 	writer := csv.NewWriter(&buffer)
 	_ = writer.Write([]string{
 		"cell_id", "dataset_id", "identities", "models", "api_keys", "resource_id", "cpu", "memory_mib",
-		"status", "startup_seconds", "warmup_seconds", "hard_events_per_second", "interactive_events_per_second", "recommended_events_per_second",
-		"peak_memory_bytes", "capacity_peak_memory_bytes", "capacity_cpu_utilization_percent", "capacity_http_core_p95_ms", "capacity_http_overall_p99_ms",
+		"status", "startup_seconds", "warmup_seconds", "hard_events_per_second", "lowest_hard_failure_events_per_second",
+		"interactive_events_per_second", "lowest_interactive_failure_events_per_second", "recommended_events_per_second",
+		"peak_memory_bytes", "capacity_peak_memory_bytes", "capacity_cpu_utilization_percent", "capacity_http_core_p95_ms", "capacity_http_core_p99_ms",
+		"analysis_latency_p50_ms", "analysis_latency_p95_ms", "analysis_latency_p99_ms", "analysis_latency_max_ms",
+		"analysis_latency_samples", "analysis_latency_errors", "analysis_latency_status",
 		"dashboard_status", "slowest_dashboard_path", "slowest_dashboard_p99_ms", "shared_driver", "error",
 	})
 	for _, cell := range summary.Cells {
@@ -267,9 +334,13 @@ func writeSummaryCSV(path string, summary RunSummary) error {
 			cell.CellID, cell.DatasetID, strconv.Itoa(cell.Identities), strconv.Itoa(cell.Models), strconv.Itoa(cell.APIKeys),
 			cell.ResourceID, strconv.FormatFloat(cell.CPU, 'f', -1, 64), strconv.Itoa(cell.MemoryMiB), cell.Status,
 			strconv.FormatFloat(cell.StartupSeconds, 'f', 3, 64), strconv.FormatFloat(cell.WarmupSeconds, 'f', 3, 64),
-			strconv.Itoa(cell.HardEventsPerSecond), strconv.Itoa(cell.InteractiveEventsPerSecond), strconv.Itoa(cell.RecommendedEventsPerSecond),
+			strconv.Itoa(cell.HardEventsPerSecond), strconv.Itoa(cell.LowestHardFailurePerSecond),
+			strconv.Itoa(cell.InteractiveEventsPerSecond), strconv.Itoa(cell.LowestInteractiveFailureRate), strconv.Itoa(cell.RecommendedEventsPerSecond),
 			strconv.FormatInt(cell.PeakMemoryBytes, 10), strconv.FormatInt(cell.CapacityPeakMemoryBytes, 10), strconv.FormatFloat(cell.CapacityCPUUtilizationPercent, 'f', 3, 64),
 			strconv.FormatFloat(cell.BoundaryHTTPP95MS, 'f', 3, 64), strconv.FormatFloat(cell.BoundaryHTTPP99MS, 'f', 3, 64),
+			strconv.FormatFloat(cell.AnalysisLatencyP50MS, 'f', 3, 64), strconv.FormatFloat(cell.AnalysisLatencyP95MS, 'f', 3, 64),
+			strconv.FormatFloat(cell.AnalysisLatencyP99MS, 'f', 3, 64), strconv.FormatFloat(cell.AnalysisLatencyMaxMS, 'f', 3, 64),
+			strconv.FormatInt(cell.AnalysisLatencySamples, 10), strconv.FormatInt(cell.AnalysisLatencyErrors, 10), cell.AnalysisLatencyStatus,
 			cell.DashboardStatus, cell.SlowestDashboardPath, strconv.FormatFloat(cell.SlowestDashboardP99MS, 'f', 3, 64), strconv.FormatBool(cell.SharedDriver), cell.Error,
 		})
 	}
@@ -285,29 +356,33 @@ func writeReportMarkdown(path string, summary RunSummary) error {
 	report.WriteString("# CPA Usage Keeper Capacity Benchmark\n\n")
 	report.WriteString("> 容量结果与建议适用于本次记录的 linux/amd64 硬件规格、数据集指纹和 Keeper 二进制。\n\n")
 	report.WriteString("## Hardware recommendations\n\n")
-	report.WriteString("| Dataset | Resource | Ingestion max | Dashboard max | Recommended | CPU avg | Core p95 / overall p99 | Peak memory | Note |\n")
-	report.WriteString("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n")
+	report.WriteString("| Dataset | Resource | Ingestion 5m pass / lowest fail | Dashboard 5m pass / lowest fail | Recommended | CPU avg | Core p95 / p99 | Analysis Latency samples / p99 / status | Peak memory | Note |\n")
+	report.WriteString("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n")
 	for _, item := range summary.Hardware {
 		note := item.Guidance
 		if item.SharedDriver {
 			note += "；Keeper 与负载器共享宿主 CPU，结果偏保守"
 		}
-		report.WriteString(fmt.Sprintf("| %s | %s | %d | %d | %d | %.1f%% | %.1f / %.1f ms | %.1f MiB | %s |\n",
-			item.DatasetID, item.ResourceID, item.IngestionMaxEventsPerSecond, item.DashboardMaxEventsPerSecond, item.RecommendedEventsPerSecond,
-			item.CPUUtilizationPercent, item.CoreP95MS, item.OverallP99MS, float64(item.PeakMemoryBytes)/(1024*1024), note))
+		report.WriteString(fmt.Sprintf("| %s | %s | %d / %d | %d / %d | %d | %.1f%% | %.1f / %.1f ms | %d / %.1f ms / %s | %.1f MiB | %s |\n",
+			item.DatasetID, item.ResourceID, item.IngestionMaxEventsPerSecond, item.IngestionLowestFailureRate,
+			item.DashboardMaxEventsPerSecond, item.DashboardLowestFailureRate, item.RecommendedEventsPerSecond,
+			item.CPUUtilizationPercent, item.CoreP95MS, item.CoreP99MS, item.AnalysisLatencySamples, item.AnalysisLatencyP99MS, item.AnalysisLatencyStatus, float64(item.PeakMemoryBytes)/(1024*1024), note))
 	}
 	report.WriteString("\n## Cells\n\n")
-	report.WriteString("| Cell | Cardinality I/M/K | Resource | Status | Ingestion max | Dashboard max | CPU avg / peak memory | Dashboard status | Core p95 / overall p99 | Slowest endpoint p99 |\n")
-	report.WriteString("| --- | ---: | --- | --- | ---: | ---: | ---: | --- | ---: | --- |\n")
+	report.WriteString("| Cell | Cardinality I/M/K | Resource | Status | Ingestion 5m pass / lowest fail | Dashboard 5m pass / lowest fail | CPU avg / peak memory | Dashboard status | Core p95 / p99 | Analysis Latency samples/errors/status and p50/p95/p99/max | Slowest core endpoint p99 |\n")
+	report.WriteString("| --- | ---: | --- | --- | ---: | ---: | ---: | --- | ---: | ---: | --- |\n")
 	for _, cell := range summary.Cells {
 		slowest := "-"
 		if cell.SlowestDashboardPath != "" {
 			slowest = fmt.Sprintf("%s %.1f ms", cell.SlowestDashboardPath, cell.SlowestDashboardP99MS)
 		}
-		report.WriteString(fmt.Sprintf("| %s | %d/%d/%d | %s | %s | %d | %d | %.1f%% / %.1f MiB | %s | %.1f / %.1f ms | %s |\n",
+		report.WriteString(fmt.Sprintf("| %s | %d/%d/%d | %s | %s | %d / %d | %d / %d | %.1f%% / %.1f MiB | %s | %.1f / %.1f ms | %d/%d/%s; %.1f/%.1f/%.1f/%.1f ms | %s |\n",
 			cell.CellID, cell.Identities, cell.Models, cell.APIKeys, cell.ResourceID, cell.Status,
-			cell.HardEventsPerSecond, cell.InteractiveEventsPerSecond, cell.CapacityCPUUtilizationPercent, float64(cell.CapacityPeakMemoryBytes)/(1024*1024),
-			cell.DashboardStatus, cell.BoundaryHTTPP95MS, cell.BoundaryHTTPP99MS, slowest))
+			cell.HardEventsPerSecond, cell.LowestHardFailurePerSecond, cell.InteractiveEventsPerSecond, cell.LowestInteractiveFailureRate,
+			cell.CapacityCPUUtilizationPercent, float64(cell.CapacityPeakMemoryBytes)/(1024*1024),
+			cell.DashboardStatus, cell.BoundaryHTTPP95MS, cell.BoundaryHTTPP99MS,
+			cell.AnalysisLatencySamples, cell.AnalysisLatencyErrors, cell.AnalysisLatencyStatus,
+			cell.AnalysisLatencyP50MS, cell.AnalysisLatencyP95MS, cell.AnalysisLatencyP99MS, cell.AnalysisLatencyMaxMS, slowest))
 	}
 	if summary.Failures > 0 {
 		report.WriteString(fmt.Sprintf("\nFailures: %d. Inspect each cell's result and logs before using recommendations.\n", summary.Failures))

--- a/internal/benchmark/capacity/test/capacity_test.go
+++ b/internal/benchmark/capacity/test/capacity_test.go
@@ -1,0 +1,162 @@
+package capacity_test
+
+import (
+	"reflect"
+	"testing"
+
+	"cpa-usage-keeper/internal/benchmark/capacity"
+)
+
+func TestCapacitySearchUsesBoundedDiscreteBinarySearch(t *testing.T) {
+	search, err := capacity.NewCapacitySearch([]int{1, 2, 5, 10, 20, 30, 35, 40, 50, 75, 100})
+	if err != nil {
+		t.Fatalf("NewCapacitySearch returned error: %v", err)
+	}
+	var seen []int
+	for {
+		rate, ok := search.Next()
+		if !ok {
+			break
+		}
+		seen = append(seen, rate)
+		search.Record(rate, rate <= 32)
+	}
+	if len(seen) > 4 {
+		t.Fatalf("probe count=%d, want at most 4: %v", len(seen), seen)
+	}
+	if search.HardCapacity() != 30 {
+		t.Fatalf("hard capacity=%d, want highest passing configured rate 30", search.HardCapacity())
+	}
+}
+
+func TestCapacitySearchStopsWhenFirstRateFails(t *testing.T) {
+	search, err := capacity.NewCapacitySearch([]int{1, 2, 5})
+	if err != nil {
+		t.Fatalf("NewCapacitySearch returned error: %v", err)
+	}
+	for {
+		rate, ok := search.Next()
+		if !ok {
+			break
+		}
+		search.Record(rate, false)
+	}
+	if search.HardCapacity() != 0 {
+		t.Fatalf("hard capacity=%d", search.HardCapacity())
+	}
+}
+
+func TestCapacitySearchReturnsHighestRateWhenEveryProbePasses(t *testing.T) {
+	search, err := capacity.NewCapacitySearch([]int{100, 200, 300, 400, 500, 750, 1000, 1500, 2000, 3000, 5000})
+	if err != nil {
+		t.Fatalf("NewCapacitySearch returned error: %v", err)
+	}
+	var seen []int
+	for {
+		rate, ok := search.Next()
+		if !ok {
+			break
+		}
+		seen = append(seen, rate)
+		search.Record(rate, true)
+	}
+	if len(seen) > 4 {
+		t.Fatalf("probe count=%d, want at most 4: %v", len(seen), seen)
+	}
+	if search.HardCapacity() != 5000 {
+		t.Fatalf("hard capacity=%d, want 5000", search.HardCapacity())
+	}
+}
+
+func TestEvaluateProbeSeparatesHardAndInteractiveCapacity(t *testing.T) {
+	result := capacity.ProbeMetrics{
+		OfferedEvents: 10_000, PublishedEvents: 10_000, DurableEvents: 9_995,
+		BacklogStart: 0, BacklogEnd: 0, HTTPRequests: 1000,
+		HTTPP95MS: 650, HTTPP99MS: 1800,
+	}
+	evaluation := capacity.EvaluateProbe(result, capacity.ProbeThresholds{MinDurableRatio: 0.99, InteractiveP95MS: 500, InteractiveP99MS: 2000})
+	if !evaluation.HardPass {
+		t.Fatalf("hard capacity should pass: %+v", evaluation)
+	}
+	if evaluation.InteractivePass {
+		t.Fatalf("interactive capacity should fail p95: %+v", evaluation)
+	}
+}
+
+func TestEvaluateProbeRejectsOOMErrorsAndGrowingBacklog(t *testing.T) {
+	for _, metrics := range []capacity.ProbeMetrics{
+		{OfferedEvents: 100, PublishedEvents: 100, DurableEvents: 100, OOM: true},
+		{OfferedEvents: 100, PublishedEvents: 100, DurableEvents: 100, Errors: 1},
+		{OfferedEvents: 100, PublishedEvents: 100, DurableEvents: 100, BacklogStart: 0, BacklogEnd: 10},
+	} {
+		evaluation := capacity.EvaluateProbe(metrics, capacity.ProbeThresholds{MinDurableRatio: 0.99, MaxBacklogGrowth: 0})
+		if evaluation.HardPass {
+			t.Fatalf("probe should fail: metrics=%+v evaluation=%+v", metrics, evaluation)
+		}
+	}
+}
+
+func TestEvaluateProbeRejectsDriverLag(t *testing.T) {
+	evaluation := capacity.EvaluateProbe(capacity.ProbeMetrics{
+		OfferedEvents: 1000, PublishedEvents: 900, DurableEvents: 900,
+	}, capacity.ProbeThresholds{MinDurableRatio: 0.99})
+	if evaluation.HardPass {
+		t.Fatalf("driver lag should fail: %+v", evaluation)
+	}
+	found := false
+	for _, reason := range evaluation.Reasons {
+		if reason == "driver_lag" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("driver_lag reason missing: %+v", evaluation)
+	}
+}
+
+func TestEvaluateProbeAllowsSubPermilleSchedulerTail(t *testing.T) {
+	evaluation := capacity.EvaluateProbe(capacity.ProbeMetrics{
+		OfferedEvents: 15_000, PublishedEvents: 14_998, DurableEvents: 14_998,
+	}, capacity.ProbeThresholds{MinDurableRatio: 0.99})
+	if !evaluation.HardPass {
+		t.Fatalf("sub-permille ticker tail must not become driver lag: %+v", evaluation)
+	}
+}
+
+func TestEvaluateProbeAllowsOneLowRateDeliveryTail(t *testing.T) {
+	evaluation := capacity.EvaluateProbe(capacity.ProbeMetrics{
+		OfferedEvents: 30, PublishedEvents: 30, DurableEvents: 29,
+		BacklogStart: 0, BacklogEnd: 0, CheckpointLag: 0, IdentityPending: 0,
+	}, capacity.ProbeThresholds{MinDurableRatio: 0.99})
+	if !evaluation.HardPass {
+		t.Fatalf("one fully drained low-rate delivery tail must not fail the cell: %+v", evaluation)
+	}
+}
+
+func TestOOMProbeIsCapacityFailureNotCellInfrastructureFailure(t *testing.T) {
+	oom := capacity.ProbeAttempt{Error: "Keeper exited before health check", Report: capacity.ProbeReport{Metrics: capacity.ProbeMetrics{OOM: true}}}
+	if capacity.IsCapacityAttemptInfrastructureFailure(oom) {
+		t.Fatal("OOM probe must remain a capacity boundary result")
+	}
+	for _, attempt := range []capacity.ProbeAttempt{
+		{Error: "sampler failed"},
+		{Report: capacity.ProbeReport{Metrics: capacity.ProbeMetrics{Panic: true}}},
+	} {
+		if !capacity.IsCapacityAttemptInfrastructureFailure(attempt) {
+			t.Fatalf("non-OOM probe failure must remain terminal: %+v", attempt)
+		}
+	}
+}
+
+func TestSelectBoundaryCandidatesKeepsTopAndConservativeHalf(t *testing.T) {
+	var attempts []capacity.ProbeAttempt
+	for _, rate := range []int{1, 5, 20, 100, 200, 300, 350, 375} {
+		attempts = append(attempts, capacity.ProbeAttempt{
+			Phase: "search", RatePerSecond: rate,
+			Report: capacity.ProbeReport{Evaluation: capacity.ProbeEvaluation{HardPass: true}},
+		})
+	}
+	if got := capacity.SelectBoundaryCandidates(attempts, 375, 2); !reflect.DeepEqual(got, []int{375, 100}) {
+		t.Fatalf("boundary candidates=%v, want [375 100]", got)
+	}
+}

--- a/internal/benchmark/capacity/test/capacity_test.go
+++ b/internal/benchmark/capacity/test/capacity_test.go
@@ -2,12 +2,13 @@ package capacity_test
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	"cpa-usage-keeper/internal/benchmark/capacity"
 )
 
-func TestCapacitySearchUsesBoundedDiscreteBinarySearch(t *testing.T) {
+func TestCapacitySearchRampsFromLowestRateThenBisectsBoundary(t *testing.T) {
 	search, err := capacity.NewCapacitySearch([]int{1, 2, 5, 10, 20, 30, 35, 40, 50, 75, 100})
 	if err != nil {
 		t.Fatalf("NewCapacitySearch returned error: %v", err)
@@ -21,11 +22,14 @@ func TestCapacitySearchUsesBoundedDiscreteBinarySearch(t *testing.T) {
 		seen = append(seen, rate)
 		search.Record(rate, rate <= 32)
 	}
-	if len(seen) > 4 {
-		t.Fatalf("probe count=%d, want at most 4: %v", len(seen), seen)
+	if want := []int{1, 2, 5, 10, 20, 40, 30, 35}; !reflect.DeepEqual(seen, want) {
+		t.Fatalf("probe order=%v, want %v", seen, want)
 	}
 	if search.HardCapacity() != 30 {
 		t.Fatalf("hard capacity=%d, want highest passing configured rate 30", search.HardCapacity())
+	}
+	if search.FailureBoundary() != 35 {
+		t.Fatalf("failure boundary=%d, want lowest failing configured rate 35", search.FailureBoundary())
 	}
 }
 
@@ -46,6 +50,28 @@ func TestCapacitySearchStopsWhenFirstRateFails(t *testing.T) {
 	}
 }
 
+func TestCapacitySearchStartsAtConfiguredRateAndFallsBackBelowIt(t *testing.T) {
+	search, err := capacity.NewCapacitySearchAt([]int{1, 5, 10, 15, 20, 25, 50}, 25)
+	if err != nil {
+		t.Fatalf("NewCapacitySearchAt returned error: %v", err)
+	}
+	var seen []int
+	for {
+		rate, ok := search.Next()
+		if !ok {
+			break
+		}
+		seen = append(seen, rate)
+		search.Record(rate, rate <= 20)
+	}
+	if want := []int{25, 10, 15, 20}; !reflect.DeepEqual(seen, want) {
+		t.Fatalf("probe order=%v, want %v", seen, want)
+	}
+	if search.HardCapacity() != 20 || search.FailureBoundary() != 25 {
+		t.Fatalf("capacity boundary=%d..%d, want 20..25", search.HardCapacity(), search.FailureBoundary())
+	}
+}
+
 func TestCapacitySearchReturnsHighestRateWhenEveryProbePasses(t *testing.T) {
 	search, err := capacity.NewCapacitySearch([]int{100, 200, 300, 400, 500, 750, 1000, 1500, 2000, 3000, 5000})
 	if err != nil {
@@ -60,11 +86,42 @@ func TestCapacitySearchReturnsHighestRateWhenEveryProbePasses(t *testing.T) {
 		seen = append(seen, rate)
 		search.Record(rate, true)
 	}
-	if len(seen) > 4 {
-		t.Fatalf("probe count=%d, want at most 4: %v", len(seen), seen)
+	if want := []int{100, 200, 400, 1000, 2000, 5000}; !reflect.DeepEqual(seen, want) {
+		t.Fatalf("probe order=%v, want %v", seen, want)
 	}
 	if search.HardCapacity() != 5000 {
 		t.Fatalf("hard capacity=%d, want 5000", search.HardCapacity())
+	}
+	if search.FailureBoundary() != 0 {
+		t.Fatalf("failure boundary=%d, want no observed failure", search.FailureBoundary())
+	}
+}
+
+func TestCapacitySearchCanPromoteAConfirmedBoundaryPass(t *testing.T) {
+	search, err := capacity.NewCapacitySearch([]int{25, 50, 100, 200, 400})
+	if err != nil {
+		t.Fatalf("NewCapacitySearch returned error: %v", err)
+	}
+	for {
+		rate, ok := search.Next()
+		if !ok {
+			break
+		}
+		search.Record(rate, rate <= 100)
+	}
+	if search.HardCapacity() != 100 || search.FailureBoundary() != 200 {
+		t.Fatalf("initial boundary=%d..%d, want 100..200", search.HardCapacity(), search.FailureBoundary())
+	}
+	if err := search.PromoteFailure(200); err != nil {
+		t.Fatalf("PromoteFailure returned error: %v", err)
+	}
+	rate, ok := search.Next()
+	if !ok || rate != 400 {
+		t.Fatalf("next rate=%d ok=%v, want 400", rate, ok)
+	}
+	search.Record(rate, true)
+	if search.HardCapacity() != 400 || search.FailureBoundary() != 0 {
+		t.Fatalf("promoted boundary=%d..%d, want 400 with no failure", search.HardCapacity(), search.FailureBoundary())
 	}
 }
 
@@ -80,6 +137,32 @@ func TestEvaluateProbeSeparatesHardAndInteractiveCapacity(t *testing.T) {
 	}
 	if evaluation.InteractivePass {
 		t.Fatalf("interactive capacity should fail p95: %+v", evaluation)
+	}
+}
+
+func TestEvaluateProbeSeparatesCoreAndAnalysisLatencyErrors(t *testing.T) {
+	diagnosticFailure := capacity.EvaluateProbe(capacity.ProbeMetrics{
+		OfferedEvents: 100, PublishedEvents: 100, DurableEvents: 100,
+		HTTPRequests: 10, AnalysisLatencyErrors: 1,
+	}, capacity.ProbeThresholds{MinDurableRatio: 0.99, InteractiveP99MS: 3000})
+	if !diagnosticFailure.HardPass || !diagnosticFailure.InteractivePass || diagnosticFailure.AnalysisLatencyPass {
+		t.Fatalf("analysis latency errors must remain a separate diagnostic failure: %+v", diagnosticFailure)
+	}
+
+	coreFailure := capacity.EvaluateProbe(capacity.ProbeMetrics{
+		OfferedEvents: 100, PublishedEvents: 100, DurableEvents: 100,
+		HTTPRequests: 10, CoreHTTPErrors: 1,
+	}, capacity.ProbeThresholds{MinDurableRatio: 0.99, InteractiveP99MS: 3000})
+	if !coreFailure.HardPass || coreFailure.InteractivePass || !coreFailure.AnalysisLatencyPass {
+		t.Fatalf("core HTTP errors must fail only the interactive gate: %+v", coreFailure)
+	}
+
+	ingestionFailure := capacity.EvaluateProbe(capacity.ProbeMetrics{
+		OfferedEvents: 100, PublishedEvents: 100, DurableEvents: 50,
+		AnalysisLatencyRequests: 1,
+	}, capacity.ProbeThresholds{MinDurableRatio: 0.99, InteractiveP99MS: 3000})
+	if ingestionFailure.HardPass || ingestionFailure.InteractivePass || !ingestionFailure.AnalysisLatencyPass {
+		t.Fatalf("ingestion failure must not relabel a successful diagnostic request: %+v", ingestionFailure)
 	}
 }
 
@@ -133,6 +216,19 @@ func TestEvaluateProbeAllowsOneLowRateDeliveryTail(t *testing.T) {
 	}
 }
 
+func TestEvaluateProbeRejectsDrainBeyondStabilityBudget(t *testing.T) {
+	evaluation := capacity.EvaluateProbe(capacity.ProbeMetrics{
+		OfferedEvents: 30_000, PublishedEvents: 30_000, DurableEvents: 30_000,
+		DrainSeconds: 5.1,
+	}, capacity.ProbeThresholds{MinDurableRatio: 0.99, MaxDrainSeconds: 5})
+	if evaluation.HardPass {
+		t.Fatalf("probe that needs excessive catch-up must fail: %+v", evaluation)
+	}
+	if !slices.Contains(evaluation.Reasons, "drain_lag") {
+		t.Fatalf("drain_lag reason missing: %+v", evaluation)
+	}
+}
+
 func TestOOMProbeIsCapacityFailureNotCellInfrastructureFailure(t *testing.T) {
 	oom := capacity.ProbeAttempt{Error: "Keeper exited before health check", Report: capacity.ProbeReport{Metrics: capacity.ProbeMetrics{OOM: true}}}
 	if capacity.IsCapacityAttemptInfrastructureFailure(oom) {
@@ -158,5 +254,33 @@ func TestSelectBoundaryCandidatesKeepsTopAndConservativeHalf(t *testing.T) {
 	}
 	if got := capacity.SelectBoundaryCandidates(attempts, 375, 2); !reflect.DeepEqual(got, []int{375, 100}) {
 		t.Fatalf("boundary candidates=%v, want [375 100]", got)
+	}
+}
+
+func TestSelectBoundaryCandidatesKeepsMinimumPassingFallback(t *testing.T) {
+	var attempts []capacity.ProbeAttempt
+	for _, rate := range []int{25, 50, 100, 200, 300, 350, 375} {
+		attempts = append(attempts, capacity.ProbeAttempt{
+			Phase: "search", RatePerSecond: rate,
+			Report: capacity.ProbeReport{Evaluation: capacity.ProbeEvaluation{HardPass: true}},
+		})
+	}
+	if got := capacity.SelectBoundaryCandidates(attempts, 375, 3); !reflect.DeepEqual(got, []int{375, 100, 25}) {
+		t.Fatalf("boundary candidates=%v, want [375 100 25]", got)
+	}
+}
+
+func TestNormalizeFailureBoundaryKeepsOnlyStrictUpperBound(t *testing.T) {
+	for _, test := range []struct {
+		pass, failure, want int
+	}{
+		{pass: 100, failure: 125, want: 125},
+		{pass: 100, failure: 100, want: 0},
+		{pass: 100, failure: 75, want: 0},
+		{pass: 100, failure: 0, want: 0},
+	} {
+		if got := capacity.NormalizeFailureBoundary(test.pass, test.failure); got != test.want {
+			t.Fatalf("NormalizeFailureBoundary(%d, %d)=%d, want %d", test.pass, test.failure, got, test.want)
+		}
 	}
 }

--- a/internal/benchmark/capacity/test/dataset_test.go
+++ b/internal/benchmark/capacity/test/dataset_test.go
@@ -1,0 +1,119 @@
+package capacity_test
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/benchmark/capacity"
+)
+
+func TestDatasetResultJSONOmitsLocalPath(t *testing.T) {
+	data, err := json.Marshal(capacity.DatasetResult{Path: "/private/benchmark/reference.db", HotEvents: 1})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if strings.Contains(string(data), "/private/") || strings.Contains(string(data), "path") {
+		t.Fatalf("dataset JSON leaked a local path: %s", data)
+	}
+}
+
+func TestGenerateDatasetBuildsValidatedSteadyState(t *testing.T) {
+	location := time.FixedZone("Asia/Shanghai", 8*60*60)
+	options := capacity.GenerateOptions{
+		Path:          filepath.Join(t.TempDir(), "dataset.db"),
+		HotEvents:     400,
+		ArchiveEvents: 50,
+		HotDays:       90,
+		ArchiveDays:   7,
+		FailureRate:   0.041818,
+		Seed:          20260806,
+		Now:           time.Date(2026, 8, 6, 15, 0, 0, 0, location),
+		Cardinality:   capacity.Cardinality{Identities: 12, Models: 6, APIKeys: 4},
+		TrafficTiers: []capacity.TrafficTier{
+			{Name: "high", KeyShare: 0.30, PerKeyWeight: 10},
+			{Name: "medium", KeyShare: 0.50, PerKeyWeight: 3},
+			{Name: "low", KeyShare: 0.20, PerKeyWeight: 1},
+		},
+		InsertBatchSize: 100,
+		AggregatePage:   200,
+	}
+
+	result, err := capacity.GenerateDataset(context.Background(), options)
+	if err != nil {
+		t.Fatalf("GenerateDataset returned error: %v", err)
+	}
+	if result.HotEvents != 400 || result.ArchiveEvents != 50 || result.TotalEvents != 450 {
+		t.Fatalf("unexpected generated counts: %+v", result)
+	}
+	if result.Identities != 12 || result.Models != 6 || result.APIKeys != 4 {
+		t.Fatalf("unexpected cardinality: %+v", result)
+	}
+	if result.UsedIdentities != result.Identities || result.UsedModels != result.Models || result.UsedAPIKeys != result.APIKeys {
+		t.Fatalf("every valid metadata row must be exercised: %+v", result)
+	}
+	if result.OrphanIdentities != 0 || result.OrphanModels != 0 || result.OrphanAPIKeys != 0 {
+		t.Fatalf("generated dataset contains orphan metadata: %+v", result)
+	}
+	if result.TokenSemanticViolations != 0 {
+		t.Fatalf("generated dataset contains non-canonical token rows: %+v", result)
+	}
+	if result.DuplicateEventKeys == 0 {
+		t.Fatal("generated dataset should preserve controlled duplicate event keys")
+	}
+	if result.OverviewHourlyRequests != 450 || result.OverviewDailyRequests != 450 || result.IdentityRequests != 450 {
+		t.Fatalf("derived totals do not match raw events: %+v", result)
+	}
+	if result.QuickCheck != "ok" {
+		t.Fatalf("quick check=%q", result.QuickCheck)
+	}
+}
+
+func TestGenerateDatasetIsSemanticallyDeterministic(t *testing.T) {
+	location := time.FixedZone("Asia/Shanghai", 8*60*60)
+	base := capacity.GenerateOptions{
+		HotEvents:     120,
+		ArchiveEvents: 12,
+		HotDays:       30,
+		ArchiveDays:   2,
+		FailureRate:   0.05,
+		Seed:          99,
+		Now:           time.Date(2026, 8, 6, 15, 0, 0, 0, location),
+		Cardinality:   capacity.Cardinality{Identities: 6, Models: 4, APIKeys: 4},
+		TrafficTiers: []capacity.TrafficTier{
+			{Name: "high", KeyShare: 0.30, PerKeyWeight: 10},
+			{Name: "medium", KeyShare: 0.50, PerKeyWeight: 3},
+			{Name: "low", KeyShare: 0.20, PerKeyWeight: 1},
+		},
+		InsertBatchSize: 50,
+		AggregatePage:   100,
+	}
+	firstOptions := base
+	firstOptions.Path = filepath.Join(t.TempDir(), "first.db")
+	secondOptions := base
+	secondOptions.Path = filepath.Join(t.TempDir(), "second.db")
+	first, err := capacity.GenerateDataset(context.Background(), firstOptions)
+	if err != nil {
+		t.Fatalf("first GenerateDataset returned error: %v", err)
+	}
+	second, err := capacity.GenerateDataset(context.Background(), secondOptions)
+	if err != nil {
+		t.Fatalf("second GenerateDataset returned error: %v", err)
+	}
+	if first.SemanticFingerprint != second.SemanticFingerprint {
+		t.Fatalf("semantic fingerprints differ: %q != %q", first.SemanticFingerprint, second.SemanticFingerprint)
+	}
+	thirdOptions := base
+	thirdOptions.Path = filepath.Join(t.TempDir(), "third.db")
+	thirdOptions.Seed++
+	third, err := capacity.GenerateDataset(context.Background(), thirdOptions)
+	if err != nil {
+		t.Fatalf("third GenerateDataset returned error: %v", err)
+	}
+	if first.SemanticFingerprint == third.SemanticFingerprint {
+		t.Fatalf("different seeds must produce different fingerprints: %q", first.SemanticFingerprint)
+	}
+}

--- a/internal/benchmark/capacity/test/dataset_test.go
+++ b/internal/benchmark/capacity/test/dataset_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -24,15 +25,16 @@ func TestDatasetResultJSONOmitsLocalPath(t *testing.T) {
 func TestGenerateDatasetBuildsValidatedSteadyState(t *testing.T) {
 	location := time.FixedZone("Asia/Shanghai", 8*60*60)
 	options := capacity.GenerateOptions{
-		Path:          filepath.Join(t.TempDir(), "dataset.db"),
-		HotEvents:     400,
-		ArchiveEvents: 50,
-		HotDays:       90,
-		ArchiveDays:   7,
-		FailureRate:   0.041818,
-		Seed:          20260806,
-		Now:           time.Date(2026, 8, 6, 15, 0, 0, 0, location),
-		Cardinality:   capacity.Cardinality{Identities: 12, Models: 6, APIKeys: 4},
+		Path:              filepath.Join(t.TempDir(), "dataset.db"),
+		HotEvents:         400,
+		Recent30DayEvents: 250,
+		ArchiveEvents:     50,
+		HotDays:           90,
+		ArchiveDays:       7,
+		FailureRate:       0.041818,
+		Seed:              20260806,
+		Now:               time.Date(2026, 8, 6, 15, 0, 0, 0, location),
+		Cardinality:       capacity.Cardinality{Identities: 12, Models: 6, APIKeys: 4},
 		TrafficTiers: []capacity.TrafficTier{
 			{Name: "high", KeyShare: 0.30, PerKeyWeight: 10},
 			{Name: "medium", KeyShare: 0.50, PerKeyWeight: 3},
@@ -48,6 +50,12 @@ func TestGenerateDatasetBuildsValidatedSteadyState(t *testing.T) {
 	}
 	if result.HotEvents != 400 || result.ArchiveEvents != 50 || result.TotalEvents != 450 {
 		t.Fatalf("unexpected generated counts: %+v", result)
+	}
+	if result.Recent30DayEvents != 250 {
+		t.Fatalf("recent 30-day events=%d, want 250", result.Recent30DayEvents)
+	}
+	if result.FailureRate != options.FailureRate || !reflect.DeepEqual(result.TrafficTiers, options.TrafficTiers) {
+		t.Fatalf("generation config=%v/%+v, want %v/%+v", result.FailureRate, result.TrafficTiers, options.FailureRate, options.TrafficTiers)
 	}
 	if result.Identities != 12 || result.Models != 6 || result.APIKeys != 4 {
 		t.Fatalf("unexpected cardinality: %+v", result)
@@ -75,14 +83,15 @@ func TestGenerateDatasetBuildsValidatedSteadyState(t *testing.T) {
 func TestGenerateDatasetIsSemanticallyDeterministic(t *testing.T) {
 	location := time.FixedZone("Asia/Shanghai", 8*60*60)
 	base := capacity.GenerateOptions{
-		HotEvents:     120,
-		ArchiveEvents: 12,
-		HotDays:       30,
-		ArchiveDays:   2,
-		FailureRate:   0.05,
-		Seed:          99,
-		Now:           time.Date(2026, 8, 6, 15, 0, 0, 0, location),
-		Cardinality:   capacity.Cardinality{Identities: 6, Models: 4, APIKeys: 4},
+		HotEvents:         120,
+		Recent30DayEvents: 120,
+		ArchiveEvents:     12,
+		HotDays:           30,
+		ArchiveDays:       2,
+		FailureRate:       0.05,
+		Seed:              99,
+		Now:               time.Date(2026, 8, 6, 15, 0, 0, 0, location),
+		Cardinality:       capacity.Cardinality{Identities: 6, Models: 4, APIKeys: 4},
 		TrafficTiers: []capacity.TrafficTier{
 			{Name: "high", KeyShare: 0.30, PerKeyWeight: 10},
 			{Name: "medium", KeyShare: 0.50, PerKeyWeight: 3},
@@ -115,5 +124,65 @@ func TestGenerateDatasetIsSemanticallyDeterministic(t *testing.T) {
 	}
 	if first.SemanticFingerprint == third.SemanticFingerprint {
 		t.Fatalf("different seeds must produce different fingerprints: %q", first.SemanticFingerprint)
+	}
+}
+
+func TestValidateDatasetAgainstManifestRejectsStaleOrMismatchedMetadata(t *testing.T) {
+	queryAnchor := time.Date(2026, 8, 9, 12, 0, 0, 0, time.FixedZone("Asia/Shanghai", 8*60*60))
+	actual := capacity.DatasetResult{
+		QueryAnchor: queryAnchor, EventTimeMax: queryAnchor.Add(-24 * time.Hour), Recent30DayEvents: 90,
+		HotEvents: 90, ArchiveEvents: 10, TotalEvents: 100,
+		Identities: 3, Models: 2, APIKeys: 2, UsedIdentities: 3, UsedModels: 2, UsedAPIKeys: 2,
+		OverviewHourlyRequests: 100, OverviewDailyRequests: 100, IdentityRequests: 100,
+		CheckpointMin: 100, CheckpointMax: 100, QuickCheck: "ok", SemanticFingerprint: "fingerprint",
+	}
+	metadata := actual
+	metadata.GeneratorVersion = capacity.DatasetGeneratorVersion
+	metadata.Seed = 42
+	metadata.BenchmarkNow = queryAnchor.Add(-24 * time.Hour)
+	metadata.FailureRate = 0.01
+	metadata.TrafficTiers = []capacity.TrafficTier{{Name: "all", KeyShare: 1, PerKeyWeight: 1}}
+	manifest := capacity.Manifest{Dataset: capacity.DatasetSpec{
+		HotEvents: 90, Recent30DayEvents: 90, ArchiveEvents: 10, FailureRate: 0.01, Seed: 42, BenchmarkNow: "generation-time",
+		Cardinality: capacity.Cardinality{Identities: 3, Models: 2, APIKeys: 2},
+	}, TrafficTiers: []capacity.TrafficTier{{Name: "all", KeyShare: 1, PerKeyWeight: 1}}}
+	if err := capacity.ValidateDatasetAgainstManifest(actual, metadata, manifest); err != nil {
+		t.Fatalf("valid dataset rejected: %v", err)
+	}
+
+	mismatched := actual
+	mismatched.OrphanAPIKeys = 1
+	if err := capacity.ValidateDatasetAgainstManifest(mismatched, metadata, manifest); err == nil {
+		t.Fatal("orphan API key must fail strict validation")
+	}
+
+	stale := actual
+	stale.EventTimeMax = queryAnchor.Add(-8 * 24 * time.Hour)
+	if err := capacity.ValidateDatasetAgainstManifest(stale, metadata, manifest); err == nil {
+		t.Fatal("dataset older than the freshness window must fail")
+	}
+
+	wrongMetadata := metadata
+	wrongMetadata.OverviewDailyRows++
+	if err := capacity.ValidateDatasetAgainstManifest(actual, wrongMetadata, manifest); err == nil {
+		t.Fatal("dataset statistics must match dataset.json")
+	}
+
+	wrongRecentWindow := metadata
+	wrongRecentWindow.Recent30DayEvents--
+	if err := capacity.ValidateDatasetAgainstManifest(actual, wrongRecentWindow, manifest); err == nil {
+		t.Fatal("generation-time recent 30-day count must match the manifest")
+	}
+
+	wrongFailureRate := metadata
+	wrongFailureRate.FailureRate = 0.02
+	if err := capacity.ValidateDatasetAgainstManifest(actual, wrongFailureRate, manifest); err == nil {
+		t.Fatal("dataset failure rate must match the manifest")
+	}
+
+	wrongTrafficTiers := metadata
+	wrongTrafficTiers.TrafficTiers = []capacity.TrafficTier{{Name: "all", KeyShare: 1, PerKeyWeight: 2}}
+	if err := capacity.ValidateDatasetAgainstManifest(actual, wrongTrafficTiers, manifest); err == nil {
+		t.Fatal("dataset traffic tiers must match the manifest")
 	}
 }

--- a/internal/benchmark/capacity/test/manifest_test.go
+++ b/internal/benchmark/capacity/test/manifest_test.go
@@ -1,0 +1,151 @@
+package capacity_test
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"cpa-usage-keeper/internal/benchmark/capacity"
+)
+
+func TestLoadCapacityManifestAndExpandStablePlan(t *testing.T) {
+	manifestPath := filepath.Join("..", "..", "manifest", "capacity-v1.json")
+	manifest, err := capacity.LoadManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("LoadManifest returned error: %v", err)
+	}
+	if err := manifest.Validate(); err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	plan, err := capacity.ExpandPlan(manifest)
+	if err != nil {
+		t.Fatalf("ExpandPlan returned error: %v", err)
+	}
+	if len(plan.Cells) != 3 {
+		t.Fatalf("plan cells=%d, want 3", len(plan.Cells))
+	}
+	wantIDs := []string{
+		"capacity-reference-2m-1c-unlimited",
+		"capacity-reference-2m-2c-unlimited",
+		"capacity-reference-2m-4c-unlimited",
+	}
+	wantCPUs := []float64{1, 2, 4}
+	for index, cell := range plan.Cells {
+		if cell.ID != wantIDs[index] || cell.DatasetID != "reference-2m" || cell.HotEvents != 1_946_550 || cell.ArchiveEvents != 89_190 {
+			t.Fatalf("unexpected cell %d: %+v", index, cell)
+		}
+		if cell.Cardinality != (capacity.Cardinality{Identities: 323, Models: 52, APIKeys: 27}) || cell.Resource.CPU != wantCPUs[index] || cell.Resource.MemoryMiB != 0 {
+			t.Fatalf("unexpected cell capacity profile %d: %+v", index, cell)
+		}
+	}
+	if manifest.Search.DashboardCoreP95MS != 0 || manifest.Search.DashboardOverallP99MS != 3000 || manifest.Search.SoakSeconds != 300 || !manifest.Search.SearchDashboardCapacity {
+		t.Fatalf("unexpected dashboard policy: %+v", manifest.Search)
+	}
+	second, err := capacity.ExpandPlan(manifest)
+	if err != nil {
+		t.Fatalf("second ExpandPlan returned error: %v", err)
+	}
+	if !reflect.DeepEqual(plan, second) {
+		t.Fatal("same manifest must expand to an identical plan")
+	}
+}
+
+func TestLoadManifestRejectsHostSpecificFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "manifest.json")
+	data := []byte(`{"version":"capacity-v1","target":{"machine_label":"private-machine","os":"linux","arch":"amd64"}}`)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if _, err := capacity.LoadManifest(path); err == nil {
+		t.Fatal("host-specific manifest field must be rejected")
+	}
+}
+
+func TestAllocateTrafficTiersUsesKeyShares(t *testing.T) {
+	tiers := []capacity.TrafficTier{
+		{Name: "high", KeyShare: 0.30, PerKeyWeight: 10},
+		{Name: "medium", KeyShare: 0.50, PerKeyWeight: 3},
+		{Name: "low", KeyShare: 0.20, PerKeyWeight: 1},
+	}
+	profiles, err := capacity.BuildAPIKeyProfiles(100, tiers, 20260806)
+	if err != nil {
+		t.Fatalf("BuildAPIKeyProfiles returned error: %v", err)
+	}
+	counts := map[string]int{}
+	for _, profile := range profiles {
+		counts[profile.Tier]++
+	}
+	if !reflect.DeepEqual(counts, map[string]int{"high": 30, "medium": 50, "low": 20}) {
+		t.Fatalf("tier counts=%v", counts)
+	}
+	if !(profiles[0].Weight > profiles[30].Weight && profiles[30].Weight > profiles[80].Weight) {
+		t.Fatalf("tier weights are not ordered: high=%f medium=%f low=%f", profiles[0].Weight, profiles[30].Weight, profiles[80].Weight)
+	}
+}
+
+func TestAllocateTrafficTiersRoundsSmallKeySetsDeterministically(t *testing.T) {
+	tiers := []capacity.TrafficTier{
+		{Name: "high", KeyShare: 0.30, PerKeyWeight: 10},
+		{Name: "medium", KeyShare: 0.50, PerKeyWeight: 3},
+		{Name: "low", KeyShare: 0.20, PerKeyWeight: 1},
+	}
+	profiles, err := capacity.BuildAPIKeyProfiles(4, tiers, 7)
+	if err != nil {
+		t.Fatalf("BuildAPIKeyProfiles returned error: %v", err)
+	}
+	counts := map[string]int{}
+	for _, profile := range profiles {
+		counts[profile.Tier]++
+	}
+	if !reflect.DeepEqual(counts, map[string]int{"high": 1, "medium": 2, "low": 1}) {
+		t.Fatalf("tier counts=%v", counts)
+	}
+}
+
+func TestAllocateEventsPreservesExactTotalAndTierOrdering(t *testing.T) {
+	profiles, err := capacity.BuildAPIKeyProfiles(100, []capacity.TrafficTier{
+		{Name: "high", KeyShare: 0.30, PerKeyWeight: 10},
+		{Name: "medium", KeyShare: 0.50, PerKeyWeight: 3},
+		{Name: "low", KeyShare: 0.20, PerKeyWeight: 1},
+	}, 42)
+	if err != nil {
+		t.Fatalf("BuildAPIKeyProfiles returned error: %v", err)
+	}
+	allocations, err := capacity.AllocateEvents(2_035_740, profiles)
+	if err != nil {
+		t.Fatalf("AllocateEvents returned error: %v", err)
+	}
+	var total int64
+	tierTotals := map[string]int64{}
+	for index, count := range allocations {
+		total += count
+		tierTotals[profiles[index].Tier] += count
+	}
+	if total != 2_035_740 {
+		t.Fatalf("allocated total=%d", total)
+	}
+	if !(tierTotals["high"] > tierTotals["medium"] && tierTotals["medium"] > tierTotals["low"]) {
+		t.Fatalf("tier totals=%v", tierTotals)
+	}
+}
+
+func TestManifestRejectsInvalidCapacityBounds(t *testing.T) {
+	manifest := capacity.Manifest{
+		Version: "capacity-v1",
+		Target:  capacity.Target{OS: "linux", Arch: "amd64"},
+		Dataset: capacity.DatasetSpec{
+			ID: "reference-2m", HotEvents: 1, HotDays: 1, BenchmarkNow: "2026-08-06T16:00:00+08:00",
+			Cardinality: capacity.Cardinality{Identities: 1001, Models: 101, APIKeys: 101},
+		},
+		TrafficTiers: []capacity.TrafficTier{{Name: "all", KeyShare: 1, PerKeyWeight: 1}},
+		Resources:    []capacity.Resource{{ID: "1c-unlimited", CPU: 1, MemoryMiB: 0}},
+		Search: capacity.Search{
+			RatesPerSecond: []int{1}, ProbeSeconds: 1, BoundarySeconds: 1, BoundaryRepetitions: 1,
+			SoakSeconds: 1, MaxRunSeconds: 1, DashboardOverallP99MS: 3000, DashboardRequestsPerSecond: 1, RecommendedCapacityRate: 0.7,
+		},
+	}
+	if err := manifest.Validate(); err == nil {
+		t.Fatal("Validate should reject cardinality beyond capacity bounds")
+	}
+}

--- a/internal/benchmark/capacity/test/manifest_test.go
+++ b/internal/benchmark/capacity/test/manifest_test.go
@@ -1,13 +1,102 @@
 package capacity_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"testing"
+	"time"
 
 	"cpa-usage-keeper/internal/benchmark/capacity"
 )
+
+func TestPlanSchemaRequiresRecentThirtyDayEvents(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "schema", "plan.schema.json"))
+	if err != nil {
+		t.Fatalf("read plan schema: %v", err)
+	}
+	var schema struct {
+		Properties map[string]struct {
+			Items struct {
+				Required   []string                   `json:"required"`
+				Properties map[string]json.RawMessage `json:"properties"`
+			} `json:"items"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("decode plan schema: %v", err)
+	}
+	cells := schema.Properties["cells"].Items
+	required := false
+	for _, field := range cells.Required {
+		if field == "recent_30_day_events" {
+			required = true
+			break
+		}
+	}
+	if !required {
+		t.Fatal("plan schema must require recent_30_day_events")
+	}
+	var property struct {
+		Type    string `json:"type"`
+		Minimum int    `json:"minimum"`
+	}
+	if err := json.Unmarshal(cells.Properties["recent_30_day_events"], &property); err != nil {
+		t.Fatalf("decode recent_30_day_events property: %v", err)
+	}
+	if property.Type != "integer" || property.Minimum != 1 {
+		t.Fatalf("recent_30_day_events schema=%+v, want integer minimum 1", property)
+	}
+}
+
+func TestSuiteSchemaRequiresDrainStabilityBudget(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "schema", "suite.schema.json"))
+	if err != nil {
+		t.Fatalf("read suite schema: %v", err)
+	}
+	var schema struct {
+		Properties map[string]struct {
+			Required   []string                   `json:"required"`
+			Properties map[string]json.RawMessage `json:"properties"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("decode suite schema: %v", err)
+	}
+	search := schema.Properties["search"]
+	if !slices.Contains(search.Required, "initial_rate_per_second") {
+		t.Fatal("suite schema must require initial_rate_per_second")
+	}
+	var initialRate struct {
+		Type    string `json:"type"`
+		Minimum int    `json:"minimum"`
+	}
+	if err := json.Unmarshal(search.Properties["initial_rate_per_second"], &initialRate); err != nil {
+		t.Fatalf("decode initial_rate_per_second property: %v", err)
+	}
+	if initialRate.Type != "integer" || initialRate.Minimum != 1 {
+		t.Fatalf("initial_rate_per_second schema=%+v, want positive integer", initialRate)
+	}
+	if !slices.Contains(search.Required, "max_pass_drain_seconds") {
+		t.Fatal("suite schema must require max_pass_drain_seconds")
+	}
+	if !slices.Contains(search.Required, "analysis_latency_interval_seconds") {
+		t.Fatal("suite schema must require analysis_latency_interval_seconds")
+	}
+	var property struct {
+		Type    string `json:"type"`
+		Minimum int    `json:"minimum"`
+		Maximum int    `json:"maximum"`
+	}
+	if err := json.Unmarshal(search.Properties["max_pass_drain_seconds"], &property); err != nil {
+		t.Fatalf("decode max_pass_drain_seconds property: %v", err)
+	}
+	if property.Type != "integer" || property.Minimum != 1 || property.Maximum != 30 {
+		t.Fatalf("max_pass_drain_seconds schema=%+v, want integer range 1..30", property)
+	}
+}
 
 func TestLoadCapacityManifestAndExpandStablePlan(t *testing.T) {
 	manifestPath := filepath.Join("..", "..", "manifest", "capacity-v1.json")
@@ -26,21 +115,24 @@ func TestLoadCapacityManifestAndExpandStablePlan(t *testing.T) {
 		t.Fatalf("plan cells=%d, want 3", len(plan.Cells))
 	}
 	wantIDs := []string{
-		"capacity-reference-2m-1c-unlimited",
-		"capacity-reference-2m-2c-unlimited",
-		"capacity-reference-2m-4c-unlimited",
+		"capacity-reference-3m-1c-unlimited",
+		"capacity-reference-3m-2c-unlimited",
+		"capacity-reference-3m-4c-unlimited",
 	}
 	wantCPUs := []float64{1, 2, 4}
 	for index, cell := range plan.Cells {
-		if cell.ID != wantIDs[index] || cell.DatasetID != "reference-2m" || cell.HotEvents != 1_946_550 || cell.ArchiveEvents != 89_190 {
+		if cell.ID != wantIDs[index] || cell.DatasetID != "reference-3m" || cell.HotEvents != 3_205_740 || cell.Recent30DayEvents != 1_226_326 || cell.ArchiveEvents != 0 {
 			t.Fatalf("unexpected cell %d: %+v", index, cell)
 		}
-		if cell.Cardinality != (capacity.Cardinality{Identities: 323, Models: 52, APIKeys: 27}) || cell.Resource.CPU != wantCPUs[index] || cell.Resource.MemoryMiB != 0 {
+		if cell.Cardinality != (capacity.Cardinality{Identities: 500, Models: 50, APIKeys: 50}) || cell.Resource.CPU != wantCPUs[index] || cell.Resource.MemoryMiB != 0 {
 			t.Fatalf("unexpected cell capacity profile %d: %+v", index, cell)
 		}
 	}
-	if manifest.Search.DashboardCoreP95MS != 0 || manifest.Search.DashboardOverallP99MS != 3000 || manifest.Search.SoakSeconds != 300 || !manifest.Search.SearchDashboardCapacity {
+	if manifest.Search.DashboardCoreP95MS != 0 || manifest.Search.DashboardCoreP99MS != 3000 || manifest.Search.AnalysisLatencyIntervalSeconds != 30 || manifest.Search.SoakSeconds != 300 || !manifest.Search.SearchDashboardCapacity {
 		t.Fatalf("unexpected dashboard policy: %+v", manifest.Search)
+	}
+	if manifest.Search.RatesPerSecond[0] != 1 || manifest.Search.InitialRatePerSecond != 25 || !slices.Contains(manifest.Search.RatesPerSecond, 25) || manifest.Search.MaxPassDrainSeconds != 15 || manifest.Search.BoundarySeconds != 60 || manifest.Search.BoundaryRepetitions != 1 || manifest.Search.SkipBoundary {
+		t.Fatalf("unexpected adaptive search policy: %+v", manifest.Search)
 	}
 	second, err := capacity.ExpandPlan(manifest)
 	if err != nil {
@@ -62,13 +154,49 @@ func TestLoadManifestRejectsHostSpecificFields(t *testing.T) {
 	}
 }
 
+func TestExpandPlanUsesCustomDatasetAndResourceIDs(t *testing.T) {
+	manifest := capacity.Manifest{
+		Version: "capacity-v1",
+		Target:  capacity.Target{OS: "linux", Arch: "amd64"},
+		Dataset: capacity.DatasetSpec{
+			ID: "custom-reference", HotEvents: 10, Recent30DayEvents: 10, HotDays: 1, BenchmarkNow: "2026-08-06T16:00:00+08:00",
+			Cardinality: capacity.Cardinality{Identities: 1, Models: 1, APIKeys: 1},
+		},
+		TrafficTiers: []capacity.TrafficTier{{Name: "all", KeyShare: 1, PerKeyWeight: 1}},
+		Resources:    []capacity.Resource{{ID: "single-core", CPU: 1, MemoryMiB: 0}},
+		Search: capacity.Search{
+			RatesPerSecond: []int{1}, InitialRatePerSecond: 1, ProbeSeconds: 1, BoundarySeconds: 1, BoundaryRepetitions: 1,
+			SoakSeconds: 1, MaxPassDrainSeconds: 1, MaxRunSeconds: 1, DashboardCoreP99MS: 3000, DashboardRequestsPerSecond: 1, AnalysisLatencyIntervalSeconds: 30, RecommendedCapacityRate: 0.7,
+		},
+	}
+	plan, err := capacity.ExpandPlan(manifest)
+	if err != nil {
+		t.Fatalf("ExpandPlan returned error: %v", err)
+	}
+	if len(plan.Cells) != 1 || plan.Cells[0].ID != "capacity-custom-reference-single-core" || plan.Cells[0].DatasetID != "custom-reference" {
+		t.Fatalf("custom manifest identifiers were not preserved: %+v", plan.Cells)
+	}
+}
+
+func TestResolveDatasetBenchmarkNowSupportsGenerationTime(t *testing.T) {
+	now := time.Date(2026, 8, 9, 12, 30, 0, 0, time.FixedZone("Asia/Shanghai", 8*60*60))
+	resolved, err := capacity.ResolveDatasetBenchmarkNow("generation-time", now)
+	if err != nil || !resolved.Equal(now) {
+		t.Fatalf("generation-time resolved=%s err=%v, want %s", resolved, err, now)
+	}
+	fixed, err := capacity.ResolveDatasetBenchmarkNow("2026-08-06T16:00:00+08:00", now)
+	if err != nil || fixed.Format(time.RFC3339) != "2026-08-06T16:00:00+08:00" {
+		t.Fatalf("fixed benchmark time resolved=%s err=%v", fixed, err)
+	}
+}
+
 func TestAllocateTrafficTiersUsesKeyShares(t *testing.T) {
 	tiers := []capacity.TrafficTier{
 		{Name: "high", KeyShare: 0.30, PerKeyWeight: 10},
 		{Name: "medium", KeyShare: 0.50, PerKeyWeight: 3},
 		{Name: "low", KeyShare: 0.20, PerKeyWeight: 1},
 	}
-	profiles, err := capacity.BuildAPIKeyProfiles(100, tiers, 20260806)
+	profiles, err := capacity.BuildAPIKeyProfiles(50, tiers, 20260806)
 	if err != nil {
 		t.Fatalf("BuildAPIKeyProfiles returned error: %v", err)
 	}
@@ -76,11 +204,22 @@ func TestAllocateTrafficTiersUsesKeyShares(t *testing.T) {
 	for _, profile := range profiles {
 		counts[profile.Tier]++
 	}
-	if !reflect.DeepEqual(counts, map[string]int{"high": 30, "medium": 50, "low": 20}) {
+	if !reflect.DeepEqual(counts, map[string]int{"high": 15, "medium": 25, "low": 10}) {
 		t.Fatalf("tier counts=%v", counts)
 	}
-	if !(profiles[0].Weight > profiles[30].Weight && profiles[30].Weight > profiles[80].Weight) {
-		t.Fatalf("tier weights are not ordered: high=%f medium=%f low=%f", profiles[0].Weight, profiles[30].Weight, profiles[80].Weight)
+	if !(profiles[0].Weight > profiles[15].Weight && profiles[15].Weight > profiles[40].Weight) {
+		t.Fatalf("tier weights are not ordered: high=%f medium=%f low=%f", profiles[0].Weight, profiles[15].Weight, profiles[40].Weight)
+	}
+}
+
+func TestManifestRejectsRecentWindowThatConsumesNinetyDayTotal(t *testing.T) {
+	manifest, err := capacity.LoadManifest(filepath.Join("..", "..", "manifest", "capacity-v1.json"))
+	if err != nil {
+		t.Fatalf("LoadManifest returned error: %v", err)
+	}
+	manifest.Dataset.Recent30DayEvents = manifest.Dataset.HotEvents
+	if err := manifest.Validate(); err == nil {
+		t.Fatal("90-day dataset must retain events outside the latest 30 days")
 	}
 }
 
@@ -135,14 +274,14 @@ func TestManifestRejectsInvalidCapacityBounds(t *testing.T) {
 		Version: "capacity-v1",
 		Target:  capacity.Target{OS: "linux", Arch: "amd64"},
 		Dataset: capacity.DatasetSpec{
-			ID: "reference-2m", HotEvents: 1, HotDays: 1, BenchmarkNow: "2026-08-06T16:00:00+08:00",
+			ID: "reference-3m", HotEvents: 1, Recent30DayEvents: 1, HotDays: 1, BenchmarkNow: "2026-08-06T16:00:00+08:00",
 			Cardinality: capacity.Cardinality{Identities: 1001, Models: 101, APIKeys: 101},
 		},
 		TrafficTiers: []capacity.TrafficTier{{Name: "all", KeyShare: 1, PerKeyWeight: 1}},
 		Resources:    []capacity.Resource{{ID: "1c-unlimited", CPU: 1, MemoryMiB: 0}},
 		Search: capacity.Search{
-			RatesPerSecond: []int{1}, ProbeSeconds: 1, BoundarySeconds: 1, BoundaryRepetitions: 1,
-			SoakSeconds: 1, MaxRunSeconds: 1, DashboardOverallP99MS: 3000, DashboardRequestsPerSecond: 1, RecommendedCapacityRate: 0.7,
+			RatesPerSecond: []int{1}, InitialRatePerSecond: 1, ProbeSeconds: 1, BoundarySeconds: 1, BoundaryRepetitions: 1,
+			SoakSeconds: 1, MaxPassDrainSeconds: 1, MaxRunSeconds: 1, DashboardCoreP99MS: 3000, DashboardRequestsPerSecond: 1, AnalysisLatencyIntervalSeconds: 30, RecommendedCapacityRate: 0.7,
 		},
 	}
 	if err := manifest.Validate(); err == nil {

--- a/internal/benchmark/capacity/test/orchestrator_test.go
+++ b/internal/benchmark/capacity/test/orchestrator_test.go
@@ -1,0 +1,213 @@
+package capacity_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"cpa-usage-keeper/internal/benchmark/capacity"
+)
+
+func TestResumeCellMatchesOnlyCompleteExactProvenance(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "result.json")
+	result := capacity.CellResult{
+		Status: "completed", ManifestSHA256: "manifest", KeeperBinarySHA256: "keeper", BenchctlBinarySHA256: "benchctl", DatasetFingerprint: "dataset",
+	}
+	if err := capacity.WriteJSONAtomic(path, result); err != nil {
+		t.Fatalf("WriteJSONAtomic returned error: %v", err)
+	}
+	matched, err := capacity.ResumeCellMatches(path, "manifest", "keeper", "benchctl", "dataset")
+	if err != nil || !matched {
+		t.Fatalf("expected exact result to resume: matched=%v err=%v", matched, err)
+	}
+	matched, err = capacity.ResumeCellMatches(path, "manifest", "different", "benchctl", "dataset")
+	if err != nil || matched {
+		t.Fatalf("changed binary must rerun: matched=%v err=%v", matched, err)
+	}
+}
+
+func TestExecuteRunRejectsUnsafeRootAndRunIDBeforeRuntimeSetup(t *testing.T) {
+	for _, options := range []capacity.RunOptions{
+		{Root: "/", RunID: "safe-run", KeeperBinary: "keeper"},
+		{Root: t.TempDir(), RunID: "../escape", KeeperBinary: "keeper"},
+	} {
+		if _, err := capacity.ExecuteRun(t.Context(), options); err == nil {
+			t.Fatalf("ExecuteRun should reject unsafe options: %+v", options)
+		}
+	}
+}
+
+func TestReadCgroupSampleAcceptsEmptyIOStat(t *testing.T) {
+	root := t.TempDir()
+	files := map[string]string{
+		"cpu.stat":            "usage_usec 10\nuser_usec 6\nsystem_usec 4\nthrottled_usec 0\nnr_throttled 0\n",
+		"memory.current":      "1024\n",
+		"memory.peak":         "2048\n",
+		"memory.swap.current": "0\n",
+		"memory.events":       "oom 0\noom_kill 0\n",
+		"pids.current":        "3\n",
+		"io.stat":             "\n",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	sample, err := capacity.ReadCgroupSample(root)
+	if err != nil {
+		t.Fatalf("ReadCgroupSample returned error: %v", err)
+	}
+	if sample.IOReadBytes != 0 || sample.IOWriteBytes != 0 || sample.MemoryPeakBytes != 2048 {
+		t.Fatalf("unexpected sample: %+v", sample)
+	}
+}
+
+func TestReadAndValidateCgroupLimits(t *testing.T) {
+	root := t.TempDir()
+	files := map[string]string{
+		"cpu.max":               "200000 100000\n",
+		"cpuset.cpus.effective": "0-1\n",
+		"memory.max":            "536870912\n",
+		"memory.swap.max":       "0\n",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	limits, err := capacity.ReadCgroupLimits(root)
+	if err != nil {
+		t.Fatalf("ReadCgroupLimits returned error: %v", err)
+	}
+	if err := capacity.ValidateCgroupLimits(limits, 2, 512, "0-1"); err != nil {
+		t.Fatalf("ValidateCgroupLimits returned error: %v", err)
+	}
+	if err := capacity.ValidateCgroupLimits(limits, 1, 512, "0-1"); err == nil {
+		t.Fatal("expected CPU mismatch to fail")
+	}
+}
+
+func TestReadAndValidateUnlimitedMemoryCgroupLimits(t *testing.T) {
+	root := t.TempDir()
+	files := map[string]string{
+		"cpu.max":               "100000 100000\n",
+		"cpuset.cpus.effective": "0\n",
+		"memory.max":            "max\n",
+		"memory.swap.max":       "0\n",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	limits, err := capacity.ReadCgroupLimits(root)
+	if err != nil {
+		t.Fatalf("ReadCgroupLimits returned error: %v", err)
+	}
+	if !limits.MemoryMaxUnlimited || limits.MemoryMaxBytes != 0 {
+		t.Fatalf("unlimited memory was not preserved: %+v", limits)
+	}
+	if err := capacity.ValidateCgroupLimits(limits, 1, 0, "0"); err != nil {
+		t.Fatalf("ValidateCgroupLimits returned error: %v", err)
+	}
+	if err := capacity.ValidateCgroupLimits(limits, 1, 512, "0"); err == nil {
+		t.Fatal("finite memory request must reject an unlimited cgroup")
+	}
+}
+
+func TestResumeCellMissingResultNeedsRun(t *testing.T) {
+	matched, err := capacity.ResumeCellMatches(filepath.Join(t.TempDir(), "missing.json"), "m", "k", "b", "d")
+	if err != nil || matched {
+		t.Fatalf("missing result should not resume: matched=%v err=%v", matched, err)
+	}
+}
+
+func TestPruneCompletedWorkDatabaseRemovesOnlySQLiteClone(t *testing.T) {
+	workDir := t.TempDir()
+	for _, name := range []string{"app.db", "app.db-wal", "app.db-shm", "keeper.env"} {
+		if err := os.WriteFile(filepath.Join(workDir, name), []byte(name), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	if err := capacity.PruneCompletedWorkDatabase(workDir); err != nil {
+		t.Fatalf("PruneCompletedWorkDatabase returned error: %v", err)
+	}
+	for _, name := range []string{"app.db", "app.db-wal", "app.db-shm"} {
+		if _, err := os.Stat(filepath.Join(workDir, name)); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be removed, stat err=%v", name, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(workDir, "keeper.env")); err != nil {
+		t.Fatalf("non-database artifact must remain: %v", err)
+	}
+}
+
+func TestResetDatasetCloneReplacesPreviousProbeState(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source.db")
+	destination := filepath.Join(root, "work", "app.db")
+	if output, err := exec.Command("sqlite3", source, "CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES ('canonical');").CombinedOutput(); err != nil {
+		t.Fatalf("create source database: %v: %s", err, output)
+	}
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		t.Fatalf("create work directory: %v", err)
+	}
+	for _, path := range []string{destination, destination + "-wal", destination + "-shm"} {
+		if err := os.WriteFile(path, []byte("previous probe state"), 0o600); err != nil {
+			t.Fatalf("write previous probe artifact %s: %v", path, err)
+		}
+	}
+	if err := capacity.ResetDatasetClone(t.Context(), source, destination); err != nil {
+		t.Fatalf("ResetDatasetClone returned error: %v", err)
+	}
+	output, err := exec.Command("sqlite3", destination, "SELECT value FROM marker;").CombinedOutput()
+	if err != nil {
+		t.Fatalf("query restored clone: %v: %s", err, output)
+	}
+	if string(output) != "canonical\n" {
+		t.Fatalf("unexpected restored content: %q", output)
+	}
+	for _, path := range []string{destination + "-wal", destination + "-shm"} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("stale sidecar must be removed: %s err=%v", path, err)
+		}
+	}
+}
+
+func TestResetDatasetCloneCopiesStaticCanonicalWithoutSQLiteCLI(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source.db")
+	destination := filepath.Join(root, "work", "app.db")
+	want := []byte("static canonical database bytes")
+	if err := os.WriteFile(source, want, 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	t.Setenv("PATH", t.TempDir())
+
+	if err := capacity.ResetDatasetClone(t.Context(), source, destination); err != nil {
+		t.Fatalf("ResetDatasetClone returned error: %v", err)
+	}
+	got, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("read destination: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("destination bytes=%q, want %q", got, want)
+	}
+}
+
+func TestFixedRateSoakPassedSupportsHardOnlyMode(t *testing.T) {
+	evaluation := capacity.ProbeEvaluation{HardPass: true, InteractivePass: false}
+	passed, err := capacity.FixedRateSoakPassed("hard", evaluation)
+	if err != nil || !passed {
+		t.Fatalf("hard-only soak should pass: passed=%v err=%v", passed, err)
+	}
+	passed, err = capacity.FixedRateSoakPassed("interactive", evaluation)
+	if err != nil || passed {
+		t.Fatalf("interactive soak should fail: passed=%v err=%v", passed, err)
+	}
+	if _, err := capacity.FixedRateSoakPassed("unknown", evaluation); err == nil {
+		t.Fatal("unknown fixed pass mode must fail")
+	}
+}

--- a/internal/benchmark/capacity/test/orchestrator_test.go
+++ b/internal/benchmark/capacity/test/orchestrator_test.go
@@ -4,24 +4,55 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"cpa-usage-keeper/internal/benchmark/capacity"
 )
 
-func TestResumeCellMatchesOnlyCompleteExactProvenance(t *testing.T) {
+func TestResumeCellMatchesTerminalExactProvenance(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "result.json")
+	provenance := capacity.ExecutionProvenance{
+		ManifestSHA256: "manifest", PlanSHA256: "plan", KeeperBinarySHA256: "keeper", BenchctlBinarySHA256: "benchctl",
+		DatasetFingerprint: "dataset", DatasetValidationSHA256: "proof", FixedRate: 100, FixedDurationSeconds: 300, FixedPass: "hard",
+	}
 	result := capacity.CellResult{
-		Status: "completed", ManifestSHA256: "manifest", KeeperBinarySHA256: "keeper", BenchctlBinarySHA256: "benchctl", DatasetFingerprint: "dataset",
+		Status: "completed", ManifestSHA256: "manifest", PlanSHA256: "plan", KeeperBinarySHA256: "keeper", BenchctlBinarySHA256: "benchctl", DatasetFingerprint: "dataset",
+		DatasetValidationSHA256: "proof", FixedRate: 100, FixedDurationSeconds: 300, FixedPass: "hard",
 	}
 	if err := capacity.WriteJSONAtomic(path, result); err != nil {
 		t.Fatalf("WriteJSONAtomic returned error: %v", err)
 	}
-	matched, err := capacity.ResumeCellMatches(path, "manifest", "keeper", "benchctl", "dataset")
+	matched, err := capacity.ResumeCellMatches(path, provenance)
 	if err != nil || !matched {
 		t.Fatalf("expected exact result to resume: matched=%v err=%v", matched, err)
 	}
-	matched, err = capacity.ResumeCellMatches(path, "manifest", "different", "benchctl", "dataset")
+	result.Status = "failed"
+	result.Error = "hard soak failed at 100 events/s: durable_throughput,http_p99"
+	result.Attempts = []capacity.ProbeAttempt{{RatePerSecond: 100}}
+	if err := capacity.WriteJSONAtomic(path, result); err != nil {
+		t.Fatalf("WriteJSONAtomic failed result returned error: %v", err)
+	}
+	matched, err = capacity.ResumeCellMatches(path, provenance)
+	if err != nil || !matched {
+		t.Fatalf("expected terminal fixed-rate failure to resume: matched=%v err=%v", matched, err)
+	}
+	result.Error = "start keeper: unit failed"
+	if err := capacity.WriteJSONAtomic(path, result); err != nil {
+		t.Fatalf("WriteJSONAtomic infrastructure failure returned error: %v", err)
+	}
+	matched, err = capacity.ResumeCellMatches(path, provenance)
+	if err != nil || matched {
+		t.Fatalf("infrastructure failure must rerun: matched=%v err=%v", matched, err)
+	}
+	result.Status = "completed"
+	result.Error = ""
+	result.Attempts = nil
+	if err := capacity.WriteJSONAtomic(path, result); err != nil {
+		t.Fatalf("restore completed result returned error: %v", err)
+	}
+	provenance.KeeperBinarySHA256 = "different"
+	matched, err = capacity.ResumeCellMatches(path, provenance)
 	if err != nil || matched {
 		t.Fatalf("changed binary must rerun: matched=%v err=%v", matched, err)
 	}
@@ -35,6 +66,37 @@ func TestExecuteRunRejectsUnsafeRootAndRunIDBeforeRuntimeSetup(t *testing.T) {
 		if _, err := capacity.ExecuteRun(t.Context(), options); err == nil {
 			t.Fatalf("ExecuteRun should reject unsafe options: %+v", options)
 		}
+	}
+}
+
+func TestRedisCPUSetUsesLastOnlineCPU(t *testing.T) {
+	for online, want := range map[int]string{0: "", 1: "0", 4: "3", 8: "7"} {
+		if got := capacity.RedisCPUSet(online); got != want {
+			t.Fatalf("RedisCPUSet(%d)=%q, want %q", online, got, want)
+		}
+	}
+}
+
+func TestPreflightDatasetDependenciesRequiresZstdOnlyForCompressedCanonical(t *testing.T) {
+	root := t.TempDir()
+	datasetDir := filepath.Join(root, "datasets", "custom-dataset")
+	if err := os.MkdirAll(datasetDir, 0o755); err != nil {
+		t.Fatalf("create dataset directory: %v", err)
+	}
+	compressed := filepath.Join(datasetDir, "app.db.zst")
+	if err := os.WriteFile(compressed, []byte("compressed"), 0o600); err != nil {
+		t.Fatalf("write compressed canonical: %v", err)
+	}
+	t.Setenv("PATH", t.TempDir())
+	cells := []capacity.Cell{{DatasetID: "custom-dataset"}}
+	if err := capacity.PreflightDatasetDependencies(root, cells); err == nil || !strings.Contains(err.Error(), "zstd") {
+		t.Fatalf("compressed canonical without zstd error=%v", err)
+	}
+	if err := os.WriteFile(filepath.Join(datasetDir, "app.db"), []byte("raw"), 0o600); err != nil {
+		t.Fatalf("write raw canonical: %v", err)
+	}
+	if err := capacity.PreflightDatasetDependencies(root, cells); err != nil {
+		t.Fatalf("raw canonical should not require zstd: %v", err)
 	}
 }
 
@@ -117,9 +179,19 @@ func TestReadAndValidateUnlimitedMemoryCgroupLimits(t *testing.T) {
 }
 
 func TestResumeCellMissingResultNeedsRun(t *testing.T) {
-	matched, err := capacity.ResumeCellMatches(filepath.Join(t.TempDir(), "missing.json"), "m", "k", "b", "d")
+	matched, err := capacity.ResumeCellMatches(filepath.Join(t.TempDir(), "missing.json"), capacity.ExecutionProvenance{})
 	if err != nil || matched {
 		t.Fatalf("missing result should not resume: matched=%v err=%v", matched, err)
+	}
+}
+
+func TestDropFilePageCacheAcceptsSyncedClone(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.db")
+	if err := os.WriteFile(path, []byte("sqlite pages"), 0o600); err != nil {
+		t.Fatalf("write clone: %v", err)
+	}
+	if err := capacity.DropFilePageCache(path); err != nil {
+		t.Fatalf("DropFilePageCache returned error: %v", err)
 	}
 }
 

--- a/internal/benchmark/capacity/test/orchestrator_test.go
+++ b/internal/benchmark/capacity/test/orchestrator_test.go
@@ -1,13 +1,14 @@
 package capacity_test
 
 import (
+	"database/sql"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"cpa-usage-keeper/internal/benchmark/capacity"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestResumeCellMatchesTerminalExactProvenance(t *testing.T) {
@@ -219,8 +220,16 @@ func TestResetDatasetCloneReplacesPreviousProbeState(t *testing.T) {
 	root := t.TempDir()
 	source := filepath.Join(root, "source.db")
 	destination := filepath.Join(root, "work", "app.db")
-	if output, err := exec.Command("sqlite3", source, "CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES ('canonical');").CombinedOutput(); err != nil {
-		t.Fatalf("create source database: %v: %s", err, output)
+	sourceDB, err := sql.Open("sqlite3", source)
+	if err != nil {
+		t.Fatalf("open source database: %v", err)
+	}
+	if _, err := sourceDB.Exec("CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES ('canonical');"); err != nil {
+		sourceDB.Close()
+		t.Fatalf("create source database: %v", err)
+	}
+	if err := sourceDB.Close(); err != nil {
+		t.Fatalf("close source database: %v", err)
 	}
 	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
 		t.Fatalf("create work directory: %v", err)
@@ -233,12 +242,17 @@ func TestResetDatasetCloneReplacesPreviousProbeState(t *testing.T) {
 	if err := capacity.ResetDatasetClone(t.Context(), source, destination); err != nil {
 		t.Fatalf("ResetDatasetClone returned error: %v", err)
 	}
-	output, err := exec.Command("sqlite3", destination, "SELECT value FROM marker;").CombinedOutput()
+	destinationDB, err := sql.Open("sqlite3", destination+"?mode=ro")
 	if err != nil {
-		t.Fatalf("query restored clone: %v: %s", err, output)
+		t.Fatalf("open restored clone: %v", err)
 	}
-	if string(output) != "canonical\n" {
-		t.Fatalf("unexpected restored content: %q", output)
+	defer destinationDB.Close()
+	var value string
+	if err := destinationDB.QueryRow("SELECT value FROM marker").Scan(&value); err != nil {
+		t.Fatalf("query restored clone: %v", err)
+	}
+	if value != "canonical" {
+		t.Fatalf("unexpected restored content: %q", value)
 	}
 	for _, path := range []string{destination + "-wal", destination + "-shm"} {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {

--- a/internal/benchmark/capacity/test/probe_test.go
+++ b/internal/benchmark/capacity/test/probe_test.go
@@ -1,0 +1,168 @@
+package capacity_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/benchmark/capacity"
+	"cpa-usage-keeper/internal/service/tokenprocessor"
+)
+
+func TestBuildUsagePayloadUsesValidSyntheticMetadata(t *testing.T) {
+	profiles, err := capacity.BuildAPIKeyProfiles(100, []capacity.TrafficTier{
+		{Name: "high", KeyShare: 0.30, PerKeyWeight: 10},
+		{Name: "medium", KeyShare: 0.50, PerKeyWeight: 3},
+		{Name: "low", KeyShare: 0.20, PerKeyWeight: 1},
+	}, 20260806)
+	if err != nil {
+		t.Fatalf("BuildAPIKeyProfiles returned error: %v", err)
+	}
+	payload, metadata, err := capacity.BuildUsagePayload(17, time.Date(2026, 8, 6, 15, 0, 0, 0, time.FixedZone("Asia/Shanghai", 8*60*60)), capacity.Cardinality{Identities: 1000, Models: 100, APIKeys: 100}, profiles, 9)
+	if err != nil {
+		t.Fatalf("BuildUsagePayload returned error: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if metadata.APIKeyIndex < 1 || metadata.APIKeyIndex > 100 || metadata.ModelIndex < 1 || metadata.ModelIndex > 100 || metadata.IdentityIndex < 1 || metadata.IdentityIndex > 1000 {
+		t.Fatalf("metadata outside configured cardinality: %+v", metadata)
+	}
+	if decoded["api_key"] != metadata.APIGroupKey || decoded["model"] != metadata.Model || decoded["auth_index"] != metadata.AuthIndex {
+		t.Fatalf("payload metadata mismatch: payload=%v metadata=%+v", decoded, metadata)
+	}
+}
+
+func TestBuildUsagePayloadUsesCanonicalTokenSemantics(t *testing.T) {
+	profiles, err := capacity.BuildAPIKeyProfiles(4, []capacity.TrafficTier{
+		{Name: "high", KeyShare: 0.30, PerKeyWeight: 10},
+		{Name: "medium", KeyShare: 0.50, PerKeyWeight: 3},
+		{Name: "low", KeyShare: 0.20, PerKeyWeight: 1},
+	}, 20260806)
+	if err != nil {
+		t.Fatalf("BuildAPIKeyProfiles returned error: %v", err)
+	}
+	cardinality := capacity.Cardinality{Identities: 12, Models: 6, APIKeys: 4}
+	for sequence := int64(1); sequence <= 100; sequence++ {
+		payload, _, err := capacity.BuildUsagePayload(sequence, time.Unix(sequence, 0), cardinality, profiles, 9)
+		if err != nil {
+			t.Fatalf("BuildUsagePayload(%d): %v", sequence, err)
+		}
+		var decoded struct {
+			Provider string `json:"provider"`
+			Tokens   struct {
+				InputTokens         int64 `json:"input_tokens"`
+				OutputTokens        int64 `json:"output_tokens"`
+				ReasoningTokens     int64 `json:"reasoning_tokens"`
+				CachedTokens        int64 `json:"cached_tokens"`
+				CacheReadTokens     int64 `json:"cache_read_tokens"`
+				CacheCreationTokens int64 `json:"cache_creation_tokens"`
+				TotalTokens         int64 `json:"total_tokens"`
+			} `json:"tokens"`
+		}
+		if err := json.Unmarshal(payload, &decoded); err != nil {
+			t.Fatalf("decode payload %d: %v", sequence, err)
+		}
+		resolution, err := tokenprocessor.ResolveIdentity("", decoded.Provider)
+		if err != nil {
+			t.Fatalf("ResolveIdentity(%q): %v", decoded.Provider, err)
+		}
+		result := tokenprocessor.Process(tokenprocessor.TokenValues{
+			InputTokens:         decoded.Tokens.InputTokens,
+			OutputTokens:        decoded.Tokens.OutputTokens,
+			ReasoningTokens:     decoded.Tokens.ReasoningTokens,
+			CachedTokens:        decoded.Tokens.CachedTokens,
+			CacheReadTokens:     decoded.Tokens.CacheReadTokens,
+			CacheReadPresent:    true,
+			CacheCreationTokens: decoded.Tokens.CacheCreationTokens,
+			TotalTokens:         decoded.Tokens.TotalTokens,
+		}, resolution)
+		if len(result.Actions) != 0 || len(result.Violations) != 0 || result.Outcome != tokenprocessor.TokenOutcomeValid {
+			t.Fatalf("payload %d provider=%q is not canonical: tokens=%+v actions=%+v violations=%+v outcome=%q", sequence, decoded.Provider, result.Tokens, result.Actions, result.Violations, result.Outcome)
+		}
+	}
+}
+
+func TestLatencyPercentilesUseNearestRank(t *testing.T) {
+	percentiles := capacity.LatencyPercentiles([]time.Duration{
+		10 * time.Millisecond,
+		20 * time.Millisecond,
+		30 * time.Millisecond,
+		40 * time.Millisecond,
+		100 * time.Millisecond,
+	})
+	if percentiles.P50MS != 30 || percentiles.P95MS != 100 || percentiles.P99MS != 100 {
+		t.Fatalf("unexpected percentiles: %+v", percentiles)
+	}
+}
+
+func TestSummarizeDashboardLatenciesSeparatesHeavyDiagnosticEndpoint(t *testing.T) {
+	samples := []capacity.DashboardLatencySample{
+		{Path: "/api/v1/usage/overview?range=30d", Duration: 120 * time.Millisecond},
+		{Path: "/api/v1/usage/overview/realtime?range=1h", Duration: 2 * time.Millisecond},
+		{Path: "/api/v1/usage/activity?range=30d", Duration: 210 * time.Millisecond},
+		{Path: "/api/v1/usage/analysis?range=30d", Duration: 3 * time.Millisecond},
+		{Path: "/api/v1/usage/events?range=30d&page=1&page_size=50", Duration: 140 * time.Millisecond},
+		{Path: "/api/v1/usage/analysis/latency?range=30d", Duration: 1900 * time.Millisecond},
+	}
+	overall, core, byPath := capacity.SummarizeDashboardLatencies(samples)
+	if overall.P95MS != 1900 || core.P95MS != 210 {
+		t.Fatalf("unexpected overall/core latency: overall=%+v core=%+v", overall, core)
+	}
+	if byPath["/api/v1/usage/analysis/latency?range=30d"].P99MS != 1900 {
+		t.Fatalf("heavy endpoint summary missing: %+v", byPath)
+	}
+}
+
+func TestBuildUsagePayloadKeepsProductionCorrelations(t *testing.T) {
+	tiers := []capacity.TrafficTier{
+		{Name: "high", KeyShare: 0.30, PerKeyWeight: 10},
+		{Name: "medium", KeyShare: 0.50, PerKeyWeight: 3},
+		{Name: "low", KeyShare: 0.20, PerKeyWeight: 1},
+	}
+	profiles, err := capacity.BuildAPIKeyProfiles(100, tiers, 20260806)
+	if err != nil {
+		t.Fatalf("BuildAPIKeyProfiles returned error: %v", err)
+	}
+	cardinality := capacity.Cardinality{Identities: 1000, Models: 100, APIKeys: 100}
+	identitiesByKey := map[int]map[int]bool{}
+	modelsByIdentity := map[int]map[int]bool{}
+	for sequence := int64(1); sequence <= 20_000; sequence++ {
+		_, metadata, err := capacity.BuildUsagePayload(sequence, time.Unix(sequence, 0), cardinality, profiles, 77)
+		if err != nil {
+			t.Fatalf("BuildUsagePayload(%d): %v", sequence, err)
+		}
+		if identitiesByKey[metadata.APIKeyIndex] == nil {
+			identitiesByKey[metadata.APIKeyIndex] = map[int]bool{}
+		}
+		identitiesByKey[metadata.APIKeyIndex][metadata.IdentityIndex] = true
+		if modelsByIdentity[metadata.IdentityIndex] == nil {
+			modelsByIdentity[metadata.IdentityIndex] = map[int]bool{}
+		}
+		modelsByIdentity[metadata.IdentityIndex][metadata.ModelIndex] = true
+	}
+	for key, identities := range identitiesByKey {
+		if len(identities) > 30 {
+			t.Fatalf("API key %d reached %d identities; workload regressed toward a full cross product", key, len(identities))
+		}
+	}
+	mediumKeys := 0
+	lowKeys := 0
+	for key := range identitiesByKey {
+		if key >= 31 && key <= 80 {
+			mediumKeys++
+		}
+		if key >= 81 {
+			lowKeys++
+		}
+	}
+	if mediumKeys > 18 || lowKeys > 2 {
+		t.Fatalf("temporal activity window expanded: medium=%d low=%d", mediumKeys, lowKeys)
+	}
+	for identity, models := range modelsByIdentity {
+		if len(models) > 3 {
+			t.Fatalf("identity %d reached %d models, want at most 3 correlated choices", identity, len(models))
+		}
+	}
+}

--- a/internal/benchmark/capacity/test/probe_test.go
+++ b/internal/benchmark/capacity/test/probe_test.go
@@ -2,6 +2,8 @@ package capacity_test
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,6 +30,9 @@ func TestBuildUsagePayloadUsesValidSyntheticMetadata(t *testing.T) {
 	}
 	if metadata.APIKeyIndex < 1 || metadata.APIKeyIndex > 100 || metadata.ModelIndex < 1 || metadata.ModelIndex > 100 || metadata.IdentityIndex < 1 || metadata.IdentityIndex > 1000 {
 		t.Fatalf("metadata outside configured cardinality: %+v", metadata)
+	}
+	if want := fmt.Sprintf("bench-key-%03d", metadata.APIKeyIndex); metadata.APIGroupKey != want {
+		t.Fatalf("API group key=%q, want seeded CPA API key %q", metadata.APIGroupKey, want)
 	}
 	if decoded["api_key"] != metadata.APIGroupKey || decoded["model"] != metadata.Model || decoded["auth_index"] != metadata.AuthIndex {
 		t.Fatalf("payload metadata mismatch: payload=%v metadata=%+v", decoded, metadata)
@@ -92,7 +97,7 @@ func TestLatencyPercentilesUseNearestRank(t *testing.T) {
 		40 * time.Millisecond,
 		100 * time.Millisecond,
 	})
-	if percentiles.P50MS != 30 || percentiles.P95MS != 100 || percentiles.P99MS != 100 {
+	if percentiles.Samples != 5 || percentiles.P50MS != 30 || percentiles.P95MS != 100 || percentiles.P99MS != 100 {
 		t.Fatalf("unexpected percentiles: %+v", percentiles)
 	}
 }
@@ -100,18 +105,42 @@ func TestLatencyPercentilesUseNearestRank(t *testing.T) {
 func TestSummarizeDashboardLatenciesSeparatesHeavyDiagnosticEndpoint(t *testing.T) {
 	samples := []capacity.DashboardLatencySample{
 		{Path: "/api/v1/usage/overview?range=30d", Duration: 120 * time.Millisecond},
-		{Path: "/api/v1/usage/overview/realtime?range=1h", Duration: 2 * time.Millisecond},
+		{Path: "/api/v1/usage/overview/realtime?window=60m", Duration: 2 * time.Millisecond},
 		{Path: "/api/v1/usage/activity?range=30d", Duration: 210 * time.Millisecond},
 		{Path: "/api/v1/usage/analysis?range=30d", Duration: 3 * time.Millisecond},
 		{Path: "/api/v1/usage/events?range=30d&page=1&page_size=50", Duration: 140 * time.Millisecond},
 		{Path: "/api/v1/usage/analysis/latency?range=30d", Duration: 1900 * time.Millisecond},
 	}
-	overall, core, byPath := capacity.SummarizeDashboardLatencies(samples)
-	if overall.P95MS != 1900 || core.P95MS != 210 {
-		t.Fatalf("unexpected overall/core latency: overall=%+v core=%+v", overall, core)
+	core, diagnostic, byPath := capacity.SummarizeDashboardLatencies(samples)
+	if core.Samples != 5 || diagnostic.Samples != 1 || core.P95MS != 210 || diagnostic.P95MS != 1900 {
+		t.Fatalf("unexpected core/diagnostic latency: core=%+v diagnostic=%+v", core, diagnostic)
 	}
 	if byPath["/api/v1/usage/analysis/latency?range=30d"].P99MS != 1900 {
 		t.Fatalf("heavy endpoint summary missing: %+v", byPath)
+	}
+}
+
+func TestCoreDashboardReplayExcludesAnalysisLatency(t *testing.T) {
+	for _, path := range capacity.CoreDashboardReplayPaths() {
+		if path == "/api/v1/usage/analysis/latency?range=30d" {
+			t.Fatalf("analysis latency must not participate in the core Dashboard replay: %v", capacity.CoreDashboardReplayPaths())
+		}
+	}
+}
+
+func TestDashboardReplayUsesExplicitRealtimeWindow(t *testing.T) {
+	paths := capacity.DashboardReplayPaths()
+	found := false
+	for _, path := range paths {
+		if path == "/api/v1/usage/overview/realtime?window=60m" {
+			found = true
+		}
+		if strings.Contains(path, "realtime?range=") {
+			t.Fatalf("realtime path uses ignored range parameter: %q", path)
+		}
+	}
+	if !found {
+		t.Fatalf("explicit 60-minute realtime path missing: %v", paths)
 	}
 }
 

--- a/internal/benchmark/capacity/test/summary_test.go
+++ b/internal/benchmark/capacity/test/summary_test.go
@@ -1,0 +1,104 @@
+package capacity_test
+
+import (
+	"testing"
+
+	"cpa-usage-keeper/internal/benchmark/capacity"
+)
+
+func TestBuildSummaryProducesOneRecommendationPerResource(t *testing.T) {
+	results := []capacity.CellResult{
+		cellResult("one", "1c-unlimited", 1, 150, 100, 304*1024*1024),
+		cellResult("two", "2c-unlimited", 2, 200, 200, 417*1024*1024),
+	}
+	summary := capacity.BuildSummary(results)
+	if len(summary.Hardware) != 2 {
+		t.Fatalf("hardware rows=%d, want 2", len(summary.Hardware))
+	}
+	if summary.Hardware[0].DatasetID != "reference-2m" || summary.Hardware[0].IngestionMaxEventsPerSecond != 150 || summary.Hardware[0].DashboardMaxEventsPerSecond != 100 {
+		t.Fatalf("unexpected first recommendation: %+v", summary.Hardware[0])
+	}
+	if summary.Hardware[1].CPU != 2 || summary.Hardware[1].PeakMemoryBytes != 417*1024*1024 {
+		t.Fatalf("unexpected second recommendation: %+v", summary.Hardware[1])
+	}
+}
+
+func TestBuildSummaryUsesBoundaryLatencyMedian(t *testing.T) {
+	result := cellResult("cell", "1c-unlimited", 1, 100, 70, 100)
+	result.Attempts = []capacity.ProbeAttempt{
+		{Phase: "boundary", RatePerSecond: 100, Report: capacity.ProbeReport{Evaluation: capacity.ProbeEvaluation{HardPass: true}, Metrics: capacity.ProbeMetrics{HTTPP95MS: 400, HTTPP99MS: 800}}},
+		{Phase: "boundary", RatePerSecond: 100, Report: capacity.ProbeReport{Evaluation: capacity.ProbeEvaluation{HardPass: true}, Metrics: capacity.ProbeMetrics{HTTPP95MS: 600, HTTPP99MS: 1200}}},
+	}
+	summary := capacity.BuildSummary([]capacity.CellResult{result})
+	if summary.Cells[0].BoundaryHTTPP95MS != 500 || summary.Cells[0].BoundaryHTTPP99MS != 1000 {
+		t.Fatalf("unexpected boundary latency: %+v", summary.Cells[0])
+	}
+}
+
+func TestBuildSummaryExplainsDashboardAtFiveMinuteSearchCapacity(t *testing.T) {
+	result := cellResult("cell", "2c-unlimited", 2, 200, 0, 400*1024*1024)
+	result.Attempts = []capacity.ProbeAttempt{
+		{
+			Phase: "search", RatePerSecond: 200, DurationSeconds: 300,
+			Report: capacity.ProbeReport{
+				Evaluation: capacity.ProbeEvaluation{HardPass: true, InteractivePass: false},
+				Metrics:    capacity.ProbeMetrics{HTTPP95MS: 650, HTTPP99MS: 3100},
+				LatencyByPath: map[string]capacity.LatencySummary{
+					"/overview": {P95MS: 300, P99MS: 500},
+					"/analysis": {P95MS: 1200, P99MS: 4000},
+				},
+			},
+		},
+	}
+	summary := capacity.BuildSummary([]capacity.CellResult{result})
+	cell := summary.Cells[0]
+	if cell.BoundaryHTTPP95MS != 650 || cell.BoundaryHTTPP99MS != 3100 {
+		t.Fatalf("search capacity latency not selected: %+v", cell)
+	}
+	if cell.DashboardStatus != "ingestion_only" || cell.SlowestDashboardPath != "/analysis" || cell.SlowestDashboardP99MS != 4000 {
+		t.Fatalf("unexpected dashboard assessment: %+v", cell)
+	}
+}
+
+func TestBuildSummaryExplainsIngestionOnlyCapacity(t *testing.T) {
+	result := cellResult("cell", "4c-unlimited", 4, 1000, 0, 600*1024*1024)
+	summary := capacity.BuildSummary([]capacity.CellResult{result})
+	want := "可持续 ingestion 上限为 1000 events/s；Dashboard 未通过交互 SLA"
+	if summary.Hardware[0].Guidance != want {
+		t.Fatalf("guidance=%q, want %q", summary.Hardware[0].Guidance, want)
+	}
+}
+
+func TestBuildSummarySeparatesDashboardMaximumFromRecommendedRate(t *testing.T) {
+	result := cellResult("cell", "4c-unlimited", 4, 1000, 700, 220*1024*1024)
+	result.Capacity.InteractiveEventsPerSecond = 900
+	result.Attempts = []capacity.ProbeAttempt{
+		{
+			Phase: "soak", RatePerSecond: 1000,
+			Report:       capacity.ProbeReport{Evaluation: capacity.ProbeEvaluation{HardPass: true, InteractivePass: false}},
+			Resource:     capacity.AttemptResource{CPUUtilizationPercent: 79.5},
+			PeakResource: capacity.CgroupSample{MemoryPeakBytes: 210 * 1024 * 1024},
+		},
+	}
+	summary := capacity.BuildSummary([]capacity.CellResult{result})
+	cell := summary.Cells[0]
+	if cell.CapacityCPUUtilizationPercent != 79.5 || cell.CapacityPeakMemoryBytes != 210*1024*1024 {
+		t.Fatalf("capacity telemetry missing: %+v", cell)
+	}
+	recommendation := summary.Hardware[0]
+	if recommendation.DashboardMaxEventsPerSecond != 900 || recommendation.RecommendedEventsPerSecond != 700 {
+		t.Fatalf("dashboard maximum and recommendation were conflated: %+v", recommendation)
+	}
+}
+
+func cellResult(id, resourceID string, cpu float64, hard, recommended int, peak int64) capacity.CellResult {
+	return capacity.CellResult{
+		Cell: capacity.Cell{
+			ID: id, DatasetID: "reference-2m", Cardinality: capacity.Cardinality{Identities: 323, Models: 52, APIKeys: 27},
+			Resource: capacity.Resource{ID: resourceID, CPU: cpu, MemoryMiB: 0},
+		},
+		Status: "completed", StartupSeconds: 1,
+		Capacity:     capacity.CapacityResult{HardEventsPerSecond: hard, InteractiveEventsPerSecond: recommended, RecommendedEventsPerSecond: recommended},
+		PeakResource: capacity.CgroupSample{MemoryPeakBytes: peak},
+	}
+}

--- a/internal/benchmark/capacity/test/summary_test.go
+++ b/internal/benchmark/capacity/test/summary_test.go
@@ -11,11 +11,13 @@ func TestBuildSummaryProducesOneRecommendationPerResource(t *testing.T) {
 		cellResult("one", "1c-unlimited", 1, 150, 100, 304*1024*1024),
 		cellResult("two", "2c-unlimited", 2, 200, 200, 417*1024*1024),
 	}
+	results[0].Capacity.LowestHardFailureEventsPerSecond = 175
+	results[0].Capacity.LowestInteractiveFailureEventsPerSecond = 125
 	summary := capacity.BuildSummary(results)
 	if len(summary.Hardware) != 2 {
 		t.Fatalf("hardware rows=%d, want 2", len(summary.Hardware))
 	}
-	if summary.Hardware[0].DatasetID != "reference-2m" || summary.Hardware[0].IngestionMaxEventsPerSecond != 150 || summary.Hardware[0].DashboardMaxEventsPerSecond != 100 {
+	if summary.Hardware[0].DatasetID != "reference-3m" || summary.Hardware[0].IngestionMaxEventsPerSecond != 150 || summary.Hardware[0].IngestionLowestFailureRate != 175 || summary.Hardware[0].DashboardMaxEventsPerSecond != 100 || summary.Hardware[0].DashboardLowestFailureRate != 125 {
 		t.Fatalf("unexpected first recommendation: %+v", summary.Hardware[0])
 	}
 	if summary.Hardware[1].CPU != 2 || summary.Hardware[1].PeakMemoryBytes != 417*1024*1024 {
@@ -25,13 +27,37 @@ func TestBuildSummaryProducesOneRecommendationPerResource(t *testing.T) {
 
 func TestBuildSummaryUsesBoundaryLatencyMedian(t *testing.T) {
 	result := cellResult("cell", "1c-unlimited", 1, 100, 70, 100)
+	result.Capacity.InteractiveEventsPerSecond = 100
 	result.Attempts = []capacity.ProbeAttempt{
-		{Phase: "boundary", RatePerSecond: 100, Report: capacity.ProbeReport{Evaluation: capacity.ProbeEvaluation{HardPass: true}, Metrics: capacity.ProbeMetrics{HTTPP95MS: 400, HTTPP99MS: 800}}},
-		{Phase: "boundary", RatePerSecond: 100, Report: capacity.ProbeReport{Evaluation: capacity.ProbeEvaluation{HardPass: true}, Metrics: capacity.ProbeMetrics{HTTPP95MS: 600, HTTPP99MS: 1200}}},
+		{Phase: "boundary-pass", RatePerSecond: 100, Report: capacity.ProbeReport{Evaluation: capacity.ProbeEvaluation{HardPass: true, InteractivePass: true}, Metrics: capacity.ProbeMetrics{HTTPP95MS: 400, HTTPP99MS: 800}}},
+		{Phase: "boundary-pass", RatePerSecond: 100, Report: capacity.ProbeReport{Evaluation: capacity.ProbeEvaluation{HardPass: true, InteractivePass: true}, Metrics: capacity.ProbeMetrics{HTTPP95MS: 600, HTTPP99MS: 1200}}},
 	}
 	summary := capacity.BuildSummary([]capacity.CellResult{result})
 	if summary.Cells[0].BoundaryHTTPP95MS != 500 || summary.Cells[0].BoundaryHTTPP99MS != 1000 {
 		t.Fatalf("unexpected boundary latency: %+v", summary.Cells[0])
+	}
+}
+
+func TestBuildSummaryUsesDashboardCapacityForDashboardLatency(t *testing.T) {
+	result := cellResult("cell", "2c-unlimited", 2, 200, 70, 100)
+	result.Capacity.InteractiveEventsPerSecond = 100
+	result.Attempts = []capacity.ProbeAttempt{
+		{Phase: "soak", RatePerSecond: 200, Report: capacity.ProbeReport{Evaluation: capacity.ProbeEvaluation{HardPass: true}, Metrics: capacity.ProbeMetrics{HTTPP95MS: 900, HTTPP99MS: 3200}}, Resource: capacity.AttemptResource{CPUUtilizationPercent: 80}},
+		{Phase: "soak", RatePerSecond: 100, Report: capacity.ProbeReport{Evaluation: capacity.ProbeEvaluation{HardPass: true, InteractivePass: true}, Metrics: capacity.ProbeMetrics{HTTPP95MS: 200, HTTPP99MS: 500}}},
+	}
+	summary := capacity.BuildSummary([]capacity.CellResult{result})
+	cell := summary.Cells[0]
+	if cell.BoundaryHTTPP95MS != 200 || cell.BoundaryHTTPP99MS != 500 {
+		t.Fatalf("dashboard latency came from the wrong rate: %+v", cell)
+	}
+	if cell.CapacityCPUUtilizationPercent != 80 {
+		t.Fatalf("ingestion telemetry must remain tied to the hard capacity: %+v", cell)
+	}
+}
+
+func TestRecommendedEventsPerSecondAppliesManifestRatio(t *testing.T) {
+	if got := capacity.RecommendedEventsPerSecond(100, 0.70); got != 70 {
+		t.Fatalf("recommended rate=%d, want 70", got)
 	}
 }
 
@@ -41,11 +67,13 @@ func TestBuildSummaryExplainsDashboardAtFiveMinuteSearchCapacity(t *testing.T) {
 		{
 			Phase: "search", RatePerSecond: 200, DurationSeconds: 300,
 			Report: capacity.ProbeReport{
-				Evaluation: capacity.ProbeEvaluation{HardPass: true, InteractivePass: false},
-				Metrics:    capacity.ProbeMetrics{HTTPP95MS: 650, HTTPP99MS: 3100},
+				Evaluation:      capacity.ProbeEvaluation{HardPass: true, InteractivePass: false, AnalysisLatencyPass: true},
+				Metrics:         capacity.ProbeMetrics{HTTPP95MS: 650, HTTPP99MS: 3100, AnalysisLatencyRequests: 9},
+				AnalysisLatency: capacity.LatencySummary{Samples: 9, P50MS: 3300, P95MS: 3500, P99MS: 4000, MaxMS: 4000},
 				LatencyByPath: map[string]capacity.LatencySummary{
 					"/overview": {P95MS: 300, P99MS: 500},
-					"/analysis": {P95MS: 1200, P99MS: 4000},
+					"/analysis": {P95MS: 900, P99MS: 1000},
+					"/api/v1/usage/analysis/latency?range=30d": {P95MS: 3500, P99MS: 4000},
 				},
 			},
 		},
@@ -55,8 +83,11 @@ func TestBuildSummaryExplainsDashboardAtFiveMinuteSearchCapacity(t *testing.T) {
 	if cell.BoundaryHTTPP95MS != 650 || cell.BoundaryHTTPP99MS != 3100 {
 		t.Fatalf("search capacity latency not selected: %+v", cell)
 	}
-	if cell.DashboardStatus != "ingestion_only" || cell.SlowestDashboardPath != "/analysis" || cell.SlowestDashboardP99MS != 4000 {
+	if cell.DashboardStatus != "ingestion_only" || cell.SlowestDashboardPath != "/analysis" || cell.SlowestDashboardP99MS != 1000 {
 		t.Fatalf("unexpected dashboard assessment: %+v", cell)
+	}
+	if cell.AnalysisLatencySamples != 9 || cell.AnalysisLatencyStatus != "passed" || cell.AnalysisLatencyP95MS != 3500 || cell.AnalysisLatencyP99MS != 4000 {
+		t.Fatalf("analysis latency diagnostics were not reported separately: %+v", cell)
 	}
 }
 
@@ -94,7 +125,7 @@ func TestBuildSummarySeparatesDashboardMaximumFromRecommendedRate(t *testing.T) 
 func cellResult(id, resourceID string, cpu float64, hard, recommended int, peak int64) capacity.CellResult {
 	return capacity.CellResult{
 		Cell: capacity.Cell{
-			ID: id, DatasetID: "reference-2m", Cardinality: capacity.Cardinality{Identities: 323, Models: 52, APIKeys: 27},
+			ID: id, DatasetID: "reference-3m", Cardinality: capacity.Cardinality{Identities: 500, Models: 50, APIKeys: 50},
 			Resource: capacity.Resource{ID: resourceID, CPU: cpu, MemoryMiB: 0},
 		},
 		Status: "completed", StartupSeconds: 1,

--- a/internal/benchmark/capacity/traffic.go
+++ b/internal/benchmark/capacity/traffic.go
@@ -1,0 +1,174 @@
+package capacity
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+)
+
+type APIKeyProfile struct {
+	Index  int     `json:"index"`
+	Tier   string  `json:"tier"`
+	Weight float64 `json:"weight"`
+}
+
+type apiTrafficTier struct {
+	name   string
+	start  int
+	count  int
+	weight float64
+}
+
+type apiTrafficTopology struct {
+	tiers    []apiTrafficTier
+	selector weightedSelector
+}
+
+func newAPITrafficTopology(profiles []APIKeyProfile) (apiTrafficTopology, error) {
+	if len(profiles) == 0 {
+		return apiTrafficTopology{}, fmt.Errorf("API key profiles are required")
+	}
+	var tiers []apiTrafficTier
+	for index, profile := range profiles {
+		if profile.Weight <= 0 || strings.TrimSpace(profile.Tier) == "" {
+			return apiTrafficTopology{}, fmt.Errorf("invalid API key profile %+v", profile)
+		}
+		if len(tiers) == 0 || tiers[len(tiers)-1].name != profile.Tier {
+			tiers = append(tiers, apiTrafficTier{name: profile.Tier, start: index})
+		}
+		tiers[len(tiers)-1].count++
+		tiers[len(tiers)-1].weight += profile.Weight
+	}
+	weights := make([]float64, len(tiers))
+	for index, tier := range tiers {
+		weights[index] = tier.weight
+	}
+	return apiTrafficTopology{tiers: tiers, selector: newWeightedSelector(weights)}, nil
+}
+
+func (topology apiTrafficTopology) choose(timestamp time.Time, random *splitMix64) int {
+	tierIndex := topology.selector.choose(random.float64())
+	tier := topology.tiers[tierIndex]
+	duty := 1.0
+	period := timestamp.Unix() / int64((6 * time.Hour).Seconds())
+	switch strings.ToLower(tier.name) {
+	case "medium":
+		duty = 0.35
+	case "low":
+		duty = 0.10
+		period = timestamp.Unix() / int64((24 * time.Hour).Seconds())
+	}
+	active := max(1, int(math.Ceil(float64(tier.count)*duty)))
+	if active >= tier.count {
+		return tier.start + int(random.next()%uint64(tier.count))
+	}
+	rotator := splitMix64{state: uint64(period) ^ uint64(tierIndex+1)*0x9e3779b97f4a7c15}
+	rotation := int(rotator.next() % uint64(tier.count))
+	offset := (rotation + int(random.next()%uint64(active))) % tier.count
+	return tier.start + offset
+}
+
+type fractionalShare struct {
+	index    int
+	fraction float64
+}
+
+func BuildAPIKeyProfiles(keyCount int, tiers []TrafficTier, seed uint64) ([]APIKeyProfile, error) {
+	if keyCount <= 0 {
+		return nil, fmt.Errorf("API key count must be positive")
+	}
+	if len(tiers) == 0 {
+		return nil, fmt.Errorf("traffic tiers are required")
+	}
+	counts, err := allocateTierCounts(keyCount, tiers)
+	if err != nil {
+		return nil, err
+	}
+	profiles := make([]APIKeyProfile, 0, keyCount)
+	random := splitMix64{state: seed}
+	for tierIndex, tier := range tiers {
+		for index := 0; index < counts[tierIndex]; index++ {
+			// 档内只做正负 10% 的稳定扰动，不能反转大中小档的业务层级。
+			jitter := 0.9 + random.float64()*0.2
+			profiles = append(profiles, APIKeyProfile{Index: len(profiles) + 1, Tier: tier.Name, Weight: tier.PerKeyWeight * jitter})
+		}
+	}
+	return profiles, nil
+}
+
+func allocateTierCounts(total int, tiers []TrafficTier) ([]int, error) {
+	shareTotal := 0.0
+	counts := make([]int, len(tiers))
+	remainders := make([]fractionalShare, len(tiers))
+	allocated := 0
+	for index, tier := range tiers {
+		if tier.KeyShare <= 0 || tier.PerKeyWeight <= 0 {
+			return nil, fmt.Errorf("traffic tier %q must have positive share and weight", tier.Name)
+		}
+		shareTotal += tier.KeyShare
+		exact := float64(total) * tier.KeyShare
+		counts[index] = int(math.Floor(exact))
+		allocated += counts[index]
+		remainders[index] = fractionalShare{index: index, fraction: exact - float64(counts[index])}
+	}
+	if math.Abs(shareTotal-1) > 1e-9 {
+		return nil, fmt.Errorf("traffic tier key shares sum to %.12f, want 1", shareTotal)
+	}
+	sort.SliceStable(remainders, func(left, right int) bool {
+		return remainders[left].fraction > remainders[right].fraction
+	})
+	for index := 0; index < total-allocated; index++ {
+		counts[remainders[index%len(remainders)].index]++
+	}
+	return counts, nil
+}
+
+func AllocateEvents(total int64, profiles []APIKeyProfile) ([]int64, error) {
+	if total < 0 {
+		return nil, fmt.Errorf("event total cannot be negative")
+	}
+	if len(profiles) == 0 {
+		return nil, fmt.Errorf("API key profiles are required")
+	}
+	weightTotal := 0.0
+	for _, profile := range profiles {
+		if profile.Weight <= 0 {
+			return nil, fmt.Errorf("API key %d has non-positive weight", profile.Index)
+		}
+		weightTotal += profile.Weight
+	}
+	counts := make([]int64, len(profiles))
+	remainders := make([]fractionalShare, len(profiles))
+	allocated := int64(0)
+	for index, profile := range profiles {
+		exact := float64(total) * profile.Weight / weightTotal
+		counts[index] = int64(math.Floor(exact))
+		allocated += counts[index]
+		remainders[index] = fractionalShare{index: index, fraction: exact - float64(counts[index])}
+	}
+	sort.SliceStable(remainders, func(left, right int) bool {
+		return remainders[left].fraction > remainders[right].fraction
+	})
+	for index := int64(0); index < total-allocated; index++ {
+		counts[remainders[index%int64(len(remainders))].index]++
+	}
+	return counts, nil
+}
+
+type splitMix64 struct {
+	state uint64
+}
+
+func (r *splitMix64) next() uint64 {
+	r.state += 0x9e3779b97f4a7c15
+	value := r.state
+	value = (value ^ (value >> 30)) * 0xbf58476d1ce4e5b9
+	value = (value ^ (value >> 27)) * 0x94d049bb133111eb
+	return value ^ (value >> 31)
+}
+
+func (r *splitMix64) float64() float64 {
+	return float64(r.next()>>11) / (1 << 53)
+}

--- a/internal/benchmark/cmd/benchctl/main.go
+++ b/internal/benchmark/cmd/benchctl/main.go
@@ -1,0 +1,327 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"cpa-usage-keeper/internal/benchmark/capacity"
+	"cpa-usage-keeper/internal/config"
+	"cpa-usage-keeper/internal/repository"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	if len(args) == 0 {
+		return usageError()
+	}
+	switch args[0] {
+	case "plan":
+		return runPlan(args[1:])
+	case "generate":
+		return runGenerate(args[1:])
+	case "validate":
+		return runValidate(args[1:])
+	case "probe":
+		return runProbe(args[1:])
+	case "clone":
+		return runClone(args[1:])
+	case "compress":
+		return runCompress(args[1:])
+	case "run":
+		return runSuite(args[1:], false)
+	case "resume":
+		return runSuite(args[1:], true)
+	case "summarize":
+		return runSummarize(args[1:])
+	default:
+		return usageError()
+	}
+}
+
+func usageError() error {
+	return errors.New("usage: benchctl <plan|generate|validate|probe|clone|compress|run|resume|summarize> [flags]")
+}
+
+func runPlan(args []string) error {
+	flags := flag.NewFlagSet("plan", flag.ContinueOnError)
+	manifestPath := flags.String("manifest", "internal/benchmark/manifest/capacity-v1.json", "suite manifest path")
+	outputPath := flags.String("output", "", "plan output path; stdout when empty")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	manifest, err := capacity.LoadManifest(*manifestPath)
+	if err != nil {
+		return err
+	}
+	plan, err := capacity.ExpandPlan(manifest)
+	if err != nil {
+		return err
+	}
+	data, err := capacity.MarshalPlan(plan)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(*outputPath) == "" {
+		_, err = os.Stdout.Write(data)
+		return err
+	}
+	return writeAtomic(*outputPath, data)
+}
+
+func runGenerate(args []string) error {
+	flags := flag.NewFlagSet("generate", flag.ContinueOnError)
+	manifestPath := flags.String("manifest", "internal/benchmark/manifest/capacity-v1.json", "suite manifest path")
+	databasePath := flags.String("database", "", "output SQLite database")
+	nowText := flags.String("now", "", "RFC3339 benchmark end time; manifest benchmark_now when empty")
+	vacuum := flags.Bool("vacuum", true, "vacuum canonical database after archiving")
+	insertBatch := flags.Int("insert-batch", 10_000, "raw event insert batch")
+	aggregatePage := flags.Int("aggregate-page", 5_000, "derived aggregation page used only during unrestricted preparation")
+	resultPath := flags.String("result", "", "dataset metadata output; defaults to <database-dir>/dataset.json")
+	compress := flags.Bool("compress", false, "zstd-compress canonical database and remove raw file after verification")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*databasePath) == "" {
+		return fmt.Errorf("generate requires --database")
+	}
+	manifest, err := capacity.LoadManifest(*manifestPath)
+	if err != nil {
+		return err
+	}
+	if err := manifest.Validate(); err != nil {
+		return err
+	}
+	effectiveNow := strings.TrimSpace(*nowText)
+	if effectiveNow == "" {
+		effectiveNow = manifest.Dataset.BenchmarkNow
+	}
+	now, err := time.Parse(time.RFC3339, effectiveNow)
+	if err != nil {
+		return fmt.Errorf("parse benchmark now: %w", err)
+	}
+	options := capacity.GenerateOptions{
+		Path: *databasePath, HotEvents: manifest.Dataset.HotEvents,
+		ArchiveEvents: manifest.Dataset.ArchiveEvents, HotDays: manifest.Dataset.HotDays,
+		ArchiveDays: manifest.Dataset.ArchiveDays, FailureRate: manifest.Dataset.FailureRate,
+		Seed: manifest.Dataset.Seed, Now: now, Cardinality: manifest.Dataset.Cardinality,
+		TrafficTiers: manifest.TrafficTiers, InsertBatchSize: *insertBatch, AggregatePage: *aggregatePage, Vacuum: *vacuum,
+	}
+	result, err := capacity.GenerateDataset(context.Background(), options)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(*resultPath) == "" {
+		*resultPath = filepath.Join(filepath.Dir(*databasePath), "dataset.json")
+	}
+	if err := capacity.WriteJSONAtomic(*resultPath, result); err != nil {
+		return err
+	}
+	if *compress {
+		if err := capacity.CompressDataset(context.Background(), *databasePath, *databasePath+".zst", true); err != nil {
+			return err
+		}
+	}
+	return writeJSON(os.Stdout, result)
+}
+
+func runValidate(args []string) error {
+	flags := flag.NewFlagSet("validate", flag.ContinueOnError)
+	databasePath := flags.String("database", "", "SQLite database")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*databasePath) == "" {
+		return fmt.Errorf("validate requires --database")
+	}
+	db, err := repository.OpenReadDatabase(config.Config{SQLitePath: *databasePath})
+	if err != nil {
+		return err
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		return err
+	}
+	defer sqlDB.Close()
+	result, err := capacity.ValidateDataset(db, *databasePath)
+	if err != nil {
+		return err
+	}
+	return writeJSON(os.Stdout, result)
+}
+
+func runProbe(args []string) error {
+	flags := flag.NewFlagSet("probe", flag.ContinueOnError)
+	manifestPath := flags.String("manifest", "internal/benchmark/manifest/capacity-v1.json", "suite manifest path")
+	databasePath := flags.String("database", "", "active benchmark SQLite database")
+	redisAddress := flags.String("redis", "127.0.0.1:16379", "Redis address")
+	redisPassword := flags.String("redis-password", "benchmark-only", "Redis password")
+	applicationURL := flags.String("app", "http://127.0.0.1:18080", "Keeper base URL")
+	rate := flags.Int("rate", 0, "offered usage events per second")
+	duration := flags.Duration("duration", 30*time.Second, "probe duration")
+	drainTimeout := flags.Duration("drain-timeout", 15*time.Second, "post-probe drain timeout")
+	httpRate := flags.Int("http-rate", 8, "dashboard HTTP requests per second")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *rate <= 0 || strings.TrimSpace(*databasePath) == "" {
+		return fmt.Errorf("probe requires --rate and --database")
+	}
+	manifest, err := capacity.LoadManifest(*manifestPath)
+	if err != nil {
+		return err
+	}
+	if err := manifest.Validate(); err != nil {
+		return err
+	}
+	apiProfiles, err := capacity.BuildAPIKeyProfiles(manifest.Dataset.Cardinality.APIKeys, manifest.TrafficTiers, manifest.Dataset.Seed)
+	if err != nil {
+		return err
+	}
+	report, err := capacity.RunProbe(context.Background(), capacity.ProbeOptions{
+		RedisAddress: *redisAddress, RedisPassword: *redisPassword, RedisChannel: "usage",
+		ApplicationURL: *applicationURL, DatabasePath: *databasePath, RatePerSecond: *rate,
+		Duration: *duration, DrainTimeout: *drainTimeout, HTTPRatePerSecond: *httpRate,
+		Cardinality: manifest.Dataset.Cardinality, APIKeyProfiles: apiProfiles, Seed: manifest.Dataset.Seed,
+		Thresholds: capacity.ProbeThresholds{MinDurableRatio: 0.99, MaxBacklogGrowth: 0,
+			InteractiveP95MS: float64(manifest.Search.DashboardCoreP95MS), InteractiveP99MS: float64(manifest.Search.DashboardOverallP99MS)},
+	})
+	if err != nil {
+		return err
+	}
+	return writeJSON(os.Stdout, report)
+}
+
+func runClone(args []string) error {
+	flags := flag.NewFlagSet("clone", flag.ContinueOnError)
+	source := flags.String("source", "", "source SQLite database")
+	destination := flags.String("destination", "", "destination SQLite database")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*source) == "" || strings.TrimSpace(*destination) == "" {
+		return fmt.Errorf("clone requires --source and --destination")
+	}
+	return capacity.BackupSQLite(context.Background(), *source, *destination)
+}
+
+func runCompress(args []string) error {
+	flags := flag.NewFlagSet("compress", flag.ContinueOnError)
+	source := flags.String("source", "", "uncompressed canonical SQLite database")
+	destination := flags.String("destination", "", "zstd canonical archive; defaults to <source>.zst")
+	removeSource := flags.Bool("remove-source", false, "remove source only after zstd verification succeeds")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*source) == "" {
+		return fmt.Errorf("compress requires --source")
+	}
+	if strings.TrimSpace(*destination) == "" {
+		*destination = *source + ".zst"
+	}
+	return capacity.CompressDataset(context.Background(), *source, *destination, *removeSource)
+}
+
+func runSuite(args []string, resume bool) error {
+	flags := flag.NewFlagSet("run", flag.ContinueOnError)
+	manifestPath := flags.String("manifest", "internal/benchmark/manifest/capacity-v1.json", "suite manifest path")
+	planPath := flags.String("plan", "", "expanded plan path")
+	root := flags.String("root", "/var/tmp/cpa-usage-keeper-capacity", "benchmark root")
+	runID := flags.String("run-id", "", "stable run identifier")
+	keeperBinary := flags.String("keeper", "", "Keeper server binary")
+	redisBinary := flags.String("redis-server", "redis-server", "Redis server binary")
+	redisPort := flags.Int("redis-port", 16379, "task Redis port")
+	appPort := flags.Int("app-port", 18080, "Keeper HTTP port")
+	cells := flags.String("cells", "", "comma-separated cell IDs; all cells when empty")
+	maxDuration := flags.Duration("max-duration", 8*time.Hour, "whole-run deadline")
+	fixedRate := flags.Int("fixed-rate", 0, "run one fixed-rate soak instead of capacity search")
+	fixedDuration := flags.Duration("fixed-duration", 0, "fixed-rate soak duration; manifest soak duration when empty")
+	fixedPass := flags.String("fixed-pass", "interactive", "fixed-rate pass requirement: interactive or hard")
+	searchDuration := flags.Duration("search-duration", 0, "override each capacity-search probe duration")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*planPath) == "" || strings.TrimSpace(*keeperBinary) == "" {
+		return fmt.Errorf("run requires --plan and --keeper")
+	}
+	if strings.TrimSpace(*runID) == "" {
+		*runID = "capacity-v1-" + time.Now().UTC().Format("20060102-150405")
+	}
+	var cellIDs []string
+	for _, value := range strings.Split(*cells, ",") {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			cellIDs = append(cellIDs, trimmed)
+		}
+	}
+	metadata, err := capacity.ExecuteRun(context.Background(), capacity.RunOptions{
+		ManifestPath: *manifestPath, PlanPath: *planPath, Root: *root, RunID: *runID,
+		KeeperBinary: *keeperBinary, RedisBinary: *redisBinary, RedisPort: *redisPort, AppPort: *appPort,
+		CellIDs: cellIDs, Resume: resume, MaxDuration: *maxDuration,
+		FixedRate: *fixedRate, FixedDuration: *fixedDuration, FixedPass: *fixedPass, SearchDuration: *searchDuration,
+	})
+	if err != nil {
+		return err
+	}
+	return writeJSON(os.Stdout, metadata)
+}
+
+func runSummarize(args []string) error {
+	flags := flag.NewFlagSet("summarize", flag.ContinueOnError)
+	runDir := flags.String("run-dir", "", "benchmark run directory")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*runDir) == "" {
+		return fmt.Errorf("summarize requires --run-dir")
+	}
+	summary, err := capacity.SummarizeRun(*runDir)
+	if err != nil {
+		return err
+	}
+	return writeJSON(os.Stdout, summary)
+}
+
+func writeJSON(file *os.File, value any) error {
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}
+
+func writeAtomic(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".benchctl-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary output: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if _, err := temporary.Write(data); err != nil {
+		temporary.Close()
+		return fmt.Errorf("write temporary output: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		temporary.Close()
+		return fmt.Errorf("sync temporary output: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary output: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("publish output: %w", err)
+	}
+	return nil
+}

--- a/internal/benchmark/cmd/benchctl/main.go
+++ b/internal/benchmark/cmd/benchctl/main.go
@@ -108,12 +108,12 @@ func runGenerate(args []string) error {
 	if effectiveNow == "" {
 		effectiveNow = manifest.Dataset.BenchmarkNow
 	}
-	now, err := time.Parse(time.RFC3339, effectiveNow)
+	now, err := capacity.ResolveDatasetBenchmarkNow(effectiveNow, time.Now())
 	if err != nil {
-		return fmt.Errorf("parse benchmark now: %w", err)
+		return err
 	}
 	options := capacity.GenerateOptions{
-		Path: *databasePath, HotEvents: manifest.Dataset.HotEvents,
+		Path: *databasePath, HotEvents: manifest.Dataset.HotEvents, Recent30DayEvents: manifest.Dataset.Recent30DayEvents,
 		ArchiveEvents: manifest.Dataset.ArchiveEvents, HotDays: manifest.Dataset.HotDays,
 		ArchiveDays: manifest.Dataset.ArchiveDays, FailureRate: manifest.Dataset.FailureRate,
 		Seed: manifest.Dataset.Seed, Now: now, Cardinality: manifest.Dataset.Cardinality,
@@ -140,13 +140,27 @@ func runGenerate(args []string) error {
 func runValidate(args []string) error {
 	flags := flag.NewFlagSet("validate", flag.ContinueOnError)
 	databasePath := flags.String("database", "", "SQLite database")
+	manifestPath := flags.String("manifest", "", "suite manifest used to generate the dataset")
+	metadataPath := flags.String("metadata", "", "dataset.json metadata to compare with the database")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
 	if strings.TrimSpace(*databasePath) == "" {
 		return fmt.Errorf("validate requires --database")
 	}
-	db, err := repository.OpenReadDatabase(config.Config{SQLitePath: *databasePath})
+	validationPath := *databasePath
+	if strings.HasSuffix(validationPath, ".zst") {
+		temporaryDir, err := os.MkdirTemp(filepath.Dir(validationPath), ".benchmark-validate-*")
+		if err != nil {
+			return fmt.Errorf("create compressed dataset validation directory: %w", err)
+		}
+		defer os.RemoveAll(temporaryDir)
+		validationPath = filepath.Join(temporaryDir, "app.db")
+		if err := capacity.RestoreDataset(context.Background(), *databasePath, validationPath); err != nil {
+			return err
+		}
+	}
+	db, err := repository.OpenReadDatabase(config.Config{SQLitePath: validationPath})
 	if err != nil {
 		return err
 	}
@@ -155,9 +169,33 @@ func runValidate(args []string) error {
 		return err
 	}
 	defer sqlDB.Close()
-	result, err := capacity.ValidateDataset(db, *databasePath)
+	result, err := capacity.ValidateDataset(db, validationPath)
 	if err != nil {
 		return err
+	}
+	if strings.TrimSpace(*manifestPath) != "" || strings.TrimSpace(*metadataPath) != "" {
+		if strings.TrimSpace(*manifestPath) == "" || strings.TrimSpace(*metadataPath) == "" {
+			return fmt.Errorf("strict validation requires both --manifest and --metadata")
+		}
+		manifest, err := capacity.LoadManifest(*manifestPath)
+		if err != nil {
+			return err
+		}
+		if err := manifest.Validate(); err != nil {
+			return err
+		}
+		metadata, err := capacity.LoadDatasetResult(*metadataPath)
+		if err != nil {
+			return fmt.Errorf("load dataset metadata: %w", err)
+		}
+		if err := capacity.ValidateDatasetAgainstManifest(result, metadata, manifest); err != nil {
+			return err
+		}
+		result.GeneratorVersion = metadata.GeneratorVersion
+		result.Seed = metadata.Seed
+		result.BenchmarkNow = metadata.BenchmarkNow
+		result.FailureRate = metadata.FailureRate
+		result.TrafficTiers = append([]capacity.TrafficTier(nil), metadata.TrafficTiers...)
 	}
 	return writeJSON(os.Stdout, result)
 }
@@ -194,9 +232,10 @@ func runProbe(args []string) error {
 		RedisAddress: *redisAddress, RedisPassword: *redisPassword, RedisChannel: "usage",
 		ApplicationURL: *applicationURL, DatabasePath: *databasePath, RatePerSecond: *rate,
 		Duration: *duration, DrainTimeout: *drainTimeout, HTTPRatePerSecond: *httpRate,
-		Cardinality: manifest.Dataset.Cardinality, APIKeyProfiles: apiProfiles, Seed: manifest.Dataset.Seed,
+		AnalysisLatencyInterval: time.Duration(manifest.Search.AnalysisLatencyIntervalSeconds) * time.Second,
+		Cardinality:             manifest.Dataset.Cardinality, APIKeyProfiles: apiProfiles, Seed: manifest.Dataset.Seed,
 		Thresholds: capacity.ProbeThresholds{MinDurableRatio: 0.99, MaxBacklogGrowth: 0,
-			InteractiveP95MS: float64(manifest.Search.DashboardCoreP95MS), InteractiveP99MS: float64(manifest.Search.DashboardOverallP99MS)},
+			InteractiveP95MS: float64(manifest.Search.DashboardCoreP95MS), InteractiveP99MS: float64(manifest.Search.DashboardCoreP99MS)},
 	})
 	if err != nil {
 		return err
@@ -250,6 +289,7 @@ func runSuite(args []string, resume bool) error {
 	fixedDuration := flags.Duration("fixed-duration", 0, "fixed-rate soak duration; manifest soak duration when empty")
 	fixedPass := flags.String("fixed-pass", "interactive", "fixed-rate pass requirement: interactive or hard")
 	searchDuration := flags.Duration("search-duration", 0, "override each capacity-search probe duration")
+	datasetValidationPath := flags.String("dataset-validation", "", "strict dataset validation JSON produced before the controller run")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -270,6 +310,7 @@ func runSuite(args []string, resume bool) error {
 		KeeperBinary: *keeperBinary, RedisBinary: *redisBinary, RedisPort: *redisPort, AppPort: *appPort,
 		CellIDs: cellIDs, Resume: resume, MaxDuration: *maxDuration,
 		FixedRate: *fixedRate, FixedDuration: *fixedDuration, FixedPass: *fixedPass, SearchDuration: *searchDuration,
+		DatasetValidationPath: *datasetValidationPath,
 	})
 	if err != nil {
 		return err

--- a/internal/benchmark/legacy/overview_benchmark_test.go
+++ b/internal/benchmark/legacy/overview_benchmark_test.go
@@ -1,4 +1,4 @@
-package benchmark
+package legacy
 
 import (
 	"context"

--- a/internal/benchmark/legacy/overview_custom_range_benchmark_test.go
+++ b/internal/benchmark/legacy/overview_custom_range_benchmark_test.go
@@ -1,4 +1,4 @@
-package test
+package legacy
 
 import (
 	"context"

--- a/internal/benchmark/legacy/redis_process_benchmark_test.go
+++ b/internal/benchmark/legacy/redis_process_benchmark_test.go
@@ -1,4 +1,4 @@
-package benchmark
+package legacy
 
 import (
 	"context"

--- a/internal/benchmark/manifest/capacity-v1.json
+++ b/internal/benchmark/manifest/capacity-v1.json
@@ -1,0 +1,46 @@
+{
+  "version": "capacity-v1",
+  "target": {
+    "os": "linux",
+    "arch": "amd64"
+  },
+  "dataset": {
+    "id": "reference-2m",
+    "hot_events": 1946550,
+    "archive_events": 89190,
+    "failure_rate": 0.041818,
+    "seed": 20260806,
+    "hot_days": 90,
+    "archive_days": 7,
+    "benchmark_now": "2026-08-06T16:00:00+08:00",
+    "cardinality": {
+      "identities": 323,
+      "models": 52,
+      "api_keys": 27
+    }
+  },
+  "traffic_tiers": [
+    {"name": "high", "key_share": 0.30, "per_key_weight": 10},
+    {"name": "medium", "key_share": 0.50, "per_key_weight": 3},
+    {"name": "low", "key_share": 0.20, "per_key_weight": 1}
+  ],
+  "resources": [
+    {"id": "1c-unlimited", "cpu": 1, "memory_mib": 0},
+    {"id": "2c-unlimited", "cpu": 2, "memory_mib": 0},
+    {"id": "4c-unlimited", "cpu": 4, "memory_mib": 0}
+  ],
+  "search": {
+    "rates_per_second": [25, 50, 75, 100, 150, 200, 225, 250, 275, 300, 400, 500, 600, 650, 675, 750, 900, 1000, 1250, 1500, 1750, 2000, 2500, 3000, 3500, 4000, 5000, 6000, 7500, 10000],
+    "probe_seconds": 20,
+    "boundary_seconds": 30,
+    "boundary_repetitions": 1,
+    "skip_boundary": true,
+    "soak_seconds": 300,
+    "max_run_seconds": 7200,
+    "dashboard_core_p95_ms": 0,
+    "dashboard_overall_p99_ms": 3000,
+    "dashboard_requests_per_second": 1,
+    "search_dashboard_capacity": true,
+    "recommended_capacity_ratio": 0.70
+  }
+}

--- a/internal/benchmark/manifest/capacity-v1.json
+++ b/internal/benchmark/manifest/capacity-v1.json
@@ -5,18 +5,19 @@
     "arch": "amd64"
   },
   "dataset": {
-    "id": "reference-2m",
-    "hot_events": 1946550,
-    "archive_events": 89190,
-    "failure_rate": 0.041818,
+    "id": "reference-3m",
+    "hot_events": 3205740,
+    "recent_30_day_events": 1226326,
+    "archive_events": 0,
+    "failure_rate": 0.01,
     "seed": 20260806,
     "hot_days": 90,
-    "archive_days": 7,
-    "benchmark_now": "2026-08-06T16:00:00+08:00",
+    "archive_days": 0,
+    "benchmark_now": "generation-time",
     "cardinality": {
-      "identities": 323,
-      "models": 52,
-      "api_keys": 27
+      "identities": 500,
+      "models": 50,
+      "api_keys": 50
     }
   },
   "traffic_tiers": [
@@ -30,16 +31,19 @@
     {"id": "4c-unlimited", "cpu": 4, "memory_mib": 0}
   ],
   "search": {
-    "rates_per_second": [25, 50, 75, 100, 150, 200, 225, 250, 275, 300, 400, 500, 600, 650, 675, 750, 900, 1000, 1250, 1500, 1750, 2000, 2500, 3000, 3500, 4000, 5000, 6000, 7500, 10000],
+    "rates_per_second": [1, 5, 10, 15, 20, 25, 50, 75, 100, 150, 200, 225, 250, 275, 300, 400, 500, 600, 650, 675, 750, 900, 1000, 1250, 1500, 1750, 2000, 2500, 3000, 3500, 4000, 5000, 6000, 7500, 10000],
+    "initial_rate_per_second": 25,
     "probe_seconds": 20,
-    "boundary_seconds": 30,
+    "boundary_seconds": 60,
     "boundary_repetitions": 1,
-    "skip_boundary": true,
+    "skip_boundary": false,
     "soak_seconds": 300,
-    "max_run_seconds": 7200,
-    "dashboard_core_p95_ms": 0,
-    "dashboard_overall_p99_ms": 3000,
-    "dashboard_requests_per_second": 1,
+    "max_pass_drain_seconds": 15,
+		"max_run_seconds": 7200,
+		"dashboard_core_p95_ms": 0,
+		"dashboard_core_p99_ms": 3000,
+		"dashboard_requests_per_second": 1,
+		"analysis_latency_interval_seconds": 30,
     "search_dashboard_capacity": true,
     "recommended_capacity_ratio": 0.70
   }

--- a/internal/benchmark/schema/cell-result.schema.json
+++ b/internal/benchmark/schema/cell-result.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:cpa-usage-keeper:benchmark:cell-result-v1",
+  "type": "object",
+  "required": ["version", "run_id", "cell", "status", "dataset_fingerprint", "manifest_sha256", "keeper_binary_sha256", "benchctl_binary_sha256", "attempts", "capacity"],
+  "properties": {
+    "version": {"const": "capacity-v1"},
+    "run_id": {"type": "string"},
+    "cell": {"type": "object"},
+    "status": {"enum": ["preparing", "running", "completed", "failed", "oom", "timeout", "skipped_capacity"]},
+    "dataset_fingerprint": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "manifest_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "keeper_binary_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "benchctl_binary_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "shared_driver": {"type": "boolean"},
+    "work_database_retained": {"type": "boolean"},
+    "attempts": {"type": "array", "items": {"type": "object"}},
+    "capacity": {
+      "type": "object",
+      "required": ["hard_events_per_second", "interactive_events_per_second", "recommended_events_per_second"],
+      "properties": {
+        "hard_events_per_second": {"type": "integer", "minimum": 0},
+        "interactive_events_per_second": {"type": "integer", "minimum": 0},
+        "recommended_events_per_second": {"type": "integer", "minimum": 0}
+      }
+    }
+  }
+}

--- a/internal/benchmark/schema/cell-result.schema.json
+++ b/internal/benchmark/schema/cell-result.schema.json
@@ -2,14 +2,18 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "urn:cpa-usage-keeper:benchmark:cell-result-v1",
   "type": "object",
-  "required": ["version", "run_id", "cell", "status", "dataset_fingerprint", "manifest_sha256", "keeper_binary_sha256", "benchctl_binary_sha256", "attempts", "capacity"],
+  "required": ["version", "run_id", "cell", "status", "dataset_fingerprint", "dataset_validation_sha256", "dataset_query_anchor", "dataset_recent_30_day_events", "manifest_sha256", "plan_sha256", "keeper_binary_sha256", "benchctl_binary_sha256", "attempts", "capacity"],
   "properties": {
     "version": {"const": "capacity-v1"},
     "run_id": {"type": "string"},
     "cell": {"type": "object"},
     "status": {"enum": ["preparing", "running", "completed", "failed", "oom", "timeout", "skipped_capacity"]},
     "dataset_fingerprint": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "dataset_validation_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "dataset_query_anchor": {"type": "string", "format": "date-time"},
+    "dataset_recent_30_day_events": {"type": "integer", "minimum": 1},
     "manifest_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "plan_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "keeper_binary_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "benchctl_binary_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "shared_driver": {"type": "boolean"},
@@ -20,7 +24,9 @@
       "required": ["hard_events_per_second", "interactive_events_per_second", "recommended_events_per_second"],
       "properties": {
         "hard_events_per_second": {"type": "integer", "minimum": 0},
+        "lowest_hard_failure_events_per_second": {"type": "integer", "minimum": 0},
         "interactive_events_per_second": {"type": "integer", "minimum": 0},
+        "lowest_interactive_failure_events_per_second": {"type": "integer", "minimum": 0},
         "recommended_events_per_second": {"type": "integer", "minimum": 0}
       }
     }

--- a/internal/benchmark/schema/plan.schema.json
+++ b/internal/benchmark/schema/plan.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:cpa-usage-keeper:benchmark:capacity-plan-v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "manifest_sha256", "cells"],
+  "properties": {
+    "version": {"const": "capacity-v1"},
+    "manifest_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "cells": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "kind", "dataset_id", "hot_events", "archive_events", "cardinality", "resource", "rates_per_second"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^capacity-[a-z0-9-]+$"},
+          "kind": {"const": "capacity"},
+          "dataset_id": {"type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"},
+          "hot_events": {"type": "integer", "minimum": 1},
+          "archive_events": {"type": "integer", "minimum": 0},
+          "cardinality": {"type": "object"},
+          "resource": {"type": "object"},
+          "rates_per_second": {"type": "array", "minItems": 1, "items": {"type": "integer", "minimum": 1}}
+        }
+      }
+    }
+  }
+}

--- a/internal/benchmark/schema/plan.schema.json
+++ b/internal/benchmark/schema/plan.schema.json
@@ -13,12 +13,13 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["id", "kind", "dataset_id", "hot_events", "archive_events", "cardinality", "resource", "rates_per_second"],
+        "required": ["id", "kind", "dataset_id", "hot_events", "recent_30_day_events", "archive_events", "cardinality", "resource", "rates_per_second"],
         "properties": {
           "id": {"type": "string", "pattern": "^capacity-[a-z0-9-]+$"},
           "kind": {"const": "capacity"},
           "dataset_id": {"type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"},
           "hot_events": {"type": "integer", "minimum": 1},
+          "recent_30_day_events": {"type": "integer", "minimum": 1},
           "archive_events": {"type": "integer", "minimum": 0},
           "cardinality": {"type": "object"},
           "resource": {"type": "object"},

--- a/internal/benchmark/schema/run.schema.json
+++ b/internal/benchmark/schema/run.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:cpa-usage-keeper:benchmark:run-v1",
+  "type": "object",
+  "required": ["version", "run_id", "state", "os", "arch", "manifest_sha256", "plan_sha256", "keeper_binary_sha256", "benchctl_binary_sha256", "selected_cells"],
+  "properties": {
+    "version": {"const": "capacity-v1"},
+    "run_id": {"type": "string", "minLength": 1},
+    "state": {"enum": ["preparing", "running", "completed", "failed"]},
+    "os": {"const": "linux"},
+    "arch": {"const": "amd64"},
+    "manifest_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "plan_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "keeper_binary_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "benchctl_binary_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "selected_cells": {"type": "array", "items": {"type": "string"}}
+  }
+}

--- a/internal/benchmark/schema/run.schema.json
+++ b/internal/benchmark/schema/run.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "urn:cpa-usage-keeper:benchmark:run-v1",
   "type": "object",
-  "required": ["version", "run_id", "state", "os", "arch", "manifest_sha256", "plan_sha256", "keeper_binary_sha256", "benchctl_binary_sha256", "selected_cells"],
+  "required": ["version", "run_id", "state", "os", "arch", "manifest_sha256", "plan_sha256", "keeper_binary_sha256", "benchctl_binary_sha256", "dataset_validation_sha256", "dataset_query_anchor", "dataset_recent_30_day_events", "selected_cells"],
   "properties": {
     "version": {"const": "capacity-v1"},
     "run_id": {"type": "string", "minLength": 1},
@@ -13,6 +13,10 @@
     "plan_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "keeper_binary_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "benchctl_binary_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "dataset_validation_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "dataset_query_anchor": {"type": "string", "format": "date-time"},
+    "dataset_recent_30_day_events": {"type": "integer", "minimum": 1},
+    "redis_cpus": {"type": "string", "minLength": 1},
     "selected_cells": {"type": "array", "items": {"type": "string"}}
   }
 }

--- a/internal/benchmark/schema/suite.schema.json
+++ b/internal/benchmark/schema/suite.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:cpa-usage-keeper:benchmark:capacity-v1",
+  "title": "CPA Usage Keeper capacity benchmark suite",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "target", "dataset", "traffic_tiers", "resources", "search"],
+  "properties": {
+    "version": {"const": "capacity-v1"},
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["os", "arch"],
+      "properties": {
+        "os": {"const": "linux"},
+        "arch": {"const": "amd64"}
+      }
+    },
+    "dataset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "hot_events", "archive_events", "failure_rate", "seed", "hot_days", "archive_days", "benchmark_now", "cardinality"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"},
+        "hot_events": {"type": "integer", "minimum": 1},
+        "archive_events": {"type": "integer", "minimum": 0},
+        "failure_rate": {"type": "number", "minimum": 0, "maximum": 1},
+        "seed": {"type": "integer", "minimum": 0},
+        "hot_days": {"type": "integer", "minimum": 1},
+        "archive_days": {"type": "integer", "minimum": 0},
+        "benchmark_now": {"type": "string", "format": "date-time"},
+        "cardinality": {"$ref": "#/$defs/cardinality"}
+      }
+    },
+    "traffic_tiers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "key_share", "per_key_weight"],
+        "properties": {
+          "name": {"type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"},
+          "key_share": {"type": "number", "exclusiveMinimum": 0, "maximum": 1},
+          "per_key_weight": {"type": "number", "exclusiveMinimum": 0}
+        }
+      }
+    },
+    "resources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/resource"}
+    },
+    "search": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rates_per_second", "probe_seconds", "boundary_seconds", "boundary_repetitions", "soak_seconds", "max_run_seconds", "dashboard_core_p95_ms", "dashboard_overall_p99_ms", "dashboard_requests_per_second", "recommended_capacity_ratio"],
+      "properties": {
+        "rates_per_second": {"type": "array", "minItems": 1, "items": {"type": "integer", "minimum": 1}},
+        "probe_seconds": {"type": "integer", "minimum": 1},
+        "boundary_seconds": {"type": "integer", "minimum": 1},
+        "boundary_repetitions": {"type": "integer", "minimum": 1},
+        "skip_boundary": {"type": "boolean"},
+        "soak_seconds": {"type": "integer", "minimum": 1},
+        "max_run_seconds": {"type": "integer", "minimum": 1},
+        "dashboard_core_p95_ms": {"type": "integer", "minimum": 0},
+        "dashboard_overall_p99_ms": {"type": "integer", "minimum": 1},
+        "dashboard_requests_per_second": {"type": "integer", "minimum": 1},
+        "search_dashboard_capacity": {"type": "boolean"},
+        "recommended_capacity_ratio": {"type": "number", "exclusiveMinimum": 0, "maximum": 1}
+      }
+    }
+  },
+  "$defs": {
+    "cardinality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["identities", "models", "api_keys"],
+      "properties": {
+        "identities": {"type": "integer", "minimum": 1, "maximum": 1000},
+        "models": {"type": "integer", "minimum": 1, "maximum": 100},
+        "api_keys": {"type": "integer", "minimum": 1, "maximum": 100}
+      }
+    },
+    "resource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "cpu", "memory_mib"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"},
+        "cpu": {"type": "integer", "minimum": 1, "maximum": 4},
+        "memory_mib": {
+          "anyOf": [
+            {"const": 0},
+            {"type": "integer", "minimum": 100, "maximum": 4096}
+          ]
+        }
+      }
+    }
+  }
+}

--- a/internal/benchmark/schema/suite.schema.json
+++ b/internal/benchmark/schema/suite.schema.json
@@ -19,16 +19,22 @@
     "dataset": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "hot_events", "archive_events", "failure_rate", "seed", "hot_days", "archive_days", "benchmark_now", "cardinality"],
+      "required": ["id", "hot_events", "recent_30_day_events", "archive_events", "failure_rate", "seed", "hot_days", "archive_days", "benchmark_now", "cardinality"],
       "properties": {
         "id": {"type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"},
         "hot_events": {"type": "integer", "minimum": 1},
+        "recent_30_day_events": {"type": "integer", "minimum": 1},
         "archive_events": {"type": "integer", "minimum": 0},
         "failure_rate": {"type": "number", "minimum": 0, "maximum": 1},
         "seed": {"type": "integer", "minimum": 0},
         "hot_days": {"type": "integer", "minimum": 1},
         "archive_days": {"type": "integer", "minimum": 0},
-        "benchmark_now": {"type": "string", "format": "date-time"},
+        "benchmark_now": {
+          "anyOf": [
+            {"const": "generation-time"},
+            {"type": "string", "format": "date-time"}
+          ]
+        },
         "cardinality": {"$ref": "#/$defs/cardinality"}
       }
     },
@@ -54,18 +60,21 @@
     "search": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["rates_per_second", "probe_seconds", "boundary_seconds", "boundary_repetitions", "soak_seconds", "max_run_seconds", "dashboard_core_p95_ms", "dashboard_overall_p99_ms", "dashboard_requests_per_second", "recommended_capacity_ratio"],
+		"required": ["rates_per_second", "initial_rate_per_second", "probe_seconds", "boundary_seconds", "boundary_repetitions", "soak_seconds", "max_pass_drain_seconds", "max_run_seconds", "dashboard_core_p95_ms", "dashboard_core_p99_ms", "dashboard_requests_per_second", "analysis_latency_interval_seconds", "recommended_capacity_ratio"],
       "properties": {
         "rates_per_second": {"type": "array", "minItems": 1, "items": {"type": "integer", "minimum": 1}},
+        "initial_rate_per_second": {"type": "integer", "minimum": 1},
         "probe_seconds": {"type": "integer", "minimum": 1},
         "boundary_seconds": {"type": "integer", "minimum": 1},
         "boundary_repetitions": {"type": "integer", "minimum": 1},
         "skip_boundary": {"type": "boolean"},
         "soak_seconds": {"type": "integer", "minimum": 1},
-        "max_run_seconds": {"type": "integer", "minimum": 1},
-        "dashboard_core_p95_ms": {"type": "integer", "minimum": 0},
-        "dashboard_overall_p99_ms": {"type": "integer", "minimum": 1},
-        "dashboard_requests_per_second": {"type": "integer", "minimum": 1},
+        "max_pass_drain_seconds": {"type": "integer", "minimum": 1, "maximum": 30},
+			"max_run_seconds": {"type": "integer", "minimum": 1},
+			"dashboard_core_p95_ms": {"type": "integer", "minimum": 0},
+			"dashboard_core_p99_ms": {"type": "integer", "minimum": 1},
+			"dashboard_requests_per_second": {"type": "integer", "minimum": 1},
+			"analysis_latency_interval_seconds": {"type": "integer", "minimum": 1},
         "search_dashboard_capacity": {"type": "boolean"},
         "recommended_capacity_ratio": {"type": "number", "exclusiveMinimum": 0, "maximum": 1}
       }

--- a/internal/benchmark/scripts/run-capacity.sh
+++ b/internal/benchmark/scripts/run-capacity.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPOSITORY_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
+
+# 设置 BENCHMARK_HOST 时在远端仓库执行；未设置时直接在当前主机运行。
+if [[ ${BENCHMARK_REMOTE_STAGE:-0} != 1 && -n ${BENCHMARK_HOST:-} ]]; then
+	: "${BENCHMARK_REMOTE_REPOSITORY:?set BENCHMARK_REMOTE_REPOSITORY to the repository path on the benchmark host}"
+	remote_command=
+	printf -v remote_command 'cd %q && env %q' "$BENCHMARK_REMOTE_REPOSITORY" 'BENCHMARK_REMOTE_STAGE=1'
+	for variable in BENCHMARK_ROOT BENCHMARK_MANIFEST BENCHCTL_BINARY KEEPER_BINARY CPU_LIST PREPARE_DATASET CONTROLLER_ID REDIS_PORT APP_PORT; do
+		if [[ -v $variable ]]; then
+			printf -v remote_command '%s %q' "$remote_command" "$variable=${!variable}"
+		fi
+	done
+	printf -v remote_command '%s bash %q' "$remote_command" 'internal/benchmark/scripts/run-capacity.sh'
+	exec ssh -- "$BENCHMARK_HOST" "$remote_command"
+fi
+
+ROOT=${BENCHMARK_ROOT:-/var/tmp/cpa-usage-keeper-capacity}
+SOURCE_MANIFEST=${BENCHMARK_MANIFEST:-$REPOSITORY_ROOT/internal/benchmark/manifest/capacity-v1.json}
+BENCH=${BENCHCTL_BINARY:-$ROOT/bin/benchctl}
+KEEPER=${KEEPER_BINARY:-$ROOT/bin/keeper}
+PLAN=$ROOT/config/capacity-v1.plan.json
+MANIFEST=$ROOT/config/capacity-v1.json
+DATASET_ID=reference-2m
+DATASET_DIR=$ROOT/datasets/$DATASET_ID
+CPU_LIST=${CPU_LIST:-1,2,4}
+PREPARE_DATASET=${PREPARE_DATASET:-0}
+CONTROLLER_ID=${CONTROLLER_ID:-capacity-v1-$(date -u +%Y%m%d-%H%M%S)}
+REDIS_PORT=${REDIS_PORT:-16379}
+APP_PORT=${APP_PORT:-18080}
+CONTROLLER_DIR=$ROOT/runs/$CONTROLLER_ID
+RESULTS=$CONTROLLER_DIR/controller.tsv
+
+case $(readlink -m -- "$ROOT") in
+	/|/root|"${HOME:-/root}") printf 'BENCHMARK_ROOT is too broad: %s\n' "$ROOT" >&2; exit 1 ;;
+esac
+if [[ ! $CONTROLLER_ID =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
+	printf 'CONTROLLER_ID must contain only letters, digits, dot, underscore, or hyphen\n' >&2
+	exit 1
+fi
+
+for command in go gcc jq lscpu redis-server sqlite3 systemd-run systemctl taskset; do
+	command -v "$command" >/dev/null || {
+		printf 'required command is unavailable: %s\n' "$command" >&2
+		exit 1
+	}
+done
+
+if [[ $(uname -s) != Linux || $(uname -m) != x86_64 ]]; then
+	printf 'capacity-v1 requires linux/amd64\n' >&2
+	exit 1
+fi
+
+IFS=',' read -r -a cpus <<<"$CPU_LIST"
+for cpu in "${cpus[@]}"; do
+	case $cpu in
+		1|2|4) ;;
+		*) printf 'CPU_LIST may contain only 1, 2, and 4: %s\n' "$CPU_LIST" >&2; exit 1 ;;
+	esac
+done
+
+mkdir -p "$ROOT/bin" "$ROOT/config" "$DATASET_DIR" "$CONTROLLER_DIR"
+if [[ $SOURCE_MANIFEST != "$MANIFEST" ]]; then
+	cp -- "$SOURCE_MANIFEST" "$MANIFEST"
+fi
+
+if [[ -z ${BENCHCTL_BINARY:-} ]]; then
+	go build -trimpath -o "$BENCH" ./internal/benchmark/cmd/benchctl
+fi
+if [[ -z ${KEEPER_BINARY:-} ]]; then
+	go build -trimpath -o "$KEEPER" ./cmd/server
+fi
+[[ -x $BENCH ]] || { printf 'benchctl is not executable: %s\n' "$BENCH" >&2; exit 1; }
+[[ -x $KEEPER ]] || { printf 'Keeper is not executable: %s\n' "$KEEPER" >&2; exit 1; }
+
+"$BENCH" plan --manifest "$MANIFEST" --output "$PLAN"
+
+if [[ ! -f $DATASET_DIR/app.db && ! -f $DATASET_DIR/app.db.zst ]]; then
+	if [[ $PREPARE_DATASET != 1 ]]; then
+		printf 'canonical dataset is missing: %s\n' "$DATASET_DIR" >&2
+		printf 'set PREPARE_DATASET=1 once to generate it without Keeper resource limits\n' >&2
+		exit 1
+	fi
+	"$BENCH" generate \
+		--manifest "$MANIFEST" \
+		--database "$DATASET_DIR/app.db" \
+		--result "$DATASET_DIR/dataset.json"
+fi
+
+[[ -f $DATASET_DIR/dataset.json ]] || {
+	printf 'dataset metadata is missing: %s\n' "$DATASET_DIR/dataset.json" >&2
+	exit 1
+}
+if [[ -f $DATASET_DIR/app.db ]]; then
+	"$BENCH" validate --database "$DATASET_DIR/app.db" >/dev/null
+fi
+
+RECOMMENDED_RATIO=$(jq -r '.search.recommended_capacity_ratio' "$MANIFEST")
+{
+	printf 'os=%s\n' "$(. /etc/os-release && printf '%s %s' "$NAME" "$VERSION_ID")"
+	printf 'kernel=%s\n' "$(uname -r)"
+	printf 'arch=amd64\n'
+	printf 'cpu_model=%s\n' "$(lscpu | awk -F: '$1 ~ /^Model name/ {sub(/^[[:space:]]+/, "", $2); print $2; exit}')"
+	printf 'online_cpus=%s\n' "$(getconf _NPROCESSORS_ONLN)"
+	printf 'memory_kib=%s\n' "$(awk '$1 == "MemTotal:" {print $2}' /proc/meminfo)"
+	printf 'go=%s\n' "$(go version)"
+	printf 'gcc=%s\n' "$(gcc --version | awk 'NR == 1')"
+	printf 'sqlite=%s\n' "$(sqlite3 --version)"
+	printf 'redis=%s\n' "$(redis-server --version)"
+} >"$CONTROLLER_DIR/environment.txt"
+
+if [[ ! -f $RESULTS ]]; then
+	printf 'cpu\tingestion_eps\tdashboard_eps\trecommended_eps\tingestion_cpu_percent\tingestion_peak_memory_mib\tingestion_core_p95_ms\tingestion_overall_p99_ms\tdashboard_core_p95_ms\tdashboard_overall_p99_ms\tdashboard_slowest_path\tdashboard_slowest_p99_ms\tdurable_ratio\tbacklog_end\tcheckpoint_lag\tidentity_pending\tshared_driver\thard_result\tdashboard_result\n' >"$RESULTS"
+fi
+
+cell_id() {
+	printf 'capacity-reference-2m-%sc-unlimited\n' "$1"
+}
+
+result_path() {
+	local run_id=$1 cell=$2
+	printf '%s/runs/%s/cells/%s/result.json\n' "$ROOT" "$run_id" "$cell"
+}
+
+run_benchmark() {
+	local run_id=$1 cell=$2 result
+	shift 2
+	result=$(result_path "$run_id" "$cell")
+	if [[ ! -f $result ]]; then
+		"$BENCH" run \
+			--manifest "$MANIFEST" \
+			--plan "$PLAN" \
+			--root "$ROOT" \
+			--run-id "$run_id" \
+			--keeper "$KEEPER" \
+			--redis-port "$REDIS_PORT" \
+			--app-port "$APP_PORT" \
+			--cells "$cell" \
+			--max-duration 30m \
+			"$@" || true
+	fi
+	LAST_RESULT=$result
+}
+
+next_passing_rate() {
+	local search_result=$1 upper=$2 mode=$3
+	if [[ $mode == hard ]]; then
+		jq -r --argjson upper "$upper" '
+			[.attempts[] | select(.phase == "search" and .rate_per_second < $upper and .report.evaluation.hard_pass) | .rate_per_second] | max // 0
+		' "$search_result"
+	else
+		jq -r --argjson upper "$upper" '
+			[.attempts[] | select(.phase == "search" and .rate_per_second < $upper and .report.evaluation.interactive_pass) | .rate_per_second] | max // 0
+		' "$search_result"
+	fi
+}
+
+run_fixed() {
+	local cpu=$1 label=$2 rate=$3 cell run_id
+	cell=$(cell_id "$cpu")
+	run_id="${CONTROLLER_ID}-${cpu}c-${label}-${rate}"
+	# hard 模式仍完整采集 Dashboard；它允许预期的 Dashboard 边界失败保留为有效 ingestion 证据。
+	run_benchmark "$run_id" "$cell" \
+		--fixed-rate "$rate" \
+		--fixed-duration 5m \
+		--fixed-pass hard
+}
+
+formal_cpu() {
+	local cpu=$1 cell search_id search_result hard_rate dashboard_rate hard_result dashboard_result
+	local pass interactive low_pass high_fail midpoint tolerance short_low
+	local peak cpu_percent hard_core_p95 hard_overall_p99 dashboard_core_p95 dashboard_overall_p99
+	local slowest_path slowest_p99 durable_ratio backlog checkpoint identity shared recommended hard_ref dashboard_ref
+	cell=$(cell_id "$cpu")
+	search_id="${CONTROLLER_ID}-${cpu}c-search"
+	printf '%sc search_start\n' "$cpu" >>"$CONTROLLER_DIR/controller.log"
+	run_benchmark "$search_id" "$cell" --search-duration 20s
+	search_result=$LAST_RESULT
+	if [[ ! -f $search_result ]]; then
+		printf '%sc search_result_missing\n' "$cpu" >>"$CONTROLLER_DIR/controller.log"
+		return
+	fi
+	hard_rate=$(jq -r '.capacity.hard_events_per_second // 0' "$search_result")
+	dashboard_rate=$(jq -r '.capacity.interactive_events_per_second // 0' "$search_result")
+	printf '%sc calibrated ingestion=%s dashboard=%s\n' "$cpu" "$hard_rate" "$dashboard_rate" >>"$CONTROLLER_DIR/controller.log"
+
+	hard_result=
+	low_pass=0
+	high_fail=0
+	while (( hard_rate > 0 )); do
+		run_fixed "$cpu" hard "$hard_rate"
+		[[ -f $LAST_RESULT ]] || break
+		pass=$(jq -r '.attempts[-1].report.evaluation.hard_pass // false' "$LAST_RESULT")
+		printf '%sc hard rate=%s pass=%s\n' "$cpu" "$hard_rate" "$pass" >>"$CONTROLLER_DIR/controller.log"
+		if [[ $pass == true ]]; then
+			low_pass=$hard_rate
+			hard_result=$LAST_RESULT
+			(( high_fail > 0 )) || break
+			tolerance=$((low_pass / 10))
+			(( tolerance >= 25 )) || tolerance=25
+			(( high_fail - low_pass > tolerance )) || break
+			midpoint=$(((low_pass + high_fail) / 2))
+			hard_rate=$((((midpoint + 12) / 25) * 25))
+			(( hard_rate > low_pass && hard_rate < high_fail )) || break
+			continue
+		fi
+		high_fail=$hard_rate
+		if (( low_pass > 0 )); then
+			midpoint=$(((low_pass + high_fail) / 2))
+			hard_rate=$((((midpoint + 12) / 25) * 25))
+			(( hard_rate > low_pass && hard_rate < high_fail )) || break
+		else
+			short_low=$(next_passing_rate "$search_result" "$hard_rate" hard)
+			if (( short_low <= 0 )); then
+				hard_rate=0
+				continue
+			fi
+			midpoint=$(((short_low + high_fail) / 2))
+			hard_rate=$((((midpoint + 12) / 25) * 25))
+			if (( hard_rate <= short_low || hard_rate >= high_fail )); then
+				hard_rate=$short_low
+			fi
+		fi
+	done
+	hard_rate=$low_pass
+	if [[ -z $hard_result ]]; then
+		printf '%sc no_five_minute_ingestion_capacity\n' "$cpu" >>"$CONTROLLER_DIR/controller.log"
+		return
+	fi
+
+	interactive=$(jq -r '.attempts[-1].report.evaluation.interactive_pass // false' "$hard_result")
+	dashboard_result=$hard_result
+	if [[ $interactive == true ]]; then
+		dashboard_rate=$hard_rate
+	else
+		if (( dashboard_rate <= 0 || dashboard_rate >= hard_rate )); then
+			dashboard_rate=$(next_passing_rate "$search_result" "$hard_rate" interactive)
+		fi
+		dashboard_result=
+		while (( dashboard_rate > 0 )); do
+			run_fixed "$cpu" dashboard "$dashboard_rate"
+			[[ -f $LAST_RESULT ]] || break
+			pass=$(jq -r '.attempts[-1].report.evaluation.interactive_pass // false' "$LAST_RESULT")
+			printf '%sc dashboard rate=%s pass=%s\n' "$cpu" "$dashboard_rate" "$pass" >>"$CONTROLLER_DIR/controller.log"
+			if [[ $pass == true ]]; then
+				dashboard_result=$LAST_RESULT
+				break
+			fi
+			dashboard_rate=$(next_passing_rate "$search_result" "$dashboard_rate" interactive)
+		done
+		if [[ -z $dashboard_result ]]; then
+			dashboard_rate=0
+			dashboard_result=-
+		fi
+	fi
+
+	peak=$(jq -r '(.attempts[-1].peak_resource.memory_peak_bytes // .attempts[-1].resource.memory_peak_bytes // 0) / 1048576' "$hard_result")
+	cpu_percent=$(jq -r '.attempts[-1].resource.cpu_utilization_percent // 0' "$hard_result")
+	hard_core_p95=$(jq -r '.attempts[-1].report.core_latency.p95_ms // 0' "$hard_result")
+	hard_overall_p99=$(jq -r '.attempts[-1].report.latency.p99_ms // 0' "$hard_result")
+	durable_ratio=$(jq -r 'if .attempts[-1].report.metrics.offered_events > 0 then .attempts[-1].report.metrics.durable_events / .attempts[-1].report.metrics.offered_events else 0 end' "$hard_result")
+	backlog=$(jq -r '.attempts[-1].report.metrics.backlog_end // 0' "$hard_result")
+	checkpoint=$(jq -r '.attempts[-1].report.metrics.checkpoint_lag // 0' "$hard_result")
+	identity=$(jq -r '.attempts[-1].report.metrics.identity_pending // 0' "$hard_result")
+	shared=$(jq -r '.shared_driver // false' "$hard_result")
+	recommended=$(awk -v rate="$dashboard_rate" -v ratio="$RECOMMENDED_RATIO" 'BEGIN { printf "%d", rate * ratio }')
+	if [[ $dashboard_result == - ]]; then
+		dashboard_core_p95=0
+		dashboard_overall_p99=0
+		slowest_path=-
+		slowest_p99=0
+	else
+		dashboard_core_p95=$(jq -r '.attempts[-1].report.core_latency.p95_ms // 0' "$dashboard_result")
+		dashboard_overall_p99=$(jq -r '.attempts[-1].report.latency.p99_ms // 0' "$dashboard_result")
+		slowest_path=$(jq -r '.attempts[-1].report.latency_by_path | to_entries | max_by(.value.p99_ms) | .key // "-"' "$dashboard_result")
+		slowest_p99=$(jq -r '.attempts[-1].report.latency_by_path | to_entries | max_by(.value.p99_ms) | .value.p99_ms // 0' "$dashboard_result")
+	fi
+	hard_ref=${hard_result#"$ROOT"/}
+	if [[ $dashboard_result == - ]]; then
+		dashboard_ref=-
+	else
+		dashboard_ref=${dashboard_result#"$ROOT"/}
+	fi
+	printf '%s\t%s\t%s\t%s\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%s\t%.3f\t%.6f\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+		"$cpu" "$hard_rate" "$dashboard_rate" "$recommended" "$cpu_percent" "$peak" "$hard_core_p95" "$hard_overall_p99" \
+		"$dashboard_core_p95" "$dashboard_overall_p99" "$slowest_path" "$slowest_p99" "$durable_ratio" "$backlog" "$checkpoint" "$identity" \
+		"$shared" "$hard_ref" "$dashboard_ref" >>"$RESULTS"
+	printf '%sc complete ingestion=%s dashboard=%s recommended=%s peak=%.2fMiB\n' "$cpu" "$hard_rate" "$dashboard_rate" "$recommended" "$peak" >>"$CONTROLLER_DIR/controller.log"
+}
+
+for cpu in "${cpus[@]}"; do
+	if awk -F '\t' -v cpu="$cpu" 'NR > 1 && $1 == cpu { found=1 } END { exit !found }' "$RESULTS"; then
+		continue
+	fi
+	formal_cpu "$cpu"
+done
+
+printf 'completed_at\t%s\n' "$(date --iso-8601=seconds)" >>"$CONTROLLER_DIR/controller.log"
+{
+	printf '# Capacity benchmark summary\n\n'
+	printf '| CPU | Ingestion max | Dashboard max | Recommended | Ingestion CPU | Peak memory | Dashboard core p95 | Dashboard overall p99 | Shared driver |\n'
+	printf '| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n'
+	awk -F '\t' 'NR > 1 { printf "| %sC | %s events/s | %s events/s | %s events/s | %.1f%% | %.1f MiB | %.1fms | %.1fms | %s |\n", $1, $2, $3, $4, $5, $6, $9, $10, $17 }' "$RESULTS"
+} >"$CONTROLLER_DIR/summary.md"
+printf 'capacity results: %s\n' "$RESULTS"
+printf 'capacity summary: %s\n' "$CONTROLLER_DIR/summary.md"

--- a/internal/benchmark/scripts/run-capacity.sh
+++ b/internal/benchmark/scripts/run-capacity.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPOSITORY_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
+export TZ=Asia/Shanghai
 
 # 设置 BENCHMARK_HOST 时在远端仓库执行；未设置时直接在当前主机运行。
 if [[ ${BENCHMARK_REMOTE_STAGE:-0} != 1 && -n ${BENCHMARK_HOST:-} ]]; then
@@ -24,8 +25,6 @@ BENCH=${BENCHCTL_BINARY:-$ROOT/bin/benchctl}
 KEEPER=${KEEPER_BINARY:-$ROOT/bin/keeper}
 PLAN=$ROOT/config/capacity-v1.plan.json
 MANIFEST=$ROOT/config/capacity-v1.json
-DATASET_ID=reference-2m
-DATASET_DIR=$ROOT/datasets/$DATASET_ID
 CPU_LIST=${CPU_LIST:-1,2,4}
 PREPARE_DATASET=${PREPARE_DATASET:-0}
 CONTROLLER_ID=${CONTROLLER_ID:-capacity-v1-$(date -u +%Y%m%d-%H%M%S)}
@@ -33,6 +32,7 @@ REDIS_PORT=${REDIS_PORT:-16379}
 APP_PORT=${APP_PORT:-18080}
 CONTROLLER_DIR=$ROOT/runs/$CONTROLLER_ID
 RESULTS=$CONTROLLER_DIR/controller.tsv
+RESULTS_HEADER=$'cpu\tingestion_5m_pass_eps\tingestion_lowest_fail_eps\tdashboard_5m_pass_eps\tdashboard_lowest_fail_eps\trecommended_eps\tingestion_cpu_percent\tingestion_peak_memory_mib\tdashboard_peak_memory_mib\tingestion_core_p95_ms\tingestion_core_p99_ms\tdashboard_core_p95_ms\tdashboard_core_p99_ms\tdashboard_analysis_latency_p50_ms\tdashboard_analysis_latency_p95_ms\tdashboard_analysis_latency_p99_ms\tdashboard_analysis_latency_max_ms\tdashboard_analysis_latency_samples\tdashboard_analysis_latency_errors\tdashboard_analysis_latency_status\tdashboard_slowest_core_path\tdashboard_slowest_core_p99_ms\tdurable_ratio\tbacklog_end\tcheckpoint_lag\tidentity_pending\tshared_driver\thard_result\tdashboard_result'
 
 case $(readlink -m -- "$ROOT") in
 	/|/root|"${HOME:-/root}") printf 'BENCHMARK_ROOT is too broad: %s\n' "$ROOT" >&2; exit 1 ;;
@@ -42,7 +42,7 @@ if [[ ! $CONTROLLER_ID =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
 	exit 1
 fi
 
-for command in go gcc jq lscpu redis-server sqlite3 systemd-run systemctl taskset; do
+for command in go gcc jq lscpu redis-server sha256sum sqlite3 stat systemd-run systemctl taskset; do
 	command -v "$command" >/dev/null || {
 		printf 'required command is unavailable: %s\n' "$command" >&2
 		exit 1
@@ -62,10 +62,20 @@ for cpu in "${cpus[@]}"; do
 	esac
 done
 
-mkdir -p "$ROOT/bin" "$ROOT/config" "$DATASET_DIR" "$CONTROLLER_DIR"
+mkdir -p "$ROOT/bin" "$ROOT/config" "$CONTROLLER_DIR"
 if [[ $SOURCE_MANIFEST != "$MANIFEST" ]]; then
 	cp -- "$SOURCE_MANIFEST" "$MANIFEST"
 fi
+if ! DATASET_ID=$(jq -er '.dataset.id | select(type == "string" and length > 0)' "$MANIFEST"); then
+	printf 'manifest dataset.id is missing or invalid: %s\n' "$MANIFEST" >&2
+	exit 1
+fi
+if [[ ! $DATASET_ID =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ || $DATASET_ID == *--* ]]; then
+	printf 'manifest dataset.id must be a lowercase public ID: %s\n' "$DATASET_ID" >&2
+	exit 1
+fi
+DATASET_DIR=$ROOT/datasets/$DATASET_ID
+mkdir -p "$DATASET_DIR"
 
 if [[ -z ${BENCHCTL_BINARY:-} ]]; then
 	go build -trimpath -o "$BENCH" ./internal/benchmark/cmd/benchctl
@@ -89,13 +99,47 @@ if [[ ! -f $DATASET_DIR/app.db && ! -f $DATASET_DIR/app.db.zst ]]; then
 		--database "$DATASET_DIR/app.db" \
 		--result "$DATASET_DIR/dataset.json"
 fi
+if [[ ! -f $DATASET_DIR/app.db && -f $DATASET_DIR/app.db.zst ]] && ! command -v zstd >/dev/null; then
+	printf 'compressed canonical dataset requires zstd: %s\n' "$DATASET_DIR/app.db.zst" >&2
+	exit 1
+fi
 
-[[ -f $DATASET_DIR/dataset.json ]] || {
+DATASET_METADATA=$DATASET_DIR/dataset.json
+[[ -f $DATASET_METADATA ]] || {
 	printf 'dataset metadata is missing: %s\n' "$DATASET_DIR/dataset.json" >&2
 	exit 1
 }
 if [[ -f $DATASET_DIR/app.db ]]; then
-	"$BENCH" validate --database "$DATASET_DIR/app.db" >/dev/null
+	DATASET_SOURCE=$DATASET_DIR/app.db
+else
+	DATASET_SOURCE=$DATASET_DIR/app.db.zst
+fi
+DATASET_VALIDATION=$CONTROLLER_DIR/dataset-validation.json
+if [[ ! -f $DATASET_VALIDATION ]]; then
+	validation_tmp=$DATASET_VALIDATION.tmp
+	"$BENCH" validate \
+		--database "$DATASET_SOURCE" \
+		--manifest "$MANIFEST" \
+		--metadata "$DATASET_METADATA" >"$validation_tmp"
+	mv -- "$validation_tmp" "$DATASET_VALIDATION"
+fi
+
+CONTROLLER_INPUTS=$CONTROLLER_DIR/controller-inputs.sha256
+inputs_digest=$({
+	sha256sum "$SCRIPT_DIR/run-capacity.sh" "$MANIFEST" "$PLAN" "$BENCH" "$KEEPER" "$DATASET_METADATA" "$DATASET_VALIDATION"
+	stat --printf='dataset_source=%s:%Y:%i\n' "$DATASET_SOURCE"
+	printf 'cpu_list=%s\nredis_port=%s\napp_port=%s\nsearch_strategy=staircase-v1\nsearch_duration=20s\nfixed_duration=5m\n' "$CPU_LIST" "$REDIS_PORT" "$APP_PORT"
+} | sha256sum | awk '{print $1}')
+if [[ -f $CONTROLLER_INPUTS ]]; then
+	if [[ $(<"$CONTROLLER_INPUTS") != "$inputs_digest" ]]; then
+		printf 'controller inputs changed; use a new CONTROLLER_ID instead of mixing results\n' >&2
+		exit 1
+	fi
+elif [[ -f $RESULTS && $(awk 'END {print NR}' "$RESULTS") -gt 1 ]]; then
+	printf 'existing controller results have no provenance signature; use a new CONTROLLER_ID\n' >&2
+	exit 1
+else
+	printf '%s\n' "$inputs_digest" >"$CONTROLLER_INPUTS"
 fi
 
 RECOMMENDED_RATIO=$(jq -r '.search.recommended_capacity_ratio' "$MANIFEST")
@@ -103,6 +147,7 @@ RECOMMENDED_RATIO=$(jq -r '.search.recommended_capacity_ratio' "$MANIFEST")
 	printf 'os=%s\n' "$(. /etc/os-release && printf '%s %s' "$NAME" "$VERSION_ID")"
 	printf 'kernel=%s\n' "$(uname -r)"
 	printf 'arch=amd64\n'
+	printf 'timezone=%s\n' "$TZ"
 	printf 'cpu_model=%s\n' "$(lscpu | awk -F: '$1 ~ /^Model name/ {sub(/^[[:space:]]+/, "", $2); print $2; exit}')"
 	printf 'online_cpus=%s\n' "$(getconf _NPROCESSORS_ONLN)"
 	printf 'memory_kib=%s\n' "$(awk '$1 == "MemTotal:" {print $2}' /proc/meminfo)"
@@ -112,12 +157,23 @@ RECOMMENDED_RATIO=$(jq -r '.search.recommended_capacity_ratio' "$MANIFEST")
 	printf 'redis=%s\n' "$(redis-server --version)"
 } >"$CONTROLLER_DIR/environment.txt"
 
-if [[ ! -f $RESULTS ]]; then
-	printf 'cpu\tingestion_eps\tdashboard_eps\trecommended_eps\tingestion_cpu_percent\tingestion_peak_memory_mib\tingestion_core_p95_ms\tingestion_overall_p99_ms\tdashboard_core_p95_ms\tdashboard_overall_p99_ms\tdashboard_slowest_path\tdashboard_slowest_p99_ms\tdurable_ratio\tbacklog_end\tcheckpoint_lag\tidentity_pending\tshared_driver\thard_result\tdashboard_result\n' >"$RESULTS"
+if [[ -f $RESULTS ]]; then
+	IFS= read -r existing_results_header <"$RESULTS"
+	if [[ $existing_results_header != "$RESULTS_HEADER" ]]; then
+		printf 'controller result header changed; use a new CONTROLLER_ID\n' >&2
+		exit 1
+	fi
+else
+	printf '%s\n' "$RESULTS_HEADER" >"$RESULTS"
 fi
 
 cell_id() {
-	printf 'capacity-reference-2m-%sc-unlimited\n' "$1"
+	local cpu=$1
+	jq -er --argjson cpu "$cpu" '
+		[.cells[] | select(.resource.cpu == $cpu)] as $cells |
+		if ($cells | length) == 1 then $cells[0].id
+		else error("plan must contain exactly one cell for the selected CPU") end
+	' "$PLAN"
 }
 
 result_path() {
@@ -126,21 +182,40 @@ result_path() {
 }
 
 run_benchmark() {
-	local run_id=$1 cell=$2 result
-	shift 2
+	local run_id=$1 cell=$2 kind=$3 result status=0
+	shift 3
 	result=$(result_path "$run_id" "$cell")
+	"$BENCH" resume \
+		--manifest "$MANIFEST" \
+		--plan "$PLAN" \
+		--root "$ROOT" \
+		--run-id "$run_id" \
+		--keeper "$KEEPER" \
+		--redis-port "$REDIS_PORT" \
+		--app-port "$APP_PORT" \
+		--cells "$cell" \
+		--max-duration 30m \
+		--dataset-validation "$DATASET_VALIDATION" \
+		"$@" || status=$?
 	if [[ ! -f $result ]]; then
-		"$BENCH" run \
-			--manifest "$MANIFEST" \
-			--plan "$PLAN" \
-			--root "$ROOT" \
-			--run-id "$run_id" \
-			--keeper "$KEEPER" \
-			--redis-port "$REDIS_PORT" \
-			--app-port "$APP_PORT" \
-			--cells "$cell" \
-			--max-duration 30m \
-			"$@" || true
+		printf 'benchmark result is missing after %s: %s\n' "$kind" "$result" >&2
+		return 1
+	fi
+	if jq -e '[.attempts[]? | select((.report.metrics.panic // false) or ((.error // "") != "" and ((.report.metrics.oom // false) | not)) or ((.report.publish_error // "") != ""))] | length > 0' "$result" >/dev/null; then
+		printf 'benchmark infrastructure failure during %s: %s\n' "$kind" "$result" >&2
+		return 1
+	fi
+	if ! jq -e '.status == "completed"' "$result" >/dev/null; then
+		if [[ $kind != fixed ]] || ! jq -e '(.attempts | length) > 0 and ((.error // "") | test("^(hard|interactive) soak failed at [0-9]+ events/s:"))' "$result" >/dev/null; then
+			printf 'benchmark cell failed during %s: %s\n' "$kind" "$result" >&2
+			return 1
+		fi
+	fi
+	if (( status != 0 )); then
+		if [[ $kind != fixed ]] || ! jq -e '(.attempts | length) > 0 and ((.error // "") | test("^(hard|interactive) soak failed at [0-9]+ events/s:"))' "$result" >/dev/null; then
+			printf 'benchmark command failed during %s with status %s: %s\n' "$kind" "$status" "$result" >&2
+			return "$status"
+		fi
 	fi
 	LAST_RESULT=$result
 }
@@ -158,12 +233,32 @@ next_passing_rate() {
 	fi
 }
 
+midpoint_rate() {
+	local cell=$1 low=$2 high=$3
+	jq -r --arg cell "$cell" --argjson low "$low" --argjson high "$high" '
+		[.cells[] | select(.id == $cell) | .rates_per_second[] | select(. > $low and . < $high)] as $rates |
+		($rates | length) as $count |
+		if $count == 0 then 0 else $rates[($count / 2 | floor)] end
+	' "$PLAN"
+}
+
+next_hard_rate() {
+	local cell=$1 low=$2 high=$3 midpoint candidate
+	midpoint=$(((low + high) / 2))
+	candidate=$((((midpoint + 12) / 25) * 25))
+	# 低于 25 events/s 时，固定步进可能落到区间端点；改用 manifest 中的真实候选继续收敛。
+	if (( candidate <= low || candidate >= high )); then
+		candidate=$(midpoint_rate "$cell" "$low" "$high")
+	fi
+	printf '%s\n' "$candidate"
+}
+
 run_fixed() {
 	local cpu=$1 label=$2 rate=$3 cell run_id
 	cell=$(cell_id "$cpu")
 	run_id="${CONTROLLER_ID}-${cpu}c-${label}-${rate}"
 	# hard 模式仍完整采集 Dashboard；它允许预期的 Dashboard 边界失败保留为有效 ingestion 证据。
-	run_benchmark "$run_id" "$cell" \
+	run_benchmark "$run_id" "$cell" fixed \
 		--fixed-rate "$rate" \
 		--fixed-duration 5m \
 		--fixed-pass hard
@@ -171,25 +266,33 @@ run_fixed() {
 
 formal_cpu() {
 	local cpu=$1 cell search_id search_result hard_rate dashboard_rate hard_result dashboard_result
-	local pass interactive low_pass high_fail midpoint tolerance short_low
-	local peak cpu_percent hard_core_p95 hard_overall_p99 dashboard_core_p95 dashboard_overall_p99
+	local pass interactive low_pass high_fail tolerance short_low hard_fail dashboard_fail minimum_rate
+	local dashboard_low dashboard_high dashboard_next
+	local ingestion_peak dashboard_peak cpu_percent hard_core_p95 hard_core_p99 dashboard_core_p95 dashboard_core_p99
+	local analysis_p50 analysis_p95 analysis_p99 analysis_max analysis_samples analysis_errors analysis_status
 	local slowest_path slowest_p99 durable_ratio backlog checkpoint identity shared recommended hard_ref dashboard_ref
 	cell=$(cell_id "$cpu")
+	minimum_rate=$(jq -er --arg cell "$cell" '.cells[] | select(.id == $cell) | .rates_per_second[0]' "$PLAN")
 	search_id="${CONTROLLER_ID}-${cpu}c-search"
 	printf '%sc search_start\n' "$cpu" >>"$CONTROLLER_DIR/controller.log"
-	run_benchmark "$search_id" "$cell" --search-duration 20s
+	run_benchmark "$search_id" "$cell" search --search-duration 20s
 	search_result=$LAST_RESULT
 	if [[ ! -f $search_result ]]; then
 		printf '%sc search_result_missing\n' "$cpu" >>"$CONTROLLER_DIR/controller.log"
-		return
+		return 1
 	fi
 	hard_rate=$(jq -r '.capacity.hard_events_per_second // 0' "$search_result")
 	dashboard_rate=$(jq -r '.capacity.interactive_events_per_second // 0' "$search_result")
-	printf '%sc calibrated ingestion=%s dashboard=%s\n' "$cpu" "$hard_rate" "$dashboard_rate" >>"$CONTROLLER_DIR/controller.log"
+	hard_fail=$(jq -r '.capacity.lowest_hard_failure_events_per_second // 0' "$search_result")
+	dashboard_fail=$(jq -r '.capacity.lowest_interactive_failure_events_per_second // 0' "$search_result")
+	printf '%sc calibrated ingestion=%s..<%s dashboard=%s..<%s\n' "$cpu" "$hard_rate" "$hard_fail" "$dashboard_rate" "$dashboard_fail" >>"$CONTROLLER_DIR/controller.log"
 
 	hard_result=
 	low_pass=0
 	high_fail=0
+	if (( hard_fail > hard_rate )); then
+		high_fail=$hard_fail
+	fi
 	while (( hard_rate > 0 )); do
 		run_fixed "$cpu" hard "$hard_rate"
 		[[ -f $LAST_RESULT ]] || break
@@ -199,18 +302,26 @@ formal_cpu() {
 			low_pass=$hard_rate
 			hard_result=$LAST_RESULT
 			(( high_fail > 0 )) || break
-			tolerance=$((low_pass / 10))
-			(( tolerance >= 25 )) || tolerance=25
+			if (( high_fail <= 25 )); then
+				tolerance=0
+			else
+				tolerance=$((low_pass / 10))
+				(( tolerance >= 25 )) || tolerance=25
+			fi
 			(( high_fail - low_pass > tolerance )) || break
-			midpoint=$(((low_pass + high_fail) / 2))
-			hard_rate=$((((midpoint + 12) / 25) * 25))
+			hard_rate=$(next_hard_rate "$cell" "$low_pass" "$high_fail")
 			(( hard_rate > low_pass && hard_rate < high_fail )) || break
 			continue
 		fi
 		high_fail=$hard_rate
+		if (( hard_fail <= 0 || hard_rate < hard_fail )); then
+			hard_fail=$hard_rate
+		fi
+		if (( dashboard_fail <= 0 || hard_rate < dashboard_fail )); then
+			dashboard_fail=$hard_rate
+		fi
 		if (( low_pass > 0 )); then
-			midpoint=$(((low_pass + high_fail) / 2))
-			hard_rate=$((((midpoint + 12) / 25) * 25))
+			hard_rate=$(next_hard_rate "$cell" "$low_pass" "$high_fail")
 			(( hard_rate > low_pass && hard_rate < high_fail )) || break
 		else
 			short_low=$(next_passing_rate "$search_result" "$hard_rate" hard)
@@ -218,8 +329,7 @@ formal_cpu() {
 				hard_rate=0
 				continue
 			fi
-			midpoint=$(((short_low + high_fail) / 2))
-			hard_rate=$((((midpoint + 12) / 25) * 25))
+			hard_rate=$(next_hard_rate "$cell" "$short_low" "$high_fail")
 			if (( hard_rate <= short_low || hard_rate >= high_fail )); then
 				hard_rate=$short_low
 			fi
@@ -228,7 +338,7 @@ formal_cpu() {
 	hard_rate=$low_pass
 	if [[ -z $hard_result ]]; then
 		printf '%sc no_five_minute_ingestion_capacity\n' "$cpu" >>"$CONTROLLER_DIR/controller.log"
-		return
+		return 1
 	fi
 
 	interactive=$(jq -r '.attempts[-1].report.evaluation.interactive_pass // false' "$hard_result")
@@ -236,8 +346,15 @@ formal_cpu() {
 	if [[ $interactive == true ]]; then
 		dashboard_rate=$hard_rate
 	else
+		# hard_result 已是五分钟 Dashboard 失败上界；短测失败只用于选首个候选，不进入正式区间。
+		dashboard_low=0
+		dashboard_high=$hard_rate
+		dashboard_fail=$hard_rate
 		if (( dashboard_rate <= 0 || dashboard_rate >= hard_rate )); then
 			dashboard_rate=$(next_passing_rate "$search_result" "$hard_rate" interactive)
+		fi
+		if (( dashboard_rate <= 0 && minimum_rate < hard_rate )); then
+			dashboard_rate=$minimum_rate
 		fi
 		dashboard_result=
 		while (( dashboard_rate > 0 )); do
@@ -246,21 +363,47 @@ formal_cpu() {
 			pass=$(jq -r '.attempts[-1].report.evaluation.interactive_pass // false' "$LAST_RESULT")
 			printf '%sc dashboard rate=%s pass=%s\n' "$cpu" "$dashboard_rate" "$pass" >>"$CONTROLLER_DIR/controller.log"
 			if [[ $pass == true ]]; then
+				dashboard_low=$dashboard_rate
 				dashboard_result=$LAST_RESULT
-				break
+				dashboard_next=$(midpoint_rate "$cell" "$dashboard_low" "$dashboard_high")
+				if (( dashboard_next <= 0 )); then
+					break
+				fi
+				dashboard_rate=$dashboard_next
+				continue
 			fi
-			dashboard_rate=$(next_passing_rate "$search_result" "$dashboard_rate" interactive)
+			dashboard_high=$dashboard_rate
+			if (( dashboard_fail <= 0 || dashboard_rate < dashboard_fail )); then
+				dashboard_fail=$dashboard_rate
+			fi
+			if (( dashboard_low > 0 )); then
+				dashboard_rate=$(midpoint_rate "$cell" "$dashboard_low" "$dashboard_high")
+			else
+				short_low=$(next_passing_rate "$search_result" "$dashboard_rate" interactive)
+				if (( short_low <= 0 && minimum_rate < dashboard_rate )); then
+					dashboard_rate=$minimum_rate
+				else
+					dashboard_rate=$short_low
+				fi
+			fi
 		done
+		dashboard_rate=$dashboard_low
 		if [[ -z $dashboard_result ]]; then
-			dashboard_rate=0
 			dashboard_result=-
 		fi
 	fi
+	# 短测可能受随机抖动影响；正式结果只报告严格高于五分钟通过点的失败上界。
+	if (( hard_fail <= hard_rate )); then
+		hard_fail=0
+	fi
+	if (( dashboard_fail <= dashboard_rate )); then
+		dashboard_fail=0
+	fi
 
-	peak=$(jq -r '(.attempts[-1].peak_resource.memory_peak_bytes // .attempts[-1].resource.memory_peak_bytes // 0) / 1048576' "$hard_result")
+	ingestion_peak=$(jq -r '(.attempts[-1].peak_resource.memory_peak_bytes // .attempts[-1].resource.memory_peak_bytes // 0) / 1048576' "$hard_result")
 	cpu_percent=$(jq -r '.attempts[-1].resource.cpu_utilization_percent // 0' "$hard_result")
 	hard_core_p95=$(jq -r '.attempts[-1].report.core_latency.p95_ms // 0' "$hard_result")
-	hard_overall_p99=$(jq -r '.attempts[-1].report.latency.p99_ms // 0' "$hard_result")
+	hard_core_p99=$(jq -r '.attempts[-1].report.core_latency.p99_ms // 0' "$hard_result")
 	durable_ratio=$(jq -r 'if .attempts[-1].report.metrics.offered_events > 0 then .attempts[-1].report.metrics.durable_events / .attempts[-1].report.metrics.offered_events else 0 end' "$hard_result")
 	backlog=$(jq -r '.attempts[-1].report.metrics.backlog_end // 0' "$hard_result")
 	checkpoint=$(jq -r '.attempts[-1].report.metrics.checkpoint_lag // 0' "$hard_result")
@@ -268,15 +411,31 @@ formal_cpu() {
 	shared=$(jq -r '.shared_driver // false' "$hard_result")
 	recommended=$(awk -v rate="$dashboard_rate" -v ratio="$RECOMMENDED_RATIO" 'BEGIN { printf "%d", rate * ratio }')
 	if [[ $dashboard_result == - ]]; then
+		dashboard_peak=0
 		dashboard_core_p95=0
-		dashboard_overall_p99=0
+		dashboard_core_p99=0
+		analysis_p50=0
+		analysis_p95=0
+		analysis_p99=0
+		analysis_max=0
+		analysis_samples=0
+		analysis_errors=0
+		analysis_status=not_measured
 		slowest_path=-
 		slowest_p99=0
 	else
+		dashboard_peak=$(jq -r '(.attempts[-1].peak_resource.memory_peak_bytes // .attempts[-1].resource.memory_peak_bytes // 0) / 1048576' "$dashboard_result")
 		dashboard_core_p95=$(jq -r '.attempts[-1].report.core_latency.p95_ms // 0' "$dashboard_result")
-		dashboard_overall_p99=$(jq -r '.attempts[-1].report.latency.p99_ms // 0' "$dashboard_result")
-		slowest_path=$(jq -r '.attempts[-1].report.latency_by_path | to_entries | max_by(.value.p99_ms) | .key // "-"' "$dashboard_result")
-		slowest_p99=$(jq -r '.attempts[-1].report.latency_by_path | to_entries | max_by(.value.p99_ms) | .value.p99_ms // 0' "$dashboard_result")
+		dashboard_core_p99=$(jq -r '.attempts[-1].report.core_latency.p99_ms // 0' "$dashboard_result")
+		analysis_p50=$(jq -r '.attempts[-1].report.analysis_latency.p50_ms // 0' "$dashboard_result")
+		analysis_p95=$(jq -r '.attempts[-1].report.analysis_latency.p95_ms // 0' "$dashboard_result")
+		analysis_p99=$(jq -r '.attempts[-1].report.analysis_latency.p99_ms // 0' "$dashboard_result")
+		analysis_max=$(jq -r '.attempts[-1].report.analysis_latency.max_ms // 0' "$dashboard_result")
+		analysis_samples=$(jq -r '.attempts[-1].report.analysis_latency.samples // 0' "$dashboard_result")
+		analysis_errors=$(jq -r '.attempts[-1].report.metrics.analysis_latency_errors // 0' "$dashboard_result")
+		analysis_status=$(jq -r 'if .attempts[-1].report.metrics.analysis_latency_requests == 0 then "not_measured" elif .attempts[-1].report.evaluation.analysis_latency_pass then "passed" else "failed" end' "$dashboard_result")
+		slowest_path=$(jq -r '.attempts[-1].report.latency_by_path | to_entries | map(select(.key != "/api/v1/usage/analysis/latency?range=30d")) | if length == 0 then "-" else max_by(.value.p99_ms).key end' "$dashboard_result")
+		slowest_p99=$(jq -r '.attempts[-1].report.latency_by_path | to_entries | map(select(.key != "/api/v1/usage/analysis/latency?range=30d")) | if length == 0 then 0 else max_by(.value.p99_ms).value.p99_ms end' "$dashboard_result")
 	fi
 	hard_ref=${hard_result#"$ROOT"/}
 	if [[ $dashboard_result == - ]]; then
@@ -284,11 +443,12 @@ formal_cpu() {
 	else
 		dashboard_ref=${dashboard_result#"$ROOT"/}
 	fi
-	printf '%s\t%s\t%s\t%s\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%s\t%.3f\t%.6f\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-		"$cpu" "$hard_rate" "$dashboard_rate" "$recommended" "$cpu_percent" "$peak" "$hard_core_p95" "$hard_overall_p99" \
-		"$dashboard_core_p95" "$dashboard_overall_p99" "$slowest_path" "$slowest_p99" "$durable_ratio" "$backlog" "$checkpoint" "$identity" \
+	printf '%s\t%s\t%s\t%s\t%s\t%s\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%s\t%s\t%s\t%s\t%.3f\t%.6f\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+		"$cpu" "$hard_rate" "$hard_fail" "$dashboard_rate" "$dashboard_fail" "$recommended" "$cpu_percent" "$ingestion_peak" "$dashboard_peak" "$hard_core_p95" "$hard_core_p99" \
+		"$dashboard_core_p95" "$dashboard_core_p99" "$analysis_p50" "$analysis_p95" "$analysis_p99" "$analysis_max" "$analysis_samples" "$analysis_errors" "$analysis_status" "$slowest_path" "$slowest_p99" "$durable_ratio" "$backlog" "$checkpoint" "$identity" \
 		"$shared" "$hard_ref" "$dashboard_ref" >>"$RESULTS"
-	printf '%sc complete ingestion=%s dashboard=%s recommended=%s peak=%.2fMiB\n' "$cpu" "$hard_rate" "$dashboard_rate" "$recommended" "$peak" >>"$CONTROLLER_DIR/controller.log"
+	printf '%sc complete ingestion=%s..<%s dashboard=%s..<%s recommended=%s ingestion_peak=%.2fMiB dashboard_peak=%.2fMiB\n' \
+		"$cpu" "$hard_rate" "$hard_fail" "$dashboard_rate" "$dashboard_fail" "$recommended" "$ingestion_peak" "$dashboard_peak" >>"$CONTROLLER_DIR/controller.log"
 }
 
 for cpu in "${cpus[@]}"; do
@@ -298,12 +458,20 @@ for cpu in "${cpus[@]}"; do
 	formal_cpu "$cpu"
 done
 
+for cpu in "${cpus[@]}"; do
+	rows=$(awk -F '\t' -v cpu="$cpu" 'NR > 1 && $1 == cpu { count++ } END { print count+0 }' "$RESULTS")
+	if [[ $rows != 1 ]]; then
+		printf 'controller result completeness failed for %sc: rows=%s\n' "$cpu" "$rows" >&2
+		exit 1
+	fi
+done
+
 printf 'completed_at\t%s\n' "$(date --iso-8601=seconds)" >>"$CONTROLLER_DIR/controller.log"
 {
 	printf '# Capacity benchmark summary\n\n'
-	printf '| CPU | Ingestion max | Dashboard max | Recommended | Ingestion CPU | Peak memory | Dashboard core p95 | Dashboard overall p99 | Shared driver |\n'
-	printf '| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n'
-	awk -F '\t' 'NR > 1 { printf "| %sC | %s events/s | %s events/s | %s events/s | %.1f%% | %.1f MiB | %.1fms | %.1fms | %s |\n", $1, $2, $3, $4, $5, $6, $9, $10, $17 }' "$RESULTS"
+	printf '| CPU | Ingestion 5m pass | Lowest ingestion fail | Dashboard 5m pass | Lowest Dashboard fail | Recommended | Ingestion CPU | Ingestion peak memory | Dashboard peak memory | Dashboard core p95 | Dashboard core p99 | Analysis Latency samples / p99 / status | Shared driver |\n'
+	printf '| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n'
+	awk -F '\t' 'NR > 1 { printf "| %sC | %s events/s | %s events/s | %s events/s | %s events/s | %s events/s | %.1f%% | %.1f MiB | %.1f MiB | %.1fms | %.1fms | %s / %.1fms / %s | %s |\n", $1, $2, $3, $4, $5, $6, $7, $8, $9, $12, $13, $18, $16, $20, $27 }' "$RESULTS"
 } >"$CONTROLLER_DIR/summary.md"
 printf 'capacity results: %s\n' "$RESULTS"
 printf 'capacity summary: %s\n' "$CONTROLLER_DIR/summary.md"


### PR DESCRIPTION
## Summary

- add a reproducible `linux/amd64` production-style capacity suite for sustained ingestion, Dashboard latency, CPU utilization, and Keeper cgroup peak memory
- provide a reusable 3,205,740-event reference dataset with strict cardinality, workload-configuration, freshness, and semantic validation
- separate the five Core Dashboard endpoints from the heavier Analysis Latency diagnostic query
- publish bilingual usage documentation and formal capacity reports, while retaining the previous Go microbenchmarks under `internal/benchmark/legacy`

Refs #409

## Benchmark scope

- dataset: 3,205,740 active events across 90 days; 1,201,775 events in the formal 30-day query window; 500 identities, 50 models, and 50 API keys; 31,831 failed events (0.993%)
- traffic distribution: 15 high-, 25 medium-, and 10 low-usage API keys with per-key weights of 10:3:1
- Keeper profiles: 1C, 2C, and 4C with unrestricted memory and measured cgroup `memory.peak`
- workload: Redis ingestion plus five Core Dashboard endpoints at 1 request/s; Analysis Latency sampled separately every 30 seconds
- method: adaptive short search, 60-second boundary confirmation, and five-minute fixed-rate formal validation

## Verified capacity

| Keeper CPU | Five-minute pass / lowest fail | 70% sustained recommendation | Peak memory at pass |
| --- | ---: | ---: | ---: |
| 1C | 150 / 200 events/s | 105 events/s | 472.9 MiB |
| 2C | 200 / 250 events/s | 140 events/s | 522.2 MiB |
| 4C | 500 / 600 events/s | 350 events/s | 995.7 MiB |

Full methodology and endpoint results are available in [the English report](./internal/benchmark/REPORT.md) and [the Chinese report](./internal/benchmark/REPORT.zh.md).

## Validation

- fresh `go test ./internal/benchmark/...`
- `go vet ./internal/benchmark/...`
- Windows amd64 benchmark compile gate
- complete backend verification
- `bash -n internal/benchmark/scripts/run-capacity.sh`
- JSON, Markdown table, formatting, and `git diff --check` validation