### PR TITLE
feat(quota): add Cursor quota provider and fix null tasks encoding

### DIFF
--- a/internal/quota/config.go
+++ b/internal/quota/config.go
@@ -51,6 +51,9 @@ type ProviderConfigs struct {
 	Kimi                     APICallConfig
 	XAIWeekly                APICallConfig
 	XAIMonthly               APICallConfig
+	CursorPlan               APICallConfig
+	CursorPeriod             APICallConfig
+	CursorAgent              APICallConfig
 }
 
 func DefaultProviderConfigs() ProviderConfigs {
@@ -164,6 +167,28 @@ func DefaultProviderConfigs() ProviderConfigs {
 			URL:     "https://cli-chat-proxy.grok.com/v1/billing",
 			Headers: xaiRequestHeaders(),
 		},
+		CursorPlan: APICallConfig{
+			Method:  "POST",
+			URL:     "https://api2.cursor.sh/aiserver.v1.DashboardService/GetPlanInfo",
+			Headers: cursorRequestHeaders(),
+		},
+		CursorPeriod: APICallConfig{
+			Method:  "POST",
+			URL:     "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
+			Headers: cursorRequestHeaders(),
+		},
+		CursorAgent: APICallConfig{
+			Method:  "POST",
+			URL:     "https://api2.cursor.sh/aiserver.v1.DashboardService/GetSandUsageStatus",
+			Headers: cursorRequestHeaders(),
+		},
+	}
+}
+
+func cursorRequestHeaders() map[string]string {
+	return map[string]string{
+		"Authorization": "Bearer $TOKEN$",
+		"Content-Type":  "application/json",
 	}
 }
 
@@ -179,7 +204,7 @@ func xaiRequestHeaders() map[string]string {
 }
 
 func (c ProviderConfigs) APICallTemplates() []APICallConfig {
-	templates := make([]APICallConfig, 0, len(c.Antigravity)+len(c.AntigravitySubscriptions)+8)
+	templates := make([]APICallConfig, 0, len(c.Antigravity)+len(c.AntigravitySubscriptions)+11)
 	templates = append(templates, c.Antigravity...)
 	templates = append(templates, c.AntigravitySubscriptions...)
 	templates = append(templates,
@@ -191,6 +216,9 @@ func (c ProviderConfigs) APICallTemplates() []APICallConfig {
 		c.Kimi,
 		c.XAIWeekly,
 		c.XAIMonthly,
+		c.CursorPlan,
+		c.CursorPeriod,
+		c.CursorAgent,
 	)
 	return templates
 }

--- a/internal/quota/cursor.go
+++ b/internal/quota/cursor.go
@@ -1,0 +1,103 @@
+package quota
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"cpa-usage-keeper/internal/cpa/dto/apicall"
+)
+
+const cursorConnectUnaryBody = "{}"
+
+type cursorProvider struct {
+	caller       ManagementAPICaller
+	planConfig   APICallConfig
+	periodConfig APICallConfig
+	agentConfig  APICallConfig
+}
+
+func NewCursorProvider(caller ManagementAPICaller, planConfig APICallConfig, periodConfig APICallConfig, agentConfig APICallConfig) ProviderHandler {
+	return cursorProvider{caller: caller, planConfig: planConfig, periodConfig: periodConfig, agentConfig: agentConfig}
+}
+
+func (p cursorProvider) Check(ctx context.Context, input ProviderInput) (ProviderOutput, error) {
+	if p.periodConfig.URL == "" {
+		return ProviderOutput{}, fmt.Errorf("%w: cursor period config is required", ErrProviderInput)
+	}
+
+	var (
+		period    *CursorPeriodPayload
+		plan      *CursorPlanPayload
+		agent     *CursorAgentPayload
+		periodErr error
+		wg        sync.WaitGroup
+	)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		period, periodErr = p.requestPeriod(ctx, input)
+	}()
+	if p.planConfig.URL != "" {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			plan = p.requestPlan(ctx, input)
+		}()
+	}
+	if p.agentConfig.URL != "" {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			agent = p.requestAgent(ctx, input)
+		}()
+	}
+	wg.Wait()
+	if periodErr != nil {
+		return ProviderOutput{}, periodErr
+	}
+	return ProviderOutput{Provider: "cursor", Result: CursorResult{Plan: plan, Period: period, Agent: agent}}, nil
+}
+
+func (p cursorProvider) requestPeriod(ctx context.Context, input ProviderInput) (*CursorPeriodPayload, error) {
+	response, err := p.call(ctx, input, p.periodConfig)
+	if err != nil {
+		return nil, err
+	}
+	return parseCursorPeriodPayload(response)
+}
+
+func (p cursorProvider) requestPlan(ctx context.Context, input ProviderInput) *CursorPlanPayload {
+	response, err := p.call(ctx, input, p.planConfig)
+	if err != nil {
+		return nil
+	}
+	plan, err := parseCursorPlanPayload(response)
+	if err != nil {
+		return nil
+	}
+	return plan
+}
+
+func (p cursorProvider) requestAgent(ctx context.Context, input ProviderInput) *CursorAgentPayload {
+	response, err := p.call(ctx, input, p.agentConfig)
+	if err != nil {
+		return nil
+	}
+	agent, err := parseCursorAgentPayload(response)
+	if err != nil {
+		return nil
+	}
+	return agent
+}
+
+func (p cursorProvider) call(ctx context.Context, input ProviderInput, config APICallConfig) (*apicall.Response, error) {
+	return p.caller.CallManagementAPI(ctx, apicall.Request{
+		AuthIndex: input.Identity.Identity,
+		Method:    config.Method,
+		URL:       config.URL,
+		Header:    copyHeaders(config.Headers),
+		Data:      cursorConnectUnaryBody,
+	})
+}

