### PR TITLE
fix(credentials): align error event card radii

### DIFF
--- a/web/src/components/usage/credentials/CredentialErrorEventsList.module.scss
+++ b/web/src/components/usage/credentials/CredentialErrorEventsList.module.scss
@@ -30,7 +30,7 @@
   min-width: 0;
   padding: 14px;
   border: 1px solid var(--border-color);
-  border-radius: 10px;
+  border-radius: var(--keeper-card-radius);
   // Drawer 本身使用 bg-primary，卡片切到页面底色后才有清晰但克制的层级。
   background: var(--bg-secondary);
   box-shadow: var(--shadow);
@@ -101,7 +101,7 @@
   margin: 10px 0 0;
   padding: 10px 11px;
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: var(--keeper-card-radius);
   // 与 Session Management 的 User-Agent 共用次级信息面板层级，保证各主题下都能从卡片中分离。
   background: var(--bg-tertiary);
   color: var(--text-primary);

--- a/web/src/components/usage/credentials/test/CredentialErrorEventsList.styles.test.ts
+++ b/web/src/components/usage/credentials/test/CredentialErrorEventsList.styles.test.ts
@@ -19,7 +19,9 @@ const scssRule = (selector: string) => {
 
 describe('Credential error event list styles', () => {
   it('separates error cards and their body from the drawer surface', () => {
+    expect(scssRule('.card')).toContain('border-radius: var(--keeper-card-radius)')
     expect(scssRule('.card')).toContain('background: var(--bg-secondary)')
+    expect(scssRule('.body')).toContain('border-radius: var(--keeper-card-radius)')
     expect(scssRule('.body')).toContain('background: var(--bg-tertiary)')
     expect(scssRule('.body')).toContain('border: 1px solid var(--border-color)')
     expect(scssRule('.body')).toContain('color: var(--text-primary)')


### PR DESCRIPTION
## Summary

- align credential Error event cards with the shared Keeper radius
- apply the same rounded treatment to each JSON/body panel
- add SCSS regression coverage for both surfaces

## Validation

- `/root/projects/cpa-usage-keeper/.codex/skills/cpa-usage-keeper/scripts/verify-local.sh frontend`
- targeted CredentialErrorEventsList tests: 4 passed