### PR TITLE
feat(cpa-api-keys): support key-policy plugin keys with source isolation

### DIFF
--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -5,12 +5,16 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"cpa-usage-keeper/internal/auth"
+	"cpa-usage-keeper/internal/config"
 	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+	"cpa-usage-keeper/internal/service"
 )
 
 type authCPAAPIKeyStub struct {
@@ -198,6 +202,51 @@ func TestAuthAPIKeyLoginFailuresAreGenericUnauthorized(t *testing.T) {
 		if resp.Code != http.StatusUnauthorized || !contains(resp.Body.String(), "invalid credentials") {
 			t.Fatalf("expected generic 401 for %s, got %d %s", body, resp.Code, resp.Body.String())
 		}
+	}
+}
+
+func TestAuthAPIKeyLoginRejectsPluginKeys(t *testing.T) {
+	// 插件 key 的 id 是短字符串、可猜测，存进 key 表后必须仍然无法用于 api-key 登录。
+	db, err := repository.OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "auth-plugin-key.db")})
+	if err != nil {
+		t.Fatalf("OpenDatabase returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		sqlDB, err := db.DB()
+		if err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	syncedAt := time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC)
+	if err := repository.SyncCPAAPIKeys(db, []string{"sk-alpha123456"}, syncedAt); err != nil {
+		t.Fatalf("seed CPA API keys: %v", err)
+	}
+	if err := repository.SyncPluginAPIKeys(db, []repository.PluginAPIKey{{ID: "kath", Name: "凯瑟琳"}}, syncedAt); err != nil {
+		t.Fatalf("seed plugin API keys: %v", err)
+	}
+
+	sessions := auth.NewSessionManager(time.Hour)
+	authConfig := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
+	// 使用真实 DB-backed provider，验证仓储层确实排除了 plugin 行。
+	router := NewRouter(nil, nil, nil, nil, authConfig, NewAuthHandler(authConfig, sessions), "", OptionalProviders{CPAAPIKeys: service.NewCPAAPIKeyService(db)})
+
+	pluginResp := httptest.NewRecorder()
+	pluginReq := httptest.NewRequest(http.MethodPost, "/api/v1/auth/api-key-login", strings.NewReader(`{"apiKey":"kath"}`))
+	pluginReq.Header.Set(requestIntentHeaderName, requestIntentHeaderValueFetch)
+	pluginReq.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(pluginResp, pluginReq)
+	if pluginResp.Code != http.StatusUnauthorized || !contains(pluginResp.Body.String(), "invalid credentials") {
+		t.Fatalf("expected plugin key login to return generic 401, got %d %s", pluginResp.Code, pluginResp.Body.String())
+	}
+
+	// CPA 核心 key 登录保持原有成功路径，确认排除只针对 plugin 行。
+	cpaResp := httptest.NewRecorder()
+	cpaReq := httptest.NewRequest(http.MethodPost, "/api/v1/auth/api-key-login", strings.NewReader(`{"apiKey":"sk-alpha123456"}`))
+	cpaReq.Header.Set(requestIntentHeaderName, requestIntentHeaderValueFetch)
+	cpaReq.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(cpaResp, cpaReq)
+	if cpaResp.Code != http.StatusNoContent {
+		t.Fatalf("expected CPA key login status 204, got %d %s", cpaResp.Code, cpaResp.Body.String())
 	}
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -215,6 +215,8 @@ func NewWithConfig(cfg config.Config) (*App, error) {
 		UsageAggregationNotifier: usageAggregationRunner,
 		// Header 独立进入 Quota worker 的惰性一分钟窗口，不再等待 Overview 水位。
 		UsageHeaderQuota: quotaService,
+		// 插件 key 同步由 KEY_POLICY_SYNC_ENABLED 控制，默认关闭时行为与既有版本一致。
+		KeyPolicySyncEnabled: cfg.KeyPolicySyncEnabled,
 	})
 	// metadataSyncRunner 提前创建，保证控制消息和后台任务使用同一个调度器实例。
 	metadataSyncRunner := NewMetadataSyncRunner(syncService, cfg.MetadataSyncInterval)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,8 @@ type Config struct {
 	CPAManagementKey string
 	// CPARequestLogAccessEnabled 控制是否允许通过 Keeper 访问 CPA request log。
 	CPARequestLogAccessEnabled bool
+	// KeyPolicySyncEnabled 控制是否同步 key-policy 插件发行的 key 清单。
+	KeyPolicySyncEnabled bool
 	// RedisQueueAddr 是 CPA management data stream 的 TCP 地址，空值时按 CPA_BASE_URL 推导。
 	RedisQueueAddr string
 	// RedisQueueTLS 控制是否使用 TLS 连接 Redis 队列。
@@ -233,6 +235,10 @@ func Load(options LoadOptions) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	keyPolicySyncEnabled, err := getBool("KEY_POLICY_SYNC_ENABLED", false)
+	if err != nil {
+		return nil, err
+	}
 
 	appBasePath, err := normalizeBasePath(strings.TrimSpace(os.Getenv("APP_BASE_PATH")))
 	if err != nil {
@@ -253,6 +259,7 @@ func Load(options LoadOptions) (*Config, error) {
 		CPABaseURL:                 strings.TrimSpace(os.Getenv("CPA_BASE_URL")),
 		CPAManagementKey:           strings.TrimSpace(os.Getenv("CPA_MANAGEMENT_KEY")),
 		CPARequestLogAccessEnabled: cpaRequestLogAccessEnabled,
+		KeyPolicySyncEnabled:       keyPolicySyncEnabled,
 		RedisQueueAddr:             strings.TrimSpace(os.Getenv("REDIS_QUEUE_ADDR")),
 		RedisQueueTLS:              redisQueueTLS,
 		RedisQueueBatchSize:        redisQueueBatchSize,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,6 +18,7 @@ var configEnvKeys = []string{
 	"SQLITE_PATH", "BACKUP_ENABLED", "BACKUP_DIR", "BACKUP_INTERVAL", "BACKUP_RETENTION_DAYS",
 	"REQUEST_TIMEOUT", "LOG_LEVEL", "LOG_FILE_ENABLED", "LOG_DIR", "LOG_RETENTION_DAYS",
 	"AUTH_ENABLED", "LOGIN_PASSWORD", "AUTH_SESSION_TTL", "TRUSTED_PROXY_CIDRS", "TZ", "TLS_SKIP_VERIFY", "QUOTA_REFRESH_WORKER_LIMIT",
+	"KEY_POLICY_SYNC_ENABLED",
 }
 
 func TestMain(m *testing.M) {
@@ -139,6 +140,9 @@ func TestLoadFromEnvAppliesDefaults(t *testing.T) {
 	}
 	if cfg.TLSSkipVerify {
 		t.Fatal("expected TLS skip verify to be disabled by default")
+	}
+	if cfg.KeyPolicySyncEnabled {
+		t.Fatal("expected key policy sync to be disabled by default")
 	}
 	if cfg.RedisQueueTLS {
 		t.Fatal("expected redis queue TLS to be disabled by default")
@@ -466,6 +470,25 @@ func TestLoadFromEnvParsesOverrides(t *testing.T) {
 	}
 	if cfg.AppPort != "9090" || cfg.AppBasePath != "/cpa" || cfg.CPAPublicURL != "https://cpa.public.example.com/" || cfg.WorkDir != "/tmp/work" || cfg.SQLitePath != filepath.Join("/tmp/work", "app.db") || cfg.BackupEnabled || cfg.BackupDir != filepath.Join("/tmp/work", "backups") || cfg.BackupInterval != 2*time.Hour || cfg.BackupRetentionDays != 7 || cfg.RequestTimeout != 15*time.Second || cfg.LogLevel != "debug" || cfg.LogFileEnabled || cfg.LogDir != filepath.Join("/tmp/work", "logs") || cfg.LogRetentionDays != 14 || !cfg.AuthEnabled || cfg.LoginPassword != "top-secret" || cfg.AuthSessionTTL != 12*time.Hour || cfg.RedisQueueIdleInterval != 2*time.Second || cfg.QuotaRefreshWorkerLimit != 8 {
 		t.Fatalf("unexpected config override result: %+v", cfg)
+	}
+}
+
+func TestLoadFromEnvParsesKeyPolicySyncEnabled(t *testing.T) {
+	t.Setenv("CPA_BASE_URL", "http://127.0.0.1:"+cpa.ManagementRedisDefaultPort)
+	t.Setenv("CPA_MANAGEMENT_KEY", "secret")
+	t.Setenv("KEY_POLICY_SYNC_ENABLED", "true")
+
+	cfg, err := LoadFromEnv()
+	if err != nil {
+		t.Fatalf("LoadFromEnv returned error: %v", err)
+	}
+	if !cfg.KeyPolicySyncEnabled {
+		t.Fatal("expected key policy sync to be enabled when set to true")
+	}
+
+	t.Setenv("KEY_POLICY_SYNC_ENABLED", "not-a-bool")
+	if _, err := LoadFromEnv(); err == nil || !strings.Contains(err.Error(), "KEY_POLICY_SYNC_ENABLED must be a valid bool") {
+		t.Fatalf("expected invalid bool error, got %v", err)
 	}
 }
 

--- a/internal/cpa/client.go
+++ b/internal/cpa/client.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"cpa-usage-keeper/internal/cpa/dto/apicall"
+	"cpa-usage-keeper/internal/cpa/dto/keypolicy"
 	"cpa-usage-keeper/internal/cpa/dto/providerconfig"
 	"cpa-usage-keeper/internal/cpa/dto/response"
 )
@@ -391,6 +392,25 @@ func (c *Client) FetchManagementAPIKeys(ctx context.Context) (*response.Manageme
 	if err != nil {
 		return result, err
 	}
+	return result, nil
+}
+
+func (c *Client) FetchKeyPolicyPluginKeys(ctx context.Context) (*response.KeyPolicyPluginKeysResult, error) {
+	result := &response.KeyPolicyPluginKeysResult{}
+	statusCode, body, err := c.doManagementJSONRequest(ctx, cpaManagementKeyPolicyKeysEndpoint, &result.Payload, "key policy plugin keys")
+	result.StatusCode = statusCode
+	result.Body = body
+	if err != nil {
+		return result, err
+	}
+	// 禁用 key 不再接受请求，不参与本地同步，也不能因为残留行被错误恢复。
+	enabled := make([]keypolicy.PluginKey, 0, len(result.Payload.Keys))
+	for _, key := range result.Payload.Keys {
+		if key.Enabled {
+			enabled = append(enabled, key)
+		}
+	}
+	result.Payload.Keys = enabled
 	return result, nil
 }
 

--- a/internal/cpa/client_test.go
+++ b/internal/cpa/client_test.go
@@ -281,6 +281,49 @@ func TestFetchManagementAPIKeysRejectsInvalidJSON(t *testing.T) {
 	}
 }
 
+func TestFetchKeyPolicyPluginKeysSendsBearerTokenAndKeepsEnabledKeys(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != cpaManagementKeyPolicyKeysEndpoint {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer management-secret" {
+			t.Fatalf("expected management Authorization header, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"keys":[{"id":"kath","name":"凯瑟琳","enabled":true,"key_preview":"sk-8bc0...64426","aliases":["a"],"models":["m"]},{"id":"disabled-key","name":"停用","enabled":false,"key_preview":"sk-0000...00000"}]}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "management-secret", 2*time.Second, false)
+	result, err := client.FetchKeyPolicyPluginKeys(context.Background())
+	if err != nil {
+		t.Fatalf("FetchKeyPolicyPluginKeys returned error: %v", err)
+	}
+	if result.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", result.StatusCode)
+	}
+	if len(result.Payload.Keys) != 1 {
+		t.Fatalf("expected only enabled plugin keys, got %#v", result.Payload.Keys)
+	}
+	key := result.Payload.Keys[0]
+	if key.ID != "kath" || key.Name != "凯瑟琳" || !key.Enabled || key.KeyPreview != "sk-8bc0...64426" {
+		t.Fatalf("unexpected plugin key payload: %#v", key)
+	}
+}
+
+func TestFetchKeyPolicyPluginKeysReportsNonSuccessStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "management-secret", 2*time.Second, false)
+	_, err := client.FetchKeyPolicyPluginKeys(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "management key policy plugin keys request returned status 404") {
+		t.Fatalf("expected management request failure, got %v", err)
+	}
+}
+
 func TestFetchAuthFilesParsesSyncMetadataFields(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != cpaManagementAuthFilesEndpoint {

--- a/internal/cpa/dto/keypolicy/key_policy.go
+++ b/internal/cpa/dto/keypolicy/key_policy.go
@@ -1,0 +1,14 @@
+package keypolicy
+
+// PluginKeysResponse 是 CPA key-policy 插件 /v0/management/plugins/cpa-key-policy/keys 响应 DTO。
+type PluginKeysResponse struct {
+	Keys []PluginKey `json:"keys"`
+}
+
+// PluginKey 只保留 keeper 需要的插件 key 字段；aliases、models 等其余插件字段全部忽略。
+type PluginKey struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Enabled    bool   `json:"enabled"`
+	KeyPreview string `json:"key_preview"`
+}

--- a/internal/cpa/dto/response/response.go
+++ b/internal/cpa/dto/response/response.go
@@ -5,6 +5,7 @@ import (
 
 	"cpa-usage-keeper/internal/cpa/dto/authfiles"
 	"cpa-usage-keeper/internal/cpa/dto/cpaapikeys"
+	"cpa-usage-keeper/internal/cpa/dto/keypolicy"
 	"cpa-usage-keeper/internal/cpa/dto/models"
 	"cpa-usage-keeper/internal/cpa/dto/providerconfig"
 )
@@ -14,6 +15,13 @@ type ManagementAPIKeysResult struct {
 	StatusCode int
 	Body       []byte
 	Payload    cpaapikeys.ManagementAPIKeysResponse
+}
+
+// KeyPolicyPluginKeysResult 是 FetchKeyPolicyPluginKeys 返回的 HTTP 包装，payload 只包含启用的插件 key。
+type KeyPolicyPluginKeysResult struct {
+	StatusCode int
+	Body       []byte
+	Payload    keypolicy.PluginKeysResponse
 }
 
 // ModelsResult 是 FetchModels 返回的 HTTP 包装，保留状态码、原始响应体和解析后的 DTO。

--- a/internal/cpa/endpoints.go
+++ b/internal/cpa/endpoints.go
@@ -1,9 +1,11 @@
 package cpa
 
 const (
-	cpaManagementAuthFilesEndpoint           = "/v0/management/auth-files"
-	cpaManagementAuthFilesStatusEndpoint     = "/v0/management/auth-files/status"
-	cpaManagementAPIKeysEndpoint             = "/v0/management/api-keys"
+	cpaManagementAuthFilesEndpoint       = "/v0/management/auth-files"
+	cpaManagementAuthFilesStatusEndpoint = "/v0/management/auth-files/status"
+	cpaManagementAPIKeysEndpoint         = "/v0/management/api-keys"
+	// cpaManagementKeyPolicyKeysEndpoint 只读取 key-policy 插件发行的 key 清单，不参与 CPA 核心 key 全量替换。
+	cpaManagementKeyPolicyKeysEndpoint       = "/v0/management/plugins/cpa-key-policy/keys"
 	cpaManagementVertexAPIKeyEndpoint        = "/v0/management/vertex-api-key"
 	cpaManagementGeminiAPIKeyEndpoint        = "/v0/management/gemini-api-key"
 	cpaManagementCodexAPIKeyEndpoint         = "/v0/management/codex-api-key"

--- a/internal/entities/cpa_api_key.go
+++ b/internal/entities/cpa_api_key.go
@@ -2,6 +2,13 @@ package entities
 
 import "time"
 
+const (
+	// CPAAPIKeySourceCPA 表示由 CPA 核心 /v0/management/api-keys 清单同步的 key。
+	CPAAPIKeySourceCPA = "cpa"
+	// CPAAPIKeySourcePlugin 表示由 key-policy 插件清单同步的 key；插件 key 的 id 是短字符串，绝不能用于登录。
+	CPAAPIKeySourcePlugin = "plugin"
+)
+
 // CPAAPIKey 保存 CPA 管理接口同步到本地的 API-Key，完整 key 仅供后端内部查询使用。
 type CPAAPIKey struct {
 	ID                   int64  `gorm:"primaryKey"`
@@ -9,8 +16,10 @@ type CPAAPIKey struct {
 	DisplayKey           string
 	KeyAlias             string
 	LocalRankingAvatarID *uint8
-	IsDeleted            bool       `gorm:"index:idx_cpa_api_keys_is_deleted"`
-	LastSyncedAt         *time.Time `gorm:"serializer:storageTime"`
-	CreatedAt            time.Time  `gorm:"serializer:storageTime"`
-	UpdatedAt            time.Time  `gorm:"serializer:storageTime"`
+	// Source 区分 CPA 核心 key 与插件 key；两类来源各自全量替换，互不软删。
+	Source       string     `gorm:"not null;default:cpa;index:idx_cpa_api_keys_source"`
+	IsDeleted    bool       `gorm:"index:idx_cpa_api_keys_is_deleted"`
+	LastSyncedAt *time.Time `gorm:"serializer:storageTime"`
+	CreatedAt    time.Time  `gorm:"serializer:storageTime"`
+	UpdatedAt    time.Time  `gorm:"serializer:storageTime"`
 }

--- a/internal/helper/redact.go
+++ b/internal/helper/redact.go
@@ -23,6 +23,10 @@ func RedactSensitiveValue(value string) string {
 
 // CPAAPIKeyMaskedDisplayKey 返回 CPA API Key 的安全展示 key；优先基于原始 key 重新脱敏，避免历史 DisplayKey 格式不一致。
 func CPAAPIKeyMaskedDisplayKey(row entities.CPAAPIKey) string {
+	// 插件 key 的 api_key 列存的是可猜测的短 id 而非真实密钥，展示时直接使用同步来的 key_preview。
+	if row.Source == entities.CPAAPIKeySourcePlugin {
+		return strings.TrimSpace(row.DisplayKey)
+	}
 	if strings.TrimSpace(row.APIKey) != "" {
 		return RedactSensitiveValue(row.APIKey)
 	}

--- a/internal/repository/cpa_api_key.go
+++ b/internal/repository/cpa_api_key.go
@@ -27,12 +27,13 @@ func SyncCPAAPIKeys(db *gorm.DB, keys []string, syncedAt time.Time) error {
 	}
 
 	return db.Transaction(func(tx *gorm.DB) error {
+		// CPA 核心清单只做 source=cpa 行的全量替换，插件行由 SyncPluginAPIKeys 独立维护。
 		var existingRows []struct {
 			ID        int64
 			APIKey    string
 			IsDeleted bool
 		}
-		if err := tx.Model(&entities.CPAAPIKey{}).Select("id, api_key, is_deleted").Find(&existingRows).Error; err != nil {
+		if err := tx.Model(&entities.CPAAPIKey{}).Select("id, api_key, is_deleted").Where("source = ?", entities.CPAAPIKeySourceCPA).Find(&existingRows).Error; err != nil {
 			return err
 		}
 
@@ -66,6 +67,7 @@ func SyncCPAAPIKeys(db *gorm.DB, keys []string, syncedAt time.Time) error {
 			toCreate = append(toCreate, entities.CPAAPIKey{
 				APIKey:       key,
 				DisplayKey:   helper.RedactSensitiveValue(key),
+				Source:       entities.CPAAPIKeySourceCPA,
 				IsDeleted:    false,
 				LastSyncedAt: &syncedAt,
 			})
@@ -76,6 +78,114 @@ func SyncCPAAPIKeys(db *gorm.DB, keys []string, syncedAt time.Time) error {
 			}
 		}
 
+		staleIDs := make([]int64, 0)
+		for _, row := range existingRows {
+			if row.IsDeleted {
+				continue
+			}
+			if _, ok := incoming[row.APIKey]; ok {
+				continue
+			}
+			staleIDs = append(staleIDs, row.ID)
+		}
+		if len(staleIDs) == 0 {
+			return nil
+		}
+		return tx.Model(&entities.CPAAPIKey{}).Where("id IN ?", staleIDs).Updates(map[string]any{"is_deleted": true, "updated_at": syncedAt}).Error
+	})
+}
+
+// PluginAPIKey 是 key-policy 插件清单中单个启用 key 的同步输入；ID 是插件 key 的短 id（如 "kath"），也是用量事件 api_group_key 的关联值。
+type PluginAPIKey struct {
+	ID         string
+	Name       string
+	KeyPreview string
+}
+
+// SyncPluginAPIKeys 按插件清单全量替换 source=plugin 的本地行；只有插件 API 拉取成功时才允许调用，失败必须保留现状。
+func SyncPluginAPIKeys(db *gorm.DB, keys []PluginAPIKey, syncedAt time.Time) error {
+	seen := make(map[string]struct{}, len(keys))
+	uniqueKeys := make([]PluginAPIKey, 0, len(keys))
+	for _, key := range keys {
+		key.ID = strings.TrimSpace(key.ID)
+		key.Name = strings.TrimSpace(key.Name)
+		key.KeyPreview = strings.TrimSpace(key.KeyPreview)
+		if key.ID == "" {
+			continue
+		}
+		if _, ok := seen[key.ID]; ok {
+			continue
+		}
+		seen[key.ID] = struct{}{}
+		uniqueKeys = append(uniqueKeys, key)
+	}
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		// 插件清单只维护 source=plugin 行，绝不触碰 CPA 核心 key 的替换结果。
+		var existingRows []struct {
+			ID        int64
+			APIKey    string
+			KeyAlias  string
+			IsDeleted bool
+		}
+		if err := tx.Model(&entities.CPAAPIKey{}).Select("id, api_key, key_alias, is_deleted").Where("source = ?", entities.CPAAPIKeySourcePlugin).Find(&existingRows).Error; err != nil {
+			return err
+		}
+
+		existingByKey := make(map[string]struct {
+			ID        int64
+			KeyAlias  string
+			IsDeleted bool
+		}, len(existingRows))
+		for _, row := range existingRows {
+			existingByKey[row.APIKey] = struct {
+				ID        int64
+				KeyAlias  string
+				IsDeleted bool
+			}{ID: row.ID, KeyAlias: row.KeyAlias, IsDeleted: row.IsDeleted}
+		}
+
+		incoming := make(map[string]struct{}, len(uniqueKeys))
+		toCreate := make([]entities.CPAAPIKey, 0)
+		for _, key := range uniqueKeys {
+			incoming[key.ID] = struct{}{}
+			// 插件 key 的 api_key 列存插件 id；display_key 优先使用插件自带的 key_preview，缺失时回退到 id。
+			displayKey := key.KeyPreview
+			if displayKey == "" {
+				displayKey = key.ID
+			}
+			if existing, ok := existingByKey[key.ID]; ok {
+				updates := map[string]any{
+					"display_key":    displayKey,
+					"is_deleted":     false,
+					"last_synced_at": &syncedAt,
+					"updated_at":     syncedAt,
+				}
+				// 只在本地别名为空时用插件 name 填充，不覆盖用户手工修改过的别名。
+				if strings.TrimSpace(existing.KeyAlias) == "" && key.Name != "" {
+					updates["key_alias"] = key.Name
+				}
+				if err := tx.Model(&entities.CPAAPIKey{}).Where("id = ?", existing.ID).Updates(updates).Error; err != nil {
+					return err
+				}
+				continue
+			}
+			toCreate = append(toCreate, entities.CPAAPIKey{
+				APIKey:       key.ID,
+				DisplayKey:   displayKey,
+				KeyAlias:     key.Name,
+				Source:       entities.CPAAPIKeySourcePlugin,
+				IsDeleted:    false,
+				LastSyncedAt: &syncedAt,
+			})
+		}
+		if len(toCreate) > 0 {
+			if err := tx.Create(&toCreate).Error; err != nil {
+				return err
+			}
+		}
+
+		// 插件清单里消失的 plugin 行才软删；CPA 侧同步不参与这里的判断。
 		staleIDs := make([]int64, 0)
 		for _, row := range existingRows {
 			if row.IsDeleted {
@@ -107,7 +217,8 @@ func FindActiveCPAAPIKeyByID(db *gorm.DB, id int64) (entities.CPAAPIKey, error) 
 
 func FindActiveCPAAPIKeyByValue(db *gorm.DB, apiKey string) (entities.CPAAPIKey, error) {
 	var row entities.CPAAPIKey
-	err := db.Where("api_key = ? AND is_deleted = ?", apiKey, false).First(&row).Error
+	// 插件 key 的 id 是短字符串、可猜测，绝不允许作为 api-key 登录凭据匹配。
+	err := db.Where("api_key = ? AND is_deleted = ? AND source <> ?", apiKey, false, entities.CPAAPIKeySourcePlugin).First(&row).Error
 	return row, err
 }
 

--- a/internal/repository/cpa_api_key_test.go
+++ b/internal/repository/cpa_api_key_test.go
@@ -149,6 +149,128 @@ func TestSyncCPAAPIKeysDoesNotConsumeIDsForExistingKeys(t *testing.T) {
 	}
 }
 
+func TestSyncCPAAPIKeysKeepsPluginRowsActive(t *testing.T) {
+	db := openCPAAPIKeyTestDatabase(t)
+	syncedAt := time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC)
+
+	// 插件 key 的 id（如 "kath"）不在 CPA 核心 api-keys 清单里，CPA 全量替换绝不能软删它。
+	if err := SyncPluginAPIKeys(db, []PluginAPIKey{{ID: "kath", Name: "凯瑟琳", KeyPreview: "sk-8bc0...64426"}}, syncedAt); err != nil {
+		t.Fatalf("seed plugin key: %v", err)
+	}
+	if err := SyncCPAAPIKeys(db, []string{"sk-alpha123456"}, syncedAt); err != nil {
+		t.Fatalf("SyncCPAAPIKeys returned error: %v", err)
+	}
+
+	var plugin entities.CPAAPIKey
+	if err := db.Where("api_key = ?", "kath").First(&plugin).Error; err != nil {
+		t.Fatalf("expected plugin key row: %v", err)
+	}
+	if plugin.IsDeleted || plugin.Source != entities.CPAAPIKeySourcePlugin {
+		t.Fatalf("expected plugin row to stay active, got %+v", plugin)
+	}
+	var cpaRow entities.CPAAPIKey
+	if err := db.Where("api_key = ?", "sk-alpha123456").First(&cpaRow).Error; err != nil {
+		t.Fatalf("expected cpa key row: %v", err)
+	}
+	if cpaRow.Source != entities.CPAAPIKeySourceCPA || cpaRow.IsDeleted {
+		t.Fatalf("expected cpa row with source cpa, got %+v", cpaRow)
+	}
+}
+
+func TestSyncPluginAPIKeysUpsertsAndSoftDeletes(t *testing.T) {
+	db := openCPAAPIKeyTestDatabase(t)
+	firstSync := time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC)
+	secondSync := firstSync.Add(time.Hour)
+
+	// CPA 核心行不参与插件清单替换，用来验证两侧互不干扰。
+	if err := SyncCPAAPIKeys(db, []string{"sk-alpha123456"}, firstSync); err != nil {
+		t.Fatalf("seed cpa key: %v", err)
+	}
+	if err := SyncPluginAPIKeys(db, []PluginAPIKey{
+		{ID: "kath", Name: "凯瑟琳", KeyPreview: "sk-8bc0...64426"},
+		{ID: "no-preview", Name: ""},
+	}, firstSync); err != nil {
+		t.Fatalf("initial plugin sync returned error: %v", err)
+	}
+
+	var kath entities.CPAAPIKey
+	if err := db.Where("api_key = ?", "kath").First(&kath).Error; err != nil {
+		t.Fatalf("expected plugin key row: %v", err)
+	}
+	if kath.Source != entities.CPAAPIKeySourcePlugin || kath.DisplayKey != "sk-8bc0...64426" || kath.KeyAlias != "凯瑟琳" || kath.IsDeleted {
+		t.Fatalf("unexpected plugin row after sync: %+v", kath)
+	}
+	// key_preview 缺失时 display_key 回退到插件 id。
+	var noPreview entities.CPAAPIKey
+	if err := db.Where("api_key = ?", "no-preview").First(&noPreview).Error; err != nil {
+		t.Fatalf("expected no-preview plugin row: %v", err)
+	}
+	if noPreview.DisplayKey != "no-preview" || noPreview.KeyAlias != "" {
+		t.Fatalf("expected id fallback display key, got %+v", noPreview)
+	}
+
+	// 用户手改别名后，插件 name 不能覆盖；清单里消失的行才软删。
+	if err := UpdateCPAAPIKeyAlias(db, kath.ID, "手工别名"); err != nil {
+		t.Fatalf("UpdateCPAAPIKeyAlias returned error: %v", err)
+	}
+	if err := SyncPluginAPIKeys(db, []PluginAPIKey{{ID: "kath", Name: "凯瑟琳·改", KeyPreview: "sk-8bc0...64426"}}, secondSync); err != nil {
+		t.Fatalf("second plugin sync returned error: %v", err)
+	}
+
+	if err := db.Where("api_key = ?", "kath").First(&kath).Error; err != nil {
+		t.Fatalf("reload plugin key: %v", err)
+	}
+	if kath.KeyAlias != "手工别名" || kath.IsDeleted {
+		t.Fatalf("expected manual alias to be preserved, got %+v", kath)
+	}
+	if err := db.Where("api_key = ?", "no-preview").First(&noPreview).Error; err != nil {
+		t.Fatalf("expected soft-deleted plugin row to remain: %v", err)
+	}
+	if !noPreview.IsDeleted {
+		t.Fatalf("expected missing plugin key to be marked deleted: %+v", noPreview)
+	}
+	var cpaRow entities.CPAAPIKey
+	if err := db.Where("api_key = ?", "sk-alpha123456").First(&cpaRow).Error; err != nil {
+		t.Fatalf("expected cpa key row: %v", err)
+	}
+	if cpaRow.IsDeleted {
+		t.Fatalf("expected plugin sync to leave cpa row active: %+v", cpaRow)
+	}
+
+	// 清单里重新出现的 plugin 行要恢复为 active，且空别名可以被插件 name 填充。
+	if err := SyncPluginAPIKeys(db, []PluginAPIKey{{ID: "no-preview", Name: "新名字"}}, secondSync.Add(time.Hour)); err != nil {
+		t.Fatalf("restore plugin sync returned error: %v", err)
+	}
+	if err := db.Where("api_key = ?", "no-preview").First(&noPreview).Error; err != nil {
+		t.Fatalf("reload restored plugin row: %v", err)
+	}
+	if noPreview.IsDeleted || noPreview.KeyAlias != "新名字" {
+		t.Fatalf("expected restored plugin row with filled alias, got %+v", noPreview)
+	}
+}
+
+func TestFindActiveCPAAPIKeyByValueRejectsPluginKeys(t *testing.T) {
+	db := openCPAAPIKeyTestDatabase(t)
+	syncedAt := time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC)
+
+	if err := SyncCPAAPIKeys(db, []string{"sk-alpha123456"}, syncedAt); err != nil {
+		t.Fatalf("seed cpa key: %v", err)
+	}
+	if err := SyncPluginAPIKeys(db, []PluginAPIKey{{ID: "kath", Name: "凯瑟琳"}}, syncedAt); err != nil {
+		t.Fatalf("seed plugin key: %v", err)
+	}
+
+	// CPA 核心 key 仍能按原值匹配。
+	row, err := FindActiveCPAAPIKeyByValue(db, "sk-alpha123456")
+	if err != nil || row.APIKey != "sk-alpha123456" {
+		t.Fatalf("expected cpa key lookup to succeed, got %+v err=%v", row, err)
+	}
+	// 插件 key 的短 id 可猜测，绝不能作为登录凭据匹配。
+	if _, err := FindActiveCPAAPIKeyByValue(db, "kath"); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("expected plugin key lookup to be rejected, got %v", err)
+	}
+}
+
 func openCPAAPIKeyTestDatabase(t *testing.T) *gorm.DB {
 	t.Helper()
 	db, err := OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "cpa-api-key.db")})

--- a/internal/repository/migration/20260822_cpa_api_key_source.go
+++ b/internal/repository/migration/20260822_cpa_api_key_source.go
@@ -1,0 +1,27 @@
+package migration
+
+import (
+	"fmt"
+
+	"cpa-usage-keeper/internal/entities"
+	"gorm.io/gorm"
+)
+
+// addCPAAPIKeySourceMigration 只增加来源列并把存量行回填为 cpa；插件行由后续同步写入，不在迁移中创建。
+func addCPAAPIKeySourceMigration(tx *gorm.DB) error {
+	if tx == nil {
+		return fmt.Errorf("database is nil")
+	}
+	if !tx.Migrator().HasColumn(&entities.CPAAPIKey{}, "Source") {
+		if err := tx.Migrator().AddColumn(&entities.CPAAPIKey{}, "Source"); err != nil {
+			return fmt.Errorf("add cpa_api_keys.source column: %w", err)
+		}
+	}
+	// 列已存在但历史行为 NULL 或空串时统一回填为 cpa，保证后续同步只按 source 隔离。
+	if err := tx.Model(&entities.CPAAPIKey{}).
+		Where("source IS NULL OR TRIM(source) = ''").
+		Update("source", entities.CPAAPIKeySourceCPA).Error; err != nil {
+		return fmt.Errorf("backfill cpa_api_keys.source: %w", err)
+	}
+	return nil
+}

--- a/internal/repository/migration/20260822_cpa_api_key_source_test.go
+++ b/internal/repository/migration/20260822_cpa_api_key_source_test.go
@@ -1,0 +1,74 @@
+package migration
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestRunAddsSourceToExistingCPAAPIKeys(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(testSQLiteDSN(filepath.Join(t.TempDir(), "cpa-api-key-source.db"))), &gorm.Config{NowFunc: func() time.Time {
+		return time.Date(2026, 8, 22, 0, 0, 0, 0, time.UTC)
+	}})
+	if err != nil {
+		t.Fatalf("open sqlite database: %v", err)
+	}
+	defer closeOpenedDatabase(t, db)
+
+	if err := MarkAllAsApplied(db); err != nil {
+		t.Fatalf("mark all migrations applied: %v", err)
+	}
+	if err := db.Exec("DELETE FROM schema_migrations WHERE version = ?", migrationAddCPAAPIKeySource).Error; err != nil {
+		t.Fatalf("mark target migration pending %s: %v", migrationAddCPAAPIKeySource, err)
+	}
+	if err := db.Exec(`CREATE TABLE cpa_api_keys (
+		id INTEGER PRIMARY KEY,
+		api_key TEXT,
+		display_key TEXT,
+		key_alias TEXT,
+		is_deleted BOOLEAN,
+		last_synced_at DATETIME,
+		created_at DATETIME,
+		updated_at DATETIME
+	)`).Error; err != nil {
+		t.Fatalf("create legacy cpa_api_keys: %v", err)
+	}
+	if err := db.Exec(
+		"INSERT INTO cpa_api_keys (id, api_key, display_key, is_deleted, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+		int64(1),
+		"sk-alpha123456",
+		"sk-*********123456",
+		false,
+		"2026-08-21T00:00:00Z",
+		"2026-08-21T00:00:00Z",
+	).Error; err != nil {
+		t.Fatalf("seed legacy cpa api key: %v", err)
+	}
+
+	if err := Run(db); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if !db.Migrator().HasColumn(&entities.CPAAPIKey{}, "Source") {
+		t.Fatal("expected cpa_api_keys.source column to exist after migration")
+	}
+	assertSQLiteColumnDefault(t, db, "cpa_api_keys", "source", `"cpa"`)
+	var source string
+	if err := db.Table("cpa_api_keys").Select("source").Where("api_key = ?", "sk-alpha123456").Scan(&source).Error; err != nil {
+		t.Fatalf("load migrated source: %v", err)
+	}
+	if source != entities.CPAAPIKeySourceCPA {
+		t.Fatalf("expected legacy key source to backfill to cpa, got %q", source)
+	}
+	var count int64
+	if err := db.Table("schema_migrations").Where("version = ?", migrationAddCPAAPIKeySource).Count(&count).Error; err != nil {
+		t.Fatalf("count cpa api key source migration: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected migration %s to be recorded once, got %d", migrationAddCPAAPIKeySource, count)
+	}
+}

--- a/internal/repository/migration/migration.go
+++ b/internal/repository/migration/migration.go
@@ -83,6 +83,8 @@ const (
 	migrationCreateErrorEvents = "20260820_create_error_events"
 	// migrationCodexQuotaHistory 创建 Codex 主额度周期父表和整数百分比状态子表。
 	migrationCodexQuotaHistory = "20260820_codex_quota_history"
+	// migrationAddCPAAPIKeySource 区分 CPA 核心 key 与 key-policy 插件 key，存量行回填为 cpa。
+	migrationAddCPAAPIKeySource = "20260822_add_cpa_api_key_source"
 )
 
 type schemaMigration struct {
@@ -204,6 +206,8 @@ func orderedMigrations() []databaseMigration {
 		{version: migrationCreateErrorEvents, run: createErrorEventsMigration},
 		// 新表 migration 使用默认单事务，schema 与版本标记必须一起提交或回滚。
 		{version: migrationCodexQuotaHistory, run: createCodexQuotaHistoryMigration},
+		// source 列只做加列与存量回填，默认单事务即可保证原子性。
+		{version: migrationAddCPAAPIKeySource, run: addCPAAPIKeySourceMigration},
 	}
 }
 

--- a/internal/repository/migration/migration_test.go
+++ b/internal/repository/migration/migration_test.go
@@ -83,6 +83,8 @@ func TestOrderedMigrationsPreservesExecutionOrder(t *testing.T) {
 		"20260820_create_error_events",
 		// Codex 主额度历史是当前最新 schema，必须在既有迁移之后创建父子表。
 		"20260820_codex_quota_history",
+		// CPA API Key 来源列在当前序列最后追加，不能插入已发布迁移之间。
+		"20260822_add_cpa_api_key_source",
 	}
 	assertStringSlicesEqual(t, want, got)
 }

