### PR TITLE
fix(analysis): align inner panel radii and spacing

### DIFF
--- a/web/src/components/usage/analysis/AnalysisPanel.module.scss
+++ b/web/src/components/usage/analysis/AnalysisPanel.module.scss
@@ -74,7 +74,7 @@
 .analysisChartSurface {
   padding: 14px;
   background: var(--bg-secondary);
-  border-radius: $radius-lg;
+  border-radius: var(--keeper-card-radius);
   border: 1px solid var(--border-color);
   min-width: 0;
 }
@@ -176,7 +176,7 @@
   min-width: 0;
   padding: 9px 11px;
   border: 1px solid var(--border-color);
-  border-radius: 10px;
+  border-radius: 999px;
   background: color-mix(in srgb, var(--bg-secondary) 72%, transparent);
   color: var(--text-primary);
   font: inherit;
@@ -276,9 +276,9 @@
 
 .latencyMetric {
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: var(--keeper-card-radius);
   background: var(--bg-secondary);
-  padding: 12px;
+  padding: 16px;
   min-width: 0;
 
   span,
@@ -429,7 +429,7 @@
   gap: 0;
   align-items: stretch;
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: var(--keeper-card-radius);
   background: color-mix(in srgb, var(--bg-secondary) 78%, transparent);
   overflow: hidden;
   padding: 0;
@@ -445,7 +445,7 @@
   flex-direction: column;
   justify-content: flex-start;
   min-width: 0;
-  padding: 12px;
+  padding: 16px;
 
   span,
   small {
@@ -496,8 +496,8 @@
   gap: 4px 8px;
   align-items: center;
   border: 1px solid var(--border-color);
-  border-radius: 8px;
-  padding: 10px;
+  border-radius: var(--keeper-card-radius);
+  padding: 16px;
   background: var(--bg-secondary);
   min-width: 0;
 
@@ -610,7 +610,7 @@
 
 .compositionTab {
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: 999px;
   background: var(--bg-secondary);
   color: var(--text-secondary);
   min-height: 34px;

--- a/web/src/components/usage/analysis/AnalysisPanel.module.scss
+++ b/web/src/components/usage/analysis/AnalysisPanel.module.scss
@@ -810,9 +810,16 @@
 
 .heatmapCorner,
 .heatmapHeaderCell,
+.heatmapRowLabel,
+.heatmapCell,
+.heatmapSummaryCell {
+  border-radius: $radius-lg;
+}
+
+.heatmapCorner,
+.heatmapHeaderCell,
 .heatmapCell {
   border: 1px solid var(--border-color);
-  border-radius: 6px;
   background: var(--bg-secondary);
 }
 
@@ -870,7 +877,7 @@
   position: absolute;
   inset: 0;
   z-index: -1;
-  border-radius: 0;
+  border-radius: inherit;
   background: inherit;
   pointer-events: none;
 }
@@ -911,7 +918,6 @@
   align-items: center;
   gap: 8px;
   border: 1px solid var(--border-color);
-  border-radius: 5px;
   background: var(--bg-primary);
   padding: 0 10px;
   outline: none;
@@ -939,7 +945,6 @@
   align-items: center;
   justify-content: center;
   padding: 0 4px;
-  border-radius: 5px;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.10);
   font-variant-numeric: tabular-nums;
   outline: none;
@@ -962,7 +967,6 @@
   justify-content: center;
   min-width: 0;
   border: 1px solid var(--border-color);
-  border-radius: 5px;
   background: color-mix(in srgb, var(--bg-secondary) 72%, var(--bg-primary));
   color: var(--text-primary);
   padding: 0 5px;

--- a/web/src/components/usage/analysis/test/AnalysisPanel.heatmap-fixed-columns.test.tsx
+++ b/web/src/components/usage/analysis/test/AnalysisPanel.heatmap-fixed-columns.test.tsx
@@ -130,6 +130,8 @@ describe('AnalysisPanel fixed heatmap columns demo', () => {
     expect(keyColumnMask).toContain('position: absolute;');
     expect(keyColumnMask).toContain('inset: 0;');
     expect(keyColumnMask).toContain('z-index: -1;');
+    expect(keyColumnMask).toContain('border-radius: inherit;');
+    expect(keyColumnMask).not.toContain('border-radius: 0;');
     expect(keyColumnMask).toContain('background: inherit;');
     expect(keyColumnMask).not.toContain('var(--heatmap-grid-gap)');
     expect(analysisPanelStyles).toContain(`@include mobile {
@@ -148,12 +150,24 @@ describe('AnalysisPanel fixed heatmap columns demo', () => {
     expect(keyMarker).not.toContain('box-shadow:');
     expect(analysisPanelStyles).toMatch(/\.heatmapRowLabel\s*\{[\s\S]*?height:\s*34px;[\s\S]*?border:\s*1px solid var\(--border-color\);[\s\S]*?background:\s*var\(--bg-primary\);/);
     expect(analysisPanelStyles).toContain('.heatmapRowLabel:focus-visible,\n.heatmapSummaryCell:focus-visible {');
-    const summaryCell = styleRuleBlock('.heatmapSummaryCell');
+    const summaryCell = styleRuleBlock('\n\n.heatmapSummaryCell {');
     expect(summaryCell).toContain('display: flex;');
     expect(summaryCell).toContain('justify-content: center;');
     expect(summaryCell).toContain('font-variant-numeric: tabular-nums;');
     expect(analysisPanelStyles).not.toContain('.heatmapSummaryMetric');
     expect(analysisPanelStyles).not.toContain('.heatmapCostSummaryCell');
     expect(analysisPanelStyles).not.toContain('.heatmapTooltipTarget');
+  });
+
+  it('uses the shared large radius for every heatmap header and data block', () => {
+    const roundedBlocks = styleRuleBlock(`.heatmapCorner,
+.heatmapHeaderCell,
+.heatmapRowLabel,
+.heatmapCell,
+.heatmapSummaryCell`);
+    expect(roundedBlocks).toContain('border-radius: $radius-lg;');
+    expect(styleRuleBlock('\n.heatmapRowLabel {')).not.toContain('border-radius: 5px;');
+    expect(styleRuleBlock('\n.heatmapCell {')).not.toContain('border-radius: 5px;');
+    expect(styleRuleBlock('\n\n.heatmapSummaryCell {')).not.toContain('border-radius: 5px;');
   });
 });

--- a/web/src/components/usage/analysis/test/AnalysisPanel.styles.test.ts
+++ b/web/src/components/usage/analysis/test/AnalysisPanel.styles.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const styles = readFileSync(new URL('../AnalysisPanel.module.scss', import.meta.url), 'utf8');
+
+const scssRule = (selector: string) => {
+  const needle = `\n${selector} {`;
+  const match = styles.indexOf(needle);
+  const start = match < 0 ? -1 : match + 1;
+  expect(start).toBeGreaterThanOrEqual(0);
+  const openingBrace = styles.indexOf('{', start + selector.length);
+  expect(openingBrace).toBeGreaterThan(start);
+
+  let depth = 1;
+  for (let index = openingBrace + 1; index < styles.length; index += 1) {
+    if (styles[index] === '{') depth += 1;
+    if (styles[index] === '}' && --depth === 0) return styles.slice(start, index + 1);
+  }
+  throw new Error(`Unclosed SCSS rule: ${selector}`);
+};
+
+describe('AnalysisPanel inner element radii', () => {
+  it('uses the shared card radius for chart frames and summary cards', () => {
+    for (const selector of [
+      '.analysisChartSurface',
+      '.costRatePanel',
+      '.costMetric',
+      '.latencyMetric',
+    ]) {
+      expect(scssRule(selector)).toContain('border-radius: var(--keeper-card-radius);');
+    }
+  });
+
+  it('keeps the cost bar compact while rounded metric cards preserve text clearance', () => {
+    expect(scssRule('.costStack')).toContain('border-radius: 8px;');
+    expect(scssRule('.costRateMetric')).toContain('padding: 16px;');
+    expect(scssRule('.costMetric')).toContain('padding: 16px;');
+    expect(scssRule('.latencyMetric')).toContain('padding: 16px;');
+  });
+
+  it('uses the project pill radius for model and distribution controls', () => {
+    expect(scssRule('.topModelsRankItem')).toContain('border-radius: 999px;');
+    expect(scssRule('.compositionTab')).toContain('border-radius: 999px;');
+  });
+});

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -136,7 +136,7 @@ describe('UsagePage toolbar styles', () => {
     expect(tokenActivityCardSource).toContain('keeper-card-title-track')
     expect(statCardsSource).not.toContain('keeper-card-surface')
     expect(dailyAverageCardSource).not.toContain('keeper-card-surface')
-    expect(analysisChartSurface).toContain('border-radius: $radius-lg;')
+    expect(analysisChartSurface).toContain('border-radius: var(--keeper-card-radius);')
   })
 
   it('keeps only the ranking source switch beside Refresh in the shared top toolbar', () => {


### PR DESCRIPTION
## Summary

- align Analysis chart frames, metric cards, and controls with Keeper's shared radius styles
- increase Cost Breakdown and Latency Diagnostics metric spacing while keeping the cost bar compact
- round Heatmap headers and cells while preserving sticky/mobile behavior and fixing API key mask corners

## Validation

- targeted Analysis tests: 98 passed
- frontend lint passed
- frontend typecheck passed
- Vite production build passed
- backend-served `/cpa/`, `/cpa/healthz`, and `/cpa/api/v1/auth/session` returned 200