### PR TITLE
feat(usage): add page-addressable dashboard tabs

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import { KeyOverviewPage } from './pages/KeyOverviewPage';
 import { LoginPage } from './pages/LoginPage';
 import { UsagePage } from './pages/UsagePage';
 import { cpamcEmbedSearch, isCPAMCEmbed, notifyCPAMCEmbedReady } from './embed/cpamcEmbed';
+import { getUsageTabPath, resolveUsageTabFromPath, stripAppBasePath } from './lib/usageNavigation';
 import { useUsageStatsStore } from './stores/useUsageStatsStore';
 
 type AuthState = 'checking' | 'authenticated' | 'unauthenticated';
@@ -18,15 +19,25 @@ export const getRoleHomePath = (role: AuthRole): '/' | '/key-overview' => (
   role === 'api_key_viewer' ? '/key-overview' : '/'
 );
 
-const stripBasePath = (pathname: string, basePath: string | undefined): string => {
-  if (!basePath || basePath === '/' || basePath === '__APP_BASE_PATH__') return pathname || '/';
-  const normalizedBase = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
-  if (!pathname.startsWith(normalizedBase)) return pathname || '/';
-  const stripped = pathname.slice(normalizedBase.length);
-  return stripped || '/';
+export const getRoleTargetPath = (
+  role: AuthRole,
+  currentPath: string,
+  isEmbeddedInCPAMC = false,
+): string => {
+  // 路径白名单与会话角色共同决定落点；未知路径只回到该角色自己的首页。
+  if (role === 'api_key_viewer') return '/key-overview';
+  if (currentPath === '/') return '/';
+
+  const usageTab = resolveUsageTabFromPath(currentPath);
+  if (!usageTab || (isEmbeddedInCPAMC && usageTab === 'ranking')) return '/';
+  return getUsageTabPath(usageTab);
 };
 
-export const shouldNormalizeRolePath = (role: AuthRole, currentPath: string): boolean => currentPath !== getRoleHomePath(role);
+export const shouldNormalizeRolePath = (
+  role: AuthRole,
+  currentPath: string,
+  isEmbeddedInCPAMC = false,
+): boolean => currentPath !== getRoleTargetPath(role, currentPath, isEmbeddedInCPAMC);
 
 function App() {
   const { t } = useTranslation();
@@ -75,10 +86,11 @@ function App() {
 
   useEffect(() => {
     if (authState !== 'authenticated' || !authRole) return;
-    const currentPath = stripBasePath(window.location.pathname, window.__APP_BASE_PATH__);
-    if (!shouldNormalizeRolePath(authRole, currentPath)) return;
-    window.history.replaceState(null, '', appPath(getRoleHomePath(authRole)) + cpamcEmbedSearch());
-  }, [authRole, authState]);
+    const strippedPath = stripAppBasePath(window.location.pathname, window.__APP_BASE_PATH__);
+    const targetPath = getRoleTargetPath(authRole, strippedPath ?? '/', isEmbeddedInCPAMC);
+    if (strippedPath === targetPath) return;
+    window.history.replaceState(null, '', appPath(targetPath) + cpamcEmbedSearch());
+  }, [authRole, authState, isEmbeddedInCPAMC]);
 
   const handlePasswordLogin = useCallback(async (password: string) => {
     setSubmitting(true);
@@ -91,7 +103,9 @@ function App() {
         clearSession();
         return;
       }
-      window.history.replaceState(null, '', appPath('/') + cpamcEmbedSearch());
+      const currentPath = stripAppBasePath(window.location.pathname, window.__APP_BASE_PATH__) ?? '/';
+      const targetPath = getRoleTargetPath(session.role ?? 'admin', currentPath, isEmbeddedInCPAMC);
+      window.history.replaceState(null, '', appPath(targetPath) + cpamcEmbedSearch());
     } catch (error) {
       if (error instanceof ApiError && error.status === 401) {
         setAdminLoginError(t('auth.invalid_password'));
@@ -102,7 +116,7 @@ function App() {
     } finally {
       setSubmitting(false);
     }
-  }, [clearSession, loadSession, t]);
+  }, [clearSession, isEmbeddedInCPAMC, loadSession, t]);
 
   const handleAPIKeyLogin = useCallback(async (apiKey: string) => {
     setSubmitting(true);

--- a/web/src/lib/test/usageNavigation.test.ts
+++ b/web/src/lib/test/usageNavigation.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getUsageTabPath,
+  handleUsageTabKeyActivation,
+  normalizeUsageTabValue,
+  resolveInitialUsageTab,
+  resolveUsageTabFromPath,
+  shouldHandleUsageNavigation,
+  stripAppBasePath,
+} from '../usageNavigation';
+
+describe('usage page navigation', () => {
+  it('maps only the fixed public page paths to existing tabs', () => {
+    const mappings = [
+      ['overview', '/overview'],
+      ['analysis', '/analysis'],
+      ['ranking', '/ranking'],
+      ['events', '/request-events'],
+      ['auth-files', '/auth-files'],
+      ['ai-provider', '/ai-provider'],
+      ['settings', '/settings'],
+    ] as const;
+
+    for (const [tab, path] of mappings) {
+      expect(getUsageTabPath(tab)).toBe(path);
+      expect(resolveUsageTabFromPath(path)).toBe(tab);
+    }
+    expect(resolveUsageTabFromPath('/auth-files/')).toBeNull();
+  });
+
+  it('rejects unknown, nested, encoded, and URL-shaped path input', () => {
+    expect(resolveUsageTabFromPath('/')).toBeNull();
+    expect(resolveUsageTabFromPath('/auth-files/settings')).toBeNull();
+    expect(resolveUsageTabFromPath('/auth-files%2Fsettings')).toBeNull();
+    expect(resolveUsageTabFromPath('/auth-files/../settings')).toBeNull();
+    expect(resolveUsageTabFromPath('/auth-files\\settings')).toBeNull();
+    expect(resolveUsageTabFromPath('/%2e%2e/auth-files')).toBeNull();
+    expect(resolveUsageTabFromPath('//example.com/auth-files')).toBeNull();
+    expect(resolveUsageTabFromPath('https://example.com/auth-files')).toBeNull();
+  });
+
+  it('keeps the legacy stored credential tab alias without accepting it as a route', () => {
+    expect(normalizeUsageTabValue('credentials')).toBe('auth-files');
+    expect(resolveUsageTabFromPath('/credentials')).toBeNull();
+  });
+
+  it('lets a valid direct route override storage while keeping root storage behavior', () => {
+    expect(resolveInitialUsageTab('/cpa/auth-files', '/cpa', 'analysis')).toBe('auth-files');
+    expect(resolveInitialUsageTab('/cpa/', '/cpa', 'analysis')).toBe('analysis');
+    expect(resolveInitialUsageTab('/cpa/', '/cpa', 'credentials')).toBe('auth-files');
+    expect(resolveInitialUsageTab('/cpa/', '/cpa', 'unknown')).toBe('overview');
+  });
+
+  it('strips only the configured app base-path boundary', () => {
+    expect(stripAppBasePath('/cpa/auth-files', '/cpa')).toBe('/auth-files');
+    expect(stripAppBasePath('/cpa', '/cpa/')).toBe('/');
+    expect(stripAppBasePath('/cpattack/auth-files', '/cpa')).toBeNull();
+    expect(stripAppBasePath('/auth-files', '/cpa')).toBeNull();
+    expect(stripAppBasePath('/auth-files', undefined)).toBe('/auth-files');
+  });
+
+  it('intercepts only an unmodified primary-button navigation', () => {
+    const primaryClick = {
+      button: 0,
+      defaultPrevented: false,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+    };
+
+    expect(shouldHandleUsageNavigation(primaryClick)).toBe(true);
+    expect(shouldHandleUsageNavigation({ ...primaryClick, button: 1 })).toBe(false);
+    expect(shouldHandleUsageNavigation({ ...primaryClick, ctrlKey: true })).toBe(false);
+    expect(shouldHandleUsageNavigation({ ...primaryClick, metaKey: true })).toBe(false);
+    expect(shouldHandleUsageNavigation({ ...primaryClick, shiftKey: true })).toBe(false);
+    expect(shouldHandleUsageNavigation({ ...primaryClick, defaultPrevented: true })).toBe(false);
+  });
+
+  it('activates a focused tab link on Space without allowing page scroll', () => {
+    const link = document.createElement('a');
+    link.href = '/auth-files';
+    document.body.appendChild(link);
+    link.focus();
+
+    const activate = vi.fn();
+    link.addEventListener('keydown', (event) => {
+      handleUsageTabKeyActivation(event, 'auth-files', activate);
+    });
+
+    const spaceEvent = new KeyboardEvent('keydown', {
+      key: ' ',
+      bubbles: true,
+      cancelable: true,
+    });
+    expect(document.activeElement).toBe(link);
+    expect(link.dispatchEvent(spaceEvent)).toBe(false);
+    expect(spaceEvent.defaultPrevented).toBe(true);
+    expect(activate).toHaveBeenCalledOnce();
+    expect(activate).toHaveBeenCalledWith('auth-files');
+
+    const enterEvent = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    });
+    expect(link.dispatchEvent(enterEvent)).toBe(true);
+    expect(enterEvent.defaultPrevented).toBe(false);
+    expect(activate).toHaveBeenCalledOnce();
+
+    link.remove();
+  });
+});

