### PR TITLE
fix(auth): remove API key viewer query limits

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -6,7 +6,6 @@ import (
 	"net/netip"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"cpa-usage-keeper/internal/auth"
@@ -48,9 +47,6 @@ type authHandler struct {
 	sessions          *auth.SessionManager
 	cpaAPIKeyProvider service.CPAAPIKeyProvider
 	loginAttempts     *auth.LoginAttemptLimiter
-
-	mu                  sync.Mutex
-	keyOverviewRequests map[string]time.Time
 }
 
 type loginRequest struct {
@@ -107,7 +103,6 @@ func NewAuthHandler(config AuthConfig, sessions *auth.SessionManager) *authHandl
 			GlobalLimit:    loginAttemptGlobalMax,
 			MaxSources:     loginAttemptSourceMax,
 		}),
-		keyOverviewRequests: make(map[string]time.Time),
 	}
 }
 
@@ -352,56 +347,12 @@ func (h *authHandler) allowLoginAttempt(c *gin.Context, key string) bool {
 	return false
 }
 
-func (h *authHandler) allowKeyOverviewRequest(token string, scopes ...string) bool {
-	if h == nil || token == "" {
-		return true
-	}
-	scope := "overview"
-	if len(scopes) > 0 && strings.TrimSpace(scopes[0]) != "" {
-		scope = strings.TrimSpace(scopes[0])
-	}
-	key := token
-	if scope != "overview" {
-		key = token + "\x00" + scope
-	}
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	now := time.Now()
-	if last, ok := h.keyOverviewRequests[key]; ok && now.Sub(last) < time.Second {
-		return false
-	}
-	h.keyOverviewRequests[key] = now
-	return true
-}
-
 func (h *authHandler) deleteSession(token string) {
 	if h == nil || token == "" {
 		return
 	}
 	if h.sessions != nil {
 		h.sessions.Delete(token)
-	}
-	h.clearSessionState(token)
-}
-
-func (h *authHandler) clearSessionStateForTokens(tokens []string) {
-	for _, token := range tokens {
-		h.clearSessionState(token)
-	}
-}
-
-func (h *authHandler) clearSessionState(token string) {
-	if h == nil || token == "" {
-		return
-	}
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	delete(h.keyOverviewRequests, token)
-	prefix := token + "\x00"
-	for key := range h.keyOverviewRequests {
-		if strings.HasPrefix(key, prefix) {
-			delete(h.keyOverviewRequests, key)
-		}
 	}
 }
 

--- a/internal/api/auth_sessions.go
+++ b/internal/api/auth_sessions.go
@@ -109,7 +109,6 @@ func (h *authHandler) revokeManagedSession(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "session not found"})
 		return
 	}
-	h.clearSessionStateForTokens(result.Tokens)
 	if sessionID == currentAuthSessionHash(c) {
 		clearSessionCookie(c, h.config.BasePath, resolveSessionToken(c).CookieKind)
 	}

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -301,73 +301,14 @@ func TestAuthSessionClearsInactiveViewerSession(t *testing.T) {
 	}
 }
 
