### PR TITLE
fix(settings): align cards and compact controls

### DIFF
--- a/web/src/components/usage/ApiKeySettingsCard.test.tsx
+++ b/web/src/components/usage/ApiKeySettingsCard.test.tsx
@@ -36,7 +36,9 @@ describe('ApiKeySettingsCard', () => {
     expect(html).not.toContain('placeholder="sk-alpha123456"');
     expect(html).toContain('aria-label="Show full API keys"');
     expect(html).toContain('m2 2 20 20');
-    expect(countOccurrences(html, '>Copy<')).toBe(2);
+    expect(countOccurrences(html, 'aria-label="Copy"')).toBe(2);
+    expect(countOccurrences(html, '>Copy<')).toBe(0);
+    expect(countOccurrences(html, '<rect width="14" height="14" x="8" y="8" rx="2" ry="2"></rect>')).toBe(2);
     expect(html).toContain('title="sk-*********123456"');
     expect(html).not.toContain('9007199254740993');
     expect(html).not.toContain('Local ID');

--- a/web/src/components/usage/ApiKeySettingsCard.tsx
+++ b/web/src/components/usage/ApiKeySettingsCard.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
-import { IconEye, IconEyeOff } from '@/components/ui/icons';
+import { IconCheck, IconCopy, IconEye, IconEyeOff } from '@/components/ui/icons';
 import { useScrollBoundaryContainment } from '@/hooks/useScrollBoundaryContainment';
 import type { CpaApiKeySettingsItem } from '@/lib/types';
 import styles from '@/pages/UsagePage.module.scss';
@@ -168,7 +168,19 @@ export function ApiKeySettingsCard({ apiKeys, loading = false, savingId = null, 
                 <div key={item.id} className={styles.apiKeySettingsItem}>
                   <div className={styles.apiKeySettingsSummary}>
                     <span className={styles.apiKeyFieldLabel}>{t('usage_stats.api_key_settings_display_key')}</span>
-                    <span className={styles.apiKeySettingsName} title={apiKey}>{apiKey}</span>
+                    <div className={styles.apiKeySettingsNameRow}>
+                      <span className={styles.apiKeySettingsName} title={apiKey}>{apiKey}</span>
+                      <button
+                        type="button"
+                        className={`${styles.apiKeySettingsCopyIconButton} ${copiedId === item.id ? styles.apiKeySettingsCopyIconButtonCopied : ''}`.trim()}
+                        onClick={() => void handleCopyApiKey(item)}
+                        disabled={!item.apiKey}
+                        aria-label={copyLabel}
+                        title={copyLabel}
+                      >
+                        {copiedId === item.id ? <IconCheck size={14} /> : <IconCopy size={14} />}
+                      </button>
+                    </div>
                   </div>
                   <div className={styles.apiKeySettingsForm}>
                     <label className={styles.apiKeyAliasField}>
@@ -183,16 +195,6 @@ export function ApiKeySettingsCard({ apiKeys, loading = false, savingId = null, 
                       />
                     </label>
                     <div className={styles.apiKeySettingsActions}>
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        appearance="action"
-                        className={styles.apiKeySettingsCopyButton}
-                        onClick={() => void handleCopyApiKey(item)}
-                        disabled={!item.apiKey}
-                      >
-                        {copyLabel}
-                      </Button>
                       <Button
                         variant="primary"
                         size="sm"

--- a/web/src/components/usage/pricing/PriceRulesModal.module.scss
+++ b/web/src/components/usage/pricing/PriceRulesModal.module.scss
@@ -143,22 +143,23 @@
   letter-spacing: 0.02em;
 }
 
-.ruleInput {
+.ruleInput:global(.input) {
   width: 100%;
-  height: 40px;
-  min-height: 40px;
+  height: 32px;
+  min-height: 32px;
   min-width: 0;
   box-sizing: border-box;
-  padding: 8px 12px;
+  padding: 6px 12px;
   border-radius: 999px;
   background: color-mix(in srgb, var(--bg-primary) 86%, transparent);
   box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04) inset;
   font-size: 12px;
+  line-height: 18px;
 }
 
 .removeButton {
   align-self: start;
-  margin-top: 20px;
+  margin-top: 16px;
 }
 
 .actions,

--- a/web/src/components/usage/pricing/test/PriceRulesModal.test.tsx
+++ b/web/src/components/usage/pricing/test/PriceRulesModal.test.tsx
@@ -157,6 +157,22 @@ describe('PriceRulesModal', () => {
     expect(removeButton.querySelector('svg')).toBeNull()
   })
 
+  it('keeps all three rule fields on the shared pill input contract', async () => {
+    await renderModal({ model: 'model-a', loadRules: async () => [] })
+
+    expect(document.body.querySelectorAll('.input[data-rule-field]')).toHaveLength(3)
+    const inputRule = modalStylesSource.match(/\.ruleInput:global\(\.input\)\s*\{([\s\S]*?)\n\}/)?.[1] ?? ''
+    const removeButtonRule = modalStylesSource.match(/\.removeButton\s*\{([\s\S]*?)\n\}/)?.[1] ?? ''
+
+    expect(inputRule).toContain('height: 32px;')
+    expect(inputRule).toContain('min-height: 32px;')
+    expect(inputRule).toContain('padding: 6px 12px;')
+    expect(inputRule).toContain('line-height: 18px;')
+    expect(inputRule).toContain('border-radius: 999px;')
+    expect(inputRule).not.toContain('height: 40px;')
+    expect(removeButtonRule).toContain('margin-top: 16px;')
+  })
+
   it('shows row validation and does not call the backend for a partial rule', async () => {
     const saveRules = vi.fn(async (_model: string, _rules: ReplacePricingRuleInput[]) => [])
     await renderModal({ model: 'model-a', loadRules: async () => [], saveRules })

--- a/web/src/components/usage/test/ApiKeySettingsCard.interaction.test.tsx
+++ b/web/src/components/usage/test/ApiKeySettingsCard.interaction.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CpaApiKeySettingsItem } from '@/lib/types'
+import { ApiKeySettingsCard } from '../ApiKeySettingsCard'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const translations: Record<string, string> = {
+  'common.save': 'Save',
+  'usage_stats.api_key_settings_title': 'API Key Settings',
+  'usage_stats.api_key_settings_subtitle': 'Set display aliases.',
+  'usage_stats.api_key_settings_display_key': 'API Key',
+  'usage_stats.api_key_settings_alias': 'Alias',
+  'usage_stats.api_key_settings_show_full': 'Show full API keys',
+  'usage_stats.api_key_settings_copy': 'Copy',
+  'usage_stats.api_key_settings_copied': 'Copied',
+  'usage_stats.api_key_settings_copy_success': 'API Key copied.',
+  'usage_stats.api_key_settings_copy_failed': 'Unable to copy API Key.',
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => translations[key] ?? key,
+  }),
+}))
+
+const apiKey: CpaApiKeySettingsItem = {
+  id: '9007199254740993',
+  apiKey: 'sk-alpha123456',
+  keyAlias: 'Primary',
+  displayKey: 'sk-*********123456',
+  label: 'Primary',
+  lastSyncedAt: '2026-05-13T00:00:00Z',
+}
+
+describe('ApiKeySettingsCard copy action', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let clipboardDescriptor: PropertyDescriptor | undefined
+  let execCommandDescriptor: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    clipboardDescriptor = Object.getOwnPropertyDescriptor(globalThis.navigator, 'clipboard')
+    execCommandDescriptor = Object.getOwnPropertyDescriptor(document, 'execCommand')
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    container.remove()
+    if (clipboardDescriptor) {
+      Object.defineProperty(globalThis.navigator, 'clipboard', clipboardDescriptor)
+    } else {
+      delete (globalThis.navigator as Navigator & { clipboard?: Clipboard }).clipboard
+    }
+    if (execCommandDescriptor) {
+      Object.defineProperty(document, 'execCommand', execCommandDescriptor)
+    } else {
+      delete (document as Document & { execCommand?: (command: string) => boolean }).execCommand
+    }
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  const renderCard = async (onNotice: ReturnType<typeof vi.fn>) => {
+    await act(async () => {
+      root.render(
+        <ApiKeySettingsCard
+          apiKeys={[apiKey]}
+          onSaveAlias={() => undefined}
+          onNotice={onNotice}
+        />,
+      )
+    })
+  }
+
+  it('copies the raw key, shows the success icon, and resets its label', async () => {
+    vi.useFakeTimers()
+    const writeText = vi.fn(async () => undefined)
+    const onNotice = vi.fn()
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    await renderCard(onNotice)
+
+    const copyButton = container.querySelector<HTMLButtonElement>('button[aria-label="Copy"]')
+    expect(copyButton).not.toBeNull()
+    expect(container.textContent).toContain(apiKey.displayKey)
+    expect(container.textContent).not.toContain(apiKey.apiKey)
+    const copyIcon = copyButton?.querySelector('svg')?.innerHTML
+
+    await act(async () => {
+      copyButton?.click()
+      await Promise.resolve()
+    })
+
+    expect(writeText).toHaveBeenCalledWith(apiKey.apiKey)
+    expect(onNotice).toHaveBeenCalledWith('success', 'API Key copied.')
+    const copiedButton = container.querySelector<HTMLButtonElement>('button[aria-label="Copied"]')
+    expect(copiedButton).not.toBeNull()
+    expect(copiedButton?.querySelector('svg')?.innerHTML).not.toBe(copyIcon)
+
+    await act(async () => vi.advanceTimersByTime(1600))
+    expect(container.querySelector('button[aria-label="Copy"]')).not.toBeNull()
+    expect(container.querySelector('button[aria-label="Copied"]')).toBeNull()
+  })
+
+  it('keeps the copy icon and reports an error when both copy paths fail', async () => {
+    const writeText = vi.fn(async () => { throw new Error('blocked') })
+    const execCommand = vi.fn(() => false)
+    const onNotice = vi.fn()
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execCommand,
+    })
+    await renderCard(onNotice)
+
+    const copyButton = container.querySelector<HTMLButtonElement>('button[aria-label="Copy"]')
+    expect(copyButton).not.toBeNull()
+
+    await act(async () => {
+      copyButton?.click()
+      await Promise.resolve()
+    })
+
+    expect(writeText).toHaveBeenCalledWith(apiKey.apiKey)
+    expect(execCommand).toHaveBeenCalledWith('copy')
+    expect(onNotice).toHaveBeenCalledWith('error', 'Unable to copy API Key.')
+    expect(container.querySelector('button[aria-label="Copy"]')).not.toBeNull()
+    expect(container.querySelector('button[aria-label="Copied"]')).toBeNull()
+  })
+})

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -1921,10 +1921,18 @@
   min-width: 0;
 }
 