--- a/web/src/lib/usageNavigation.ts
+++ b/web/src/lib/usageNavigation.ts
@@ -1,0 +1,87 @@
+export const USAGE_TAB_OPTIONS = [
+  'overview',
+  'analysis',
+  'ranking',
+  'events',
+  'auth-files',
+  'ai-provider',
+  'settings',
+] as const;
+
+export type UsageTab = (typeof USAGE_TAB_OPTIONS)[number];
+export const DEFAULT_USAGE_TAB: UsageTab = 'overview';
+
+const USAGE_TAB_PATHS: Record<UsageTab, string> = {
+  overview: '/overview',
+  analysis: '/analysis',
+  ranking: '/ranking',
+  events: '/request-events',
+  'auth-files': '/auth-files',
+  'ai-provider': '/ai-provider',
+  settings: '/settings',
+};
+
+const USAGE_PATH_TABS = new Map<string, UsageTab>(
+  Object.entries(USAGE_TAB_PATHS).map(([tab, path]) => [path, tab as UsageTab]),
+);
+
+export const normalizeUsageTabValue = (value: unknown): UsageTab | null => {
+  if (value === 'credentials') return 'auth-files';
+  return typeof value === 'string' && USAGE_TAB_OPTIONS.includes(value as UsageTab)
+    ? value as UsageTab
+    : null;
+};
+
+export const getUsageTabPath = (tab: UsageTab): string => USAGE_TAB_PATHS[tab];
+
+export const resolveUsageTabFromPath = (path: string): UsageTab | null => {
+  // 仅精确匹配静态白名单，不兼容尾斜杠或嵌套路径，避免扩大服务端路由边界。
+  return USAGE_PATH_TABS.get(path) ?? null;
+};
+
+export const stripAppBasePath = (pathname: string, basePath: string | undefined): string | null => {
+  if (!basePath || basePath === '/' || basePath === '__APP_BASE_PATH__') return pathname || '/';
+
+  const normalizedBase = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
+  if (pathname === normalizedBase) return '/';
+  if (!pathname.startsWith(`${normalizedBase}/`)) return null;
+
+  return pathname.slice(normalizedBase.length) || '/';
+};
+
+export const resolveInitialUsageTab = (
+  pathname: string,
+  basePath: string | undefined,
+  storedTab: unknown,
+): UsageTab => {
+  const currentPath = stripAppBasePath(pathname, basePath);
+  const routedTab = currentPath === null ? null : resolveUsageTabFromPath(currentPath);
+  return routedTab ?? normalizeUsageTabValue(storedTab) ?? DEFAULT_USAGE_TAB;
+};
+
+type UsageNavigationEvent = Pick<
+  MouseEvent,
+  'altKey' | 'button' | 'ctrlKey' | 'defaultPrevented' | 'metaKey' | 'shiftKey'
+>;
+
+export const shouldHandleUsageNavigation = (event: UsageNavigationEvent): boolean => (
+  !event.defaultPrevented
+  && event.button === 0
+  && !event.altKey
+  && !event.ctrlKey
+  && !event.metaKey
+  && !event.shiftKey
+);
+
+type UsageTabKeyEvent = Pick<KeyboardEvent, 'key' | 'preventDefault'>;
+
+export const handleUsageTabKeyActivation = (
+  event: UsageTabKeyEvent,
+  tab: UsageTab,
+  activate: (tab: UsageTab) => void,
+): void => {
+  // 链接原生支持 Enter；这里只恢复原 button 页签已有的 Space 激活行为。
+  if (event.key !== ' ') return;
+  event.preventDefault();
+  activate(tab);
+};

