### PR TITLE
refactor(ranking): extract reusable leaderboard results

### DIFF
--- a/web/src/features/ranking/RankingPage.tsx
+++ b/web/src/features/ranking/RankingPage.tsx
@@ -8,13 +8,12 @@ import { Modal } from '@/components/ui/Modal';
 import { QuestionMarkHelp } from '@/components/ui/QuestionMarkHelp';
 import { RankingApiError } from './api';
 import { RankingAvatar } from './components/RankingAvatar';
+import { RankingLeaderboardResults } from './components/RankingLeaderboardResults';
 import { RankingMetricSelect, RankingToolbar } from './components/RankingToolbar';
-import { formatLeaderboardValue, formatOverallMetricValue } from './format';
 import { normalizeRankingDisplayName, RANKING_DISPLAY_NAME_MAX_LENGTH, type RankingProfileError } from './profile';
 import type {
   LocalRankingProfileRequest,
   LocalRankingProfileResponse,
-  RankingDetailMetric,
   RankingLeaderboardEntry,
   RankingLeaderboardResponse,
   RankingMetadataResponse,
@@ -27,15 +26,6 @@ import type {
 import styles from './RankingPage.module.scss';
 
 const AVATAR_IDS = Array.from({ length: 66 }, (_, index) => index + 1);
-const OVERALL_METRICS: RankingDetailMetric[] = [
-  'total_tokens',
-  'request_count',
-  'cache_read_rate',
-  'ttft_average',
-  'latency_average',
-  'peak_tpm',
-  'peak_rpm',
-];
 
 type RankingAction = 'join' | 'sync' | 'pause' | 'resume' | 'exit' | null;
 type ProfileAction = Exclude<RankingAction, 'join' | null>;
@@ -701,8 +691,6 @@ function LeaderboardCard({
   language,
 }: LeaderboardCardProps) {
   const rows = useMemo(() => board?.entries.slice(0, 100) ?? [], [board]);
-  const podium = rows.slice(0, 3);
-  const tableRows = rows;
   const scoreExplanation = resolveScoreExplanation(scoreExplanationBoard, metric, language);
   const hasRankingProfile = status?.status === 'active' || status?.status === 'paused';
   const profileActionAriaLabel = hasRankingProfile && status.display_name
@@ -806,132 +794,14 @@ function LeaderboardCard({
           description={t(scope === 'local' ? 'ranking.local_empty_description' : 'ranking.empty_description')}
         />
       ) : (
-        <div className={styles.leaderboardResults}>
-          <div className={styles.podiumGrid} aria-label={`${t('ranking.rank')} 1–3`} data-ranking-podium>
-            {podium.map((entry, index) => (
-              <PodiumCard
-                key={entry.participant_id}
-                entry={entry}
-                position={index + 1}
-                metric={metric}
-                scope={scope}
-                onEditLocalProfile={onEditLocalProfile}
-                t={t}
-              />
-            ))}
-          </div>
-          {tableRows.length > 0 ? (
-            <div className={styles.tableScroll}>
-              <table className={styles.table}>
-                <thead>
-                  <tr>
-                    <th className={styles.rankColumn} data-ranking-rank-column>{t('ranking.rank')}</th>
-                    <th className={styles.participantColumn} data-ranking-participant-column>
-                      {t(scope === 'local' ? 'ranking.api_key' : 'ranking.participant')}
-                    </th>
-                    {metric === 'overall' ? (
-                      <>
-                        <th className={styles.numberCell}>{t('ranking.score')}</th>
-                        {OVERALL_METRICS.map((item) => <th key={item} className={styles.numberCell}>{t(`ranking.metric_short_${item}`)}</th>)}
-                      </>
-                    ) : <th className={styles.numberCell}>{t(`ranking.metric_${metric}`)}</th>}
-                  </tr>
-                </thead>
-                <tbody>
-                  {tableRows.map((entry, index) => (
-                    <tr key={entry.participant_id} data-ranking-row>
-                      <td className={styles.rankColumn} data-ranking-rank-column>
-                        <span className={styles.rankBadge} data-ranking-position>{index + 1}</span>
-                      </td>
-                      <td className={styles.participantColumn} data-ranking-participant-column>
-                        <div className={styles.participantCell}>
-                          <LeaderboardEntryAvatar
-                            entry={entry}
-                            scope={scope}
-                            className={styles.tableAvatar}
-                            onEditLocalProfile={onEditLocalProfile}
-                            t={t}
-                          />
-                          <strong>{entry.display_name}</strong>
-                        </div>
-                      </td>
-                      {metric === 'overall' ? (
-                        <>
-                          <td className={`${styles.numberCell} ${styles.scoreCell}`.trim()}>{formatLeaderboardValue(metric, entry, scope)}</td>
-                          {OVERALL_METRICS.map((item) => (
-                            <td key={item} className={styles.numberCell}>{formatOverallMetricValue(item, entry)}</td>
-                          ))}
-                        </>
-                      ) : <td className={`${styles.numberCell} ${styles.scoreCell}`.trim()}>{formatLeaderboardValue(metric, entry, scope)}</td>}
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          ) : null}
-        </div>
+        <RankingLeaderboardResults
+          scope={scope}
+          metric={metric}
+          entries={rows}
+          onEditLocalProfile={onEditLocalProfile}
+        />
       )}
     </article>
-  );
-}
-
-function PodiumCard({ entry, position, metric, scope, onEditLocalProfile, t }: {
-  entry: RankingLeaderboardEntry;
-  position: number;
-  metric: RankingMetric;
-  scope: RankingScope;
-  onEditLocalProfile: (entry: RankingLeaderboardEntry) => void;
-  t: Translate;
-}) {
-  const value = formatLeaderboardValue(metric, entry, scope);
-  const valueSizeClass = value.length >= 11
-    ? styles.podiumValueCompact
-    : value.length >= 8
-      ? styles.podiumValueMedium
-      : '';
-
-  return (
-    <article
-      className={`${styles.podiumCard} ${styles[`podiumCard${position}` as keyof typeof styles]}`.trim()}
-      data-ranking-podium-rank={position}
-    >
-      <div className={styles.podiumRank}>
-        <span>{t('ranking.rank')}</span>
-        <strong>{String(position).padStart(2, '0')}</strong>
-      </div>
-      <LeaderboardEntryAvatar
-        entry={entry}
-        scope={scope}
-        className={styles.podiumAvatar}
-        onEditLocalProfile={onEditLocalProfile}
-        t={t}
-      />
-      <strong className={styles.podiumName}>{entry.display_name}</strong>
-      <span className={`${styles.podiumValue} ${valueSizeClass}`.trim()}>{value}</span>
-    </article>
-  );
-}
-
-function LeaderboardEntryAvatar({ entry, scope, className, onEditLocalProfile, t }: {
-  entry: RankingLeaderboardEntry;
-  scope: RankingScope;
-  className: string;
-  onEditLocalProfile: (entry: RankingLeaderboardEntry) => void;
-  t: Translate;
-}) {
-  if (scope !== 'local') {
-    return <RankingAvatar avatarID={entry.avatar_id} name={entry.display_name} className={className} decorative />;
-  }
-  return (
-    <button
-      type="button"
-      className={`${styles.localProfileAvatarButton} ${className}`.trim()}
-      aria-label={t('ranking.local_profile_edit_label', { name: entry.display_name })}
-      onClick={() => onEditLocalProfile(entry)}
-      data-ranking-local-profile-edit={entry.participant_id}
-    >
-      <RankingAvatar avatarID={entry.avatar_id} name={entry.display_name} decorative />
-    </button>
   );
 }
 

--- a/web/src/features/ranking/components/RankingLeaderboardResults.tsx
+++ b/web/src/features/ranking/components/RankingLeaderboardResults.tsx
@@ -1,0 +1,159 @@
+import { useTranslation } from 'react-i18next';
+import { formatLeaderboardValue, formatOverallMetricValue } from '../format';
+import type {
+  RankingDetailMetric,
+  RankingLeaderboardEntry,
+  RankingMetric,
+  RankingScope,
+} from '../types';
+import styles from '../RankingPage.module.scss';
+import { RankingAvatar } from './RankingAvatar';
+
+const OVERALL_METRICS: RankingDetailMetric[] = [
+  'total_tokens',
+  'request_count',
+  'cache_read_rate',
+  'ttft_average',
+  'latency_average',
+  'peak_tpm',
+  'peak_rpm',
+];
+
+export interface RankingLeaderboardResultsProps {
+  scope: RankingScope;
+  metric: RankingMetric;
+  entries: readonly RankingLeaderboardEntry[];
+  onEditLocalProfile?: (entry: RankingLeaderboardEntry) => void;
+}
+
+export function RankingLeaderboardResults({
+  scope,
+  metric,
+  entries,
+  onEditLocalProfile,
+}: RankingLeaderboardResultsProps) {
+  const { t } = useTranslation();
+  const podium = entries.slice(0, 3);
+
+  return (
+    <div className={styles.leaderboardResults} data-ranking-results>
+      <div className={styles.podiumGrid} aria-label={`${t('ranking.rank')} 1–3`} data-ranking-podium>
+        {podium.map((entry, index) => (
+          <PodiumCard
+            key={entry.participant_id}
+            entry={entry}
+            position={index + 1}
+            metric={metric}
+            scope={scope}
+            onEditLocalProfile={onEditLocalProfile}
+          />
+        ))}
+      </div>
+      <div className={styles.tableScroll}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th className={styles.rankColumn} data-ranking-rank-column>{t('ranking.rank')}</th>
+              <th className={styles.participantColumn} data-ranking-participant-column>
+                {t(scope === 'local' ? 'ranking.api_key' : 'ranking.participant')}
+              </th>
+              {metric === 'overall' ? (
+                <>
+                  <th className={styles.numberCell}>{t('ranking.score')}</th>
+                  {OVERALL_METRICS.map((item) => <th key={item} className={styles.numberCell}>{t(`ranking.metric_short_${item}`)}</th>)}
+                </>
+              ) : <th className={styles.numberCell}>{t(`ranking.metric_${metric}`)}</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((entry, index) => (
+              <tr key={entry.participant_id} data-ranking-row>
+                <td className={styles.rankColumn} data-ranking-rank-column>
+                  <span className={styles.rankBadge} data-ranking-position>{index + 1}</span>
+                </td>
+                <td className={styles.participantColumn} data-ranking-participant-column>
+                  <div className={styles.participantCell}>
+                    <LeaderboardEntryAvatar
+                      entry={entry}
+                      scope={scope}
+                      className={styles.tableAvatar}
+                      onEditLocalProfile={onEditLocalProfile}
+                    />
+                    <strong>{entry.display_name}</strong>
+                  </div>
+                </td>
+                {metric === 'overall' ? (
+                  <>
+                    <td className={`${styles.numberCell} ${styles.scoreCell}`.trim()}>{formatLeaderboardValue(metric, entry, scope)}</td>
+                    {OVERALL_METRICS.map((item) => (
+                      <td key={item} className={styles.numberCell}>{formatOverallMetricValue(item, entry)}</td>
+                    ))}
+                  </>
+                ) : <td className={`${styles.numberCell} ${styles.scoreCell}`.trim()}>{formatLeaderboardValue(metric, entry, scope)}</td>}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function PodiumCard({ entry, position, metric, scope, onEditLocalProfile }: {
+  entry: RankingLeaderboardEntry;
+  position: number;
+  metric: RankingMetric;
+  scope: RankingScope;
+  onEditLocalProfile?: (entry: RankingLeaderboardEntry) => void;
+}) {
+  const { t } = useTranslation();
+  const value = formatLeaderboardValue(metric, entry, scope);
+  const valueSizeClass = value.length >= 11
+    ? styles.podiumValueCompact
+    : value.length >= 8
+      ? styles.podiumValueMedium
+      : '';
+
+  return (
+    <article
+      className={`${styles.podiumCard} ${styles[`podiumCard${position}` as keyof typeof styles]}`.trim()}
+      data-ranking-podium-rank={position}
+    >
+      <div className={styles.podiumRank}>
+        <span>{t('ranking.rank')}</span>
+        <strong>{String(position).padStart(2, '0')}</strong>
+      </div>
+      <LeaderboardEntryAvatar
+        entry={entry}
+        scope={scope}
+        className={styles.podiumAvatar}
+        onEditLocalProfile={onEditLocalProfile}
+      />
+      <strong className={styles.podiumName}>{entry.display_name}</strong>
+      <span className={`${styles.podiumValue} ${valueSizeClass}`.trim()}>{value}</span>
+    </article>
+  );
+}
+
+function LeaderboardEntryAvatar({ entry, scope, className, onEditLocalProfile }: {
+  entry: RankingLeaderboardEntry;
+  scope: RankingScope;
+  className: string;
+  onEditLocalProfile?: (entry: RankingLeaderboardEntry) => void;
+}) {
+  const { t } = useTranslation();
+  if (scope !== 'local' || !onEditLocalProfile) {
+    return <RankingAvatar avatarID={entry.avatar_id} name={entry.display_name} className={className} decorative />;
+  }
+  return (
+    <button
+      type="button"
+      className={`${styles.localProfileAvatarButton} ${className}`.trim()}
+      aria-label={t('ranking.local_profile_edit_label', { name: entry.display_name })}
+      onClick={() => onEditLocalProfile(entry)}
+      data-ranking-local-profile-edit={entry.participant_id}
+    >
+      <RankingAvatar avatarID={entry.avatar_id} name={entry.display_name} decorative />
+    </button>
+  );
+}

--- a/web/src/features/ranking/components/test/RankingLeaderboardResults.test.tsx
+++ b/web/src/features/ranking/components/test/RankingLeaderboardResults.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RankingLeaderboardResults } from '../RankingLeaderboardResults';
+import type { RankingLeaderboardEntry } from '../../types';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string | number>) => params ? `${key}:${JSON.stringify(params)}` : key,
+  }),
+}));
+
+const entries: RankingLeaderboardEntry[] = [
+  { rank: 1, participant_id: '1', display_name: 'Alpha', avatar_id: 1, value: 100 },
+  { rank: 2, participant_id: '2', display_name: 'Beta', avatar_id: 2, value: 90 },
+  { rank: 3, participant_id: '3', display_name: 'Gamma', avatar_id: 3, value: 80 },
+  { rank: 4, participant_id: '4', display_name: 'Delta', avatar_id: 4, value: 70 },
+];
+
+describe('RankingLeaderboardResults', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    document.body.replaceChildren();
+  });
+
+  it('renders the same local podium and table as a read-only view without an edit callback', async () => {
+    await act(async () => {
+      root.render(<RankingLeaderboardResults scope="local" metric="overall" entries={entries} />);
+    });
+
+    expect(container.querySelectorAll('[data-ranking-podium-rank]')).toHaveLength(3);
+    expect(container.querySelectorAll('[data-ranking-row]')).toHaveLength(4);
+    expect(container.querySelectorAll('[data-ranking-local-profile-edit]')).toHaveLength(0);
+    expect(container.querySelector('[data-ranking-participant-column]')?.textContent).toBe('ranking.api_key');
+  });
+
+  it('exposes both podium and table avatar edits only when the caller provides the action', async () => {
+    const onEditLocalProfile = vi.fn();
+    await act(async () => {
+      root.render(
+        <RankingLeaderboardResults
+          scope="local"
+          metric="overall"
+          entries={entries}
+          onEditLocalProfile={onEditLocalProfile}
+        />,
+      );
+    });
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>(
+        '[data-ranking-podium-rank="1"] [data-ranking-local-profile-edit="1"]',
+      )?.click();
+    });
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>(
+        'tbody [data-ranking-local-profile-edit="4"]',
+      )?.click();
+    });
+
+    expect(onEditLocalProfile).toHaveBeenNthCalledWith(1, entries[0]);
+    expect(onEditLocalProfile).toHaveBeenNthCalledWith(2, entries[3]);
+  });
+});


### PR DESCRIPTION
## Summary

- extract the ranking podium and leaderboard table into reusable RankingLeaderboardResults
- keep toolbar, loading and error states, community management, and local profile dialogs in RankingPage
- make local avatar editing opt-in so future API-key callers can render the same results read-only

## Validation

- 141 frontend test files and 1191 tests passed
- ESLint passed
- TypeScript typecheck passed
- production build passed
- git diff --check passed
- project-skill review found no P0-P3 issues
- backend-served page, health, and session endpoints returned HTTP 200

Related to #460