+.apiKeySettingsNameRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  min-height: 32px;
+}
+
 .apiKeySettingsName {
   display: -webkit-box;
   min-width: 0;
-  min-height: 40px;
   overflow: hidden;
   color: var(--text-primary);
   font-size: 13px;
@@ -1933,6 +1941,42 @@
   word-break: break-all;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+}
+
+.apiKeySettingsCopyIconButton {
+  appearance: none;
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+
+  &:hover:not(:disabled) {
+    background: var(--bg-primary);
+    color: var(--text-primary);
+  }
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--primary-color) 54%, transparent);
+    outline-offset: -2px;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+  }
+}
+
+.apiKeySettingsCopyIconButtonCopied {
+  color: var(--success-color);
 }
 
 .apiKeySettingsMeta {
@@ -1958,6 +2002,12 @@
   flex-direction: column;
   gap: 5px;
   min-width: 0;
+
+  :global(.form-group) {
+    width: 100%;
+    min-width: 0;
+    margin-bottom: 0;
+  }
 }
 
 .apiKeyFieldLabel,
@@ -1971,19 +2021,24 @@
 
 .apiKeyAliasInput:global(.input) {
   width: 100%;
+  height: 32px;
+  min-height: 32px;
+  box-sizing: border-box;
+  padding: 6px 12px;
   border-radius: 999px;
+  font-size: 12px;
+  line-height: 18px;
 }
 
 .apiKeySettingsActions {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  align-self: stretch;
+  align-self: end;
   gap: 8px;
   min-width: 0;
 }
 