--- a/internal/service/cpa_api_keys_service_test.go
+++ b/internal/service/cpa_api_keys_service_test.go
@@ -92,6 +92,36 @@ func TestFindActiveCPAAPIKeyByIDReturnsOnlyActiveRows(t *testing.T) {
 	}
 }
 
+func TestFindActiveCPAAPIKeyByValueRejectsPluginKeys(t *testing.T) {
+	db, err := repository.OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "api-keys-plugin.db")})
+	if err != nil {
+		t.Fatalf("OpenDatabase returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		sqlDB, err := db.DB()
+		if err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	syncedAt := time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC)
+	if err := repository.SyncCPAAPIKeys(db, []string{"sk-alpha123456"}, syncedAt); err != nil {
+		t.Fatalf("seed CPA API keys: %v", err)
+	}
+	if err := repository.SyncPluginAPIKeys(db, []repository.PluginAPIKey{{ID: "kath", Name: "凯瑟琳"}}, syncedAt); err != nil {
+		t.Fatalf("seed plugin API keys: %v", err)
+	}
+	provider := NewCPAAPIKeyService(db)
+
+	// CPA 核心 key 保持原有按值匹配行为。
+	if _, err := provider.FindActiveCPAAPIKeyByValue(context.Background(), "sk-alpha123456"); err != nil {
+		t.Fatalf("expected CPA key lookup to succeed, got %v", err)
+	}
+	// 插件 key 的短 id 可猜测，必须按 not found 拒绝登录匹配。
+	if _, err := provider.FindActiveCPAAPIKeyByValue(context.Background(), "kath"); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("expected plugin key lookup to be rejected, got %v", err)
+	}
+}
+
 func TestUpdateCPAAPIKeyAliasAcceptsParsedInt64ID(t *testing.T) {
 	db, err := repository.OpenDatabase(config.Config{SQLitePath: filepath.Join(t.TempDir(), "api-keys-service.db")})
 	if err != nil {

--- a/internal/service/metadata_fetcher.go
+++ b/internal/service/metadata_fetcher.go
@@ -13,6 +13,8 @@ type MetadataFetcher interface {
 	FetchAuthFiles(context.Context) (*response.AuthFilesResult, error)
 	// FetchManagementAPIKeys 读取 CPA 管理接口访问 key 清单。
 	FetchManagementAPIKeys(context.Context) (*response.ManagementAPIKeysResult, error)
+	// FetchKeyPolicyPluginKeys 读取 key-policy 插件发行的启用 key 清单。
+	FetchKeyPolicyPluginKeys(context.Context) (*response.KeyPolicyPluginKeysResult, error)
 	// Fetcher 嵌入 provider 纯包定义的固定七来源接口，避免 service 再维护第二份列表。
 	providermetadata.Fetcher
 }

--- a/internal/service/metadata_management_api_keys.go
+++ b/internal/service/metadata_management_api_keys.go
@@ -1,11 +1,13 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"cpa-usage-keeper/internal/cpa/dto/response"
 	"cpa-usage-keeper/internal/repository"
+	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
@@ -33,4 +35,28 @@ func syncManagementAPIKeys(db *gorm.DB, result *response.ManagementAPIKeysResult
 	}
 	// 成功空列表和非空列表都完成本轮同步。
 	return nil
+}
+
+// syncKeyPolicyPluginKeys 拉取 key-policy 插件 key 清单并同步到本地；任何失败只记日志，不影响 CPA 主同步流程。
+func (s *SyncService) syncKeyPolicyPluginKeys(ctx context.Context, syncedAt time.Time) {
+	// 只在 CPA 管理 key 同步成功后由 SyncMetadata 调用，此时 db 与 fetcher 已通过 validate。
+	result, fetchErr := s.metadataFetcher.FetchKeyPolicyPluginKeys(ctx)
+	// fetch failure 没有完整插件清单，必须保留本地 plugin rows。
+	if fetchErr != nil {
+		logrus.WithError(fetchErr).Warn("key policy plugin keys fetch failed")
+		return
+	}
+	// nil response 不是成功空列表，不能删除本地 plugin keys。
+	if result == nil {
+		logrus.Warn("key policy plugin keys fetch returned empty response")
+		return
+	}
+	keys := make([]repository.PluginAPIKey, 0, len(result.Payload.Keys))
+	for _, key := range result.Payload.Keys {
+		keys = append(keys, repository.PluginAPIKey{ID: key.ID, Name: key.Name, KeyPreview: key.KeyPreview})
+	}
+	if err := repository.SyncPluginAPIKeys(s.db, keys, syncedAt); err != nil {
+		// repository failure 同样只记日志，不回滚本轮已提交的 CPA key 同步。
+		logrus.WithError(err).Error("sync key policy plugin keys failed")
+	}
 }

--- a/internal/service/metadata_sync.go
+++ b/internal/service/metadata_sync.go
@@ -31,6 +31,10 @@ func (s *SyncService) SyncMetadata(ctx context.Context) error {
 	authSyncErr := syncAuthFiles(ctx, s.db, authFilesResult, authFilesErr, fetchedAt)
 	// 管理 API Keys 第二个串行写入，不与 SQLite provider 写入并发。
 	apiKeySyncErr := syncManagementAPIKeys(s.db, apiKeysResult, apiKeysErr, fetchedAt)
+	// 插件 key 同步只在 CPA key 同步成功且开关启用时追加；插件失败只记日志，不影响主流程。
+	if apiKeySyncErr == nil && s.keyPolicySyncEnabled {
+		s.syncKeyPolicyPluginKeys(ctx, fetchedAt)
+	}
 	// provider snapshot 最后一次进入 scoped replace 单事务，并分开返回 persistence error 与 fetch warning。
 	providerSyncErr, providerWarningErr := persistProviderMetadata(ctx, s.db, providerSnapshot, providerFetchErr, fetchedAt)
 	// 三类持久化错误按 Auth Files、管理 key、provider 的既有顺序合并。

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -62,13 +62,16 @@ type SyncService struct {
 	usageAggregation UsageAggregationNotifier
 	// usageHeaderQuota 与聚合 runner 解耦，在 Quota worker 内按一分钟窗口自行合并。
 	usageHeaderQuota UsageHeaderSnapshotAppender
+	// keyPolicySyncEnabled 控制是否在 CPA key 同步成功后追加 key-policy 插件 key 同步。
+	keyPolicySyncEnabled bool
 }
 
 // NewSyncService 按生产配置组装 CPA metadata client；远端 usage 拉取由 poller 独立负责。
 func NewSyncService(db *gorm.DB, cfg config.Config) *SyncService {
 	return NewSyncServiceWithOptions(db, SyncServiceOptions{
-		BaseURL: cfg.CPABaseURL,
-		Client:  cpa.NewClient(cfg.CPABaseURL, cfg.CPAManagementKey, cfg.RequestTimeout, cfg.TLSSkipVerify),
+		BaseURL:              cfg.CPABaseURL,
+		Client:               cpa.NewClient(cfg.CPABaseURL, cfg.CPAManagementKey, cfg.RequestTimeout, cfg.TLSSkipVerify),
+		KeyPolicySyncEnabled: cfg.KeyPolicySyncEnabled,
 	})
 }
 
@@ -83,6 +86,8 @@ type SyncServiceOptions struct {
 	UsageAggregationNotifier UsageAggregationNotifier
 	// UsageHeaderQuota 独立接收原始 Header；是否配置聚合 notifier 不影响它。
 	UsageHeaderQuota UsageHeaderSnapshotAppender
+	// KeyPolicySyncEnabled 对应 KEY_POLICY_SYNC_ENABLED；关闭时插件 key 同步完全不执行。
+	KeyPolicySyncEnabled bool
 }
 
 // NewSyncServiceWithOptions 是统一构造入口，负责填充默认时钟和 metadata fetcher。
@@ -106,6 +111,8 @@ func NewSyncServiceWithOptions(db *gorm.DB, opts SyncServiceOptions) *SyncServic
 		usageAggregation: opts.UsageAggregationNotifier,
 		// Header appender 始终独立于聚合 notifier，生产 App 会同时注入两个接收方。
 		usageHeaderQuota: opts.UsageHeaderQuota,
+		// 插件 key 同步开关只从构造选项读取，运行期不可变。
+		keyPolicySyncEnabled: opts.KeyPolicySyncEnabled,
 	}
 }
 