--- a/web/src/pages/UsagePage.module.scss
+++ b/web/src/pages/UsagePage.module.scss
@@ -348,6 +348,7 @@
   font-size: 12px;
   font-weight: 600;
   line-height: 1.2;
+  text-decoration: none;
   padding: 8px 12px;
   border-radius: 999px;
   cursor: pointer;

--- a/web/src/pages/UsagePage.tsx
+++ b/web/src/pages/UsagePage.tsx
@@ -1,7 +1,8 @@
-import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { useState, useMemo, useCallback, useEffect, useRef, type MouseEvent as ReactMouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ApiError, createUsageEventRequestLogDownloadURL, exportUsageEvents, fetchAnalysis, fetchAnalysisLatency, fetchAuthSessions, fetchCpaApiKeyOptions, fetchCpaApiKeySettings, fetchStatus, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventRequestLog, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchVersion, isUsageRangeBoundsConflict, logout, revokeAuthSession, updateCpaApiKeyAlias, type UsageEventsExportFormat } from '@/lib/api';
+import { ApiError, appPath, createUsageEventRequestLogDownloadURL, exportUsageEvents, fetchAnalysis, fetchAnalysisLatency, fetchAuthSessions, fetchCpaApiKeyOptions, fetchCpaApiKeySettings, fetchStatus, fetchUpdateCheck, fetchUsageEventModelFilterOptions, fetchUsageEventRequestLog, fetchUsageEventSourceFilterOptions, fetchUsageEvents, fetchVersion, isUsageRangeBoundsConflict, logout, revokeAuthSession, updateCpaApiKeyAlias, type UsageEventsExportFormat } from '@/lib/api';
 import type { AnalysisLatencyDiagnostics, AnalysisResponse, AuthManagedSessionItem, CpaApiKeyOption, CpaApiKeySettingsItem, OverviewRealtimeWindow, StatusResponse, UsageCustomRange, UsageEvent, UsageEventRequestLogResponse, UsageSourceFilterOption, UsageTimeRange, VersionResponse } from '@/lib/types';