-func TestAuthLogoutClearsKeyOverviewRateLimitForSession(t *testing.T) {
-	sessions := auth.NewSessionManager(time.Hour)
-	token, _, err := sessions.CreateAPIKeyViewer(42)
-	if err != nil {
-		t.Fatalf("CreateAPIKeyViewer returned error: %v", err)
-	}
-	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
-	handler := NewAuthHandler(config, sessions)
-	router := NewRouter(nil, nil, nil, nil, config, handler, "")
-
-	if !handler.allowKeyOverviewRequest(token) {
-		t.Fatal("expected initial key overview request to be allowed")
-	}
-
-	resp := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
-	req.Header.Set(requestIntentHeaderName, requestIntentHeaderValueFetch)
-	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
-	router.ServeHTTP(resp, req)
-	if resp.Code != http.StatusNoContent {
-		t.Fatalf("expected logout status 204, got %d", resp.Code)
-	}
-	if _, ok := handler.keyOverviewRequests[token]; ok {
-		t.Fatal("expected logout to clear key overview rate limit entry")
-	}
-}
-
-func TestAuthSessionClearsKeyOverviewRateLimitForInactiveViewerSession(t *testing.T) {
-	sessions := auth.NewSessionManager(time.Hour)
-	token, _, err := sessions.CreateAPIKeyViewer(42)
-	if err != nil {
-		t.Fatalf("CreateAPIKeyViewer returned error: %v", err)
-	}
-	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
-	keyProvider := &authCPAAPIKeyStub{findErr: context.Canceled}
-	handler := NewAuthHandler(config, sessions)
-	router := NewRouter(nil, nil, nil, nil, config, handler, "", OptionalProviders{CPAAPIKeys: keyProvider})
-
-	if !handler.allowKeyOverviewRequest(token) {
-		t.Fatal("expected initial key overview request to be allowed")
-	}
-
-	resp := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/session", nil)
-	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
-	router.ServeHTTP(resp, req)
-	if resp.Code != http.StatusOK || !contains(resp.Body.String(), `"authenticated":false`) {
-		t.Fatalf("unexpected inactive session response: %d %s", resp.Code, resp.Body.String())
-	}
-	if _, ok := handler.keyOverviewRequests[token]; ok {
-		t.Fatal("expected inactive viewer session cleanup to clear key overview rate limit entry")
-	}
-}
-
-func TestAuthSessionClearsKeyOverviewRateLimitForExpiredSession(t *testing.T) {
+func TestAuthSessionRejectsExpiredSession(t *testing.T) {
 	sessions := auth.NewSessionManager(-time.Hour)
 	token, _, err := sessions.CreateAPIKeyViewer(42)
 	if err != nil {
 		t.Fatalf("CreateAPIKeyViewer returned error: %v", err)
 	}
 	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: -time.Hour}
-	handler := NewAuthHandler(config, sessions)
-	router := NewRouter(nil, nil, nil, nil, config, handler, "")
-
-	if !handler.allowKeyOverviewRequest(token) {
-		t.Fatal("expected initial key overview request to be allowed")
-	}
+	router := NewRouter(nil, nil, nil, nil, config, NewAuthHandler(config, sessions), "")
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/session", nil)
@@ -376,24 +317,16 @@ func TestAuthSessionClearsKeyOverviewRateLimitForExpiredSession(t *testing.T) {
 	if resp.Code != http.StatusOK || !contains(resp.Body.String(), `"authenticated":false`) {
 		t.Fatalf("unexpected expired session response: %d %s", resp.Code, resp.Body.String())
 	}
-	if _, ok := handler.keyOverviewRequests[token]; ok {
-		t.Fatal("expected expired auth session cleanup to clear key overview rate limit entry")
-	}
 }
 
-func TestAuthMiddlewareClearsKeyOverviewRateLimitForExpiredSession(t *testing.T) {
+func TestAuthMiddlewareRejectsExpiredSession(t *testing.T) {
 	sessions := auth.NewSessionManager(-time.Hour)
 	token, _, err := sessions.CreateAPIKeyViewer(42)
 	if err != nil {
 		t.Fatalf("CreateAPIKeyViewer returned error: %v", err)
 	}
 	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: -time.Hour}
-	handler := NewAuthHandler(config, sessions)
-	router := NewRouter(nil, nil, nil, nil, config, handler, "")
-
-	if !handler.allowKeyOverviewRequest(token) {
-		t.Fatal("expected initial key overview request to be allowed")
-	}
+	router := NewRouter(nil, nil, nil, nil, config, NewAuthHandler(config, sessions), "")
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/usage/overview", nil)
@@ -401,9 +334,6 @@ func TestAuthMiddlewareClearsKeyOverviewRateLimitForExpiredSession(t *testing.T)
 	router.ServeHTTP(resp, req)
 	if resp.Code != http.StatusUnauthorized {
 		t.Fatalf("expected expired session to return 401, got %d %s", resp.Code, resp.Body.String())
-	}
-	if _, ok := handler.keyOverviewRequests[token]; ok {
-		t.Fatal("expected expired middleware session cleanup to clear key overview rate limit entry")
 	}
 }
 

--- a/internal/api/test/key_viewer_query_access_test.go
+++ b/internal/api/test/key_viewer_query_access_test.go
@@ -1,0 +1,54 @@
+package test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	. "cpa-usage-keeper/internal/api"
+	"cpa-usage-keeper/internal/auth"
+	"cpa-usage-keeper/internal/entities"
+	servicedto "cpa-usage-keeper/internal/service/dto"
+)
+
+func TestAPIKeyViewerAllowsRepeatedReadQueries(t *testing.T) {
+	sessions := auth.NewSessionManager(time.Hour)
+	token, _, err := sessions.CreateAPIKeyViewerWithSource(42, auth.SessionSourceStandard)
+	if err != nil {
+		t.Fatalf("create API key viewer session: %v", err)
+	}
+	provider := &usageActivityRouteStub{
+		UsageProvider: &usageEventsStub{},
+		activity: &servicedto.UsageActivitySnapshot{
+			Window:  servicedto.UsageActivityWindowWeek,
+			Grain:   "medium",
+			Rows:    7,
+			Columns: 52,
+			Blocks:  []servicedto.UsageActivityBlock{},
+		},
+	}
+	keyProvider := &authCPAAPIKeyStub{row: entities.CPAAPIKey{
+		ID: 42, APIKey: "provider-a", DisplayKey: "provider-a",
+	}}
+	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
+	router := NewRouter(nil, nil, provider, nil, config, NewAuthHandler(config, sessions), "", OptionalProviders{CPAAPIKeys: keyProvider})
+
+	for _, path := range []string{
+		"/api/v1/key-overview?range=24h",
+		"/api/v1/key-overview/realtime?window=60m",
+		"/api/v1/key-activity?window=year",
+	} {
+		t.Run(path, func(t *testing.T) {
+			for requestNumber := 1; requestNumber <= 2; requestNumber++ {
+				response := httptest.NewRecorder()
+				request := httptest.NewRequest(http.MethodGet, path, nil)
+				request.AddCookie(&http.Cookie{Name: standardSessionCookieName, Value: token})
+				router.ServeHTTP(response, request)
+				if response.Code != http.StatusOK {
+					t.Fatalf("request %d status=%d, want 200: %s", requestNumber, response.Code, response.Body.String())
+				}
+			}
+		})
+	}
+}