--- a/internal/service/test/metadata_test_helpers_test.go
+++ b/internal/service/test/metadata_test_helpers_test.go
@@ -36,6 +36,10 @@ type metadataTestFetcher struct {
 	managementAPIKeysResult *response.ManagementAPIKeysResult
 	// managementAPIKeysErr 注入管理 API Keys fetch failure。
 	managementAPIKeysErr error
+	// keyPolicyPluginKeysResult 保存 key-policy 插件 keys 的直接响应。
+	keyPolicyPluginKeysResult *response.KeyPolicyPluginKeysResult
+	// keyPolicyPluginKeysErr 注入 key-policy 插件 keys fetch failure。
+	keyPolicyPluginKeysErr error
 	// standardResults 按 source 保存六类标准 API Key endpoint 响应。
 	standardResults map[string]*response.ProviderKeyConfigResult
 	// standardErrors 按 source 注入独立 fetch error。
@@ -122,6 +126,18 @@ func (f *metadataTestFetcher) FetchManagementAPIKeys(context.Context) (*response
 	f.recordCall("management-api-keys")
 	// 返回预设结果与错误。
 	return f.managementAPIKeysResult, f.managementAPIKeysErr
+}
+
+// FetchKeyPolicyPluginKeys 返回测试配置的 key-policy 插件 keys 结果，默认空清单成功响应。
+func (f *metadataTestFetcher) FetchKeyPolicyPluginKeys(context.Context) (*response.KeyPolicyPluginKeysResult, error) {
+	// 插件 keys 只在开关启用时被 SyncMetadata 调用。
+	f.recordCall("key-policy-plugin-keys")
+	// 未显式配置时保持成功空清单，与插件未发行任何 key 的线上形态一致。
+	if f.keyPolicyPluginKeysResult == nil && f.keyPolicyPluginKeysErr == nil {
+		return &response.KeyPolicyPluginKeysResult{StatusCode: 200}, nil
+	}
+	// 返回预设结果与错误。
+	return f.keyPolicyPluginKeysResult, f.keyPolicyPluginKeysErr
 }
 
 // fetchStandardProvider 复用六类标准 API Key endpoint 的测试分派逻辑。

--- a/internal/service/test/plugin_key_sync_test.go
+++ b/internal/service/test/plugin_key_sync_test.go
@@ -1,0 +1,154 @@
+package test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/cpa/dto/keypolicy"
+	"cpa-usage-keeper/internal/cpa/dto/response"
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+	"cpa-usage-keeper/internal/service"
+)
+
+// TestSyncMetadataSyncsPluginKeysWhenEnabled 验证开关启用时插件 key 随 CPA key 同步成功后写入本地。
+func TestSyncMetadataSyncsPluginKeysWhenEnabled(t *testing.T) {
+	// db 使用真实 repository schema 验证最终持久化字段。
+	db := openMetadataTestDatabase(t, "plugin-key-sync.db")
+	// now 固定本轮所有 metadata 行的时间边界。
+	now := time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC)
+	// fetcher 默认管理 API Keys 成功空列表，本测试补充一条插件 key。
+	fetcher := newMetadataTestFetcher()
+	fetcher.keyPolicyPluginKeysResult = &response.KeyPolicyPluginKeysResult{
+		StatusCode: 200,
+		Payload:    keypolicy.PluginKeysResponse{Keys: []keypolicy.PluginKey{{ID: "kath", Name: "凯瑟琳", Enabled: true, KeyPreview: "sk-8bc0...64426"}}},
+	}
+	// syncer 注入固定时钟、函数式 fetcher 和启用的插件同步开关。
+	syncer := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{
+		BaseURL:              "https://cpa.example.com",
+		MetadataFetcher:      fetcher,
+		Now:                  func() time.Time { return now },
+		KeyPolicySyncEnabled: true,
+	})
+
+	// 执行一轮完整 metadata 同步。
+	if err := syncer.SyncMetadata(context.Background()); err != nil {
+		// 全部 endpoint 成功时不应返回 warning。
+		t.Fatalf("SyncMetadata returned error: %v", err)
+	}
+	// 插件 keys 每轮只在 CPA key 同步成功后读取一次。
+	if fetcher.callCount("key-policy-plugin-keys") != 1 {
+		t.Fatalf("key-policy-plugin-keys calls = %d", fetcher.callCount("key-policy-plugin-keys"))
+	}
+	// 插件行必须保存 id、插件别名和来源标记。
+	var row entities.CPAAPIKey
+	if err := db.Where("api_key = ?", "kath").First(&row).Error; err != nil {
+		t.Fatalf("expected plugin key row: %v", err)
+	}
+	if row.Source != entities.CPAAPIKeySourcePlugin || row.DisplayKey != "sk-8bc0...64426" || row.KeyAlias != "凯瑟琳" || row.IsDeleted {
+		t.Fatalf("unexpected plugin key row: %+v", row)
+	}
+}
+
+// TestSyncMetadataPluginFetchFailurePreservesPluginRows 验证插件拉取失败只记日志，本地 plugin rows 保持现状。
+func TestSyncMetadataPluginFetchFailurePreservesPluginRows(t *testing.T) {
+	// db 保存首轮成功数据与次轮失败后的状态。
+	db := openMetadataTestDatabase(t, "plugin-key-sync-failure.db")
+	now := time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC)
+	fetcher := newMetadataTestFetcher()
+	fetcher.keyPolicyPluginKeysResult = &response.KeyPolicyPluginKeysResult{
+		StatusCode: 200,
+		Payload:    keypolicy.PluginKeysResponse{Keys: []keypolicy.PluginKey{{ID: "kath", Name: "凯瑟琳", Enabled: true, KeyPreview: "sk-8bc0...64426"}}},
+	}
+	syncer := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{
+		BaseURL:              "https://cpa.example.com",
+		MetadataFetcher:      fetcher,
+		Now:                  func() time.Time { return now },
+		KeyPolicySyncEnabled: true,
+	})
+	// 首轮成功同步写入一条 plugin row。
+	if err := syncer.SyncMetadata(context.Background()); err != nil {
+		t.Fatalf("first SyncMetadata returned error: %v", err)
+	}
+
+	// 第二轮插件拉取失败；fetch failure 没有完整新清单，必须保留本地 plugin rows。
+	fetcher.keyPolicyPluginKeysResult = nil
+	fetcher.keyPolicyPluginKeysErr = errors.New("plugin endpoint unavailable")
+	if err := syncer.SyncMetadata(context.Background()); err != nil {
+		// 插件失败只记日志，不允许以 warning 形式出现在主流程返回值里。
+		t.Fatalf("SyncMetadata with plugin fetch failure returned error: %v", err)
+	}
+	row, err := repository.FindActiveCPAAPIKeyByID(db, 1)
+	if err != nil {
+		t.Fatalf("expected plugin row to survive fetch failure: %v", err)
+	}
+	if row.APIKey != "kath" || row.IsDeleted {
+		t.Fatalf("expected plugin row to stay active after fetch failure, got %+v", row)
+	}
+}
+
+// TestSyncMetadataSkipsPluginKeysWhenDisabled 锁定开关关闭时的零行为变化：不发起插件请求，也不写 plugin rows。
+func TestSyncMetadataSkipsPluginKeysWhenDisabled(t *testing.T) {
+	// db 验证关闭开关后数据库不产生任何 plugin 行。
+	db := openMetadataTestDatabase(t, "plugin-key-disabled.db")
+	fetcher := newMetadataTestFetcher()
+	fetcher.keyPolicyPluginKeysResult = &response.KeyPolicyPluginKeysResult{
+		StatusCode: 200,
+		Payload:    keypolicy.PluginKeysResponse{Keys: []keypolicy.PluginKey{{ID: "kath", Name: "凯瑟琳", Enabled: true, KeyPreview: "sk-8bc0...64426"}}},
+	}
+	// 默认构造不带 KeyPolicySyncEnabled，保持既有行为。
+	syncer := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{
+		BaseURL:         "https://cpa.example.com",
+		MetadataFetcher: fetcher,
+		Now:             func() time.Time { return time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC) },
+	})
+
+	if err := syncer.SyncMetadata(context.Background()); err != nil {
+		t.Fatalf("SyncMetadata returned error: %v", err)
+	}
+	// 开关关闭时绝不能访问插件 endpoint。
+	if fetcher.callCount("key-policy-plugin-keys") != 0 {
+		t.Fatalf("expected no plugin fetch when disabled, got %d calls", fetcher.callCount("key-policy-plugin-keys"))
+	}
+	var count int64
+	if err := db.Model(&entities.CPAAPIKey{}).Where("source = ?", entities.CPAAPIKeySourcePlugin).Count(&count).Error; err != nil {
+		t.Fatalf("count plugin rows: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected no plugin rows when disabled, got %d", count)
+	}
+}
+
+// TestSyncMetadataSkipsPluginKeysWhenCPASyncFails 验证 CPA key 同步失败时不得触碰本地 plugin rows。
+func TestSyncMetadataSkipsPluginKeysWhenCPASyncFails(t *testing.T) {
+	// db 先用直写 repository 准备一条 plugin row，再验证 CPA 失败后它保持 active。
+	db := openMetadataTestDatabase(t, "plugin-key-cpa-failure.db")
+	now := time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC)
+	if err := repository.SyncPluginAPIKeys(db, []repository.PluginAPIKey{{ID: "kath", Name: "凯瑟琳"}}, now); err != nil {
+		t.Fatalf("seed plugin key: %v", err)
+	}
+	// fetcher 注入管理 API Keys fetch failure；CPA 侧没有完整新清单时插件同步也不允许执行。
+	fetcher := newMetadataTestFetcher()
+	fetcher.managementAPIKeysErr = errors.New("management endpoint unavailable")
+	fetcher.keyPolicyPluginKeysResult = &response.KeyPolicyPluginKeysResult{StatusCode: 200, Payload: keypolicy.PluginKeysResponse{}}
+	syncer := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{
+		BaseURL:              "https://cpa.example.com",
+		MetadataFetcher:      fetcher,
+		Now:                  func() time.Time { return now },
+		KeyPolicySyncEnabled: true,
+	})
+
+	// 管理 key 失败仍作为 warning 返回，但插件 rows 不能随之被替换。
+	if err := syncer.SyncMetadata(context.Background()); err == nil {
+		t.Fatal("expected SyncMetadata to report management api keys failure")
+	}
+	if fetcher.callCount("key-policy-plugin-keys") != 0 {
+		t.Fatalf("expected no plugin fetch when CPA sync failed, got %d calls", fetcher.callCount("key-policy-plugin-keys"))
+	}
+	row, err := repository.FindActiveCPAAPIKeyByID(db, 1)
+	if err != nil || row.APIKey != "kath" || row.IsDeleted {
+		t.Fatalf("expected plugin row to stay active after CPA sync failure, got %+v err=%v", row, err)
+	}
+}