+import { DEFAULT_USAGE_TAB, getUsageTabPath, handleUsageTabKeyActivation, resolveInitialUsageTab, shouldHandleUsageNavigation, USAGE_TAB_OPTIONS, type UsageTab } from '@/lib/usageNavigation';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { LanguageSwitcher } from '@/components/ui/LanguageSwitcher';
 import { Select } from '@/components/ui/Select';
@@ -46,7 +47,7 @@ import { buildUsageRangeQuery } from '@/utils/usage/rangeQuery';
 import { getDailyAverageCardUsage, isDailyAverageRange } from '@/utils/usage/overview';
 import type { Theme } from '@/types';
 import { BrandLink } from '@/components/BrandLink';
-import { isCPAMCEmbed } from '@/embed/cpamcEmbed';
+import { cpamcEmbedSearch, isCPAMCEmbed } from '@/embed/cpamcEmbed';
 import { RankingPage } from '@/features/ranking/RankingPage';
 import { RankingScopeSwitch } from '@/features/ranking/components/RankingScopeSwitch';
 import { useRankingData } from '@/features/ranking/hooks/useRankingData';
@@ -67,10 +68,8 @@ const THEME_OPTIONS: ReadonlyArray<{ value: Theme; labelKey: string }> = [
   { value: 'dark', labelKey: 'usage_stats.theme_dark' },
   { value: 'auto', labelKey: 'usage_stats.theme_auto' }
 ];
