### PR TITLE
test(request-events): settle virtualizer before teardown

### DIFF
--- a/web/src/components/usage/test/RequestEventsDetailsCardRequestLog.test.tsx
+++ b/web/src/components/usage/test/RequestEventsDetailsCardRequestLog.test.tsx
@@ -107,6 +107,12 @@ describe('RequestEventsDetailsCard request log virtualization', () => {
   });
 
   afterEach(async () => {
+    // TanStack Virtual 默认在 150ms 后发送滚动结束更新，销毁 Happy DOM 前先等待该更新完成。
+    await act(async () => {
+      const { promise: settleVirtualizer, resolve } = Promise.withResolvers<void>();
+      window.setTimeout(resolve, 200);
+      await settleVirtualizer;
+    });
     await act(async () => root.unmount());
     container.remove();
     document.body.innerHTML = '';


### PR DESCRIPTION
## Summary
- wait for the TanStack Virtual scroll-end debounce before tearing down Happy DOM
- prevent the request log virtualization test from updating React after the test environment is removed
- keep the fix test-only with no production behavior changes

## Validation
- request log virtualization test passed in five parallel repetitions
- frontend verification passed: 115 test files / 1084 tests, lint, typecheck, and production build
- git diff --check