### PR TITLE
fix(credentials): align detail overview card styling

### DIFF
--- a/web/src/components/usage/credentials/CredentialDetailDrawer.module.scss
+++ b/web/src/components/usage/credentials/CredentialDetailDrawer.module.scss
@@ -168,15 +168,15 @@
   border-radius: var(--keeper-card-radius);
   background: var(--bg-secondary);
 
-  span,
-  strong,
-  small {
+  > span,
+  > strong,
+  > small {
     display: block;
     min-width: 0;
   }
 
-  span,
-  small {
+  > span,
+  > small {
     color: var(--text-secondary);
     font-size: 10px;
     font-weight: 700;
@@ -185,7 +185,6 @@
   strong {
     margin-top: 7px;
     overflow: hidden;
-    color: var(--text-primary);
     font-size: 20px;
     font-weight: 850;
     font-variant-numeric: tabular-nums;

--- a/web/src/components/usage/credentials/CredentialDetailDrawer.module.scss
+++ b/web/src/components/usage/credentials/CredentialDetailDrawer.module.scss
@@ -165,7 +165,7 @@
   min-width: 0;
   padding: 12px;
   border: 1px solid var(--border-color);
-  border-radius: 9px;
+  border-radius: var(--keeper-card-radius);
   background: var(--bg-secondary);
 
   span,
@@ -214,7 +214,7 @@
   min-width: 0;
   padding: 15px;
   border: 1px solid var(--border-color);
-  border-radius: 10px;
+  border-radius: var(--keeper-card-radius);
   background: var(--bg-primary);
 
   h3 {

--- a/web/src/components/usage/credentials/CredentialDetailDrawer.tsx
+++ b/web/src/components/usage/credentials/CredentialDetailDrawer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react'
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Modal } from '@/components/ui/Modal'
 import { IconRefreshCw } from '@/components/ui/icons'
@@ -9,7 +9,7 @@ import type { ErrorEvent, UsageEvent, UsageEventRequestLogResponse } from '@/lib
 import { AuthFileQuotaPanel } from './AuthFileCredentialsSection'
 import { CredentialErrorEventsList } from './CredentialErrorEventsList'
 import { CredentialHealthPanel } from './CredentialHealthPanel'
-import { CredentialPriorityBadge, formatCredentialNumber, formatCredentialPercent } from './CredentialSectionShell'
+import { CredentialPriorityBadge, cacheReadRateTone, credentialToneClassName, formatCredentialNumber, formatCredentialPercent, successRateTone } from './CredentialSectionShell'
 import { CredentialSubscriptionBadge } from './CredentialSubscriptionBadge'
 import { CredentialRequestEventsList } from './CredentialRequestEventsList'
 import { CodexQuotaHistoryPanel } from './CodexQuotaHistoryPanel'
@@ -494,10 +494,20 @@ export function CredentialDetailDrawer({
         {activeTab === 'overview' ? (
           <section id={overviewPanelId} role="tabpanel" aria-labelledby={overviewTabId} className={styles.overviewPanel}>
           <div className={styles.summaryGrid}>
-            <DetailMetric label={t('usage_stats.total_requests')} value={formatCredentialNumber(row.totalRequests)} detail={`${t('usage_stats.success')} ${formatCredentialNumber(row.successCount)} · ${t('usage_stats.failure')} ${formatCredentialNumber(row.failureCount)}`} />
-            <DetailMetric label={t('usage_stats.success_rate')} value={formatCredentialPercent(row.successRate)} />
+            <DetailMetric
+              label={t('usage_stats.total_requests')}
+              value={formatCredentialNumber(row.totalRequests)}
+              detail={(
+                <>
+                  <span className={credentialStyles.credentialMetricValueSuccess}>{t('usage_stats.success')} {formatCredentialNumber(row.successCount)}</span>
+                  {' · '}
+                  <span className={credentialStyles.credentialMetricValueDanger}>{t('usage_stats.failure')} {formatCredentialNumber(row.failureCount)}</span>
+                </>
+              )}
+            />
+            <DetailMetric valueTone={successRateTone(row.successRate)} label={t('usage_stats.success_rate')} value={formatCredentialPercent(row.successRate)} />
             <DetailMetric label={t('usage_stats.total_tokens')} value={formatCredentialNumber(row.totalTokens)} />
-            <DetailMetric label={t('usage_stats.cache_rate')} value={formatCredentialPercent(row.cacheReadRate)} />
+            <DetailMetric valueTone={cacheReadRateTone(row.cacheReadRate)} label={t('usage_stats.cache_rate')} value={formatCredentialPercent(row.cacheReadRate)} />
           </div>
           <div className={`${styles.overviewGrid} ${selection.kind === 'ai-provider' ? styles.overviewGridSingle : ''}`.trim()}>
             <section className={styles.overviewSection}>
@@ -577,11 +587,15 @@ export function CredentialDetailDrawer({
   )
 }
 
-function DetailMetric({ label, value, detail }: { label: string; value: string; detail?: string }) {
+type DetailMetricTone = 'success' | 'warning' | 'danger' | 'neutral'
+
+function DetailMetric({ valueTone, label, value, detail }: { valueTone?: DetailMetricTone; label: string; value: string; detail?: ReactNode }) {
+  const resolvedValueTone = valueTone ?? 'neutral'
+
   return (
-    <div className={styles.summaryMetric}>
+    <div className={styles.summaryMetric} data-credential-detail-metric-tone={valueTone}>
       <span>{label}</span>
-      <strong>{value}</strong>
+      <strong className={credentialToneClassName('credentialMetricValue', resolvedValueTone)}>{value}</strong>
       {detail ? <small>{detail}</small> : null}
     </div>
   )

--- a/web/src/components/usage/credentials/test/CredentialDetailDrawer.styles.test.ts
+++ b/web/src/components/usage/credentials/test/CredentialDetailDrawer.styles.test.ts
@@ -56,4 +56,14 @@ describe('CredentialDetailDrawer styles', () => {
       expect(radiusDeclarations).toEqual(['border-radius: var(--keeper-card-radius);'])
     }
   })
+
+  it('keeps neutral cards unchanged while allowing list tone classes in request details', () => {
+    const summaryDeclarations = topLevelDeclarations('.summaryMetric')
+
+    expect(summaryDeclarations).toContain('border: 1px solid var(--border-color);')
+    expect(summaryDeclarations).toContain('background: var(--bg-secondary);')
+    expect(scssRule('.summaryMetric')).toContain('> span,\n  > strong,\n  > small')
+    expect(drawerStyles).not.toContain('#3b82f6')
+    expect(drawerStyles).not.toContain('#8b5cf6')
+  })
 })

--- a/web/src/components/usage/credentials/test/CredentialDetailDrawer.styles.test.ts
+++ b/web/src/components/usage/credentials/test/CredentialDetailDrawer.styles.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const drawerStyles = readFileSync(new URL('../CredentialDetailDrawer.module.scss', import.meta.url), 'utf8')
+
+const scssRule = (selector: string) => {
+  const start = drawerStyles.indexOf(selector)
+  expect(start).toBeGreaterThanOrEqual(0)
+
+  const openingBrace = drawerStyles.indexOf('{', start + selector.length)
+  expect(openingBrace).toBeGreaterThan(start)
+  let depth = 1
+  for (let index = openingBrace + 1; index < drawerStyles.length; index += 1) {
+    if (drawerStyles[index] === '{') {
+      depth += 1
+    } else if (drawerStyles[index] === '}' && --depth === 0) {
+      return drawerStyles.slice(start, index + 1)
+    }
+  }
+
+  throw new Error(`Unclosed SCSS rule: ${selector}`)
+}
+
+describe('CredentialDetailDrawer styles', () => {
+  it('uses the shared Keeper radius for every Overview card surface', () => {
+    expect(scssRule('.summaryMetric')).toContain('border-radius: var(--keeper-card-radius);')
+    expect(scssRule('.overviewSection')).toContain('border-radius: var(--keeper-card-radius);')
+  })
+})

--- a/web/src/components/usage/credentials/test/CredentialDetailDrawer.styles.test.ts
+++ b/web/src/components/usage/credentials/test/CredentialDetailDrawer.styles.test.ts
@@ -21,9 +21,39 @@ const scssRule = (selector: string) => {
   throw new Error(`Unclosed SCSS rule: ${selector}`)
 }
 
+const topLevelDeclarations = (selector: string) => {
+  const rule = scssRule(selector)
+  const openingBrace = rule.indexOf('{')
+  const declarations: string[] = []
+  let nestedDepth = 0
+  let declarationStart = openingBrace + 1
+
+  for (let index = declarationStart; index < rule.length; index += 1) {
+    if (rule[index] === '{') {
+      nestedDepth += 1
+    } else if (rule[index] === '}') {
+      if (nestedDepth === 0) {
+        break
+      }
+      nestedDepth -= 1
+      if (nestedDepth === 0) {
+        declarationStart = index + 1
+      }
+    } else if (rule[index] === ';' && nestedDepth === 0) {
+      declarations.push(rule.slice(declarationStart, index + 1).trim())
+      declarationStart = index + 1
+    }
+  }
+
+  return declarations
+}
+
 describe('CredentialDetailDrawer styles', () => {
   it('uses the shared Keeper radius for every Overview card surface', () => {
-    expect(scssRule('.summaryMetric')).toContain('border-radius: var(--keeper-card-radius);')
-    expect(scssRule('.overviewSection')).toContain('border-radius: var(--keeper-card-radius);')
+    for (const selector of ['.summaryMetric', '.overviewSection']) {
+      const radiusDeclarations = topLevelDeclarations(selector).filter((declaration) => /^border-radius\s*:/.test(declaration))
+
+      expect(radiusDeclarations).toEqual(['border-radius: var(--keeper-card-radius);'])
+    }
   })
 })

--- a/web/src/components/usage/credentials/test/CredentialDetailDrawer.test.tsx
+++ b/web/src/components/usage/credentials/test/CredentialDetailDrawer.test.tsx
@@ -291,14 +291,43 @@ describe('CredentialDetailDrawer', () => {
       await Promise.resolve()
     })
 
-    const tonedMetrics = [...document.body.querySelectorAll<HTMLElement>('[data-credential-detail-metric-tone]')]
+    const overviewMetrics = [...document.body.querySelectorAll<HTMLElement>('[class*="summaryMetric"]')]
+    const tonedMetrics = overviewMetrics.filter((metric) => metric.hasAttribute('data-credential-detail-metric-tone'))
     const tones = tonedMetrics.map((metric) => metric.dataset.credentialDetailMetricTone)
 
+    expect(overviewMetrics).toHaveLength(4)
+    expect(overviewMetrics.map((metric) => metric.querySelector('strong')?.className)).toEqual([
+      expect.stringContaining('credentialMetricValueNeutral'),
+      expect.stringContaining('credentialMetricValueWarning'),
+      expect.stringContaining('credentialMetricValueNeutral'),
+      expect.stringContaining('credentialMetricValueNeutral'),
+    ])
     expect(tones).toEqual(['warning', 'neutral'])
-    expect(tonedMetrics[0]?.querySelector('strong')?.className).toContain('credentialMetricValueWarning')
-    expect(tonedMetrics[1]?.querySelector('strong')?.className).toContain('credentialMetricValueNeutral')
     expect(document.body.querySelector('small [class*="credentialMetricValueSuccess"]')?.textContent).toBe('usage_stats.success 9')
     expect(document.body.querySelector('small [class*="credentialMetricValueDanger"]')?.textContent).toBe('usage_stats.failure 1')
+  })
+
+  it.each([
+    { label: 'success boundaries', successRate: 95, cacheReadRate: 50, expectedTones: ['success', 'success'] },
+    { label: 'warning boundaries', successRate: 80, cacheReadRate: 20, expectedTones: ['warning', 'warning'] },
+    { label: 'below warning boundaries', successRate: 79.99, cacheReadRate: 19.99, expectedTones: ['danger', 'neutral'] },
+    { label: 'missing rates', successRate: null, cacheReadRate: null, expectedTones: ['neutral', 'neutral'] },
+  ])('uses the shared list thresholds for $label', async ({ successRate, cacheReadRate, expectedTones }) => {
+    await act(async () => {
+      root.render(
+        <CredentialDetailDrawer
+          open
+          selection={{ kind: 'ai-provider', row: { ...row, successRate, cacheReadRate } }}
+          onClose={() => undefined}
+        />,
+      )
+      await Promise.resolve()
+    })
+
+    const tones = [...document.body.querySelectorAll<HTMLElement>('[data-credential-detail-metric-tone]')]
+      .map((metric) => metric.dataset.credentialDetailMetricTone)
+
+    expect(tones).toEqual(expectedTones)
   })
 
   it('loads the dedicated latest-event list lazily and appends the next cursor page on scroll', async () => {

--- a/web/src/components/usage/credentials/test/CredentialDetailDrawer.test.tsx
+++ b/web/src/components/usage/credentials/test/CredentialDetailDrawer.test.tsx
@@ -279,6 +279,28 @@ describe('CredentialDetailDrawer', () => {
     expect(document.activeElement).toBe(requestsTab)
   })
 
+  it('uses the credential list tones for Overview metrics', async () => {
+    await act(async () => {
+      root.render(
+        <CredentialDetailDrawer
+          open
+          selection={selection}
+          onClose={() => undefined}
+        />,
+      )
+      await Promise.resolve()
+    })
+
+    const tonedMetrics = [...document.body.querySelectorAll<HTMLElement>('[data-credential-detail-metric-tone]')]
+    const tones = tonedMetrics.map((metric) => metric.dataset.credentialDetailMetricTone)
+
+    expect(tones).toEqual(['warning', 'neutral'])
+    expect(tonedMetrics[0]?.querySelector('strong')?.className).toContain('credentialMetricValueWarning')
+    expect(tonedMetrics[1]?.querySelector('strong')?.className).toContain('credentialMetricValueNeutral')
+    expect(document.body.querySelector('small [class*="credentialMetricValueSuccess"]')?.textContent).toBe('usage_stats.success 9')
+    expect(document.body.querySelector('small [class*="credentialMetricValueDanger"]')?.textContent).toBe('usage_stats.failure 1')
+  })
+
   it('loads the dedicated latest-event list lazily and appends the next cursor page on scroll', async () => {
     await act(async () => {
       root.render(


### PR DESCRIPTION
## Summary

- align credential and AI provider Overview cards with the shared Keeper card radius
- reuse credential-list semantic tones for Success, Failure, Success Rate, and Cache Rate while keeping the other metrics neutral
- add focused coverage for top-level radius declarations, tone boundaries, and missing-rate fallbacks

## Validation

- 126 test files / 1136 tests
- ESLint
- TypeScript typecheck
- production build