-const USAGE_TAB_OPTIONS = ['overview', 'analysis', 'ranking', 'events', 'auth-files', 'ai-provider', 'settings'] as const;
 const RANKING_PREVIEW_API = resolveRankingPreviewAPI(import.meta.env.VITE_RANKING_PREVIEW_MOCK);
 const LOCAL_RANKING_PREVIEW_API = resolveLocalRankingPreviewAPI(import.meta.env.VITE_RANKING_PREVIEW_MOCK);
-type UsageTab = (typeof USAGE_TAB_OPTIONS)[number];
 type Translate = (key: string) => string;
 const USAGE_TAB_LABEL_KEYS: Record<UsageTab, string> = {
   overview: 'usage_stats.tab_overview',
@@ -81,7 +80,6 @@ const USAGE_TAB_LABEL_KEYS: Record<UsageTab, string> = {
   'ai-provider': 'usage_stats.tab_ai_provider',
   settings: 'usage_stats.tab_settings',
 };
-const DEFAULT_USAGE_TAB: UsageTab = 'overview';
 const USAGE_TAB_STORAGE_KEY = 'cli-proxy-usage-tab-v1';
 const REQUEST_EVENTS_DEFAULT_PAGE_SIZE = 50;
 const REQUEST_EVENTS_CUSTOM_DAY_RANGE_MAX_DAYS = 90;
@@ -611,15 +609,7 @@ const loadTimeRange = (): LoadedUsageRangeState => loadUsageRangeState(
   typeof localStorage === 'undefined' ? undefined : localStorage,
 );
 
-const isUsageTab = (value: unknown): value is UsageTab =>
-  typeof value === 'string' && USAGE_TAB_OPTIONS.includes(value as UsageTab);
-
-export const normalizeUsageTabValue = (value: unknown): UsageTab | null => {
-  if (value === 'credentials') {
-    return 'auth-files';
-  }
-  return isUsageTab(value) ? value : null;
-};
+export { normalizeUsageTabValue } from '@/lib/usageNavigation';
 
 export const getUsageTabOptions = (
   translate: Translate,
@@ -631,15 +621,18 @@ export const getUsageTabOptions = (
   }));
 
 const loadUsageTab = (): UsageTab => {
+  let storedTab: unknown = null;
   try {
-    if (typeof localStorage === 'undefined') {
-      return DEFAULT_USAGE_TAB;
-    }
-    const raw = localStorage.getItem(USAGE_TAB_STORAGE_KEY);
-    return normalizeUsageTabValue(raw) ?? DEFAULT_USAGE_TAB;
+    if (typeof localStorage !== 'undefined') storedTab = localStorage.getItem(USAGE_TAB_STORAGE_KEY);
   } catch {
-    return DEFAULT_USAGE_TAB;
+    // 忽略存储异常；直达路由不依赖 localStorage 仍可工作。
   }
+
+  return resolveInitialUsageTab(
+    typeof window === 'undefined' ? '/' : window.location.pathname,
+    typeof window === 'undefined' ? undefined : window.__APP_BASE_PATH__,
+    storedTab,
+  );
 };
 
 const isOverviewRealtimeWindow = (value: unknown): value is OverviewRealtimeWindow => (
@@ -691,6 +684,17 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
     const loadedTab = loadUsageTab();
     return isEmbeddedInCPAMC && loadedTab === 'ranking' ? DEFAULT_USAGE_TAB : loadedTab;
   });
