### PR TITLE
fix(request-events): open export menu only on click

### DIFF
--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -353,8 +353,6 @@ function RequestEventsExportMenu({
   return (
     <div
       className={styles.requestEventsExportMenu}
-      onMouseEnter={() => !disabled && setOpen(true)}
-      onMouseLeave={() => setOpen(false)}
       onKeyDown={handleKeyDown}
       onBlur={handleBlur}
     >

--- a/web/src/components/usage/test/RequestEventsDetailsCardExportMenu.test.tsx
+++ b/web/src/components/usage/test/RequestEventsDetailsCardExportMenu.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RequestEventsDetailsCard } from '../RequestEventsDetailsCard';
+
+const baseProps: React.ComponentProps<typeof RequestEventsDetailsCard> = {
+  events: [],
+  loading: false,
+  totalCount: 0,
+  modelOptions: [],
+  sourceOptions: [],
+  modelFilter: '__all__',
+  sourceFilter: '__all__',
+  resultFilter: '__all__',
+  onModelFilterChange: () => undefined,
+  onSourceFilterChange: () => undefined,
+  onResultFilterChange: () => undefined,
+};
+
+describe('RequestEventsDetailsCard export menu', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('opens only after a click and keeps the existing format selection behavior', async () => {
+    const onExport = vi.fn();
+    await act(async () => {
+      root.render(<RequestEventsDetailsCard {...baseProps} onExport={onExport} />);
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>('button[aria-haspopup="menu"]');
+    const menuRoot = trigger?.closest<HTMLDivElement>('div');
+    expect(trigger).not.toBeNull();
+    expect(menuRoot).not.toBeNull();
+    expect(container.querySelector('[role="menu"]')).toBeNull();
+
+    await act(async () => {
+      menuRoot?.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    });
+    expect(container.querySelector('[role="menu"]')).toBeNull();
+
+    await act(async () => trigger?.click());
+    expect(container.querySelector('[role="menu"]')).not.toBeNull();
+
+    await act(async () => {
+      menuRoot?.dispatchEvent(new MouseEvent('mouseout', { bubbles: true, relatedTarget: document.body }));
+    });
+    expect(container.querySelector('[role="menu"]')).not.toBeNull();
+
+    const jsonItem = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'))
+      .find((item) => item.textContent?.includes('JSON'));
+    await act(async () => jsonItem?.click());
+
+    expect(onExport).toHaveBeenCalledOnce();
+    expect(onExport).toHaveBeenCalledWith('json');
+    expect(container.querySelector('[role="menu"]')).toBeNull();
+  });
+});

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -1543,7 +1543,7 @@ describe('UsagePage toolbar styles', () => {
     expect(priceSettingsSource).not.toContain('styles.usagePillAction')
   })
 
-  it('keeps the Request Event export menu styled and hoverable like the credential inspection control', () => {
+  it('keeps the Request Event export menu aligned with the credential inspection control', () => {
     const exportMenuBlock = styleRuleBlock(usagePageStyles, '.requestEventsExportMenu')
     const exportDropdownBlock = usagePageStyles.slice(
       usagePageStyles.indexOf('.requestEventsExportDropdown {'),


### PR DESCRIPTION
## Summary

- open the Request Event export format menu only after a button click
- keep the click-opened menu stable when the pointer leaves
- cover hover, click, and format selection behavior with an interaction test

## Testing

- frontend test suite: 141 files, 1190 tests
- ESLint
- TypeScript typecheck
- production build