--- a/internal/quota/normalize.go
+++ b/internal/quota/normalize.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -63,9 +64,139 @@ func NormalizeQuotaRows(output ProviderOutput) []QuotaRow {
 			return nil
 		}
 		return normalizeXAIQuotaRows(*result)
+	case CursorResult:
+		return normalizeCursorQuotaRows(result)
+	case *CursorResult:
+		if result == nil {
+			return nil
+		}
+		return normalizeCursorQuotaRows(*result)
 	default:
 		return nil
 	}
+}
+
+func normalizeCursorQuotaRows(result CursorResult) []QuotaRow {
+	rows := make([]QuotaRow, 0, 2)
+	if row, ok := cursorMonthlyQuotaRow(result); ok {
+		rows = append(rows, row)
+	}
+	if row, ok := cursorWeeklyQuotaRow(result.Agent); ok {
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func cursorMonthlyQuotaRow(result CursorResult) (QuotaRow, bool) {
+	used, hasUsed := cursorPeriodSpend(result.Period)
+	limit, hasLimit := cursorPeriodLimit(result)
+	if !hasUsed && !hasLimit {
+		return QuotaRow{}, false
+	}
+	row := QuotaRow{
+		Key:     "plan.monthly",
+		Label:   "Monthly",
+		Scope:   "billing",
+		Metric:  "usd_cents",
+		Window:  &QuotaWindow{Seconds: intPtr(quotaWindowAverageMonthSeconds)},
+		ResetAt: cursorCycleEnd(result),
+	}
+	if hasUsed {
+		row.Used = floatPtr(used)
+	}
+	if hasLimit {
+		row.Limit = floatPtr(limit)
+	}
+	if hasUsed && hasLimit {
+		remaining := math.Max(0, limit-used)
+		row.Remaining = floatPtr(remaining)
+		if limit > 0 {
+			usedPercent := used / limit * 100
+			row.UsedPercent = floatPtr(usedPercent)
+			limitReached := used >= limit
+			row.LimitReached = boolPtr(limitReached)
+			row.Allowed = boolPtr(!limitReached)
+		}
+	} else if remaining, ok := cursorPeriodRemaining(result.Period); ok {
+		row.Remaining = floatPtr(remaining)
+	}
+	return row, true
+}
+
+func cursorWeeklyQuotaRow(agent *CursorAgentPayload) (QuotaRow, bool) {
+	if agent == nil {
+		return QuotaRow{}, false
+	}
+	if agent.HasNonZeroIncludedLimit != nil && !*agent.HasNonZeroIncludedLimit {
+		return QuotaRow{}, false
+	}
+	if agent.UsagePercent == nil && strings.TrimSpace(agent.NextResetTimestampUTC) == "" {
+		return QuotaRow{}, false
+	}
+	row := QuotaRow{
+		Key:     "agent.weekly",
+		Label:   "Weekly",
+		Scope:   "window",
+		Metric:  "weekly",
+		Window:  &QuotaWindow{Seconds: intPtr(quotaWindowSevenDaySeconds)},
+		ResetAt: strings.TrimSpace(agent.NextResetTimestampUTC),
+	}
+	if agent.UsagePercent != nil {
+		usedPercent := *agent.UsagePercent
+		row.UsedPercent = floatPtr(usedPercent)
+		limitReached := usedPercent >= 100 || (agent.HasAvailableUsage != nil && !*agent.HasAvailableUsage)
+		row.LimitReached = boolPtr(limitReached)
+		row.Allowed = boolPtr(!limitReached)
+	}
+	return row, true
+}
+
+func cursorPeriodSpend(period *CursorPeriodPayload) (float64, bool) {
+	if period == nil || period.PlanUsage == nil {
+		return 0, false
+	}
+	return period.PlanUsage.TotalSpend, true
+}
+
+func cursorPeriodRemaining(period *CursorPeriodPayload) (float64, bool) {
+	if period == nil || period.PlanUsage == nil {
+		return 0, false
+	}
+	return period.PlanUsage.Remaining, true
+}
+
+func cursorPeriodLimit(result CursorResult) (float64, bool) {
+	if result.Period != nil && result.Period.PlanUsage != nil && result.Period.PlanUsage.Limit > 0 {
+		return result.Period.PlanUsage.Limit, true
+	}
+	if result.Plan != nil && result.Plan.PlanInfo != nil && result.Plan.PlanInfo.IncludedAmountCents > 0 {
+		return result.Plan.PlanInfo.IncludedAmountCents, true
+	}
+	return 0, false
+}
+
+func cursorCycleEnd(result CursorResult) string {
+	if result.Period != nil {
+		if resetAt := cursorMillisTimestamp(result.Period.BillingCycleEnd); resetAt != "" {
+			return resetAt
+		}
+	}
+	if result.Plan != nil && result.Plan.PlanInfo != nil {
+		return cursorMillisTimestamp(result.Plan.PlanInfo.BillingCycleEnd)
+	}
+	return ""
+}
+
+func cursorMillisTimestamp(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	ms, err := strconv.ParseInt(trimmed, 10, 64)
+	if err != nil || ms <= 0 {
+		return ""
+	}
+	return time.UnixMilli(ms).UTC().Format(time.RFC3339Nano)
 }
 
 func normalizeClaudeQuotaRows(result ClaudeResult) []QuotaRow {

--- a/internal/quota/payloads.go
+++ b/internal/quota/payloads.go
@@ -447,6 +447,56 @@ func parseKimiLimitWindow(object map[string]json.RawMessage) *KimiLimitWindow {
 	}
 }
 
+func parseCursorPlanPayload(response *apicall.Response) (*CursorPlanPayload, error) {
+	object, err := parseResponseObject(response)
+	if err != nil {
+		return nil, err
+	}
+	planInfo := objectField(object, "planInfo", "plan_info")
+	if planInfo == nil {
+		return &CursorPlanPayload{}, nil
+	}
+	return &CursorPlanPayload{PlanInfo: &CursorPlanInfo{
+		PlanName:            stringField(planInfo, "planName", "plan_name"),
+		IncludedAmountCents: floatField(planInfo, "includedAmountCents", "included_amount_cents"),
+		Price:               stringField(planInfo, "price"),
+		BillingCycleEnd:     stringField(planInfo, "billingCycleEnd", "billing_cycle_end"),
+	}}, nil
+}
+
+func parseCursorPeriodPayload(response *apicall.Response) (*CursorPeriodPayload, error) {
+	object, err := parseResponseObject(response)
+	if err != nil {
+		return nil, err
+	}
+	payload := &CursorPeriodPayload{
+		BillingCycleStart: stringField(object, "billingCycleStart", "billing_cycle_start"),
+		BillingCycleEnd:   stringField(object, "billingCycleEnd", "billing_cycle_end"),
+	}
+	if planUsage := objectField(object, "planUsage", "plan_usage"); planUsage != nil {
+		payload.PlanUsage = &CursorPlanUsage{
+			TotalSpend: floatField(planUsage, "totalSpend", "total_spend"),
+			Remaining:  floatField(planUsage, "remaining"),
+			Limit:      floatField(planUsage, "limit"),
+		}
+	}
+	return payload, nil
+}
+
+func parseCursorAgentPayload(response *apicall.Response) (*CursorAgentPayload, error) {
+	object, err := parseResponseObject(response)
+	if err != nil {
+		return nil, err
+	}
+	return &CursorAgentPayload{
+		UsagePercent:            floatPtrField(object, "usagePercent", "usage_percent"),
+		HasNonZeroIncludedLimit: boolPtrField(object, "hasNonZeroIncludedLimit", "has_non_zero_included_limit"),
+		HasAvailableUsage:       boolPtrField(object, "hasAvailableUsage", "has_available_usage"),
+		CurrentPeriodStart:      stringField(object, "currentPeriodStart", "current_period_start"),
+		NextResetTimestampUTC:   stringField(object, "nextResetTimestampUtc", "next_reset_timestamp_utc"),
+	}, nil
+}
+
 func parseCodexResetCreditResponse(response *apicall.Response) (ProviderResetOutput, error) {
 	object, err := parseResponseObject(response)
 	if err != nil {

--- a/internal/quota/refresh.go
+++ b/internal/quota/refresh.go
@@ -153,7 +153,11 @@ func (s *Service) Refresh(ctx context.Context, request RefreshRequest) (RefreshR
 		return RefreshResponse{}, fmt.Errorf("%w: auth_indexes are required", ErrValidation)
 	}
 	// response 先记录 Limit，后续循环逐步填充 accepted/skipped/tasks/rejected。
-	response := RefreshResponse{Limit: limit}
+	response := RefreshResponse{
+		Tasks:    make([]RefreshTaskRef, 0),
+		Rejected: make([]RefreshRejectedAuthIndex, 0),
+		Limit:    limit,
+	}
 	// seen 记录本次请求内已经处理过的 auth_index，避免一个请求内重复入队。
 	seen := make(map[string]struct{}, len(request.AuthIndexes))
 	// queuedAuthIndexes 收集本次真正入队的任务，循环结束后交给单个 dispatcher 派发。

--- a/internal/quota/registry.go
+++ b/internal/quota/registry.go
@@ -14,6 +14,7 @@ func NewDefaultProviderRegistry(caller ManagementAPICaller, configs ProviderConf
 		"claude":      NewClaudeProvider(caller, configs.ClaudeUsage, configs.ClaudeProfile),
 		"kimi":        NewKimiProvider(caller, configs.Kimi),
 		"xai":         NewXAIProvider(caller, configs.XAIWeekly, configs.XAIMonthly),
+		"cursor":      NewCursorProvider(caller, configs.CursorPlan, configs.CursorPeriod, configs.CursorAgent),
 	})
 }
 

--- a/internal/quota/subscription.go
+++ b/internal/quota/subscription.go
@@ -12,6 +12,7 @@ var subscriptionResolvers = map[string]subscriptionResolver{
 	"antigravity": resolveAntigravitySubscription,
 	"claude":      resolveClaudeSubscription,
 	"codex":       resolveCodexSubscription,
+	"cursor":      resolveCursorSubscription,
 }
 
 // NormalizeSubscription 将 provider 已取得的原始结果转换为响应级订阅，不执行任何外部请求。

--- a/internal/quota/subscription_cursor.go
+++ b/internal/quota/subscription_cursor.go
@@ -1,0 +1,27 @@
+package quota
+
+import "strings"
+
+func resolveCursorSubscription(result any) *SubscriptionInfo {
+	var plan *CursorPlanPayload
+	switch value := result.(type) {
+	case CursorResult:
+		plan = value.Plan
+	case *CursorResult:
+		if value != nil {
+			plan = value.Plan
+		}
+	}
+	if plan == nil || plan.PlanInfo == nil {
+		return nil
+	}
+	return newCursorSubscription(plan.PlanInfo.PlanName)
+}
+
+func newCursorSubscription(rawPlan string) *SubscriptionInfo {
+	displayPlan := strings.TrimSpace(rawPlan)
+	if displayPlan == "" {
+		return nil
+	}
+	return &SubscriptionInfo{Provider: "cursor", Plan: strings.ToLower(displayPlan)}
+}

--- a/internal/quota/test/config_test.go
+++ b/internal/quota/test/config_test.go
@@ -9,8 +9,8 @@ import (
 func TestDefaultProviderConfigsContainsAPICallTemplates(t *testing.T) {
 	configs := quota.DefaultProviderConfigs()
 	templates := configs.APICallTemplates()
-	if len(templates) != 13 {
-		t.Fatalf("expected 13 api-call templates, got %d", len(templates))
+	if len(templates) != 16 {
+		t.Fatalf("expected 16 api-call templates, got %d", len(templates))
 	}
 	if len(configs.Antigravity) != 3 {
 		t.Fatalf("expected 3 antigravity api-call templates, got %d", len(configs.Antigravity))
@@ -52,6 +52,15 @@ func TestDefaultProviderConfigsContainsAPICallTemplates(t *testing.T) {
 	if configs.XAIMonthly.Method != "GET" || configs.XAIMonthly.URL != "https://cli-chat-proxy.grok.com/v1/billing" {
 		t.Fatalf("unexpected xai monthly config: %+v", configs.XAIMonthly)
 	}
+	if configs.CursorPlan.Method != "POST" || configs.CursorPlan.URL != "https://api2.cursor.sh/aiserver.v1.DashboardService/GetPlanInfo" {
+		t.Fatalf("unexpected cursor plan config: %+v", configs.CursorPlan)
+	}
+	if configs.CursorPeriod.Method != "POST" || configs.CursorPeriod.URL != "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage" {
+		t.Fatalf("unexpected cursor period config: %+v", configs.CursorPeriod)
+	}
+	if configs.CursorAgent.Method != "POST" || configs.CursorAgent.URL != "https://api2.cursor.sh/aiserver.v1.DashboardService/GetSandUsageStatus" {
+		t.Fatalf("unexpected cursor agent config: %+v", configs.CursorAgent)
+	}
 
 	if configs.Antigravity[0].Headers["Authorization"] != "Bearer $TOKEN$" || configs.Antigravity[0].Headers["Content-Type"] != "application/json" || configs.Antigravity[0].Headers["User-Agent"] != "antigravity/cli/1.0.13 (aidev_client; os_type=darwin; arch=arm64)" {
 		t.Fatalf("unexpected antigravity headers: %+v", configs.Antigravity[0].Headers)
@@ -89,6 +98,11 @@ func TestDefaultProviderConfigsContainsAPICallTemplates(t *testing.T) {
 		}
 		if _, ok := config.Headers["x-userid"]; ok {
 			t.Fatalf("x-userid must not be fabricated without a reliable subject: %+v", config.Headers)
+		}
+	}
+	for _, config := range []quota.APICallConfig{configs.CursorPlan, configs.CursorPeriod, configs.CursorAgent} {
+		if config.Headers["Authorization"] != "Bearer $TOKEN$" || config.Headers["Content-Type"] != "application/json" {
+			t.Fatalf("unexpected cursor headers: %+v", config.Headers)
 		}
 	}
 }

--- a/internal/quota/test/cursor_test.go
+++ b/internal/quota/test/cursor_test.go
@@ -1,0 +1,190 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"cpa-usage-keeper/internal/cpa/dto/apicall"
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/quota"
+)
+
+const (
+	cursorPlanInfoURL     = "https://api2.cursor.sh/aiserver.v1.DashboardService/GetPlanInfo"
+	cursorPeriodUsageURL  = "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage"
+	cursorAgentUsageURL   = "https://api2.cursor.sh/aiserver.v1.DashboardService/GetSandUsageStatus"
+	cursorEmptyJSONObject = `{}`
+)
+
+func TestCursorProviderCallsRequiredPeriodUsage(t *testing.T) {
+	periodJSON := `{"billingCycleStart":"1787248499000","billingCycleEnd":"1789830899000","planUsage":{"totalSpend":183,"remaining":39817,"limit":40000}}`
+	planJSON := `{"planInfo":{"planName":"Ultra","includedAmountCents":20000,"price":"$200/mo","billingCycleEnd":"1789830899000"}}`
+	agentJSON := `{"usagePercent":17,"hasNonZeroIncludedLimit":true,"hasAvailableUsage":true,"currentPeriodStart":"2026-08-13T00:00:00Z","nextResetTimestampUtc":"2026-08-20T00:00:00Z"}`
+	caller := newCursorManagementCaller(map[string]*apicall.Response{
+		cursorPlanInfoURL:    cursorJSONResponse(planJSON),
+		cursorPeriodUsageURL: cursorJSONResponse(periodJSON),
+		cursorAgentUsageURL:  cursorJSONResponse(agentJSON),
+	})
+	configs := quota.DefaultProviderConfigs()
+	provider := quota.NewCursorProvider(caller, configs.CursorPlan, configs.CursorPeriod, configs.CursorAgent)
+
+	output, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "4607c833fca18295"}})
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if output.Provider != "cursor" {
+		t.Fatalf("expected cursor output provider, got %q", output.Provider)
+	}
+	result, ok := output.Result.(quota.CursorResult)
+	if !ok {
+		t.Fatalf("expected cursor result type, got %T", output.Result)
+	}
+	if result.Period == nil || result.Period.PlanUsage == nil || result.Period.PlanUsage.Limit != 40000 || result.Period.PlanUsage.TotalSpend != 183 {
+		t.Fatalf("expected parsed period usage, got %#v", result.Period)
+	}
+	if result.Plan == nil || result.Plan.PlanInfo == nil || result.Plan.PlanInfo.PlanName != "Ultra" || result.Plan.PlanInfo.Price != "$200/mo" {
+		t.Fatalf("expected parsed plan info, got %#v", result.Plan)
+	}
+	if result.Agent == nil || result.Agent.UsagePercent == nil || *result.Agent.UsagePercent != 17 {
+		t.Fatalf("expected parsed agent usage, got %#v", result.Agent)
+	}
+
+	requests := caller.requestsSnapshot()
+	if len(requests) != 3 {
+		t.Fatalf("expected three api-call requests, got %d", len(requests))
+	}
+	periodRequest, ok := caller.requestForURL(cursorPeriodUsageURL)
+	if !ok || periodRequest.AuthIndex != "4607c833fca18295" || periodRequest.Method != "POST" {
+		t.Fatalf("unexpected period request: %+v", periodRequest)
+	}
+	if periodRequest.Header["Authorization"] != "Bearer $TOKEN$" || periodRequest.Header["Content-Type"] != "application/json" {
+		t.Fatalf("unexpected period request headers: %+v", periodRequest.Header)
+	}
+	if periodRequest.Data != cursorEmptyJSONObject {
+		t.Fatalf("expected Connect unary empty object body, got %#v", periodRequest.Data)
+	}
+	for _, url := range []string{cursorPlanInfoURL, cursorAgentUsageURL} {
+		request, ok := caller.requestForURL(url)
+		if !ok || request.Method != "POST" || request.Data != cursorEmptyJSONObject {
+			t.Fatalf("unexpected optional request for %s: %+v ok=%v", url, request, ok)
+		}
+	}
+}
+
+func TestCursorProviderFailsWhenRequiredPeriodUsageIsUnavailable(t *testing.T) {
+	tests := []struct {
+		name     string
+		response *apicall.Response
+	}{
+		{name: "non 2xx", response: &apicall.Response{StatusCode: 401, BodyText: `{"message":"unauthorized"}`}},
+		{name: "parse failure", response: &apicall.Response{StatusCode: 200, BodyText: `not-json`, Body: json.RawMessage(`null`)}},
+		{name: "empty body", response: &apicall.Response{StatusCode: 200}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			caller := newCursorManagementCaller(map[string]*apicall.Response{
+				cursorPlanInfoURL:    cursorJSONResponse(`{"planInfo":{"planName":"Ultra"}}`),
+				cursorPeriodUsageURL: test.response,
+				cursorAgentUsageURL:  cursorJSONResponse(`{"usagePercent":17}`),
+			})
+			configs := quota.DefaultProviderConfigs()
+			provider := quota.NewCursorProvider(caller, configs.CursorPlan, configs.CursorPeriod, configs.CursorAgent)
+
+			_, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "cursor-auth"}})
+			if err == nil {
+				t.Fatal("expected required period usage failure")
+			}
+			if _, ok := caller.requestForURL(cursorPeriodUsageURL); !ok {
+				t.Fatalf("expected the period usage request, got %+v", caller.requestsSnapshot())
+			}
+		})
+	}
+}
+
+func TestCursorProviderKeepsPeriodWhenOptionalReadsFail(t *testing.T) {
+	periodJSON := `{"planUsage":{"totalSpend":183,"limit":40000}}`
+	caller := newCursorManagementCaller(map[string]*apicall.Response{
+		cursorPlanInfoURL:    {StatusCode: 503, BodyText: `{"message":"unavailable"}`},
+		cursorPeriodUsageURL: cursorJSONResponse(periodJSON),
+		cursorAgentUsageURL:  {StatusCode: 200, BodyText: `not-json`, Body: json.RawMessage(`null`)},
+	})
+	configs := quota.DefaultProviderConfigs()
+	provider := quota.NewCursorProvider(caller, configs.CursorPlan, configs.CursorPeriod, configs.CursorAgent)
+
+	output, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "cursor-auth"}})
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	result, ok := output.Result.(quota.CursorResult)
+	if !ok || result.Period == nil || result.Period.PlanUsage == nil || result.Period.PlanUsage.Limit != 40000 {
+		t.Fatalf("expected period usage to be preserved, got %#v", output.Result)
+	}
+	if result.Plan != nil || result.Agent != nil {
+		t.Fatalf("expected unavailable optional payloads to be omitted, got %#v", result)
+	}
+}
+
+func TestCursorProviderPrefersPeriodLimitOverPlanIncludedAmount(t *testing.T) {
+	periodJSON := `{"billingCycleEnd":"1789830899000","planUsage":{"totalSpend":132,"limit":40000}}`
+	planJSON := `{"planInfo":{"planName":"Ultra","includedAmountCents":2000,"price":"$200/mo","billingCycleEnd":"1780000000000"}}`
+	caller := newCursorManagementCaller(map[string]*apicall.Response{
+		cursorPlanInfoURL:    cursorJSONResponse(planJSON),
+		cursorPeriodUsageURL: cursorJSONResponse(periodJSON),
+	})
+	configs := quota.DefaultProviderConfigs()
+	provider := quota.NewCursorProvider(caller, configs.CursorPlan, configs.CursorPeriod, configs.CursorAgent)
+
+	output, err := provider.Check(context.Background(), quota.ProviderInput{Identity: entities.UsageIdentity{Identity: "cursor-auth"}})
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	rows := quota.NormalizeQuotaRows(output)
+	monthly := findQuotaRow(t, rows, "plan.monthly")
+	assertFloatField(t, monthly.Used, 132, "monthly used")
+	assertFloatField(t, monthly.Limit, 40000, "monthly limit")
+	assertFloatField(t, monthly.Remaining, 39868, "monthly remaining")
+	assertApproxFloatField(t, monthly.UsedPercent, 0.33, "monthly usedPercent")
+}
+
+type cursorManagementCaller struct {
+	mu        sync.Mutex
+	requests  []apicall.Request
+	responses map[string]*apicall.Response
+}
+
+func newCursorManagementCaller(responses map[string]*apicall.Response) *cursorManagementCaller {
+	return &cursorManagementCaller{responses: responses}
+}
+
+func cursorJSONResponse(body string) *apicall.Response {
+	return &apicall.Response{StatusCode: 200, BodyText: body, Body: json.RawMessage(body)}
+}
+
+func (c *cursorManagementCaller) CallManagementAPI(_ context.Context, request apicall.Request) (*apicall.Response, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.requests = append(c.requests, request)
+	response := c.responses[request.URL]
+	if response == nil {
+		return &apicall.Response{StatusCode: 500, BodyText: "missing test response"}, nil
+	}
+	return response, nil
+}
+
+func (c *cursorManagementCaller) requestsSnapshot() []apicall.Request {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]apicall.Request(nil), c.requests...)
+}
+
+func (c *cursorManagementCaller) requestForURL(targetURL string) (apicall.Request, bool) {
+	for _, request := range c.requestsSnapshot() {
+		if request.URL == targetURL {
+			return request, true
+		}
+	}
+	return apicall.Request{}, false
+}

