### PR TITLE
fix(activity): align dark token heatmap levels

### DIFF
--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -3927,12 +3927,12 @@
 }
 
 :global([data-theme='dark']) .tokenActivityCard {
-  --activity-heatmap-idle: #1f2937;
-  --token-activity-level-1: #172554;
-  --token-activity-level-2: #1e3a8a;
-  --token-activity-level-3: #1d4ed8;
-  --token-activity-level-4: #3b82f6;
-  --token-activity-level-5: #60a5fa;
+  // 两种主题都用浅→深表示 Token 量增加；暗色背景下收窄亮度范围以保留辨识度。
+  --token-activity-level-1: #60a5fa;
+  --token-activity-level-2: #3b82f6;
+  --token-activity-level-3: #2563eb;
+  --token-activity-level-4: #1d4ed8;
+  --token-activity-level-5: #1e40af;
 }
 
 .activityCardHeader {

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -69,6 +69,20 @@ const styleRuleBlock = (source: string, selector: string) => {
   return source.slice(open + 1, close)
 }
 
+const cssHexVariable = (rule: string, name: string) => {
+  const match = rule.match(new RegExp(`${name}:\\s*(#[0-9a-fA-F]{6});`))
+  if (!match) throw new Error(`Missing CSS variable: ${name}`)
+  return match[1]
+}
+
+const relativeLuminance = (hex: string) => {
+  const channels = hex.slice(1).match(/.{2}/g)?.map((value) => Number.parseInt(value, 16) / 255) ?? []
+  const [red, green, blue] = channels.map((value) => (
+    value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
+  ))
+  return (0.2126 * red) + (0.7152 * green) + (0.0722 * blue)
+}
+
 describe('UsagePage toolbar styles', () => {
   it('renders every authenticated page header logo at 20px without pill chrome', () => {
     for (const pageStyles of [usagePageStyles, keyOverviewPageStyles]) {
@@ -595,6 +609,8 @@ describe('UsagePage toolbar styles', () => {
   it('renders Recent Activity between the stat cards and realtime metrics', () => {
     const realtimeCard = styleRuleBlock(usagePageStyles, '.overviewRealtimeCard')
     const realtimeCompactCard = styleRuleBlock(usagePageStyles, '.overviewRealtimeCardCompact')
+    const lightTokenActivityCard = styleRuleBlock(usagePageStyles, '.tokenActivityCard')
+    const darkTokenActivityCard = styleRuleBlock(usagePageStyles, ":global([data-theme='dark']) .tokenActivityCard")
 
     expect(usagePageSource).toContain('<OverviewRealtimePanel')
     expect(keyOverviewPageSource).toContain('<OverviewRealtimePanel')
@@ -617,7 +633,11 @@ describe('UsagePage toolbar styles', () => {
     expect(usagePageStyles).toContain('--token-activity-level-3: #60a5fa;')
     expect(usagePageStyles).toContain('--token-activity-level-4: #3b82f6;')
     expect(usagePageStyles).toContain('--token-activity-level-5: #1d4ed8;')
-    expect(usagePageStyles).toMatch(/:global\(\[data-theme='dark'\]\) \.tokenActivityCard\s*\{[\s\S]*?--token-activity-level-1:\s*#172554;/)
+    expect(darkTokenActivityCard).not.toContain('--activity-heatmap-idle:')
+    const lightLevelLuminance = [1, 2, 3, 4, 5].map((level) => relativeLuminance(cssHexVariable(lightTokenActivityCard, `--token-activity-level-${level}`)))
+    const darkLevelLuminance = [1, 2, 3, 4, 5].map((level) => relativeLuminance(cssHexVariable(darkTokenActivityCard, `--token-activity-level-${level}`)))
+    lightLevelLuminance.slice(0, -1).forEach((luminance, index) => expect(luminance).toBeGreaterThan(lightLevelLuminance[index + 1]))
+    darkLevelLuminance.slice(0, -1).forEach((luminance, index) => expect(luminance).toBeGreaterThan(darkLevelLuminance[index + 1]))
     expect(usagePageStyles).toMatch(/\.overviewRealtimeGrid\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2, minmax\(0, 1fr\)\);/)
     expect(usagePageStyles).toMatch(/\.overviewRealtimeGrid\s*\{[\s\S]*?@include mobile\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\);/)
     expect(usagePageStyles).toMatch(/\.overviewRealtimeCardFull\s*\{[\s\S]*?grid-column:\s*1 \/ -1;/)


### PR DESCRIPTION
## Summary

- reuse the shared idle heatmap color so empty Token Activity cells match Request Health
- keep Token Activity levels light-to-dark in both themes with a dark-background-tuned blue range
- add regression coverage for shared idle coloring and monotonic theme luminance

## Validation

- targeted UsagePage style tests: 92 passed
- frontend verification: 119 test files / 1105 tests passed
- lint, typecheck, and production build passed
- integrated preview page, health check, and auth session endpoints returned HTTP 200