### PR TITLE
fix(ranking): align podium cards with shared radius

### DIFF
--- a/web/src/features/ranking/RankingPage.module.scss
+++ b/web/src/features/ranking/RankingPage.module.scss
@@ -581,7 +581,7 @@
   overflow: hidden;
   border: 1px solid var(--border-color);
   border-top: 3px solid var(--podium-accent);
-  border-radius: 12px;
+  border-radius: var(--keeper-card-radius);
   background: linear-gradient(145deg, color-mix(in srgb, var(--podium-accent) 9%, var(--bg-primary)), var(--bg-primary));
   box-shadow: var(--shadow);
 

--- a/web/src/features/ranking/test/RankingPage.styles.test.ts
+++ b/web/src/features/ranking/test/RankingPage.styles.test.ts
@@ -224,6 +224,7 @@ describe('Ranking table context styles', () => {
     expect(card).toContain('grid-template-areas:');
     expect(card).toContain('min-height: 136px;');
     expect(card).toContain('border-top: 3px solid var(--podium-accent);');
+    expect(card).toContain('border-radius: var(--keeper-card-radius);');
     expect(first).toContain('grid-column: 2;');
     expect(first).not.toContain('transform:');
     expect(second).toContain('grid-column: 1;');


### PR DESCRIPTION
## Summary

- align Local and Community Ranking podium cards with the shared Keeper card radius
- add regression coverage that locks the podium surface to the project radius token

## Validation

- targeted Ranking style tests: 24 passed
- frontend test suite: 125 files / 1127 tests passed
- frontend lint, typecheck, and production build passed
- project read-only review: no P0-P3 findings