### PR TITLE
feat(usage): add model dimension dropdown for analysis and realtime o…

### DIFF
--- a/internal/api/usage_filter.go
+++ b/internal/api/usage_filter.go
@@ -55,7 +55,23 @@ func parseUsageEventsTimeFilterQuery(req *http.Request, anchor time.Time) (servi
 
 // Analysis 主数据来自 hourly/daily 汇总，因此和 Overview 一样放宽至统一的一年上限。
 func parseUsageAnalysisTimeFilterQuery(req *http.Request, anchor time.Time) (servicedto.UsageFilter, error) {
-	return parseUsageTimeFilterQueryWithOptions(req, anchor, true, timeutil.UsageQueryRangeOptions{MaxCustomDayRangeDays: timeutil.LongCustomDayRangeMaxDays})
+	filter, err := parseUsageTimeFilterQueryWithOptions(req, anchor, true, timeutil.UsageQueryRangeOptions{MaxCustomDayRangeDays: timeutil.LongCustomDayRangeMaxDays})
+	if err != nil {
+		return servicedto.UsageFilter{}, err
+	}
+	filter.ModelDimension = parseUsageModelDimension(req)
+	return filter, nil
+}
+
+// parseUsageModelDimension 只接受 alias；其余值或缺失一律回退 model，保持既有统计口径。
+func parseUsageModelDimension(req *http.Request) string {
+	if req == nil {
+		return servicedto.ModelDimensionModel
+	}
+	if strings.TrimSpace(req.URL.Query().Get("model_dimension")) == servicedto.ModelDimensionAlias {
+		return servicedto.ModelDimensionAlias
+	}
+	return servicedto.ModelDimensionModel
 }
 
 func parseUsageTimeFilterQueryWithClientAPIKey(req *http.Request, anchor time.Time, includeClientAPIKey bool) (servicedto.UsageFilter, error) {
@@ -238,6 +254,7 @@ func parseUsageRealtimeFilterQueryWithClientAPIKey(req *http.Request, anchor tim
 	filter := servicedto.UsageFilter{
 		RealtimeWindow: realtimeWindow,
 		APIKeyID:       apiKeyID,
+		ModelDimension: parseUsageModelDimension(req),
 	}
 	switch realtimeWindow {
 	case "15m", "30m", "60m":

--- a/internal/repository/dto/usage_query_filter.go
+++ b/internal/repository/dto/usage_query_filter.go
@@ -4,8 +4,8 @@ import "time"
 
 // UsageQueryFilter 是仓储层的 usage 查询条件。
 type UsageQueryFilter struct {
-	Range        string
-	CustomUnit   string
+	Range      string
+	CustomUnit string
 	StartTime    *time.Time
 	EndTime      *time.Time
 	EndExclusive bool
@@ -24,6 +24,15 @@ type UsageQueryFilter struct {
 	AuthIndex       string
 	APIGroupKey     string
 	Result          string
+	// ModelDimension 控制模型维度聚合口径；model 表示按真实模型名，alias 表示按模型别名。
+	ModelDimension string
 }
+
+const (
+	// ModelDimensionModel 保持既有按真实模型名聚合的行为。
+	ModelDimensionModel = "model"
+	// ModelDimensionAlias 改按模型别名聚合。
+	ModelDimensionAlias = "alias"
+)
 
 const DefaultUsageEventsLimit = 100

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -1615,8 +1615,8 @@ func resolveUsageOverviewRealtimeModelKey(event entities.UsageEvent, modelDimens
 	if modelDimension != dto.ModelDimensionAlias {
 		return modelName
 	}
-	alias := normalizeUsageOverviewDimension(usageEventModelAlias(event))
-	if alias == "unknown" {
+	alias := strings.TrimSpace(usageEventModelAlias(event))
+	if alias == "" {
 		return modelName
 	}
 	return alias
@@ -2114,8 +2114,8 @@ func resolveUsageModelDimensionKey(modelName, modelAlias, modelDimension string)
 	if modelDimension != dto.ModelDimensionAlias {
 		return modelName
 	}
-	alias := normalizeUsageOverviewDimension(modelAlias)
-	if alias == "unknown" {
+	alias := strings.TrimSpace(modelAlias)
+	if alias == "" {
 		return modelName
 	}
 	return alias

--- a/internal/repository/usage.go
+++ b/internal/repository/usage.go
@@ -430,7 +430,7 @@ func BuildAnalysisWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, costResol
 		if err != nil {
 			return nil, err
 		}
-		applyAnalysisDailyRows(record, dailyRows, dailyIdentityLookup, costResolver)
+		applyAnalysisDailyRows(record, dailyRows, dailyIdentityLookup, costResolver, filter.ModelDimension)
 		return record, nil
 	}
 
@@ -447,7 +447,7 @@ func BuildAnalysisWithFilter(db *gorm.DB, filter dto.UsageQueryFilter, costResol
 	if err != nil {
 		return nil, err
 	}
-	applyAnalysisHourlyRows(record, rows, identityLookup, costResolver)
+	applyAnalysisHourlyRows(record, rows, identityLookup, costResolver, filter.ModelDimension)
 	fillAnalysisFullDayHourlyBuckets(record, filter)
 	return record, nil
 }
@@ -550,7 +550,7 @@ func loadAnalysisIdentityLookup(db *gorm.DB, authIndexes []string) (analysisIden
 	return lookup, nil
 }
 
-func applyAnalysisHourlyRows(record *dto.AnalysisRecord, rows []analysisOverviewStatProjection, identityLookup analysisIdentityLookup, costResolver pricing.Resolver) {
+func applyAnalysisHourlyRows(record *dto.AnalysisRecord, rows []analysisOverviewStatProjection, identityLookup analysisIdentityLookup, costResolver pricing.Resolver, modelDimension string) {
 	bucketTotals := map[time.Time]*dto.AnalysisTokenUsageBucketRecord{}
 	modelUsageTotals := map[analysisModelUsageKey]*dto.AnalysisModelUsageRecord{}
 	apiTotals := map[string]*dto.AnalysisCompositionRecord{}
@@ -562,13 +562,13 @@ func applyAnalysisHourlyRows(record *dto.AnalysisRecord, rows []analysisOverview
 		bucket := timeutil.NormalizeStorageTime(row.BucketStart).Truncate(time.Hour)
 		costResult := calculateAnalysisOverviewProjectionCost(costResolver, row)
 		cost, costAvailable := costResult.Cost, costResult.Available
-		applyAnalysisRow(record, bucketTotals, modelUsageTotals, apiTotals, modelTotals, heatmapTotals, bucket, row.APIGroupKey, row.Model, row.RequestCount, row.InputTokens, row.OutputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, row.TotalTokens, cost, costAvailable)
+		applyAnalysisRow(record, bucketTotals, modelUsageTotals, apiTotals, modelTotals, heatmapTotals, bucket, row.APIGroupKey, row.Model, row.ModelAlias, modelDimension, row.RequestCount, row.InputTokens, row.OutputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, row.TotalTokens, cost, costAvailable)
 		applyAnalysisIdentityComposition(identityLookup, authFileTotals, aiProviderTotals, row.AuthIndex, row.RequestCount, row.InputTokens, row.OutputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, row.TotalTokens, cost, costAvailable)
 	}
 	finalizeAnalysisRecord(record, bucketTotals, modelUsageTotals, apiTotals, modelTotals, authFileTotals, aiProviderTotals, heatmapTotals)
 }
 
-func applyAnalysisDailyRows(record *dto.AnalysisRecord, dailyRows []analysisOverviewStatProjection, dailyIdentityLookup analysisIdentityLookup, costResolver pricing.Resolver) {
+func applyAnalysisDailyRows(record *dto.AnalysisRecord, dailyRows []analysisOverviewStatProjection, dailyIdentityLookup analysisIdentityLookup, costResolver pricing.Resolver, modelDimension string) {
 	bucketTotals := map[time.Time]*dto.AnalysisTokenUsageBucketRecord{}
 	modelUsageTotals := map[analysisModelUsageKey]*dto.AnalysisModelUsageRecord{}
 	apiTotals := map[string]*dto.AnalysisCompositionRecord{}
@@ -580,15 +580,16 @@ func applyAnalysisDailyRows(record *dto.AnalysisRecord, dailyRows []analysisOver
 		bucket := timeutil.NormalizeStorageTime(row.BucketStart)
 		costResult := calculateAnalysisOverviewProjectionCost(costResolver, row)
 		cost, costAvailable := costResult.Cost, costResult.Available
-		applyAnalysisRow(record, bucketTotals, modelUsageTotals, apiTotals, modelTotals, heatmapTotals, bucket, row.APIGroupKey, row.Model, row.RequestCount, row.InputTokens, row.OutputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, row.TotalTokens, cost, costAvailable)
+		applyAnalysisRow(record, bucketTotals, modelUsageTotals, apiTotals, modelTotals, heatmapTotals, bucket, row.APIGroupKey, row.Model, row.ModelAlias, modelDimension, row.RequestCount, row.InputTokens, row.OutputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, row.TotalTokens, cost, costAvailable)
 		applyAnalysisIdentityComposition(dailyIdentityLookup, authFileTotals, aiProviderTotals, row.AuthIndex, row.RequestCount, row.InputTokens, row.OutputTokens, row.CacheReadTokens, row.CacheCreationTokens, row.ReasoningTokens, row.TotalTokens, cost, costAvailable)
 	}
 	finalizeAnalysisRecord(record, bucketTotals, modelUsageTotals, apiTotals, modelTotals, authFileTotals, aiProviderTotals, heatmapTotals)
 }
 
-func applyAnalysisRow(record *dto.AnalysisRecord, bucketTotals map[time.Time]*dto.AnalysisTokenUsageBucketRecord, modelUsageTotals map[analysisModelUsageKey]*dto.AnalysisModelUsageRecord, apiTotals, modelTotals map[string]*dto.AnalysisCompositionRecord, heatmapTotals map[analysisHeatmapKey]*dto.AnalysisHeatmapRecord, bucket time.Time, apiGroupKey, model string, requests, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, reasoningTokens, totalTokens int64, cost helper.UsageTokenCostBreakdown, costAvailable bool) {
+func applyAnalysisRow(record *dto.AnalysisRecord, bucketTotals map[time.Time]*dto.AnalysisTokenUsageBucketRecord, modelUsageTotals map[analysisModelUsageKey]*dto.AnalysisModelUsageRecord, apiTotals, modelTotals map[string]*dto.AnalysisCompositionRecord, heatmapTotals map[analysisHeatmapKey]*dto.AnalysisHeatmapRecord, bucket time.Time, apiGroupKey, model, modelAlias, modelDimension string, requests, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, reasoningTokens, totalTokens int64, cost helper.UsageTokenCostBreakdown, costAvailable bool) {
 	apiKey := normalizeUsageOverviewDimension(apiGroupKey)
 	modelName := normalizeUsageOverviewDimension(model)
+	modelKey := resolveUsageModelDimensionKey(modelName, modelAlias, modelDimension)
 	bucketTotal := bucketTotals[bucket]
 	if bucketTotal == nil {
 		bucketTotal = &dto.AnalysisTokenUsageBucketRecord{Bucket: bucket, CostAvailable: true}
@@ -607,10 +608,10 @@ func applyAnalysisRow(record *dto.AnalysisRecord, bucketTotals map[time.Time]*dt
 	}
 
 	// Top Models 与总 Token 图共享同一 bucket；这里只在既有 rows 遍历中补充模型维度累加。
-	modelUsageKey := analysisModelUsageKey{bucket: bucket, model: modelName}
+	modelUsageKey := analysisModelUsageKey{bucket: bucket, model: modelKey}
 	modelUsage := modelUsageTotals[modelUsageKey]
 	if modelUsage == nil {
-		modelUsage = &dto.AnalysisModelUsageRecord{Bucket: bucket, Model: modelName}
+		modelUsage = &dto.AnalysisModelUsageRecord{Bucket: bucket, Model: modelKey}
 		modelUsageTotals[modelUsageKey] = modelUsage
 	}
 	modelUsage.TotalTokens += totalTokens
@@ -623,17 +624,17 @@ func applyAnalysisRow(record *dto.AnalysisRecord, bucketTotals map[time.Time]*dt
 	}
 	applyAnalysisCompositionTotals(apiTotal, requests, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, reasoningTokens, totalTokens, cost.TotalCostUSD, costAvailable)
 
-	modelTotal := modelTotals[modelName]
+	modelTotal := modelTotals[modelKey]
 	if modelTotal == nil {
-		modelTotal = &dto.AnalysisCompositionRecord{Key: modelName, CostAvailable: true}
-		modelTotals[modelName] = modelTotal
+		modelTotal = &dto.AnalysisCompositionRecord{Key: modelKey, CostAvailable: true}
+		modelTotals[modelKey] = modelTotal
 	}
 	applyAnalysisCompositionTotals(modelTotal, requests, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, reasoningTokens, totalTokens, cost.TotalCostUSD, costAvailable)
 
-	heatmapKey := analysisHeatmapKey{apiKey: apiKey, model: modelName}
+	heatmapKey := analysisHeatmapKey{apiKey: apiKey, model: modelKey}
 	heatmapTotal := heatmapTotals[heatmapKey]
 	if heatmapTotal == nil {
-		heatmapTotal = &dto.AnalysisHeatmapRecord{APIKey: apiKey, Model: modelName, CostAvailable: true}
+		heatmapTotal = &dto.AnalysisHeatmapRecord{APIKey: apiKey, Model: modelKey, CostAvailable: true}
 		heatmapTotals[heatmapKey] = heatmapTotal
 	}
 	heatmapTotal.Requests += requests
@@ -1385,7 +1386,7 @@ func buildUsageOverviewRealtime(db *gorm.DB, filter dto.UsageQueryFilter, costRe
 		bucket.requests++
 		if visibleEvent {
 			// current usage 的请求数同样包含成功和失败，token 后续只由成功请求累计。
-			applyUsageOverviewRealtimeRequest(realtimeEvent, modelUsage, apiKeyUsage, authFileUsage, aiProviderUsage, identityLookup)
+			applyUsageOverviewRealtimeRequest(realtimeEvent, modelUsage, apiKeyUsage, authFileUsage, aiProviderUsage, identityLookup, filter.ModelDimension)
 		}
 		if !event.Failed && usageEventGenerateEnabled(event.Generate) && event.TTFTMS != nil && *event.TTFTMS > 0 && event.LatencyMS > 0 {
 			// TTFT 和 Latency 共用同一有效请求样本，避免两张响应分布图的统计口径不一致。
@@ -1411,7 +1412,7 @@ func buildUsageOverviewRealtime(db *gorm.DB, filter dto.UsageQueryFilter, costRe
 		}
 		if visibleEvent {
 			// current usage 的 token 占比只统计有 token 的成功请求。
-			applyUsageOverviewRealtimeTokenUsage(realtimeEvent, cost, costResult.Available, modelUsage, apiKeyUsage, authFileUsage, aiProviderUsage, identityLookup)
+			applyUsageOverviewRealtimeTokenUsage(realtimeEvent, cost, costResult.Available, modelUsage, apiKeyUsage, authFileUsage, aiProviderUsage, identityLookup, filter.ModelDimension)
 		}
 	}
 
@@ -1579,10 +1580,11 @@ func collectRealtimeAuthIndexes(events []usageOverviewRealtimeEvent, visibleStar
 	return result
 }
 
-func applyUsageOverviewRealtimeRequest(realtimeEvent usageOverviewRealtimeEvent, modelUsage, apiKeyUsage, authFileUsage, aiProviderUsage map[string]*usageOverviewRealtimeTopAccumulator, identityLookup analysisIdentityLookup) {
+func applyUsageOverviewRealtimeRequest(realtimeEvent usageOverviewRealtimeEvent, modelUsage, apiKeyUsage, authFileUsage, aiProviderUsage map[string]*usageOverviewRealtimeTopAccumulator, identityLookup analysisIdentityLookup, modelDimension string) {
 	event := realtimeEvent.event
-	// 模型维度的请求数不区分成功失败。
-	applyUsageOverviewRealtimeRequestToTotals(modelUsage, normalizeUsageOverviewDimension(event.Model), normalizeUsageOverviewDimension(event.Model))
+	// 模型维度的请求数不区分成功失败；alias 模式下合并同名别名。
+	modelKey := resolveUsageOverviewRealtimeModelKey(event, modelDimension)
+	applyUsageOverviewRealtimeRequestToTotals(modelUsage, modelKey, modelKey)
 	// API Key 维度使用 api_group_key，KeyOverview 前端会隐藏这个 tab。
 	applyUsageOverviewRealtimeRequestToTotals(apiKeyUsage, normalizeUsageOverviewDimension(event.APIGroupKey), normalizeUsageOverviewDimension(event.APIGroupKey))
 	// Auth File / AI Provider 维度先走身份表，缺失时再用缓存 fallback。
@@ -1595,14 +1597,37 @@ func applyUsageOverviewRealtimeRequestToTotals(totals map[string]*usageOverviewR
 	item.requests++
 }
 
-func applyUsageOverviewRealtimeTokenUsage(realtimeEvent usageOverviewRealtimeEvent, cost float64, costAvailable bool, modelUsage, apiKeyUsage, authFileUsage, aiProviderUsage map[string]*usageOverviewRealtimeTopAccumulator, identityLookup analysisIdentityLookup) {
+func applyUsageOverviewRealtimeTokenUsage(realtimeEvent usageOverviewRealtimeEvent, cost float64, costAvailable bool, modelUsage, apiKeyUsage, authFileUsage, aiProviderUsage map[string]*usageOverviewRealtimeTopAccumulator, identityLookup analysisIdentityLookup, modelDimension string) {
 	event := realtimeEvent.event
-	// token share 的模型维度只统计成功且有 token 的请求。
-	applyUsageOverviewRealtimeTokenUsageToTotals(modelUsage, normalizeUsageOverviewDimension(event.Model), normalizeUsageOverviewDimension(event.Model), event.TotalTokens, cost, costAvailable)
+	// token share 的模型维度只统计成功且有 token 的请求；alias 模式下与请求数使用相同键。
+	modelKey := resolveUsageOverviewRealtimeModelKey(event, modelDimension)
+	applyUsageOverviewRealtimeTokenUsageToTotals(modelUsage, modelKey, modelKey, event.TotalTokens, cost, costAvailable)
 	// token share 的 API Key 维度同样按 api_group_key 聚合。
 	applyUsageOverviewRealtimeTokenUsageToTotals(apiKeyUsage, normalizeUsageOverviewDimension(event.APIGroupKey), normalizeUsageOverviewDimension(event.APIGroupKey), event.TotalTokens, cost, costAvailable)
 	// 身份维度 token 聚合保持和请求数相同的身份解析策略。
 	applyUsageOverviewRealtimeIdentityTokenUsage(realtimeEvent, authFileUsage, aiProviderUsage, identityLookup, cost, costAvailable)
+}
+
+// resolveUsageOverviewRealtimeModelKey 返回实时聚合的模型统计键；alias 模式使用 ModelAlias，为空回退真实模型名。
+// 成本仍按原始真实模型名解析，不使用该键。
+func resolveUsageOverviewRealtimeModelKey(event entities.UsageEvent, modelDimension string) string {
+	modelName := normalizeUsageOverviewDimension(event.Model)
+	if modelDimension != dto.ModelDimensionAlias {
+		return modelName
+	}
+	alias := normalizeUsageOverviewDimension(usageEventModelAlias(event))
+	if alias == "unknown" {
+		return modelName
+	}
+	return alias
+}
+
+// usageEventModelAlias 安全提取事件 ModelAlias，nil 时返回空串。
+func usageEventModelAlias(event entities.UsageEvent) string {
+	if event.ModelAlias == nil {
+		return ""
+	}
+	return *event.ModelAlias
 }
 
 func applyUsageOverviewRealtimeTokenUsageToTotals(totals map[string]*usageOverviewRealtimeTopAccumulator, key, label string, tokens int64, cost float64, costAvailable bool) {
@@ -2081,6 +2106,19 @@ func normalizeUsageOverviewDimension(value string) string {
 		return "unknown"
 	}
 	return trimmed
+}
+
+// resolveUsageModelDimensionKey 返回模型维度的统计展示键；alias 模式优先使用模型别名，别名缺失时回退真实模型名。
+// 定价计算不使用该键，价格仍按原始真实模型名和原始别名解析。
+func resolveUsageModelDimensionKey(modelName, modelAlias, modelDimension string) string {
+	if modelDimension != dto.ModelDimensionAlias {
+		return modelName
+	}
+	alias := normalizeUsageOverviewDimension(modelAlias)
+	if alias == "unknown" {
+		return modelName
+	}
+	return alias
 }
 
 const (

--- a/internal/service/dto/usage.go
+++ b/internal/service/dto/usage.go
@@ -8,6 +8,12 @@ import (
 
 const DefaultUsageEventsLimit = 100
 
+// 模型维度聚合口径。ModelDimensionModel 保持既有行为，ModelDimensionAlias 改按模型别名聚合。
+const (
+	ModelDimensionModel = "model"
+	ModelDimensionAlias = "alias"
+)
+
 // UsageFilter 是服务层的 usage 查询条件。
 type UsageFilter struct {
 	Range string
@@ -37,6 +43,8 @@ type UsageFilter struct {
 	AuthIndex       string
 	APIKeyID        string
 	Result          string
+	// ModelDimension 控制按模型名统计还是按模型别名统计；默认 model 保持既有行为。
+	ModelDimension string
 }
 
 // UsageEventsPage 是 usage events 列表的服务层结果。

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -248,6 +248,7 @@ func (s *usageService) GetUsageOverviewRealtime(ctx context.Context, filter serv
 		RealtimeWindow:  filter.RealtimeWindow,
 		RealtimeEndTime: filter.RealtimeEndTime,
 		APIGroupKey:     apiGroupKey,
+		ModelDimension:  filter.ModelDimension,
 	}, s.recentUsage, s.pricing.NewResolver())
 	if err != nil {
 		return nil, err
@@ -482,12 +483,13 @@ func (s *usageService) GetAnalysis(ctx context.Context, filter servicedto.UsageF
 		return nil, err
 	}
 	record, err := repository.BuildAnalysisWithFilter(s.db.WithContext(ctx), repodto.UsageQueryFilter{
-		Range:        filter.Range,
-		CustomUnit:   filter.CustomUnit,
-		StartTime:    filter.StartTime,
-		EndTime:      filter.EndTime,
-		EndExclusive: filter.EndExclusive,
-		APIGroupKey:  apiGroupKey,
+		Range:         filter.Range,
+		CustomUnit:    filter.CustomUnit,
+		StartTime:     filter.StartTime,
+		EndTime:       filter.EndTime,
+		EndExclusive:  filter.EndExclusive,
+		APIGroupKey:   apiGroupKey,
+		ModelDimension: filter.ModelDimension,
 	}, s.pricing.NewResolver())
 	if err != nil {
 		return nil, err

--- a/web/src/components/usage/OverviewRealtimePanel.tsx
+++ b/web/src/components/usage/OverviewRealtimePanel.tsx
@@ -4,6 +4,7 @@ import '@/lib/chartjs';
 import type { ChartData, ChartOptions } from 'chart.js';
 import { Chart, Line } from 'react-chartjs-2';
 import type {
+  ModelDimension,
   OverviewRealtimeBlock,
   OverviewRealtimeWindow,
   RealtimeResponseAveragePoint,
@@ -18,6 +19,7 @@ import {
   formatUsd,
 } from '@/utils/usage';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import { Select } from '@/components/ui/Select';
 import styles from '@/pages/UsagePage.module.scss';
 
 type RealtimeDimensionKey = 'models' | 'api_keys' | 'auth_files' | 'ai_providers';
@@ -48,6 +50,8 @@ interface OverviewRealtimePanelProps {
   isMobile: boolean;
   timezone?: string;
   visibleDimensions?: readonly RealtimeDimensionKey[];
+  modelDimension?: ModelDimension;
+  onModelDimensionChange?: (dimension: ModelDimension) => void;
 }
 
 const REALTIME_WINDOWS: OverviewRealtimeWindow[] = ['15m', '30m', '60m'];
@@ -569,7 +573,7 @@ function UsageMetaPill({ label, value }: { label: string; value: string }) {
   );
 }
 
-export function OverviewRealtimePanel({ realtime, loading, error, window, onWindowChange, isDark, isMobile, timezone, visibleDimensions = DEFAULT_VISIBLE_DIMENSIONS }: OverviewRealtimePanelProps) {
+export function OverviewRealtimePanel({ realtime, loading, error, window, onWindowChange, isDark, isMobile, timezone, visibleDimensions = DEFAULT_VISIBLE_DIMENSIONS, modelDimension = 'model', onModelDimensionChange }: OverviewRealtimePanelProps) {
   const { t } = useTranslation();
   const data = realtime ?? emptyRealtime(window);
   const initialLoading = loading && !realtime;
@@ -734,6 +738,20 @@ export function OverviewRealtimePanel({ realtime, loading, error, window, onWind
             </div>
 
             <RealtimeCard title={t('usage_stats.overview_realtime_current_usage')} className={styles.overviewRealtimeCurrentUsageCard}>
+              {onModelDimensionChange && (
+                <div className={styles.overviewRealtimeDimensionToolbar}>
+                  <Select
+                    value={modelDimension}
+                    options={[
+                      { value: 'model', label: t('usage_stats.model_dimension_model') },
+                      { value: 'alias', label: t('usage_stats.model_dimension_alias') },
+                    ]}
+                    onChange={(value) => onModelDimensionChange(value as ModelDimension)}
+                    ariaLabel={t('usage_stats.model_dimension_label')}
+                    className={styles.overviewRealtimeDimensionSelect}
+                  />
+                </div>
+              )}
               <div className={styles.overviewRealtimeDimensionTabs}>
                 {dimensions.map((dimension) => (
                   <button

--- a/web/src/components/usage/analysis/AnalysisPanel.module.scss
+++ b/web/src/components/usage/analysis/AnalysisPanel.module.scss
@@ -7,6 +7,17 @@
   gap: 18px;
 }
 
+.analysisDimensionToolbar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+}
+
+.analysisDimensionSelect {
+  min-width: 160px;
+}
+
 .analysisCard {
   padding: var(--keeper-card-padding);
   min-width: 0;

--- a/web/src/components/usage/analysis/AnalysisPanel.tsx
+++ b/web/src/components/usage/analysis/AnalysisPanel.tsx
@@ -4,8 +4,9 @@ import '@/lib/chartjs';
 import { Interaction, Tooltip } from 'chart.js';
 import type { Chart, ChartData, ChartOptions, InteractionItem, InteractionModeFunction, Plugin, ScriptableContext, TooltipModel, TooltipPositionerFunction } from 'chart.js';
 import { Bar, Doughnut, Scatter } from 'react-chartjs-2';
-import type { AnalysisCompositionItem, AnalysisCostBreakdown, AnalysisHeatmapCell, AnalysisLatencyDiagnostics, AnalysisModelEfficiencyItem, AnalysisModelUsagePayload, AnalysisResponse, AnalysisTokenUsageBucket } from '@/lib/types';
+import type { AnalysisCompositionItem, AnalysisCostBreakdown, AnalysisHeatmapCell, AnalysisLatencyDiagnostics, AnalysisModelEfficiencyItem, AnalysisModelUsagePayload, AnalysisResponse, AnalysisTokenUsageBucket, ModelDimension } from '@/lib/types';
 import { calculateDisplayInputTokens, calculateDisplayOutputTokens, formatCompactNumber, formatDurationMs, formatPerMinuteValue, formatUsd } from '@/utils/usage';
+import { Select } from '@/components/ui/Select';
 import styles from './AnalysisPanel.module.scss';
 
 interface AnalysisPanelProps {
@@ -14,6 +15,8 @@ interface AnalysisPanelProps {
   latencyDiagnostics?: AnalysisLatencyDiagnostics | null;
   latencyLoading?: boolean;
   latencyError?: string;
+  modelDimension?: ModelDimension;
+  onModelDimensionChange?: (dimension: ModelDimension) => void;
   isDark: boolean;
   isMobile: boolean;
 }
@@ -2388,7 +2391,7 @@ function Heatmap({ cells, apiKeys, apiKeyLabels, models, loading, isDark }: { ce
   );
 }
 
-export function AnalysisPanel({ analysis, loading, latencyDiagnostics, latencyLoading = false, latencyError = '', isDark, isMobile }: AnalysisPanelProps) {
+export function AnalysisPanel({ analysis, loading, latencyDiagnostics, latencyLoading = false, latencyError = '', modelDimension = 'model', onModelDimensionChange, isDark, isMobile }: AnalysisPanelProps) {
   const { t } = useTranslation();
   const tokenRows = useMemo(() => buildTokenUsageRows(analysis?.token_usage ?? [], analysis?.granularity ?? 'hourly', analysis?.timezone), [analysis]);
   const apiComposition = useMemo(() => takeMajorComposition(analysis?.api_key_composition ?? [], t('usage_stats.analysis_others')), [analysis, t]);
@@ -2402,9 +2405,24 @@ export function AnalysisPanel({ analysis, loading, latencyDiagnostics, latencyLo
     { id: 'auth_files', label: t('usage_stats.analysis_composition_auth_files_tab'), items: authFilesComposition },
     { id: 'ai_provider', label: t('usage_stats.analysis_composition_ai_provider_tab'), items: aiProviderComposition },
   ], [apiComposition, modelComposition, authFilesComposition, aiProviderComposition, t]);
+  const modelDimensionOptions = useMemo(() => [
+    { value: 'model', label: t('usage_stats.model_dimension_model') },
+    { value: 'alias', label: t('usage_stats.model_dimension_alias') },
+  ], [t]);
 
   return (
     <div className={styles.analysisPanel}>
+      {onModelDimensionChange && (
+        <div className={styles.analysisDimensionToolbar}>
+          <Select
+            value={modelDimension}
+            options={modelDimensionOptions}
+            onChange={(value) => onModelDimensionChange(value as ModelDimension)}
+            ariaLabel={t('usage_stats.model_dimension_label')}
+            className={styles.analysisDimensionSelect}
+          />
+        </div>
+      )}
       <TokenUsageChart rows={tokenRows} loading={loading} isDark={isDark} isMobile={isMobile} />
       <div className={styles.insightGrid}>
         <CostBreakdownCard breakdown={analysis?.cost_breakdown} rows={tokenRows} loading={loading} />

--- a/web/src/components/usage/hooks/useOverviewRealtimeData.test.ts
+++ b/web/src/components/usage/hooks/useOverviewRealtimeData.test.ts
@@ -22,20 +22,20 @@ const realtimeForWindow = (window: OverviewRealtimeWindow): OverviewRealtimeBloc
 });
 
 describe('resolveDisplayRealtime', () => {
-  it('keeps the previous realtime block visible while a new window is loading', () => {
+  it('hides the previous realtime block while a new window is loading', () => {
     expect(resolveDisplayRealtime({
       realtime: realtimeForWindow('15m'),
       lastRealtimeQueryKey: ':15m',
       realtimeQueryKey: ':60m',
-    })?.window).toBe('15m');
+    })).toBeNull();
   });
 
-  it('keeps the previous realtime block visible before same-scope window loading starts', () => {
+  it('hides the previous realtime block before same-scope window loading starts', () => {
     expect(resolveDisplayRealtime({
       realtime: realtimeForWindow('15m'),
       lastRealtimeQueryKey: 'key-a:15m',
       realtimeQueryKey: 'key-a:60m',
-    })?.window).toBe('15m');
+    })).toBeNull();
   });
 
   it('hides stale realtime data after a same-scope window query fails', () => {
@@ -60,6 +60,22 @@ describe('resolveDisplayRealtime', () => {
       realtime: realtimeForWindow('15m'),
       lastRealtimeQueryKey: 'key-a:15m',
       realtimeQueryKey: 'key-b:15m',
+    })).toBeNull();
+  });
+
+  it('returns the realtime block when the query key matches exactly', () => {
+    expect(resolveDisplayRealtime({
+      realtime: realtimeForWindow('15m'),
+      lastRealtimeQueryKey: 'key-a:15m:model',
+      realtimeQueryKey: 'key-a:15m:model',
+    })?.window).toBe('15m');
+  });
+
+  it('hides stale realtime data when only the model dimension changes', () => {
+    expect(resolveDisplayRealtime({
+      realtime: realtimeForWindow('15m'),
+      lastRealtimeQueryKey: 'key-a:15m:model',
+      realtimeQueryKey: 'key-a:15m:alias',
     })).toBeNull();
   });
 });

--- a/web/src/components/usage/hooks/useOverviewRealtimeData.ts
+++ b/web/src/components/usage/hooks/useOverviewRealtimeData.ts
@@ -25,12 +25,6 @@ interface ResolveDisplayRealtimeOptions {
   realtimeQueryKey: string;
 }
 
-const realtimeQueryScope = (queryKey: string | null): string | null => {
-  if (queryKey === null) return null;
-  const separatorIndex = queryKey.lastIndexOf(':');
-  return separatorIndex === -1 ? queryKey : queryKey.slice(0, separatorIndex);
-};
-
 export function resolveDisplayRealtime({
   realtime,
   lastRealtimeQueryKey,
@@ -39,9 +33,6 @@ export function resolveDisplayRealtime({
 }: ResolveDisplayRealtimeOptions): OverviewRealtimeBlock | null {
   if (lastRealtimeQueryKey === realtimeQueryKey) return realtime;
   if (lastRealtimeErrorQueryKey === realtimeQueryKey) return null;
-  if (realtime && realtimeQueryScope(lastRealtimeQueryKey) === realtimeQueryScope(realtimeQueryKey)) {
-    return realtime;
-  }
   return null;
 }
 

--- a/web/src/components/usage/hooks/useOverviewRealtimeData.ts
+++ b/web/src/components/usage/hooks/useOverviewRealtimeData.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from 'react';
 import { ApiError } from '@/lib/api';
-import type { OverviewRealtimeBlock, OverviewRealtimeWindow } from '@/lib/types';
+import type { ModelDimension, OverviewRealtimeBlock, OverviewRealtimeWindow } from '@/lib/types';
 import { USAGE_STATS_STALE_TIME_MS, useUsageStatsStore } from '@/stores';
 
 export interface UseOverviewRealtimeDataReturn {
@@ -15,6 +15,7 @@ export interface UseOverviewRealtimeDataOptions {
   enabled?: boolean;
   apiKeyId?: string;
   realtimeWindow?: OverviewRealtimeWindow;
+  modelDimension?: ModelDimension;
 }
 
 interface ResolveDisplayRealtimeOptions {
@@ -45,14 +46,14 @@ export function resolveDisplayRealtime({
 }
 
 export function useOverviewRealtimeData(options: UseOverviewRealtimeDataOptions = {}): UseOverviewRealtimeDataReturn {
-  const { onAuthRequired, enabled = true, apiKeyId, realtimeWindow } = options;
+  const { onAuthRequired, enabled = true, apiKeyId, realtimeWindow, modelDimension } = options;
   const realtime = useUsageStatsStore((state) => state.realtime);
   const loading = useUsageStatsStore((state) => state.realtimeLoading);
   const storeError = useUsageStatsStore((state) => state.realtimeError);
   const lastRealtimeQueryKey = useUsageStatsStore((state) => state.lastRealtimeQueryKey);
   const lastRealtimeErrorQueryKey = useUsageStatsStore((state) => state.lastRealtimeErrorQueryKey);
   const loadUsageStatsRealtime = useUsageStatsStore((state) => state.loadUsageStatsRealtime);
-  const realtimeQueryKey = `${apiKeyId ?? ''}:${realtimeWindow ?? ''}`;
+  const realtimeQueryKey = `${apiKeyId ?? ''}:${realtimeWindow ?? ''}:${modelDimension ?? 'model'}`;
   const currentRealtime = resolveDisplayRealtime({
     realtime,
     lastRealtimeQueryKey,
@@ -67,6 +68,7 @@ export function useOverviewRealtimeData(options: UseOverviewRealtimeDataOptions 
         staleTimeMs: USAGE_STATS_STALE_TIME_MS,
         apiKeyId,
         realtimeWindow,
+        modelDimension,
       });
     } catch (error) {
       if (error instanceof ApiError && error.status === 401) {
@@ -74,7 +76,7 @@ export function useOverviewRealtimeData(options: UseOverviewRealtimeDataOptions 
       }
       throw error;
     }
-  }, [apiKeyId, loadUsageStatsRealtime, onAuthRequired, realtimeWindow]);
+  }, [apiKeyId, loadUsageStatsRealtime, modelDimension, onAuthRequired, realtimeWindow]);
 
   useEffect(() => {
     if (!enabled) {
@@ -84,12 +86,13 @@ export function useOverviewRealtimeData(options: UseOverviewRealtimeDataOptions 
       staleTimeMs: USAGE_STATS_STALE_TIME_MS,
       apiKeyId,
       realtimeWindow,
+      modelDimension,
     }).catch((error) => {
       if (error instanceof ApiError && error.status === 401) {
         onAuthRequired?.();
       }
     });
-  }, [apiKeyId, enabled, loadUsageStatsRealtime, onAuthRequired, realtimeWindow]);
+  }, [apiKeyId, enabled, loadUsageStatsRealtime, modelDimension, onAuthRequired, realtimeWindow]);
 
   return {
     realtime: currentRealtime,

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -657,7 +657,10 @@ const resources = {
         analysis_heatmap_low: 'Low',
         analysis_heatmap_high: 'High',
         analysis_heatmap_legend: 'Heatmap intensity legend',
-        analysis_others: 'Others'
+        analysis_others: 'Others',
+        model_dimension_label: 'Model dimension',
+        model_dimension_model: 'By model name',
+        model_dimension_alias: 'By model alias'
       },
       ranking: {
         kicker: 'Community leaderboard',
@@ -1412,7 +1415,10 @@ const resources = {
         analysis_heatmap_low: '低',
         analysis_heatmap_high: '高',
         analysis_heatmap_legend: '热力强度示例',
-        analysis_others: '其他'
+        analysis_others: '其他',
+        model_dimension_label: '模型维度',
+        model_dimension_model: '按模型名',
+        model_dimension_alias: '按模型别名'
       },
       ranking: {
         kicker: '社区排行榜',
@@ -2167,7 +2173,10 @@ const resources = {
         analysis_heatmap_low: '低',
         analysis_heatmap_high: '高',
         analysis_heatmap_legend: '熱力強度示例',
-        analysis_others: '其他'
+        analysis_others: '其他',
+        model_dimension_label: '模型維度',
+        model_dimension_model: '依模型名稱',
+        model_dimension_alias: '依模型別名'
       },
       ranking: {
         kicker: '社群排行榜',

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { type AnalysisLatencyDiagnostics, type AnalysisResponse, type AuthFilesManagementResponse, type AuthManagedSessionsResponse, type AuthSessionResponse, type CpaApiKeyDisplayItem, type CpaApiKeyOptionsResponse, type CpaApiKeySettingsResponse, type CpaApiKeysResponse, type OverviewRealtimeBlock, type OverviewRealtimeWindow, type PricingEntry, type PricingResponse, type PricingRulesResponse, type PricingSyncPreviewResponse, type QuotaAutoRefreshSettings, type ReplacePricingRulesRequest, type StatusResponse, type UpdateCheckResponse, type UsageActivityRequest, type UsageActivityResponse, type UsageEventModelFilterOptionsResponse, type UsageEventRequestLogResponse, type UsageEventSourceFilterOptionsResponse, type UsageRangeRequest, type UsedModelsResponse, type UsageIdentitiesPageResponse, type UsageIdentitiesResponse, type UsageEventsResponse, type UsageIdentity, type UsageIdentityAuthType, type UsageOverviewResponse, type UsageQuotaCacheResponse, type UsageQuotaInspectionStatusResponse, type UsageQuotaRefreshResponse, type UsageQuotaRefreshTaskResponse, type UsageQuotaResetCreditsResponse, type UsageQuotaResetResponse, type VersionResponse } from './types'
+import { type AnalysisLatencyDiagnostics, type AnalysisResponse, type AuthFilesManagementResponse, type AuthManagedSessionsResponse, type AuthSessionResponse, type CpaApiKeyDisplayItem, type CpaApiKeyOptionsResponse, type CpaApiKeySettingsResponse, type CpaApiKeysResponse, type ModelDimension, type OverviewRealtimeBlock, type OverviewRealtimeWindow, type PricingEntry, type PricingResponse, type PricingRulesResponse, type PricingSyncPreviewResponse, type QuotaAutoRefreshSettings, type ReplacePricingRulesRequest, type StatusResponse, type UpdateCheckResponse, type UsageActivityRequest, type UsageActivityResponse, type UsageEventModelFilterOptionsResponse, type UsageEventRequestLogResponse, type UsageEventSourceFilterOptionsResponse, type UsageRangeRequest, type UsedModelsResponse, type UsageIdentitiesPageResponse, type UsageIdentitiesResponse, type UsageEventsResponse, type UsageIdentity, type UsageIdentityAuthType, type UsageOverviewResponse, type UsageQuotaCacheResponse, type UsageQuotaInspectionStatusResponse, type UsageQuotaRefreshResponse, type UsageQuotaRefreshTaskResponse, type UsageQuotaResetCreditsResponse, type UsageQuotaResetResponse, type VersionResponse } from './types'
 import { isCPAMCEmbed } from '@/embed/cpamcEmbed'
 import { resolveUsageRequestRange } from '@/utils/usage/rangeQuery'
 
@@ -93,6 +93,7 @@ function normalizeOverviewRealtimeBlock(
 export interface FetchKeyOverviewRealtimeOptions {
   window?: OverviewRealtimeWindow
   signal?: AbortSignal
+  modelDimension?: ModelDimension
 }
 
 export interface FetchUsageOverviewRealtimeOptions extends FetchKeyOverviewRealtimeOptions {
@@ -340,10 +341,13 @@ export async function fetchKeyActivity({ request, signal }: FetchUsageActivityOp
 }
 
 export async function fetchKeyOverviewRealtime(options: FetchKeyOverviewRealtimeOptions = {}): Promise<OverviewRealtimeBlock> {
-  const { window, signal } = options
+  const { window, signal, modelDimension } = options
   const params = new URLSearchParams()
   if (window) {
     params.set('window', window)
+  }
+  if (modelDimension === 'alias') {
+    params.set('model_dimension', 'alias')
   }
   const query = params.toString()
   const response = await apiFetch(`${apiPath('/key-overview/realtime')}${query ? `?${query}` : ''}`, { signal })
@@ -384,7 +388,7 @@ export async function fetchUsageActivity({ request, apiKeyId, signal }: FetchUsa
 }
 
 export async function fetchUsageOverviewRealtime(options: FetchUsageOverviewRealtimeOptions = {}): Promise<OverviewRealtimeBlock> {
-  const { signal, apiKeyId, window } = options
+  const { signal, apiKeyId, window, modelDimension } = options
   const params = new URLSearchParams()
   const selectedAPIKeyId = apiKeyId?.trim()
   if (selectedAPIKeyId) {
@@ -392,6 +396,9 @@ export async function fetchUsageOverviewRealtime(options: FetchUsageOverviewReal
   }
   if (window) {
     params.set('window', window)
+  }
+  if (modelDimension === 'alias') {
+    params.set('model_dimension', 'alias')
   }
   const query = params.toString()
   const response = await apiFetch(`${apiPath('/usage/overview/realtime')}${query ? `?${query}` : ''}`, { signal })
@@ -703,11 +710,14 @@ export async function deleteAuthFiles(names: string[]): Promise<AuthFilesManagem
   return response.json()
 }
 
-export async function fetchAnalysis(request: UsageRangeRequest, signal?: AbortSignal, apiKeyId?: string): Promise<AnalysisResponse> {
+export async function fetchAnalysis(request: UsageRangeRequest, signal?: AbortSignal, apiKeyId?: string, modelDimension?: ModelDimension): Promise<AnalysisResponse> {
   const params = buildUsageRangeParams(request)
   const selectedAPIKeyId = apiKeyId?.trim()
   if (selectedAPIKeyId) {
     params.set('api_key_id', selectedAPIKeyId)
+  }
+  if (modelDimension === 'alias') {
+    params.set('model_dimension', 'alias')
   }
   const query = params.toString()
   const response = await apiFetch(`${apiPath('/usage/analysis')}${query ? `?${query}` : ''}`, { signal })

--- a/web/src/lib/test/api.test.ts
+++ b/web/src/lib/test/api.test.ts
@@ -542,7 +542,7 @@ describe('fetchUsageEvents', () => {
     expect(analysisUrl.searchParams.get('end')).toBe('2026-04-21');
     expect(analysisUrl.searchParams.get('api_key_id')).toBe('9007199254740993');
     expect(Array.from(analysisUrl.searchParams.keys())).toEqual(['range', 'unit', 'start', 'end', 'api_key_id']);
-    expect(fetchAnalysis).toHaveLength(3);
+    expect(fetchAnalysis).toHaveLength(4);
   });
 
   it('loads Analysis latency from its independent endpoint with the same filters', async () => {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -142,6 +142,9 @@ export interface UsageActivityResponse {
 
 export type OverviewRealtimeWindow = '15m' | '30m' | '60m'
 
+// ModelDimension 控制按模型名统计还是按模型别名统计，与分析页和实时概览的全局 dropdown 共享。
+export type ModelDimension = 'model' | 'alias'
+
 export interface RealtimeTokenVelocityPoint {
   bucket: string
   tokens_per_minute: number

--- a/web/src/pages/KeyOverviewPage.styles.test.ts
+++ b/web/src/pages/KeyOverviewPage.styles.test.ts
@@ -53,8 +53,8 @@ describe('KeyOverviewPage layout', () => {
     expect(source).not.toContain('manualRefreshLoading || loading || realtimeLoading || refreshThrottled')
   })
 
-  it('keeps existing realtime data visible during background refreshes', () => {
-    expect(source).not.toContain('setRealtime(null)')
+  it('clears stale realtime data on dimension or window change before the new response arrives', () => {
+    expect(source).toContain('setRealtime(null)')
     expect(source).toContain('realtime?.window === realtimeWindow ? realtime : undefined')
   })
 

--- a/web/src/pages/KeyOverviewPage.styles.test.ts
+++ b/web/src/pages/KeyOverviewPage.styles.test.ts
@@ -25,7 +25,7 @@ describe('KeyOverviewPage layout', () => {
     expect(source).not.toContain('}, [onAuthRequired, recoverRangeBoundsConflict, t, usageRangeQuery, usageRangeQueryKey]);')
     expect(source).not.toContain('}, [onAuthRequired, realtimeWindow, t]);')
     expect(source).toContain('}, [onAuthRequired, recoverRangeBoundsConflict, usageRangeQuery, usageRangeQueryKey]);')
-    expect(source).toContain('}, [onAuthRequired, realtimeWindow]);')
+    expect(source).toContain('}, [modelDimension, onAuthRequired, realtimeWindow]);')
   })
 
   it('loads overview, Activity, and realtime data through separate requests', () => {

--- a/web/src/pages/KeyOverviewPage.tsx
+++ b/web/src/pages/KeyOverviewPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ApiError, fetchKeyOverview, fetchKeyOverviewRealtime, isUsageRangeBoundsConflict, logout } from '@/lib/api';
-import type { AuthSessionAPIKeySummary, OverviewRealtimeBlock, OverviewRealtimeWindow, UsageCustomRange, UsageOverviewResponse, UsageTimeRange } from '@/lib/types';
+import type { AuthSessionAPIKeySummary, ModelDimension, OverviewRealtimeBlock, OverviewRealtimeWindow, UsageCustomRange, UsageOverviewResponse, UsageTimeRange } from '@/lib/types';
 import { LanguageSwitcher } from '@/components/ui/LanguageSwitcher';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { MainActionButton } from '@/components/ui/MainActionButton';
@@ -160,6 +160,7 @@ export function KeyOverviewPage({ apiKey, onAuthRequired }: KeyOverviewPageProps
   const [timeRangeState, setTimeRangeState] = useState<StoredUsageRangeState>(loadTimeRange);
   const { range: timeRange, customRange } = timeRangeState;
   const [realtimeWindow, setRealtimeWindow] = useState<OverviewRealtimeWindow>(loadRealtimeWindow);
+  const [modelDimension, setModelDimension] = useState<ModelDimension>('model');
   const [usage, setUsage] = useState<UsageOverviewPayload | null>(null);
   const [loadedUsageRange, setLoadedUsageRange] = useState<string | null>(null);
   const [realtime, setRealtime] = useState<OverviewRealtimeBlock | null>(null);
@@ -275,6 +276,7 @@ export function KeyOverviewPage({ apiKey, onAuthRequired }: KeyOverviewPageProps
       const nextRealtime = await fetchKeyOverviewRealtime({
         window: realtimeWindow,
         signal: controller.signal,
+        modelDimension,
       });
       if (realtimeRequestControllerRef.current !== controller) return;
       setRealtime(nextRealtime);
@@ -295,7 +297,7 @@ export function KeyOverviewPage({ apiKey, onAuthRequired }: KeyOverviewPageProps
         realtimeRequestControllerRef.current = null;
       }
     }
-  }, [onAuthRequired, realtimeWindow]);
+  }, [modelDimension, onAuthRequired, realtimeWindow]);
 
   useEffect(() => {
     void loadOverview();
@@ -546,6 +548,8 @@ export function KeyOverviewPage({ apiKey, onAuthRequired }: KeyOverviewPageProps
               isMobile={isMobile}
               timezone={realtime?.timezone ?? usage?.timezone}
               visibleDimensions={KEY_OVERVIEW_REALTIME_VISIBLE_DIMENSIONS}
+              modelDimension={modelDimension}
+              onModelDimensionChange={setModelDimension}
             />
           </div>
         </main>

--- a/web/src/pages/KeyOverviewPage.tsx
+++ b/web/src/pages/KeyOverviewPage.tsx
@@ -272,6 +272,7 @@ export function KeyOverviewPage({ apiKey, onAuthRequired }: KeyOverviewPageProps
     realtimeRequestControllerRef.current = controller;
     setRealtimeLoading(true);
     setRealtimeError('');
+    setRealtime(null);
     try {
       const nextRealtime = await fetchKeyOverviewRealtime({
         window: realtimeWindow,

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -3762,6 +3762,18 @@
   }
 }
 
+.overviewRealtimeDimensionToolbar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.overviewRealtimeDimensionSelect {
+  min-width: 150px;
+}
+
 .overviewRealtimeDimensionTabs {
   display: flex;
   gap: 4px;

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -1295,10 +1295,11 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     }
   }, [loadAuthSessions, onAuthRequired, showTopNotice, t]);
 
-  const loadAnalysis = useCallback(async () => {
+  const loadAnalysis = useCallback(async (options: { force?: boolean } = {}) => {
     if (!usageRangeQuery.valid) return;
+    const { force = false } = options;
     const analysisCacheKey = `${usageRangeQuery.range}:${usageRangeQuery.unit ?? ''}:${usageRangeQuery.start ?? ''}:${usageRangeQuery.end ?? ''}:${selectedApiKeyId ?? ''}:${modelDimension}`;
-    const cached = analysisDimensionCacheRef.current.get(analysisCacheKey);
+    const cached = !force ? analysisDimensionCacheRef.current.get(analysisCacheKey) : undefined;
     if (cached) {
       setAnalysisData(cached);
       setAnalysisLoading(false);
@@ -1319,11 +1320,13 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     setAnalysisLatencyData(null);
 
     await loadAnalysisSections({
-      loadCore: () => fetchAnalysis(usageRangeQuery, controller.signal, selectedApiKeyId, modelDimension),
+      loadCore: cached ? () => Promise.resolve(cached) : () => fetchAnalysis(usageRangeQuery, controller.signal, selectedApiKeyId, modelDimension),
       loadLatency: () => fetchAnalysisLatency(usageRangeQuery, controller.signal, selectedApiKeyId),
       onCoreLoaded: (response) => {
         if (analysisRequestControllerRef.current !== controller) return;
-        setAnalysisData(response);
+        if (!cached) {
+          setAnalysisData(response);
+        }
         setAnalysisLoading(false);
         analysisDimensionCacheRef.current.set(analysisCacheKey, response);
       },
@@ -1762,7 +1765,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
       return;
     }
     if (activeTab === 'analysis') {
-      await loadAnalysis();
+      await loadAnalysis({ force: true });
       return;
     }
     if (activeTab === 'settings') {

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ApiError, createUsageEventRequestLogDownloadURL, exportUsageEvents, fetchAnalysis, fetchAnalysisLatency, fetchAuthSessions, fetchCpaApiKeyOptions, fetchCpaApiKeySettings, fetchStatus, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventRequestLog, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchVersion, isUsageRangeBoundsConflict, logout, revokeAuthSession, updateCpaApiKeyAlias, type UsageEventsExportFormat } from '@/lib/api';
-import type { AnalysisLatencyDiagnostics, AnalysisResponse, AuthManagedSessionItem, CpaApiKeyOption, CpaApiKeySettingsItem, OverviewRealtimeWindow, StatusResponse, UsageCustomRange, UsageEvent, UsageEventRequestLogResponse, UsageSourceFilterOption, UsageTimeRange, VersionResponse } from '@/lib/types';
+import type { AnalysisLatencyDiagnostics, AnalysisResponse, AuthManagedSessionItem, CpaApiKeyOption, CpaApiKeySettingsItem, ModelDimension, OverviewRealtimeWindow, StatusResponse, UsageCustomRange, UsageEvent, UsageEventRequestLogResponse, UsageSourceFilterOption, UsageTimeRange, VersionResponse } from '@/lib/types';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { LanguageSwitcher } from '@/components/ui/LanguageSwitcher';
 import { Select } from '@/components/ui/Select';
@@ -898,6 +898,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   const [timeRangeState, setTimeRangeState] = useState<StoredUsageRangeState>(loadedTimeRange.state);
   const { range: timeRange, customRange } = timeRangeState;
   const [realtimeWindow, setRealtimeWindow] = useState<OverviewRealtimeWindow>(loadRealtimeWindow);
+  const [modelDimension, setModelDimension] = useState<ModelDimension>('model');
   const [selectedApiKeyId, setSelectedApiKeyId] = useState('');
   const [apiKeyOptions, setApiKeyOptions] = useState<CpaApiKeyOption[]>([]);
   const [status, setStatus] = useState<StatusResponse | null>(null);
@@ -989,6 +990,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     enabled: activeTab === 'overview',
     apiKeyId: selectedApiKeyId,
     realtimeWindow,
+    modelDimension,
   });
   const {
     modelNames,
@@ -1117,6 +1119,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
   const [analysisLatencyError, setAnalysisLatencyError] = useState('');
   const [analysisLatencyData, setAnalysisLatencyData] = useState<AnalysisLatencyDiagnostics | null>(null);
   const analysisRequestControllerRef = useRef<AbortController | null>(null);
+  const analysisDimensionCacheRef = useRef<Map<string, AnalysisResponse>>(new Map());
 
   const tabOptions = useMemo(
     () => getUsageTabOptions(t, { includeRanking: !isEmbeddedInCPAMC }),
@@ -1294,24 +1297,35 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
 
   const loadAnalysis = useCallback(async () => {
     if (!usageRangeQuery.valid) return;
+    const analysisCacheKey = `${usageRangeQuery.range}:${usageRangeQuery.unit ?? ''}:${usageRangeQuery.start ?? ''}:${usageRangeQuery.end ?? ''}:${selectedApiKeyId ?? ''}:${modelDimension}`;
+    const cached = analysisDimensionCacheRef.current.get(analysisCacheKey);
+    if (cached) {
+      setAnalysisData(cached);
+      setAnalysisLoading(false);
+      setAnalysisError('');
+    } else {
+      setAnalysisLoading(true);
+      setAnalysisError('');
+    }
     analysisRequestControllerRef.current?.abort();
     const controller = new AbortController();
     analysisRequestControllerRef.current = controller;
 
-    setAnalysisLoading(true);
-    setAnalysisError('');
-    setAnalysisData(null);
+    if (!cached) {
+      setAnalysisData(null);
+    }
     setAnalysisLatencyLoading(true);
     setAnalysisLatencyError('');
     setAnalysisLatencyData(null);
 
     await loadAnalysisSections({
-      loadCore: () => fetchAnalysis(usageRangeQuery, controller.signal, selectedApiKeyId),
+      loadCore: () => fetchAnalysis(usageRangeQuery, controller.signal, selectedApiKeyId, modelDimension),
       loadLatency: () => fetchAnalysisLatency(usageRangeQuery, controller.signal, selectedApiKeyId),
       onCoreLoaded: (response) => {
         if (analysisRequestControllerRef.current !== controller) return;
         setAnalysisData(response);
         setAnalysisLoading(false);
+        analysisDimensionCacheRef.current.set(analysisCacheKey, response);
       },
       onCoreError: (error) => {
         if (controller.signal.aborted || analysisRequestControllerRef.current !== controller) return;
@@ -1345,7 +1359,7 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     if (analysisRequestControllerRef.current === controller) {
       analysisRequestControllerRef.current = null;
     }
-  }, [onAuthRequired, recoverRangeBoundsConflict, selectedApiKeyId, usageRangeQuery]);
+  }, [modelDimension, onAuthRequired, recoverRangeBoundsConflict, selectedApiKeyId, usageRangeQuery]);
 
   useEffect(() => {
     try {
@@ -2236,6 +2250,8 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                   isDark={isDark}
                   isMobile={isMobile}
                   timezone={currentRealtime?.timezone ?? usage?.timezone}
+                  modelDimension={modelDimension}
+                  onModelDimensionChange={setModelDimension}
                 />
               </>
             )}
@@ -2249,6 +2265,8 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                   latencyDiagnostics={analysisLatencyData}
                   latencyLoading={analysisLatencyLoading}
                   latencyError={analysisLatencyError}
+                  modelDimension={modelDimension}
+                  onModelDimensionChange={setModelDimension}
                   isDark={isDark}
                   isMobile={isMobile}
                 />

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -239,7 +239,7 @@ describe('UsagePage toolbar styles', () => {
     expect(usagePageSource).toContain('customRange={activeCustomRange}')
     expect(usagePageSource).toContain("maxCustomDayRangeDays={activeTab === 'events' ? REQUEST_EVENTS_CUSTOM_DAY_RANGE_MAX_DAYS : undefined}")
     expect(usagePageSource).toContain('onChange={handleTimeRangeChange}')
-    expect(usagePageSource).toContain('fetchAnalysis(usageRangeQuery, controller.signal, selectedApiKeyId)')
+    expect(usagePageSource).toContain('fetchAnalysis(usageRangeQuery, controller.signal, selectedApiKeyId, modelDimension)')
     expect(usagePageSource).toContain('fetchAnalysisLatency(usageRangeQuery, controller.signal, selectedApiKeyId)')
     expect(usagePageSource).toContain('fetchUsageEvents(usageRangeQuery, controller.signal, {')
     expect(usagePageSource).toContain('exportUsageEvents(usageRangeQuery, format, {')

--- a/web/src/stores/useUsageStatsStore.ts
+++ b/web/src/stores/useUsageStatsStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { ApiError, fetchUsageOverview, fetchUsageOverviewRealtime } from '@/lib/api';
-import type { OverviewRealtimeBlock, OverviewRealtimeWindow, UsageCustomRangeUnit, UsageOverviewResponse, UsageRangeRequest, UsageTimeRange } from '@/lib/types';
+import type { ModelDimension, OverviewRealtimeBlock, OverviewRealtimeWindow, UsageCustomRangeUnit, UsageOverviewResponse, UsageRangeRequest, UsageTimeRange } from '@/lib/types';
 
 export const USAGE_STATS_STALE_TIME_MS = 60_000;
 
@@ -19,6 +19,7 @@ interface LoadUsageStatsRealtimeOptions {
   staleTimeMs?: number;
   apiKeyId?: string;
   realtimeWindow?: OverviewRealtimeWindow;
+  modelDimension?: ModelDimension;
 }
 
 interface UsageStatsState {
@@ -48,8 +49,8 @@ let activeRealtimeRequestController: AbortController | null = null;
 export const buildUsageStatsQueryKey = (request: UsageRangeRequest, apiKeyId?: string): string =>
   `${request.range}:${request.unit ?? ''}:${request.start ?? ''}:${request.end ?? ''}:${apiKeyId ?? ''}`;
 
-const buildRealtimeQueryKey = (apiKeyId?: string, realtimeWindow?: OverviewRealtimeWindow): string =>
-  `${apiKeyId ?? ''}:${realtimeWindow ?? ''}`;
+const buildRealtimeQueryKey = (apiKeyId?: string, realtimeWindow?: OverviewRealtimeWindow, modelDimension?: ModelDimension): string =>
+  `${apiKeyId ?? ''}:${realtimeWindow ?? ''}:${modelDimension ?? 'model'}`;
 
 export const useUsageStatsStore = create<UsageStatsState>((set, get) => ({
   usage: null,
@@ -142,10 +143,11 @@ export const useUsageStatsStore = create<UsageStatsState>((set, get) => ({
       staleTimeMs = USAGE_STATS_STALE_TIME_MS,
       apiKeyId,
       realtimeWindow,
+      modelDimension,
     } = options;
     const { lastRealtimeRefreshedAt, realtimeLoading, realtime, lastRealtimeQueryKey, realtimeError, lastRealtimeErrorQueryKey } = get();
     const now = Date.now();
-    const realtimeQueryKey = buildRealtimeQueryKey(apiKeyId, realtimeWindow);
+    const realtimeQueryKey = buildRealtimeQueryKey(apiKeyId, realtimeWindow, modelDimension);
     const realtimeFresh = Boolean(!force && realtime && lastRealtimeRefreshedAt && lastRealtimeQueryKey === realtimeQueryKey && now - lastRealtimeRefreshedAt < staleTimeMs);
 
     if (realtimeFresh) {
@@ -177,6 +179,7 @@ export const useUsageStatsStore = create<UsageStatsState>((set, get) => ({
           signal: controller.signal,
           apiKeyId,
           window: realtimeWindow,
+          modelDimension,
         });
         if (activeRealtimeRequestController !== controller) return;
         set({


### PR DESCRIPTION
## Summary

Add global model_dimension query parameter to analysis and realtime overview APIs, supporting 'model' (default) and 'alias' modes. In alias mode, model statistics aggregate by model_alias with fallback to the normalized model name when alias is empty. Pricing continues to use the real model name and alias for rule matching.

Frontend adds a global dropdown to AnalysisPanel and OverviewRealtimePanel controlling model ranking, efficiency, composition, heatmap, and realtime current usage. Analysis responses are cached per dimension to avoid refetching on toggle. Realtime query keys include model_dimension to prevent stale cache reuse.