--- a/internal/api/test/usage_activity_range_test.go
+++ b/internal/api/test/usage_activity_range_test.go
@@ -267,7 +267,7 @@ func TestUsageActivityReturnsInternalErrorWhenUsageProviderIsMissing(t *testing.
 	}
 }
 
-func TestKeyActivityForcesViewerAPIKeyAndUsesAnIndependentRateLimitScope(t *testing.T) {
+func TestKeyActivityForcesViewerAPIKeyAndIgnoresEventsOnlyFilters(t *testing.T) {
 	sessions := auth.NewSessionManager(time.Hour)
 	token, _, err := sessions.CreateAPIKeyViewerWithSource(42, auth.SessionSourceStandard)
 	if err != nil {
@@ -286,14 +286,6 @@ func TestKeyActivityForcesViewerAPIKeyAndUsesAnIndependentRateLimitScope(t *test
 	keyProvider := &authCPAAPIKeyStub{row: entities.CPAAPIKey{ID: 42, APIKey: "provider-a", DisplayKey: "provider-a"}}
 	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
 	router := NewRouter(nil, nil, provider, nil, config, NewAuthHandler(config, sessions), "", OptionalProviders{CPAAPIKeys: keyProvider})
-
-	overviewResponse := httptest.NewRecorder()
-	overviewRequest := httptest.NewRequest(http.MethodGet, "/api/v1/key-overview?range=24h", nil)
-	overviewRequest.AddCookie(&http.Cookie{Name: standardSessionCookieName, Value: token})
-	router.ServeHTTP(overviewResponse, overviewRequest)
-	if overviewResponse.Code != http.StatusOK {
-		t.Fatalf("key overview status=%d body=%s", overviewResponse.Code, overviewResponse.Body.String())
-	}
 
 	activityResponse := httptest.NewRecorder()
 	activityRequest := httptest.NewRequest(http.MethodGet, "/api/v1/key-activity?window=year&api_key_id=not-a-number&page=0&result=bogus", nil)

--- a/internal/api/usage_activity.go
+++ b/internal/api/usage_activity.go
@@ -155,10 +155,6 @@ func registerKeyActivityRoute(router gin.IRoutes, usageProvider service.UsagePro
 			writeUsageFilterParseError(c, err)
 			return
 		}
-		if authHandler != nil && !authHandler.allowKeyOverviewRequest(fmt.Sprint(token), "activity") {
-			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "too many requests"})
-			return
-		}
 		filter.APIKeyID = fmt.Sprintf("%d", session.CPAAPIKeyID)
 		writeUsageActivityResponse(c, usageProvider, filter)
 	})

