### PR TITLE
test(credentials): settle drawer virtualizer before teardown

### DIFF
--- a/web/src/components/usage/credentials/test/CredentialDetailDrawer.test.tsx
+++ b/web/src/components/usage/credentials/test/CredentialDetailDrawer.test.tsx
@@ -163,6 +163,12 @@ describe('CredentialDetailDrawer', () => {
   })
 
   afterEach(async () => {
+    // TanStack Virtual 默认在 150ms 后发送滚动结束更新，销毁 Happy DOM 前先等待该更新完成。
+    await act(async () => {
+      const { promise: settleVirtualizer, resolve } = Promise.withResolvers<void>()
+      window.setTimeout(resolve, 200)
+      await settleVirtualizer
+    })
     await act(async () => root.unmount())
     container.remove()
     document.body.innerHTML = ''


### PR DESCRIPTION
## Summary

- Wait for TanStack Virtual delayed scroll-end updates before destroying the Credential Detail Drawer test environment.
- Prevent intermittent window-is-not-defined errors after all drawer assertions have passed.
- Keep production virtualizer behavior unchanged.

## Validation

- CredentialDetailDrawer test file run five times in parallel: 40 tests passed.
- Private frontend verifier after merging latest main: 122 files and 1111 tests passed, plus lint, typecheck, and production build.