### PR TITLE
feat(web): localize all displayed event times

### DIFF
--- a/web/src/components/AppFooter.tsx
+++ b/web/src/components/AppFooter.tsx
@@ -3,6 +3,7 @@ import { fetchVersion } from '@/lib/api';
 import type { VersionResponse } from '@/lib/types';
 import { IconGithub } from '@/components/ui/icons';
 import { CLIPROXYAPI_REPOSITORY_URL, GITHUB_PROFILE_URL, GITHUB_REPOSITORY_URL } from '@/utils/constants';
+import { TimezoneSettings } from '@/components/ui/TimezoneSettings';
 
 type FooterVersionLoader = (signal: AbortSignal) => Promise<Pick<VersionResponse, 'version'>>;
 
@@ -52,6 +53,7 @@ export function AppFooter({ version: fixedVersion, loadVersion = true }: { versi
         <span>·</span>
         <a href={CLIPROXYAPI_REPOSITORY_URL} target="_blank" rel="noreferrer">CLIProxyAPI Integration</a>
       </div>
+      <TimezoneSettings />
       <div className="app-footer-line app-footer-powered">
         <span>Powered By</span>
         <a href={GITHUB_PROFILE_URL} target="_blank" rel="noreferrer" aria-label="Willxup GitHub profile">

--- a/web/src/components/ui/TimezoneSettings.tsx
+++ b/web/src/components/ui/TimezoneSettings.tsx
@@ -1,0 +1,10 @@
+import { useEffect, useState } from 'react';
+import { getBrowserTimeZone, getDisplayTimeZone, getTimeZonePreference, saveTimeZonePreference, TIME_ZONE_CHANGE_EVENT } from '@/utils/timezone';
+
+const COMMON = ['America/Chicago', 'America/Los_Angeles', 'America/New_York', 'Europe/London', 'Europe/Berlin', 'Asia/Shanghai', 'Asia/Tokyo', 'Australia/Sydney'];
+export function TimezoneSettings() {
+  const [preference, setPreference] = useState(getTimeZonePreference);
+  useEffect(() => { const onChange = () => setPreference(getTimeZonePreference()); window.addEventListener(TIME_ZONE_CHANGE_EVENT, onChange); return () => window.removeEventListener(TIME_ZONE_CHANGE_EVENT, onChange); }, []);
+  const change = (value: string) => { setPreference(value); saveTimeZonePreference(value); };
+  return <label className="app-timezone-setting">Time zone: <select value={preference} onChange={(event) => change(event.target.value)}><option value="auto">Automatic ({getBrowserTimeZone()})</option>{COMMON.map((zone) => <option key={zone} value={zone}>{zone}</option>)}</select><small>Displaying {getDisplayTimeZone(preference)}</small></label>;
+}

--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -26,6 +26,7 @@ import {
   normalizeAuthIndex,
 } from '@/utils/usage';
 import styles from '@/pages/UsagePage.module.scss';
+import { formatDateTime, useDisplayTimeZone } from '@/utils/timezone';
 import {
   REQUEST_EVENT_COLUMN_IDS,
   normalizeRequestEventColumnOrder,
@@ -216,11 +217,11 @@ const toNumber = (value: unknown): number => {
   return parsed;
 };
 
-const formatRequestEventTimestamp = (timestamp: string): string => {
-  const match = timestamp.match(/^(\d{4})-(\d{2})-(\d{2})[T\s](\d{2}):(\d{2}):(\d{2})/);
-  if (!match) return timestamp || '-';
-  return `${match[1]}/${match[2]}/${match[3]} ${match[4]}:${match[5]}:${match[6]}`;
-};
+const formatRequestEventTimestamp = (timestamp: string): string => formatDateTime(timestamp, {
+  dateStyle: undefined, timeStyle: undefined,
+  year: 'numeric', month: '2-digit', day: '2-digit',
+  hour: '2-digit', minute: '2-digit', second: '2-digit',
+}) || timestamp || '-';
 
 const formatCacheReadRate = (cacheReadTokens: number, inputTokens: number): string => {
   const rate = calculateCacheReadRate({ inputTokens, cacheReadTokens });
@@ -410,6 +411,7 @@ export function RequestEventsDetailsCard({
   requestLogDownloading = false,
 }: RequestEventsDetailsCardProps) {
   const { t } = useTranslation();
+  const displayTimeZone = useDisplayTimeZone();
   const {
     tooltip: requestEventsTooltip,
     showOnMouseEnter: handleRequestEventsTooltipMouseEnter,
@@ -517,7 +519,7 @@ export function RequestEventsDetailsCard({
         costLabel: costAvailable && cost !== null ? formatUsd(cost) : '-',
       };
     });
-  }, [events, t]);
+  }, [displayTimeZone, events, t]);
   const virtualizeRows = rows.length > REQUEST_EVENT_VIRTUALIZATION_THRESHOLD;
   // TanStack Virtual 依赖内部可变测量状态，不参与 React Compiler 自动记忆化。
   // eslint-disable-next-line react-hooks/incompatible-library

--- a/web/src/components/usage/credentials/AuthFileCredentialsSection.tsx
+++ b/web/src/components/usage/credentials/AuthFileCredentialsSection.tsx
@@ -1,3 +1,4 @@
+import { formatDateTime, useDisplayTimeZone } from '@/utils/timezone'
 import { useCallback, useEffect, useId, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
@@ -117,6 +118,7 @@ interface AuthFileCredentialsSectionProps {
 
 export function AuthFileCredentialsSection({ rows, total, page, totalPages, pageSize, activeOnly, sort, loading, quotaRefreshing, quotaRefreshError, quotaInspectionStatus, quotaInspectionLoading, quotaInspectionStarting, quotaInspectionError, onPageChange, onPageSizeChange, onActiveOnlyChange, onSortChange, onRefreshQuota, onRefreshQuotaForAuthIndex, onResetQuotaForAuthIndex, aliasSavingId, onSaveAlias, onOpenDetails, onRefreshInspectionStatus, onStartInspection, onAfterInvalidAccountAction }: AuthFileCredentialsSectionProps) {
   const { t } = useTranslation()
+  useDisplayTimeZone()
   const [inspectionOpen, setInspectionOpen] = useState(false)
   const [quotaUsageMode, setQuotaUsageMode] = useState<QuotaUsageMode>('current')
   const [displayMode, setDisplayModeState] = useState<AuthFileDisplayMode>(() => readStoredAuthFileDisplayMode())
@@ -1553,7 +1555,7 @@ export function formatInspectionCompletedAt(value: string | undefined): string {
   if (Number.isNaN(date.getTime())) {
     return ''
   }
-  return date.toLocaleString()
+  return formatDateTime(date)
 }
 
 function formatInspectionDate(value: string | undefined): string {

--- a/web/src/components/usage/credentials/CredentialErrorEventsList.tsx
+++ b/web/src/components/usage/credentials/CredentialErrorEventsList.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, type UIEvent } from 'react'
+import { formatDateTime, useDisplayTimeZone } from '@/utils/timezone'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useTranslation } from 'react-i18next'
 import { EmptyState } from '@/components/ui/EmptyState'
@@ -24,9 +25,7 @@ interface CredentialErrorEventsListProps {
 
 const formatErrorTimestamp = (timestamp: string | undefined): string => {
   const value = String(timestamp ?? '')
-  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})[T\s](\d{2}):(\d{2}):(\d{2})/)
-  if (!match) return value || '-'
-  return `${match[1]}/${match[2]}/${match[3]} ${match[4]}:${match[5]}:${match[6]}`
+  return formatDateTime(value, { dateStyle: undefined, timeStyle: undefined, year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit' }) || value || '-'
 }
 
 export function CredentialErrorEventsList({
@@ -38,6 +37,7 @@ export function CredentialErrorEventsList({
   onLoadMore,
 }: CredentialErrorEventsListProps) {
   const { t } = useTranslation()
+  useDisplayTimeZone()
   const scrollerRef = useRef<HTMLDivElement | null>(null)
   // 首个完整 cursor 页正好是 50 条；此时即启用虚拟化，避免追加第二页后切换渲染模式造成滚动跳位。
   const virtualizeEvents = events.length >= VIRTUALIZATION_THRESHOLD

--- a/web/src/components/usage/credentials/CredentialHealthPanel.tsx
+++ b/web/src/components/usage/credentials/CredentialHealthPanel.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { UsageCredentialHealth } from '@/lib/types'
 import { healthGreenThreshold } from '@/utils/usage/health'
+import { formatDateTime, useDisplayTimeZone } from '@/utils/timezone'
 import { IconRefreshCw, IconTimer } from '@/components/ui/icons'
 import styles from './CredentialSections.module.scss'
 
@@ -57,6 +58,7 @@ export function CredentialHealthPanel({ displayName, health, lastUsedAt, statsUp
   const buckets = useMemo(() => buildHealthBuckets(health), [health])
   const score = resolveCredentialHealthScore(health, buckets)
   const summary = resolveCredentialHealthSummary(buckets, health, t)
+  useDisplayTimeZone()
   const lastUsed = formatCredentialHealthDate(lastUsedAt)
   const statsUpdated = formatCredentialHealthDate(statsUpdatedAt)
 
@@ -398,20 +400,6 @@ function formatClockMinutes(value: number): string {
 }
 
 function formatCredentialHealthDate(value: string | undefined): string {
-  if (!value) {
-    return ''
-  }
-  const apiDateTime = value.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/)
-  if (apiDateTime) {
-    return `${apiDateTime[2]}/${apiDateTime[3]} ${apiDateTime[4]}:${apiDateTime[5]}`
-  }
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) {
-    return ''
-  }
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  const hours = String(date.getHours()).padStart(2, '0')
-  const minutes = String(date.getMinutes()).padStart(2, '0')
-  return `${month}/${day} ${hours}:${minutes}`
+  if (!value) return ''
+  return formatDateTime(value, { dateStyle: undefined, timeStyle: undefined, month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })
 }

--- a/web/src/components/usage/credentials/CredentialRequestEventsList.tsx
+++ b/web/src/components/usage/credentials/CredentialRequestEventsList.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, type UIEvent } from 'react'
+import { formatDateTime, useDisplayTimeZone } from '@/utils/timezone'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useTranslation } from 'react-i18next'
 import { EmptyState } from '@/components/ui/EmptyState'
@@ -51,11 +52,11 @@ const toNumber = (value: unknown): number => {
   return Number.isFinite(parsed) ? Math.max(parsed, 0) : 0
 }
 
-const formatTimestamp = (timestamp: string): string => {
-  const match = timestamp.match(/^(\d{4})-(\d{2})-(\d{2})[T\s](\d{2}):(\d{2}):(\d{2})/)
-  if (!match) return timestamp || '-'
-  return `${match[1]}/${match[2]}/${match[3]} ${match[4]}:${match[5]}:${match[6]}`
-}
+const formatTimestamp = (timestamp: string): string => formatDateTime(timestamp, {
+  dateStyle: undefined, timeStyle: undefined,
+  year: 'numeric', month: '2-digit', day: '2-digit',
+  hour: '2-digit', minute: '2-digit', second: '2-digit',
+}) || timestamp || '-'
 
 const parseRequestEndpoint = (rawEndpoint: unknown): { requestType: string; endpoint: string } => {
   const raw = String(rawEndpoint ?? '').trim().replace(/\s+/g, ' ')
@@ -122,8 +123,9 @@ export function CredentialRequestEventsList({
   requestLogLoadingEventId = null,
 }: CredentialRequestEventsListProps) {
   const { t } = useTranslation()
+  const displayTimeZone = useDisplayTimeZone()
   const scrollerRef = useRef<HTMLDivElement | null>(null)
-  const rows = useMemo(() => events.map(buildRow), [events])
+  const rows = useMemo(() => events.map(buildRow), [displayTimeZone, events])
   const virtualizeRows = rows.length > VIRTUALIZATION_THRESHOLD
   // TanStack Virtual 依赖内部可变测量状态，不参与 React Compiler 自动记忆化。
   // eslint-disable-next-line react-hooks/incompatible-library

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -1,3 +1,4 @@
+import { formatDateTime } from '@/utils/timezone';
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ApiError, createUsageEventRequestLogDownloadURL, exportUsageEvents, fetchAnalysis, fetchAnalysisLatency, fetchAuthSessions, fetchCpaApiKeyOptions, fetchCpaApiKeySettings, fetchStatus, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventRequestLog, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchVersion, isUsageRangeBoundsConflict, logout, revokeAuthSession, updateCpaApiKeyAlias, type UsageEventsExportFormat } from '@/lib/api';

--- a/web/src/utils/timezone.ts
+++ b/web/src/utils/timezone.ts
@@ -1,0 +1,30 @@
+export const DEFAULT_TIME_ZONE = 'America/Chicago';
+export const TIME_ZONE_STORAGE_KEY = 'cpa-usage-keeper-time-zone-v1';
+export const TIME_ZONE_CHANGE_EVENT = 'cpa-usage-keeper-time-zone-change';
+
+export const isValidTimeZone = (value: unknown): value is string => {
+  if (typeof value !== 'string' || !value.trim()) return false;
+  try { new Intl.DateTimeFormat('en-US', { timeZone: value }).format(); return true; } catch { return false; }
+};
+
+export const getBrowserTimeZone = (): string => {
+  try { return isValidTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone) ? Intl.DateTimeFormat().resolvedOptions().timeZone : DEFAULT_TIME_ZONE; } catch { return DEFAULT_TIME_ZONE; }
+};
+
+export type TimeZonePreference = 'auto' | string;
+export const getTimeZonePreference = (): TimeZonePreference => {
+  if (typeof window === 'undefined') return 'auto';
+  const value = window.localStorage.getItem(TIME_ZONE_STORAGE_KEY);
+  return value === 'auto' || isValidTimeZone(value) ? (value ?? 'auto') : 'auto';
+};
+export const getDisplayTimeZone = (preference = getTimeZonePreference()): string => preference === 'auto' ? getBrowserTimeZone() : (isValidTimeZone(preference) ? preference : DEFAULT_TIME_ZONE);
+export const formatDateTime = (value: string | number | Date, options: Intl.DateTimeFormatOptions = {}): string => {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short', timeZone: getDisplayTimeZone(), ...options }).format(date);
+};
+export const saveTimeZonePreference = (value: TimeZonePreference): void => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(TIME_ZONE_STORAGE_KEY, value);
+  window.dispatchEvent(new CustomEvent(TIME_ZONE_CHANGE_EVENT));
+};

--- a/web/src/utils/timezone.ts
+++ b/web/src/utils/timezone.ts
@@ -1,3 +1,5 @@
+import { useSyncExternalStore } from 'react';
+
 export const DEFAULT_TIME_ZONE = 'America/Chicago';
 export const TIME_ZONE_STORAGE_KEY = 'cpa-usage-keeper-time-zone-v1';
 export const TIME_ZONE_CHANGE_EVENT = 'cpa-usage-keeper-time-zone-change';
@@ -28,3 +30,17 @@ export const saveTimeZonePreference = (value: TimeZonePreference): void => {
   window.localStorage.setItem(TIME_ZONE_STORAGE_KEY, value);
   window.dispatchEvent(new CustomEvent(TIME_ZONE_CHANGE_EVENT));
 };
+
+const subscribeToTimeZone = (onStoreChange: () => void): (() => void) => {
+  if (typeof window === 'undefined') return () => undefined;
+  window.addEventListener(TIME_ZONE_CHANGE_EVENT, onStoreChange);
+  window.addEventListener('storage', onStoreChange);
+  return () => {
+    window.removeEventListener(TIME_ZONE_CHANGE_EVENT, onStoreChange);
+    window.removeEventListener('storage', onStoreChange);
+  };
+};
+
+export const useDisplayTimeZone = (): string => useSyncExternalStore(
+  subscribeToTimeZone, getDisplayTimeZone, () => DEFAULT_TIME_ZONE,
+);


### PR DESCRIPTION
User-visible event timestamps previously followed the server or runtime timezone, causing incorrect dates for users in different regions. Add a browser-first IANA timezone preference with localStorage persistence and an America/Chicago fallback, then route refresh timestamps through the shared formatter. This keeps the same UTC instant while rendering each user's selected timezone, including DST-aware offsets.