--- a/internal/api/usage_overview.go
+++ b/internal/api/usage_overview.go
@@ -196,10 +196,6 @@ func registerKeyOverviewRoute(router gin.IRoutes, usageProvider service.UsagePro
 			writeUsageFilterParseError(c, err)
 			return
 		}
-		if authHandler != nil && !authHandler.allowKeyOverviewRequest(fmt.Sprint(token)) {
-			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "too many requests"})
-			return
-		}
 		filter.APIKeyID = fmt.Sprintf("%d", session.CPAAPIKeyID)
 		writeUsageOverviewResponse(c, usageProvider, filter)
 	})
@@ -226,10 +222,6 @@ func registerKeyOverviewRoute(router gin.IRoutes, usageProvider service.UsagePro
 		filter, err := parseKeyUsageRealtimeFilterQuery(c.Request, timeutil.NormalizeStorageTime(time.Now()))
 		if err != nil {
 			writeUsageFilterParseError(c, err)
-			return
-		}
-		if authHandler != nil && !authHandler.allowKeyOverviewRequest(fmt.Sprint(token), "realtime") {
-			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "too many requests"})
 			return
 		}
 		filter.APIKeyID = fmt.Sprintf("%d", session.CPAAPIKeyID)

--- a/internal/api/usage_overview_test.go
+++ b/internal/api/usage_overview_test.go
@@ -98,14 +98,13 @@ func TestKeyOverviewIgnoresClientAPIKeyIDAndReturnsViewerOverview(t *testing.T) 
 	}
 }
 