-.apiKeySettingsCopyButton,
 .apiKeySettingsSaveButton {
   min-width: 68px;
   justify-content: center;
@@ -2233,19 +2288,12 @@
     justify-content: stretch;
   }
 
-  .apiKeySettingsCopyButton,
   .apiKeySettingsSaveButton {
     flex: 1 1 0;
   }
 
   .apiKeyAliasField {
     width: 100%;
-
-    :global(.form-group) {
-      width: 100%;
-      min-width: 0;
-      margin-bottom: 0;
-    }
   }
 
   .apiKeyAliasInput {

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -1898,7 +1898,7 @@
 .apiKeySettingsList {
   display: grid;
   gap: 10px;
-  grid-template-columns: repeat(auto-fill, minmax(min(100%, 420px), 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .apiKeySettingsItem {
@@ -1969,8 +1969,9 @@
   line-height: 1;
 }
 
-.apiKeyAliasInput {
+.apiKeyAliasInput:global(.input) {
   width: 100%;
+  border-radius: 999px;
 }
 
 .apiKeySettingsActions {
@@ -2025,7 +2026,7 @@
   gap: 12px 16px;
   padding: 14px;
   border: 1px solid color-mix(in srgb, var(--border-color) 86%, transparent);
-  border-radius: 8px;
+  border-radius: 20px;
   background: color-mix(in srgb, var(--bg-secondary) 76%, transparent);
 }
 
@@ -2134,7 +2135,7 @@
   min-width: 0;
   padding: 9px 10px;
   border: 1px solid var(--border-color);
-  border-radius: 6px;
+  border-radius: 16px;
   background: var(--bg-tertiary);
   font-size: 11px;
   line-height: 1.5;
@@ -2188,6 +2189,10 @@
 }
 
 @include tablet {
+  .apiKeySettingsList {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   .apiKeySettingsItem {
     grid-template-columns: minmax(0, 1fr);
     align-items: stretch;

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -912,15 +912,18 @@ describe('UsagePage toolbar styles', () => {
     expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeySettingsItem\s*\{[^}]*grid-template-columns:\s*minmax\(0, 1fr\);/)
     expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeySettingsItem\s*\{[^}]*align-items:\s*stretch;/)
     expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeyAliasField\s*\{[\s\S]*?width:\s*100%;/)
-    expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeyAliasField\s*\{[\s\S]*?:global\(\.form-group\)\s*\{[\s\S]*?width:\s*100%;/)
-    expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeyAliasField\s*\{[\s\S]*?:global\(\.form-group\)\s*\{[\s\S]*?min-width:\s*0;/)
-    expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeyAliasField\s*\{[\s\S]*?:global\(\.form-group\)\s*\{[\s\S]*?margin-bottom:\s*0;/)
     expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeyAliasInput\s*\{[\s\S]*?max-width:\s*100%;/)
   })
 
   it('keeps Settings data cards and alias controls on the shared rounded layout', () => {
     const apiKeySettingsListBlock = styleRuleBlock(usagePageStyles, '.apiKeySettingsList')
     const apiKeyAliasInputBlock = styleRuleBlock(usagePageStyles, '.apiKeyAliasInput:global(.input)')
+    const apiKeyAliasFieldBlock = usagePageStyles.slice(
+      usagePageStyles.indexOf('.apiKeyAliasField {'),
+      usagePageStyles.indexOf('.apiKeyFieldLabel,'),
+    )
+    const apiKeyNameRowBlock = styleRuleBlock(usagePageStyles, '.apiKeySettingsNameRow')
+    const apiKeyCopyIconBlock = styleRuleBlock(usagePageStyles, '.apiKeySettingsCopyIconButton')
     const sessionSettingsItemBlock = styleRuleBlock(usagePageStyles, '.sessionSettingsItem')
     const tabletBlock = usagePageStyles.slice(
       usagePageStyles.indexOf('@include tablet {\n  .apiKeySettingsList'),
@@ -928,7 +931,16 @@ describe('UsagePage toolbar styles', () => {
     )
 
     expect(apiKeySettingsListBlock).toContain('grid-template-columns: repeat(2, minmax(0, 1fr));')
+    expect(apiKeyAliasInputBlock).toContain('height: 32px;')
+    expect(apiKeyAliasInputBlock).toContain('min-height: 32px;')
+    expect(apiKeyAliasInputBlock).toContain('padding: 6px 12px;')
+    expect(apiKeyAliasInputBlock).toContain('line-height: 18px;')
     expect(apiKeyAliasInputBlock).toContain('border-radius: 999px;')
+    expect(apiKeyAliasInputBlock).not.toContain('height: 40px;')
+    expect(apiKeyAliasFieldBlock).toMatch(/:global\(\.form-group\)\s*\{[\s\S]*?width:\s*100%;[\s\S]*?min-width:\s*0;[\s\S]*?margin-bottom:\s*0;/)
+    expect(apiKeyNameRowBlock).toContain('grid-template-columns: minmax(0, 1fr) auto;')
+    expect(apiKeyCopyIconBlock).toContain('width: 28px;')
+    expect(apiKeyCopyIconBlock).toContain('height: 28px;')
     expect(sessionSettingsItemBlock).toContain('border-radius: 20px;')
     expect(tabletBlock).toMatch(/\.apiKeySettingsList\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\);/)
   })
@@ -1002,7 +1014,7 @@ describe('UsagePage toolbar styles', () => {
 
   it('keeps Session and API Key Settings row actions compact like Model Pricing actions', () => {
     const apiKeyButtonsBlock = usagePageStyles.slice(
-      usagePageStyles.indexOf('.apiKeySettingsCopyButton,'),
+      usagePageStyles.indexOf('.apiKeySettingsSaveButton {'),
       usagePageStyles.indexOf('.sessionSettingsCard:global(.card)')
     )
     const sessionButtonBlock = usagePageStyles.slice(
@@ -1013,7 +1025,8 @@ describe('UsagePage toolbar styles', () => {
     expect(usagePageStyles).not.toContain('.settingsCompactAction')
     expect(apiKeyButtonsBlock).not.toContain('min-height: 40px;')
     expect(sessionButtonBlock).not.toContain('min-height: 40px;')
-    expect(apiKeySettingsSource.match(/appearance="action"/g)).toHaveLength(2)
+    expect(apiKeySettingsSource.match(/appearance="action"/g)).toHaveLength(1)
+    expect(apiKeySettingsSource).not.toContain('styles.apiKeySettingsCopyButton')
     expect(sessionSettingsSource.match(/appearance="action"/g)).toHaveLength(3)
   })
 
@@ -1512,11 +1525,11 @@ describe('Pricing rules component boundary', () => {
 
   it('matches the compact model-pricing control sizes and aligns each rule row', () => {
     expect(priceRulesSource.match(/className=\{styles\.ruleInput\}/g)).toHaveLength(3)
-    expect(styleRuleBlock(priceRulesStyles, '.ruleInput')).toMatch(/height:\s*40px;/)
+    expect(styleRuleBlock(priceRulesStyles, '.ruleInput')).toMatch(/height:\s*32px;/)
     expect(styleRuleBlock(priceRulesStyles, '.ruleInput')).toMatch(/border-radius:\s*999px;/)
     expect(priceRulesStyles).toMatch(/\.ruleRow\s+:global\(\.form-group > label\)\s*\{[\s\S]*?font-size:\s*10px;/)
     expect(styleRuleBlock(priceRulesStyles, '.removeButton')).not.toMatch(/min-height:/)
-    expect(styleRuleBlock(priceRulesStyles, '.removeButton')).toMatch(/margin-top:\s*20px;/)
+    expect(styleRuleBlock(priceRulesStyles, '.removeButton')).toMatch(/margin-top:\s*16px;/)
     expect(priceRulesStyles).not.toContain('.actionButton')
     expect(priceRulesSource.match(/appearance="action"/g)).toHaveLength(4)
     expect(priceRulesSource).not.toContain('usageStyles')

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -918,6 +918,21 @@ describe('UsagePage toolbar styles', () => {
     expect(apiKeySettingsMobileBlock).toMatch(/\.apiKeyAliasInput\s*\{[\s\S]*?max-width:\s*100%;/)
   })
 
+  it('keeps Settings data cards and alias controls on the shared rounded layout', () => {
+    const apiKeySettingsListBlock = styleRuleBlock(usagePageStyles, '.apiKeySettingsList')
+    const apiKeyAliasInputBlock = styleRuleBlock(usagePageStyles, '.apiKeyAliasInput:global(.input)')
+    const sessionSettingsItemBlock = styleRuleBlock(usagePageStyles, '.sessionSettingsItem')
+    const tabletBlock = usagePageStyles.slice(
+      usagePageStyles.indexOf('@include tablet {\n  .apiKeySettingsList'),
+      usagePageStyles.indexOf('@include mobile {\n  .apiKeySettingsCard:global(.card)'),
+    )
+
+    expect(apiKeySettingsListBlock).toContain('grid-template-columns: repeat(2, minmax(0, 1fr));')
+    expect(apiKeyAliasInputBlock).toContain('border-radius: 999px;')
+    expect(sessionSettingsItemBlock).toContain('border-radius: 20px;')
+    expect(tabletBlock).toMatch(/\.apiKeySettingsList\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\);/)
+  })
+
   it('lets Session Management content shrink until it needs to scroll', () => {
     const sessionSettingsBodyBlock = usagePageStyles.slice(
       usagePageStyles.indexOf('.sessionSettingsBody {'),
@@ -959,6 +974,7 @@ describe('UsagePage toolbar styles', () => {
     expect(clientBlock).toMatch(/white-space:\s*normal;/)
     expect(clientBlock).toMatch(/overflow-wrap:\s*anywhere;/)
     expect(clientBlock).toContain('border: 1px solid var(--border-color);')
+    expect(clientBlock).toContain('border-radius: 16px;')
     expect(clientBlock).toContain('background: var(--bg-tertiary);')
     expect(clientBlock).not.toMatch(/text-overflow:\s*ellipsis;/)
     expect(clientBlock).not.toMatch(/white-space:\s*nowrap;/)


### PR DESCRIPTION
## Summary

- align Session Management cards and User-Agent surfaces with the shared rounded styling
- cap API Key Settings at two columns and compact the alias and copy controls
- align Pricing Rules inputs with compact action button sizing
- add interaction coverage for API Key copy success, failure, and reset behavior

## Validation

- Frontend tests: 123 files, 1115 tests passed
- Frontend lint passed
- Frontend typecheck passed
- Frontend build passed