### PR DESCRIPTION
## Problem

API keys issued by the [cpa-plugin-key-policy](https://github.com/origin652/cpa-plugin-key-policy) CPA plugin never appear in per-key statistics / rankings:

- Usage events from plugin keys **are** ingested correctly (`usage_events.api_group_key` carries the plugin key id, e.g. `kath`), and overview aggregations include them.
- But `cpa_api_keys` is synced from CPA's `/v0/management/api-keys` with **full-replace semantics** (`SyncCPAAPIKeys`): any row not in that list is soft-deleted. Plugin keys are never in CPA's core `api-keys`, so a manually added row cannot survive even one sync cycle.
- Ranking / usage-analysis queries join `cpa_api_keys ... AND is_deleted = 0`, so plugin keys are permanently invisible in the UI.

## Solution

Opt-in support for key-policy plugin keys, behind `KEY_POLICY_SYNC_ENABLED` (default **false** — zero behavior change when off):

- **New column `cpa_api_keys.source`** (`cpa` / `plugin`, migration `20260822_add_cpa_api_key_source`, existing rows backfilled to `cpa`).
- `SyncCPAAPIKeys` now only soft-deletes `source='cpa'` rows; plugin rows are untouched by the CPA full-replace sync.
- New client call `FetchKeyPolicyPluginKeys` → `GET {CPA_BASE_URL}/v0/management/plugins/cpa-key-policy/keys` (same management Bearer token; only `enabled` keys are kept).
- New `SyncPluginAPIKeys`: upserts plugin keys by their **id** (which is exactly what usage events carry in `api_group_key`), `display_key` uses the plugin's `key_preview` (falls back to id), `key_alias` is filled from the plugin key's name only when locally empty (user-edited aliases are never overwritten). Plugin keys removed from the plugin side are soft-deleted — but only when the plugin fetch **succeeded**; on failure, local state is left untouched (same semantics as the CPA key sync).
- Plugin sync runs only after a successful CPA key sync, so a CPA-side failure can't cascade.

## Security

`cpa_api_keys` doubles as the credential store for api-key viewer login (`apiKeyLogin` → `FindActiveCPAAPIKeyByValue`). Plugin key ids are short, human-meaningful strings (e.g. `kath`) — storing them as login-able key values would be a weak-password equivalent. `FindActiveCPAAPIKeyByValue` therefore excludes `source='plugin'` rows: plugin keys are visible in stats but **cannot** be used to log in.

No plaintext plugin secrets are handled: the plugin's management API exposes only id/name/key_preview (the raw key is shown once at creation), and none is needed for attribution.

## Tests

- CPA full-replace sync no longer soft-deletes plugin rows.
- Plugin sync upsert / soft-delete / restore semantics; fetch failure preserves state.
- Plugin key login rejected (401) at repository, service, and API handler level; CPA key login still works.
- Flag disabled → zero behavior change (plugin endpoint never called, no plugin rows).
- Migration test (column add, backfill, idempotency); client tests (Bearer header, enabled filter, non-2xx).

`go build ./...`, `go vet ./...`, `go test ./...` all green.

## Notes

Verified in production against CLIProxyAPI Plus v7.2.127 + cpa-key-policy v0.4.4: plugin key appears in rankings, survives CPA restarts and metadata sync cycles, and new usage aggregates correctly.