-func TestKeyOverviewRealtimeIgnoresClientAPIKeyIDAndAllowsParallelOverviewRequest(t *testing.T) {
+func TestKeyOverviewRealtimeIgnoresClientAPIKeyID(t *testing.T) {
 	sessions := auth.NewSessionManager(time.Hour)
 	token, _, err := sessions.CreateAPIKeyViewer(42)
 	if err != nil {
 		t.Fatalf("CreateAPIKeyViewer returned error: %v", err)
 	}
 	provider := &usageFilterStub{
-		overview: &servicedto.UsageOverviewSnapshot{Usage: &dto.StatisticsSnapshot{TotalRequests: 3}},
 		realtime: &servicedto.UsageOverviewRealtime{
 			Window:        "60m",
 			BucketSeconds: 120,
@@ -119,14 +118,6 @@ func TestKeyOverviewRealtimeIgnoresClientAPIKeyIDAndAllowsParallelOverviewReques
 	keyProvider := &authCPAAPIKeyStub{row: entities.CPAAPIKey{ID: 42, DisplayKey: "sk-*********live"}}
 	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
 	router := NewRouter(nil, nil, provider, nil, config, NewAuthHandler(config, sessions), "", OptionalProviders{CPAAPIKeys: keyProvider})
-
-	overviewResp := httptest.NewRecorder()
-	overviewReq := httptest.NewRequest(http.MethodGet, "/api/v1/key-overview?range=24h", nil)
-	overviewReq.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
-	router.ServeHTTP(overviewResp, overviewReq)
-	if overviewResp.Code != http.StatusOK {
-		t.Fatalf("expected overview status 200, got %d %s", overviewResp.Code, overviewResp.Body.String())
-	}
 
 	realtimeResp := httptest.NewRecorder()
 	realtimeReq := httptest.NewRequest(http.MethodGet, "/api/v1/key-overview/realtime?window=60m&api_key_id=not-a-number", nil)
@@ -154,8 +145,8 @@ func TestKeyOverviewRealtimeIgnoresClientAPIKeyIDAndAllowsParallelOverviewReques
 	if contains(realtimeResp.Body.String(), `"api_keys":`) || contains(realtimeResp.Body.String(), `"auth_files":`) || contains(realtimeResp.Body.String(), `"ai_providers":`) {
 		t.Fatalf("expected key overview realtime to omit internal current-usage dimensions, got %s", realtimeResp.Body.String())
 	}
-	if provider.overviewCalls != 1 || provider.realtimeCalls != 1 {
-		t.Fatalf("expected one overview and one realtime call, got overview=%d realtime=%d", provider.overviewCalls, provider.realtimeCalls)
+	if provider.realtimeCalls != 1 {
+		t.Fatalf("expected one realtime call, got %d", provider.realtimeCalls)
 	}
 }
 
@@ -208,28 +199,6 @@ func TestKeyOverviewReturnsConflictForExpiredCustomRange(t *testing.T) {
 	}
 }
 
-func TestKeyOverviewRateLimitsPerViewerSession(t *testing.T) {
-	sessions := auth.NewSessionManager(time.Hour)
-	token, _, err := sessions.CreateAPIKeyViewer(42)
-	if err != nil {
-		t.Fatalf("CreateAPIKeyViewer returned error: %v", err)
-	}
-	provider := &usageFilterStub{overview: &servicedto.UsageOverviewSnapshot{}}
-	keyProvider := &authCPAAPIKeyStub{row: entities.CPAAPIKey{ID: 42, DisplayKey: "sk-*********live"}}
-	config := AuthConfig{Enabled: true, LoginPassword: "secret", SessionTTL: time.Hour}
-	router := NewRouter(nil, nil, provider, nil, config, NewAuthHandler(config, sessions), "", OptionalProviders{CPAAPIKeys: keyProvider})
-
-	for i, expected := range []int{http.StatusOK, http.StatusTooManyRequests} {
-		resp := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/key-overview?range=24h", nil)
-		req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
-		router.ServeHTTP(resp, req)
-		if resp.Code != expected {
-			t.Fatalf("request %d expected %d, got %d %s", i+1, expected, resp.Code, resp.Body.String())
-		}
-	}
-}
-
 func TestKeyOverviewClearsInactiveViewerSession(t *testing.T) {
 	sessions := auth.NewSessionManager(time.Hour)
 	token, _, err := sessions.CreateAPIKeyViewer(42)
@@ -242,10 +211,6 @@ func TestKeyOverviewClearsInactiveViewerSession(t *testing.T) {
 	handler := NewAuthHandler(config, sessions)
 	router := NewRouter(nil, nil, provider, nil, config, handler, "/cpa", OptionalProviders{CPAAPIKeys: keyProvider})
 
-	if !handler.allowKeyOverviewRequest(token) {
-		t.Fatal("expected initial key overview request to be allowed")
-	}
-
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/cpa/api/v1/key-overview?range=24h", nil)
 	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
@@ -256,9 +221,6 @@ func TestKeyOverviewClearsInactiveViewerSession(t *testing.T) {
 	}
 	if sessions.Validate(token) {
 		t.Fatal("expected inactive viewer session to be deleted")
-	}
-	if _, ok := handler.keyOverviewRequests[token]; ok {
-		t.Fatal("expected inactive key overview cleanup to clear rate limit entry")
 	}
 	cookies := resp.Result().Cookies()
 	if len(cookies) == 0 || cookies[0].Path != "/cpa" || cookies[0].MaxAge >= 0 {

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -263,7 +263,6 @@ type SessionClientMetadata struct {
 
 type RevokeResult struct {
 	Deleted int
-	Tokens  []string
 }
 
 type sessionActivityUpdate struct {
@@ -584,7 +583,6 @@ func (m *SessionManager) DeleteByTokenHash(tokenHash string) RevokeResult {
 		}
 		delete(m.sessions, token)
 		result.Deleted = 1
-		result.Tokens = append(result.Tokens, token)
 	}
 	if m.store != nil {
 		deleted, err := m.store.DeleteByTokenHash(tokenHash)
@@ -610,7 +608,6 @@ func (m *SessionManager) DeleteByRole(role Role) RevokeResult {
 		}
 		delete(m.sessions, token)
 		result.Deleted++
-		result.Tokens = append(result.Tokens, token)
 	}
 	if m.store != nil {
 		deleted, err := m.store.DeleteByRole(role)

--- a/web/src/components/usage/RecentActivityPanel.tsx
+++ b/web/src/components/usage/RecentActivityPanel.tsx
@@ -45,11 +45,9 @@ export function RecentActivityPanel({
     : '';
   const displayError = error === 'ACTIVITY_LOAD_FAILED'
     ? t('usage_stats.recent_activity_load_failed')
-    : error === 'KEY_ACTIVITY_RATE_LIMITED'
-      ? t('usage_stats.recent_activity_rate_limited')
-      : error === 'AUTH_REQUIRED'
-        ? t('auth.session_expired')
-        : error;
+    : error === 'AUTH_REQUIRED'
+      ? t('auth.session_expired')
+      : error;
 
   return (
     <section className={styles.recentActivitySection}>

--- a/web/src/components/usage/hooks/test/useUsageActivityData.test.tsx
+++ b/web/src/components/usage/hooks/test/useUsageActivityData.test.tsx
@@ -231,10 +231,6 @@ describe('useUsageActivityData', () => {
     await renderOptions({ viewer: 'key', request: { range: '8h' }, onAuthRequired });
     expect(onAuthRequired).toHaveBeenCalledTimes(1);
     expect(latest?.error).toBe('AUTH_REQUIRED');
-
-    apiMocks.fetchKeyActivity.mockRejectedValueOnce(new ApiError('limited', 429));
-    await act(async () => latest?.loadActivity());
-    expect(latest?.error).toBe('KEY_ACTIVITY_RATE_LIMITED');
   });
 
   it('normalizes backend failures to the Activity-specific error state', async () => {

--- a/web/src/components/usage/hooks/useUsageActivityData.ts
+++ b/web/src/components/usage/hooks/useUsageActivityData.ts
@@ -97,8 +97,6 @@ export function useUsageActivityData({
         if (nextError instanceof ApiError && nextError.status === 401) {
           message = 'AUTH_REQUIRED';
           onAuthRequired?.();
-        } else if (viewer === 'key' && nextError instanceof ApiError && nextError.status === 429) {
-          message = 'KEY_ACTIVITY_RATE_LIMITED';
         }
         setLoading(false);
         setError(message);

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -78,8 +78,7 @@ const resources = {
         tabs_aria_label: 'API Key overview sections',
         identity_unknown: 'Current API Key',
         logout: 'Sign out',
-        load_failed: 'Unable to load API Key overview',
-        rate_limited: 'The overview is refreshing too often. Please wait a moment before trying again.'
+        load_failed: 'Unable to load API Key overview'
       },
       usage_stats: {
         title: 'Usage',
@@ -688,7 +687,6 @@ const resources = {
         recent_activity_window_month: 'Month',
         recent_activity_window_year: 'Year',
         recent_activity_load_failed: 'Unable to load recent activity.',
-        recent_activity_rate_limited: 'Too many recent activity requests. Please try again shortly.',
         recent_activity_empty: 'No activity data.',
         service_health_unhealthy: 'Unhealthy',
         service_health_healthy: 'Healthy',
@@ -923,8 +921,7 @@ const resources = {
         tabs_aria_label: 'API Key 概览分区',
         identity_unknown: '当前 API Key',
         logout: '退出登录',
-        load_failed: '无法加载 API Key 概览',
-        rate_limited: '概览刷新过于频繁，请稍候再试。'
+        load_failed: '无法加载 API Key 概览'
       },
       usage_stats: {
         title: '用量',
@@ -1533,7 +1530,6 @@ const resources = {
         recent_activity_window_month: '月',
         recent_activity_window_year: '年',
         recent_activity_load_failed: '无法加载最近活动。',
-        recent_activity_rate_limited: '最近活动请求过于频繁，请稍后重试。',
         recent_activity_empty: '暂无活动数据。',
         service_health_unhealthy: '不健康',
         service_health_healthy: '健康',
@@ -1768,8 +1764,7 @@ const resources = {
         tabs_aria_label: 'API Key 總覽分區',
         identity_unknown: '目前 API Key',
         logout: '登出',
-        load_failed: '無法載入 API Key 總覽',
-        rate_limited: '總覽重新整理過於頻繁，請稍候再試。'
+        load_failed: '無法載入 API Key 總覽'
       },
       usage_stats: {
         title: '用量',
@@ -2378,7 +2373,6 @@ const resources = {
         recent_activity_window_month: '月',
         recent_activity_window_year: '年',
         recent_activity_load_failed: '無法載入最近活動。',
-        recent_activity_rate_limited: '最近活動請求過於頻繁，請稍後重試。',
         recent_activity_empty: '暫無活動資料。',
         service_health_unhealthy: '不健康',
         service_health_healthy: '健康',

--- a/web/src/pages/KeyOverviewPage.styles.test.ts
+++ b/web/src/pages/KeyOverviewPage.styles.test.ts
@@ -48,9 +48,9 @@ describe('KeyOverviewPage layout', () => {
     expect(source).toContain('intervalMs: KEY_OVERVIEW_AUTO_REFRESH_INTERVAL_MS')
   })
 
-  it('keeps manual refresh available while background loads are in flight', () => {
-    expect(source).toContain('const refreshDisabled = manualRefreshLoading || refreshThrottled')
-    expect(source).not.toContain('manualRefreshLoading || loading || realtimeLoading || refreshThrottled')
+  it('disables manual refresh only while its own request is in flight', () => {
+    expect(source).toContain('const refreshDisabled = manualRefreshLoading')
+    expect(source).not.toContain('manualRefreshLoading || loading || realtimeLoading')
   })
 
   it('keeps existing realtime data visible during background refreshes', () => {

--- a/web/src/pages/KeyOverviewPage.tsx
+++ b/web/src/pages/KeyOverviewPage.tsx
@@ -30,7 +30,6 @@ const OVERVIEW_REALTIME_WINDOW_STORAGE_KEY = 'cli-proxy-usage-overview-realtime-
 const DEFAULT_TIME_RANGE: UsageTimeRange = 'today';
 const DEFAULT_REALTIME_WINDOW: OverviewRealtimeWindow = '15m';
 const KEY_OVERVIEW_REALTIME_VISIBLE_DIMENSIONS = ['models'] as const;
-const REFRESH_THROTTLE_MS = 1_000;
 const KEY_OVERVIEW_AUTO_REFRESH_INTERVAL_MS = 10_000;
 
 const THEME_OPTIONS: ReadonlyArray<{ value: Theme; labelKey: string }> = [
@@ -168,11 +167,9 @@ export function KeyOverviewPage({ apiKey, onAuthRequired }: KeyOverviewPageProps
   const [error, setError] = useState('');
   const [realtimeError, setRealtimeError] = useState('');
   const [manualRefreshLoading, setManualRefreshLoading] = useState(false);
-  const [refreshThrottled, setRefreshThrottled] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
   const overviewRequestControllerRef = useRef<AbortController | null>(null);
   const realtimeRequestControllerRef = useRef<AbortController | null>(null);
-  const refreshThrottleTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
   const usageRangeQuery = useMemo(() => buildUsageRangeQuery({
     range: timeRange,
     customUnit: customRange?.unit,
@@ -249,10 +246,6 @@ export function KeyOverviewPage({ apiKey, onAuthRequired }: KeyOverviewPageProps
         onAuthRequired?.();
         return;
       }
-      if (nextError instanceof ApiError && nextError.status === 429) {
-        setError('KEY_OVERVIEW_RATE_LIMITED');
-        return;
-      }
       setError(nextError instanceof Error ? nextError.message : 'KEY_OVERVIEW_LOAD_FAILED');
     } finally {
       if (overviewRequestControllerRef.current === controller) {
@@ -284,10 +277,6 @@ export function KeyOverviewPage({ apiKey, onAuthRequired }: KeyOverviewPageProps
         onAuthRequired?.();
         return;
       }
-      if (nextError instanceof ApiError && nextError.status === 429) {
-        setRealtimeError('KEY_OVERVIEW_RATE_LIMITED');
-        return;
-      }
       setRealtimeError('KEY_OVERVIEW_REALTIME_LOAD_FAILED');
     } finally {
       if (realtimeRequestControllerRef.current === controller) {
@@ -313,13 +302,6 @@ export function KeyOverviewPage({ apiKey, onAuthRequired }: KeyOverviewPageProps
     };
   }, [loadRealtime]);
 
-  useEffect(() => () => {
-    if (refreshThrottleTimerRef.current !== null) {
-      window.clearTimeout(refreshThrottleTimerRef.current);
-      refreshThrottleTimerRef.current = null;
-    }
-  }, []);
-
   const refreshKeyOverview = useCallback(async (options: KeyOverviewLoadOptions = {}) => {
     await Promise.all([loadOverview(options), loadActivity(options), loadRealtime(options)]);
   }, [loadActivity, loadOverview, loadRealtime]);
@@ -327,10 +309,6 @@ export function KeyOverviewPage({ apiKey, onAuthRequired }: KeyOverviewPageProps
   const handleAutoRefreshError = useCallback((nextError: unknown) => {
     if (nextError instanceof ApiError && nextError.status === 401) {
       onAuthRequired?.();
-      return;
-    }
-    if (nextError instanceof ApiError && nextError.status === 429) {
-      setError('KEY_OVERVIEW_RATE_LIMITED');
       return;
     }
     setError('KEY_OVERVIEW_LOAD_FAILED');
@@ -376,20 +354,12 @@ export function KeyOverviewPage({ apiKey, onAuthRequired }: KeyOverviewPageProps
     costSparkline,
   } = useSparklines({ usage, loading });
 
-  const refreshDisabled = manualRefreshLoading || refreshThrottled;
+  const refreshDisabled = manualRefreshLoading;
   const handleManualRefresh = useCallback(async () => {
     if (refreshDisabled) return;
     setManualRefreshLoading(true);
     try {
       await refreshKeyOverview();
-      setRefreshThrottled(true);
-      if (refreshThrottleTimerRef.current !== null) {
-        window.clearTimeout(refreshThrottleTimerRef.current);
-      }
-      refreshThrottleTimerRef.current = window.setTimeout(() => {
-        refreshThrottleTimerRef.current = null;
-        setRefreshThrottled(false);
-      }, REFRESH_THROTTLE_MS);
     } finally {
       setManualRefreshLoading(false);
     }
@@ -406,15 +376,11 @@ export function KeyOverviewPage({ apiKey, onAuthRequired }: KeyOverviewPageProps
   }, [onAuthRequired]);
 
   const identityLabel = apiKey?.display_key || t('key_overview.identity_unknown');
-  const displayError = error === 'KEY_OVERVIEW_RATE_LIMITED'
-    ? t('key_overview.rate_limited')
-    : error === 'KEY_OVERVIEW_LOAD_FAILED'
-      ? t('key_overview.load_failed')
-      : error;
+  const displayError = error === 'KEY_OVERVIEW_LOAD_FAILED'
+    ? t('key_overview.load_failed')
+    : error;
   const displayRealtimeError = realtimeError
-    ? realtimeError === 'KEY_OVERVIEW_RATE_LIMITED'
-      ? t('key_overview.rate_limited')
-      : t('usage_stats.overview_realtime_load_failed')
+    ? t('usage_stats.overview_realtime_load_failed')
     : '';
 
   return (


### PR DESCRIPTION
## Summary

- remove per-session query throttling from API key viewer Overview, Realtime, and Activity reads
- remove the frontend refresh cooldown and obsolete 429-specific UI handling
- simplify session revocation state and cover immediate repeated viewer reads

## Validation

- Go test suite passed
- Auth/API targeted verification passed: 400 tests
- frontend verification passed: 142 test files, 1192 tests, ESLint, TypeScript, and production build
- Activity hook targeted verification passed: 11 tests
- `git diff --check`

Related to #460