+  const activateUsageTab = useCallback((tab: UsageTab) => {
+    setActiveTab(tab);
+    window.history.replaceState(null, '', appPath(getUsageTabPath(tab)) + cpamcEmbedSearch());
+  }, []);
+  const handleUsageTabNavigation = useCallback((event: ReactMouseEvent<HTMLAnchorElement>, tab: UsageTab) => {
+    // 普通左键保持现有无刷新切换；组合键和中键交给原生链接打开新页面。
+    if (!shouldHandleUsageNavigation(event.nativeEvent)) return;
+
+    event.preventDefault();
+    activateUsageTab(tab);
+  }, [activateUsageTab]);
   const [rankingScope, setRankingScope] = useState<RankingScope>(loadRankingScope);
   const handleRankingScopeChange = useCallback((scope: RankingScope) => {
     setRankingScope(scope);
@@ -1925,16 +1929,17 @@ export function UsagePage({ onAuthRequired }: { onAuthRequired?: () => void }) {
                 lang={i18n.resolvedLanguage || i18n.language}
               >
                 {tabOptions.map((option) => (
-                  <button
+                  <a
                     key={option.value}
-                    type="button"
+                    href={appPath(getUsageTabPath(option.value)) + cpamcEmbedSearch()}
                     role="tab"
                     aria-selected={activeTab === option.value}
                     className={`${styles.tabPill} ${activeTab === option.value ? styles.tabPillActive : ''}`.trim()}
-                    onClick={() => setActiveTab(option.value)}
+                    onClick={(event) => handleUsageTabNavigation(event, option.value)}
+                    onKeyDown={(event) => handleUsageTabKeyActivation(event, option.value, activateUsageTab)}
                   >
                     {option.label}
-                  </button>
+                  </a>
                 ))}
               </div>
 

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -20,6 +20,7 @@ const credentialStyles = readSource(new URL('../../components/usage/credentials/
 const selectSource = readSource(new URL('../../components/ui/Select.tsx', import.meta.url))
 const apiIndexSource = readSource(new URL('../../components/usage/index.ts', import.meta.url))
 const apiClientSource = readSource(new URL('../../lib/api.ts', import.meta.url))
+const usageNavigationSource = readSource(new URL('../../lib/usageNavigation.ts', import.meta.url))
 const i18nSource = readSource(new URL('../../i18n/index.ts', import.meta.url))
 const typesSource = readSource(new URL('../../lib/types.ts', import.meta.url))
 const pricingDataSource = readSource(new URL('../../components/usage/hooks/usePricingData.ts', import.meta.url))
@@ -826,7 +827,7 @@ describe('UsagePage toolbar styles', () => {
     expect(i18nSource).not.toContain("tab_analysis: 'API & Models'")
     expect(i18nSource).not.toContain("tab_analysis: 'API 与模型'")
     expect(i18nSource).not.toContain("tab_analysis: 'API 與模型'")
-    expect(usagePageSource).toContain("const USAGE_TAB_OPTIONS = ['overview', 'analysis', 'ranking', 'events', 'auth-files', 'ai-provider', 'settings'] as const")
+    expect(usageNavigationSource).toMatch(/USAGE_TAB_OPTIONS = \[\s*'overview',\s*'analysis',\s*'ranking',\s*'events',\s*'auth-files',\s*'ai-provider',\s*'settings',\s*\] as const/)
   })
 
   it('keeps Sign out as the rightmost shared main action after Check Updates', () => {
@@ -865,6 +866,7 @@ describe('UsagePage toolbar styles', () => {
 
   it('removes per-tab frames while keeping connected tab labels stable at every width', () => {
     const connectedTabPill = styleRuleBlock(usagePageStyles, '.tabBarConnected .tabPill')
+    const tabPill = styleRuleBlock(usagePageStyles, '.tabPill')
 
     expect(connectedTabPill).toContain('min-height: 32px;')
     expect(connectedTabPill).toContain('padding: 7px 12px;')
@@ -875,6 +877,25 @@ describe('UsagePage toolbar styles', () => {
     expect(connectedTabPill).toContain('font-weight: 700;')
     expect(connectedTabPill).toContain('white-space: nowrap;')
     expect(connectedTabPill).not.toContain('transform:')
+    expect(tabPill).toContain('text-decoration: none;')
+  })
+
+  it('renders primary navigation as direct links without replacing activeTab rendering', () => {
+    const navigationStart = usagePageSource.indexOf('{tabOptions.map((option) => (')
+    const navigationEnd = usagePageSource.indexOf('))}', navigationStart)
+    const navigationBlock = usagePageSource.slice(navigationStart, navigationEnd)
+
+    expect(navigationStart).toBeGreaterThanOrEqual(0)
+    expect(navigationEnd).toBeGreaterThan(navigationStart)
+    expect(navigationBlock).toContain('<a')
+    expect(navigationBlock).toContain('href={appPath(getUsageTabPath(option.value)) + cpamcEmbedSearch()}')
+    expect(navigationBlock).toContain('onClick={(event) => handleUsageTabNavigation(event, option.value)}')
+    expect(navigationBlock).toContain('onKeyDown={(event) => handleUsageTabKeyActivation(event, option.value, activateUsageTab)}')
+    expect(navigationBlock).toContain('aria-selected={activeTab === option.value}')
+    expect(navigationBlock).not.toContain('<button')
+    expect(usagePageSource).toContain('const activateUsageTab = useCallback((tab: UsageTab) => {')
+    expect(usagePageSource).toContain('setActiveTab(tab);')
+    expect(usagePageSource).toContain("window.history.replaceState(null, '', appPath(getUsageTabPath(tab)) + cpamcEmbedSearch());")
   })
 
   it('widens simplified and traditional Chinese tabs without separating the connected segments', () => {

--- a/web/src/pages/test/UsagePageCPAMCEmbed.test.ts
+++ b/web/src/pages/test/UsagePageCPAMCEmbed.test.ts
@@ -5,7 +5,7 @@ const usagePageSource = readFileSync(new URL('../UsagePage.tsx', import.meta.url
 
 describe('UsagePage CPAMC embed behavior', () => {
   it('does not render the Back to CPA link in CPAMC embed mode', () => {
-    expect(usagePageSource).toContain("import { isCPAMCEmbed } from '@/embed/cpamcEmbed';");
+    expect(usagePageSource).toMatch(/import \{[^}]*\bisCPAMCEmbed\b[^}]*\} from '@\/embed\/cpamcEmbed';/);
     expect(usagePageSource).toMatch(/const isEmbeddedInCPAMC = isCPAMCEmbed\(\);/);
     expect(usagePageSource).toMatch(/\{\(!isEmbeddedInCPAMC && cpaManagementURL\) && \(/);
   });

--- a/web/src/test/AppUsageNavigation.test.ts
+++ b/web/src/test/AppUsageNavigation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { getRoleTargetPath, shouldNormalizeRolePath } from '../App';
+
+describe('App usage-page route authorization', () => {
+  it('allows only known usage routes for administrators', () => {
+    expect(getRoleTargetPath('admin', '/')).toBe('/');
+    expect(getRoleTargetPath('admin', '/auth-files')).toBe('/auth-files');
+    expect(getRoleTargetPath('admin', '/auth-files/')).toBe('/');
+    expect(shouldNormalizeRolePath('admin', '/auth-files/')).toBe(true);
+    expect(getRoleTargetPath('admin', '/request-events')).toBe('/request-events');
+    expect(getRoleTargetPath('admin', '/auth-files/settings')).toBe('/');
+    expect(getRoleTargetPath('admin', '//example.com/auth-files')).toBe('/');
+  });
+
+  it('keeps API key viewers isolated from administrator routes', () => {
+    expect(getRoleTargetPath('api_key_viewer', '/auth-files')).toBe('/key-overview');
+    expect(shouldNormalizeRolePath('api_key_viewer', '/auth-files')).toBe(true);
+    expect(shouldNormalizeRolePath('api_key_viewer', '/key-overview')).toBe(false);
+  });
+
+  it('keeps Ranking unavailable in CPAMC embed mode', () => {
+    expect(getRoleTargetPath('admin', '/ranking', true)).toBe('/');
+    expect(shouldNormalizeRolePath('admin', '/ranking', true)).toBe(true);
+    expect(getRoleTargetPath('admin', '/analysis', true)).toBe('/analysis');
+  });
+});


### PR DESCRIPTION
## Summary

- add exact same-origin URLs for the existing Usage dashboard tabs without replacing `activeTab` or `localStorage`
- render tab navigation as links so direct reloads and native new-tab gestures work
- preserve administrator, API Key Viewer, and CPAMC boundaries while restoring Space-key activation

## Compatibility

- keep `/` and the existing stored-tab behavior unchanged
- support only canonical paths without trailing slashes
- leave backend routing, API handling, and Vite asset configuration unchanged

## Validation

- frontend verification: 133 test files / 1164 tests
- ESLint
- TypeScript typecheck
- production build
- `git diff --check`

Fixes #426