--- a/internal/quota/test/normalizer_test.go
+++ b/internal/quota/test/normalizer_test.go
@@ -434,6 +434,66 @@ func TestNormalizeXAIDerivesPayAsYouGoUsageFromTotalSpend(t *testing.T) {
 	assertFloatField(t, onDemand.UsedPercent, 60, "derived pay-as-you-go usedPercent")
 }
 
+func TestNormalizeCursorQuotaRows(t *testing.T) {
+	usagePercent := 17.0
+	rows := quota.NormalizeQuotaRows(quota.ProviderOutput{Provider: "cursor", Result: quota.CursorResult{
+		Plan: &quota.CursorPlanPayload{PlanInfo: &quota.CursorPlanInfo{
+			PlanName:            "Ultra",
+			IncludedAmountCents: 20000,
+			Price:               "$200/mo",
+		}},
+		Period: &quota.CursorPeriodPayload{
+			BillingCycleEnd: "1789830899000",
+			PlanUsage: &quota.CursorPlanUsage{
+				TotalSpend: 183,
+				Remaining:  39817,
+				Limit:      40000,
+			},
+		},
+		Agent: &quota.CursorAgentPayload{
+			UsagePercent:            &usagePercent,
+			HasNonZeroIncludedLimit: boolPtr(true),
+			HasAvailableUsage:       boolPtr(true),
+			NextResetTimestampUTC:   "2026-08-20T00:00:00Z",
+		},
+	}})
+
+	if len(rows) != 2 {
+		t.Fatalf("expected monthly and weekly cursor quota rows, got %#v", rows)
+	}
+	monthly := findQuotaRow(t, rows, "plan.monthly")
+	assertQuotaText(t, monthly, "Monthly", "billing", "usd_cents")
+	assertFloatField(t, monthly.Used, 183, "monthly used")
+	assertFloatField(t, monthly.Limit, 40000, "monthly limit")
+	assertFloatField(t, monthly.Remaining, 39817, "monthly remaining")
+	assertApproxFloatField(t, monthly.UsedPercent, 0.4575, "monthly usedPercent")
+	if monthly.Window == nil || monthly.Window.Seconds == nil || *monthly.Window.Seconds != quotaWindowAverageMonthSeconds {
+		t.Fatalf("expected monthly window, got %#v", monthly.Window)
+	}
+	if monthly.ResetAt == "" {
+		t.Fatalf("expected monthly resetAt from cycle end, got %#v", monthly)
+	}
+	agent := findQuotaRow(t, rows, "agent.weekly")
+	assertQuotaText(t, agent, "Weekly", "window", "weekly")
+	assertFloatField(t, agent.UsedPercent, 17, "weekly usedPercent")
+	if agent.Window == nil || agent.Window.Seconds == nil || *agent.Window.Seconds != quotaWindowSevenDaySeconds {
+		t.Fatalf("expected weekly window, got %#v", agent.Window)
+	}
+	if agent.ResetAt != "2026-08-20T00:00:00Z" {
+		t.Fatalf("unexpected weekly resetAt: %#v", agent)
+	}
+}
+
+func TestNormalizeCursorQuotaRowsOmitEmptyOptionalWindows(t *testing.T) {
+	rows := quota.NormalizeQuotaRows(quota.ProviderOutput{Provider: "cursor", Result: quota.CursorResult{
+		Period: &quota.CursorPeriodPayload{PlanUsage: &quota.CursorPlanUsage{TotalSpend: 183, Limit: 40000}},
+		Agent:  &quota.CursorAgentPayload{HasNonZeroIncludedLimit: boolPtr(false)},
+	}})
+	if len(rows) != 1 || rows[0].Key != "plan.monthly" {
+		t.Fatalf("expected only monthly row when agent window is empty, got %#v", rows)
+	}
+}
+
 func TestNormalizeXAIQuotaRowsMarksPayAsYouGoExhaustion(t *testing.T) {
 	rows := quota.NormalizeQuotaRows(quota.ProviderOutput{Provider: "xai", Result: quota.XAIResult{
 		Monthly: &quota.XAIBillingPayload{Config: &quota.XAIBillingConfig{

--- a/internal/quota/test/registry_test.go
+++ b/internal/quota/test/registry_test.go
@@ -21,9 +21,10 @@ func TestProviderRegistrySupportsQuotaIdentityTypes(t *testing.T) {
 		"claude":      fakeProviderHandler{},
 		"kimi":        fakeProviderHandler{},
 		"xai":         fakeProviderHandler{},
+		"cursor":      fakeProviderHandler{},
 	})
 
-	for _, identityType := range []string{"antigravity", "codex", "gemini-cli", "claude", "kimi", "xai"} {
+	for _, identityType := range []string{"antigravity", "codex", "gemini-cli", "claude", "kimi", "xai", "cursor"} {
 		if _, ok := registry.Provider(identityType); !ok {
 			t.Fatalf("expected registry to support %q", identityType)
 		}
@@ -33,7 +34,7 @@ func TestProviderRegistrySupportsQuotaIdentityTypes(t *testing.T) {
 func TestDefaultProviderRegistrySupportsReferenceQuotaIdentityTypes(t *testing.T) {
 	registry := quota.NewDefaultProviderRegistry(&recordingManagementCaller{}, quota.DefaultProviderConfigs())
 
-	for _, identityType := range []string{"antigravity", "codex", "gemini-cli", "claude", "kimi", "xai"} {
+	for _, identityType := range []string{"antigravity", "codex", "gemini-cli", "claude", "kimi", "xai", "cursor"} {
 		if _, ok := registry.Provider(identityType); !ok {
 			t.Fatalf("expected default registry to support %q", identityType)
 		}

--- a/internal/quota/test/service_refresh_test.go
+++ b/internal/quota/test/service_refresh_test.go
@@ -552,6 +552,14 @@ func TestManualRefreshSkipsUnsupportedAuthFileWithoutCaching(t *testing.T) {
 	if len(cache.Items) != 0 {
 		t.Fatalf("expected unsupported auth file to stay out of page cache, got %+v", cache.Items)
 	}
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal refresh response: %v", err)
+	}
+	body := string(encoded)
+	if !contains(body, `"tasks":[]`) || !contains(body, `"rejected":[]`) {
+		t.Fatalf("expected empty refresh lists to encode as arrays, got %s", body)
+	}
 }
 
 func TestRefreshRejectsInvalidEntriesAndIgnoresRunningTask(t *testing.T) {

--- a/internal/quota/test/subscription_test.go
+++ b/internal/quota/test/subscription_test.go
@@ -219,10 +219,24 @@ func TestNormalizeSubscriptionRejectsMissingOrUnregisteredValues(t *testing.T) {
 		{Provider: "claude", Result: quota.ClaudeResult{}},
 		{Provider: "gemini-cli", Result: quota.GeminiCLIResult{}},
 		{Provider: "xai", Result: quota.XAIResult{}},
+		{Provider: "cursor", Result: quota.CursorResult{}},
 	} {
 		if got := quota.NormalizeSubscription(output); got != nil {
 			t.Fatalf("NormalizeSubscription(%#v) = %#v, want nil", output, got)
 		}
+	}
+}
+
+func TestNormalizeCursorSubscription(t *testing.T) {
+	got := quota.NormalizeSubscription(quota.ProviderOutput{
+		Provider: "cursor",
+		Result: quota.CursorResult{Plan: &quota.CursorPlanPayload{PlanInfo: &quota.CursorPlanInfo{
+			PlanName: "Ultra",
+			Price:    "$200/mo",
+		}}},
+	})
+	if got == nil || got.Provider != "cursor" || got.Plan != "ultra" {
+		t.Fatalf("NormalizeSubscription() = %#v, want cursor ultra", got)
 	}
 }
 

--- a/internal/quota/types.go
+++ b/internal/quota/types.go
@@ -322,6 +322,43 @@ type XAIResult struct {
 	Monthly *XAIBillingPayload `json:"monthly,omitempty"`
 }
 
+type CursorPlanInfo struct {
+	PlanName            string  `json:"planName,omitempty"`
+	IncludedAmountCents float64 `json:"includedAmountCents,omitempty"`
+	Price               string  `json:"price,omitempty"`
+	BillingCycleEnd     string  `json:"billingCycleEnd,omitempty"`
+}
+
+type CursorPlanPayload struct {
+	PlanInfo *CursorPlanInfo `json:"planInfo,omitempty"`
+}
+
+type CursorPlanUsage struct {
+	TotalSpend float64 `json:"totalSpend,omitempty"`
+	Remaining  float64 `json:"remaining,omitempty"`
+	Limit      float64 `json:"limit,omitempty"`
+}
+
+type CursorPeriodPayload struct {
+	BillingCycleStart string           `json:"billingCycleStart,omitempty"`
+	BillingCycleEnd   string           `json:"billingCycleEnd,omitempty"`
+	PlanUsage         *CursorPlanUsage `json:"planUsage,omitempty"`
+}
+
+type CursorAgentPayload struct {
+	UsagePercent            *float64 `json:"usagePercent,omitempty"`
+	HasNonZeroIncludedLimit *bool    `json:"hasNonZeroIncludedLimit,omitempty"`
+	HasAvailableUsage       *bool    `json:"hasAvailableUsage,omitempty"`
+	CurrentPeriodStart      string   `json:"currentPeriodStart,omitempty"`
+	NextResetTimestampUTC   string   `json:"nextResetTimestampUtc,omitempty"`
+}
+
+type CursorResult struct {
+	Plan   *CursorPlanPayload   `json:"plan,omitempty"`
+	Period *CursorPeriodPayload `json:"period,omitempty"`
+	Agent  *CursorAgentPayload  `json:"agent,omitempty"`
+}
+
 type ProviderHandler interface {
 	Check(context.Context, ProviderInput) (ProviderOutput, error)
 }

--- a/web/src/components/usage/credentials/useCredentialsTabData.test.ts
+++ b/web/src/components/usage/credentials/useCredentialsTabData.test.ts
@@ -5,7 +5,7 @@ import { buildCredentialQuotaStateMap, quotaRefreshDisplayError, quotaResetDispl
 import { CREDENTIAL_PAGES_REFRESH_INTERVAL_MS, mergeUsageIdentityAliasUpdate } from './useCredentialPages'
 import { buildQuotaCacheAuthIndexesKey, QUOTA_CACHE_REFRESH_INTERVAL_MS } from './useQuotaCache'
 import { buildQuotaRefreshSubmissionUpdate, buildQuotaRefreshTaskErrorUpdate } from './useQuotaRefreshTasks'
-import type { UsageIdentity } from '@/lib/types'
+import type { UsageIdentity, UsageQuotaRefreshResponse } from '@/lib/types'
 
 const credentialsTabDataSource = readFileSync(new URL('./useCredentialsTabData.ts', import.meta.url), 'utf8').replace(/\r\n/g, '\n')
 const quotaCacheSource = readFileSync(new URL('./useQuotaCache.ts', import.meta.url), 'utf8').replace(/\r\n/g, '\n')
@@ -167,6 +167,19 @@ describe('buildQuotaRefreshSubmissionUpdate', () => {
     ])
     expect(update.stateUpdates['auth-2']).toEqual({ refreshStatus: 'queued', error: undefined })
     expect(update.stateUpdates['auth-3']).toEqual({ refreshStatus: 'failed', error: 'This credential was already included in the refresh request.' })
+  })
+
+  it('treats missing tasks and rejected lists as empty', () => {
+    const update = buildQuotaRefreshSubmissionUpdate({
+      tasks: undefined as unknown as UsageQuotaRefreshResponse['tasks'],
+      rejected: undefined as unknown as UsageQuotaRefreshResponse['rejected'],
+      accepted: 0,
+      skipped: 1,
+      limit: 1,
+    }, 'row')
+
+    expect(update.pendingTasks).toEqual([])
+    expect(update.stateUpdates).toEqual({})
   })
 })
 

--- a/web/src/components/usage/credentials/useQuotaRefreshTasks.ts
+++ b/web/src/components/usage/credentials/useQuotaRefreshTasks.ts
@@ -171,7 +171,7 @@ export function useQuotaRefreshTasks({ enabled, currentAuthIndexes, setQuotaResp
 export function buildQuotaRefreshSubmissionUpdate(response: UsageQuotaRefreshResponse, source: PendingRefreshTask['source']): { pendingTasks: PendingRefreshTask[]; stateUpdates: Record<string, QuotaState> } {
   const pendingTasks: PendingRefreshTask[] = []
   const stateUpdates: Record<string, QuotaState> = {}
-  for (const task of response.tasks) {
+  for (const task of response.tasks ?? []) {
     // 新建成功的 task 进入轮询列表，后续由 /quota/refresh/:auth_index 收敛到 completed/failed。
     pendingTasks.push({ authIndex: task.authIndex, source })
     stateUpdates[task.authIndex] = {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -520,8 +520,8 @@ export interface UsageQuotaRefreshRejectedAuthIndex {
 }
 
 export interface UsageQuotaRefreshResponse {
-  tasks: UsageQuotaRefreshTaskRef[]
-  rejected: UsageQuotaRefreshRejectedAuthIndex[]
+  tasks?: UsageQuotaRefreshTaskRef[] | null
+  rejected?: UsageQuotaRefreshRejectedAuthIndex[] | null
   accepted: number
   skipped: number
   limit: number


### PR DESCRIPTION
Two changes:

**Cursor quota provider.** Adds Cursor to the quota refresh pipeline through the CPA management `api-call` endpoint, using the same `aiserver.v1.DashboardService` calls Cursor's own dashboard makes. The period read is required; plan info and weekly agent usage are optional enrichment. Includes provider registration, normalization, subscription state, and tests.

**`e.tasks is not iterable` crash fix.** The refresh endpoint encoded nil Go slices as `"tasks": null`, and the Auth Files frontend iterated `response.tasks` directly. Both sides are fixed: `Tasks`/`Rejected` initialize as empty slices so JSON encodes `[]`, and the frontend guards with `response.tasks ?? []`.

Verification: Go quota tests and the full vitest suite (1011 tests) pass; the null-tasks fix was mutation-tested (reverting either half turns the suite red on the named assertions).