### PR TITLE
fix(credentials): stack mobile detail overview cards

### DIFF
--- a/web/src/components/usage/credentials/CredentialDetailDrawer.module.scss
+++ b/web/src/components/usage/credentials/CredentialDetailDrawer.module.scss
@@ -311,6 +311,10 @@
   .summaryGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .overviewGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 @media (max-width: 420px) {

--- a/web/src/components/usage/credentials/test/CredentialDetailDrawer.styles.test.ts
+++ b/web/src/components/usage/credentials/test/CredentialDetailDrawer.styles.test.ts
@@ -66,4 +66,10 @@ describe('CredentialDetailDrawer styles', () => {
     expect(drawerStyles).not.toContain('#3b82f6')
     expect(drawerStyles).not.toContain('#8b5cf6')
   })
+
+  it('stacks identity and quota cards in the mobile Overview layout', () => {
+    const mobileRules = scssRule('@include mobile')
+
+    expect(mobileRules).toMatch(/\.overviewGrid\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\);/)
+  })
 })


### PR DESCRIPTION
## Summary

- stack credential identity and current quota cards at the mobile breakpoint
- add focused SCSS regression coverage for the mobile Overview grid

## Testing

- `verify-local.sh frontend` (130 files, 1154 tests, ESLint, TypeScript, production build)
- `git diff --check`
- real Keeper full-page mock preview on a mobile-width layout

Related to #454