### PR TITLE
fix(quota): preserve Codex history across additional limits

### DIFF
--- a/internal/quota/codex_header.go
+++ b/internal/quota/codex_header.go
@@ -10,7 +10,7 @@ import (
 
 const codexHeaderPrefix = "X-Codex-"
 
-// codexDecodedHeaderAdditional 保存一次 Header 解码得到的 Additional group，history 永远不遍历它。
+// codexDecodedHeaderAdditional 保存一次 Header 解码得到的 Additional group；history 只用 group 排除污染，不从窗口生成 observation。
 type codexDecodedHeaderAdditional struct {
 	// Group 是 X-Codex-{group}-* 中的稳定 Header group 名称，仅供读取同组窗口。
 	Group string
@@ -26,11 +26,13 @@ type codexDecodedHeaderAdditional struct {
 type codexDecodedHeaderQuota struct {
 	// PlanType 是 X-Codex-Plan-Type，用于现有 subscription cache 输出。
 	PlanType string
+	// ActiveLimit 是 X-Codex-Active-Limit，用于判断无 group 窗口是否只是 Additional 的兼容投影。
+	ActiveLimit string
 	// PrimaryWindow 是无 group 主额度 Primary，允许 cache 未知的正窗口秒数。
 	PrimaryWindow *CodexUsageWindow
 	// SecondaryWindow 是无 group 主额度 Secondary，允许 cache 未知的正窗口秒数。
 	SecondaryWindow *CodexUsageWindow
-	// Additional 保存 cache 所需 group；history 投影不会读取该切片。
+	// Additional 同时服务 cache 投影和 Active-Limit 归属判断，但它的窗口不会进入主额度历史。
 	Additional []codexDecodedHeaderAdditional
 }
 
@@ -52,6 +54,7 @@ func decodeCodexHeaderQuota(headers http.Header) (codexDecodedHeaderQuota, bool)
 	// 主额度两个窗口各解析一次，通用结果同时服务 cache/history 投影。
 	decoded := codexDecodedHeaderQuota{
 		PlanType:        strings.TrimSpace(firstHeaderValue(filtered, "X-Codex-Plan-Type")),
+		ActiveLimit:     strings.TrimSpace(firstHeaderValue(filtered, "X-Codex-Active-Limit")),
 		PrimaryWindow:   parseCodexDecodedHeaderUsageWindow(filtered, codexHeaderPrefix+"Primary-"),
 		SecondaryWindow: parseCodexDecodedHeaderUsageWindow(filtered, codexHeaderPrefix+"Secondary-"),
 	}
@@ -61,6 +64,47 @@ func decodeCodexHeaderQuota(headers http.Header) (codexDecodedHeaderQuota, bool)
 		return codexDecodedHeaderQuota{}, false
 	}
 	return decoded, true
+}
+
+// mainQuotaHistoryAllowed 只根据本次 Header 自带 provenance 决定主历史是否可信，不按请求模型猜测。
+func (decoded codexDecodedHeaderQuota) mainQuotaHistoryAllowed() bool {
+	if strings.TrimSpace(decoded.ActiveLimit) == "" {
+		// 只有原始值确实缺失时才进入旧协议兼容；非空异常值不能被规范化成“缺失”。
+		return true
+	}
+	activeAlias := normalizeCodexLimitAlias(decoded.ActiveLimit)
+	if activeAlias == "" {
+		// 非空却无法形成有效别名时，宁可留下采样缺口，也不能污染主额度历史。
+		return false
+	}
+	for _, additional := range decoded.Additional {
+		// Active-Limit 命中任一 Additional group，说明无 group 窗口只是当前附加额度的兼容投影。
+		if activeAlias == normalizeCodexLimitAlias(additional.Group) {
+			return false
+		}
+	}
+	// 生产普通主额度明确返回 premium；其它未知非空值宁可留下采样缺口，也不能污染主周期。
+	return activeAlias == "premium"
+}
+
+// normalizeCodexLimitAlias 把 Bengalfox 与 codex_bengalfox 收敛成同一别名，仅用于本次解码匹配。
+func normalizeCodexLimitAlias(value string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(value))
+	if trimmed == "" {
+		return ""
+	}
+	var normalized strings.Builder
+	normalized.Grow(len(trimmed))
+	for _, character := range trimmed {
+		if (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9') {
+			normalized.WriteRune(character)
+		}
+	}
+	alias := normalized.String()
+	if strings.HasPrefix(alias, "codex") {
+		alias = strings.TrimPrefix(alias, "codex")
+	}
+	return alias
 }
 
 func (decoded codexDecodedHeaderQuota) cacheOutput() (ProviderOutput, bool) {

--- a/internal/quota/codex_header.go
+++ b/internal/quota/codex_header.go
@@ -28,9 +28,9 @@ type codexDecodedHeaderQuota struct {
 	PlanType string
 	// ActiveLimit 是 X-Codex-Active-Limit，用于判断无 group 窗口是否只是 Additional 的兼容投影。
 	ActiveLimit string
-	// PrimaryWindow 是无 group 主额度 Primary，允许 cache 未知的正窗口秒数。
+	// PrimaryWindow 是无 group Primary；Active-Limit 命中 Additional 时，它可能是兼容投影。
 	PrimaryWindow *CodexUsageWindow
-	// SecondaryWindow 是无 group 主额度 Secondary，允许 cache 未知的正窗口秒数。
+	// SecondaryWindow 是无 group Secondary；归属规则与 PrimaryWindow 相同。
 	SecondaryWindow *CodexUsageWindow
 	// Additional 同时服务 cache 投影和 Active-Limit 归属判断，但它的窗口不会进入主额度历史。
 	Additional []codexDecodedHeaderAdditional
@@ -77,14 +77,25 @@ func (decoded codexDecodedHeaderQuota) mainQuotaHistoryAllowed() bool {
 		// 非空却无法形成有效别名时，宁可留下采样缺口，也不能污染主额度历史。
 		return false
 	}
-	for _, additional := range decoded.Additional {
-		// Active-Limit 命中任一 Additional group，说明无 group 窗口只是当前附加额度的兼容投影。
-		if activeAlias == normalizeCodexLimitAlias(additional.Group) {
-			return false
-		}
+	if decoded.activeLimitMatchesAdditionalGroup(activeAlias) {
+		// Active-Limit 命中 Additional group，无 group 窗口不属于主额度。
+		return false
 	}
 	// 生产普通主额度明确返回 premium；其它未知非空值宁可留下采样缺口，也不能污染主周期。
 	return activeAlias == "premium"
+}
+
+// activeLimitMatchesAdditionalGroup 只匹配本次 Header 已解码的 group，用于识别 Additional 兼容投影。
+func (decoded codexDecodedHeaderQuota) activeLimitMatchesAdditionalGroup(activeAlias string) bool {
+	if activeAlias == "" {
+		return false
+	}
+	for _, additional := range decoded.Additional {
+		if activeAlias == normalizeCodexLimitAlias(additional.Group) {
+			return true
+		}
+	}
+	return false
 }
 
 // normalizeCodexLimitAlias 把 Bengalfox 与 codex_bengalfox 收敛成同一别名，仅用于本次解码匹配。
@@ -108,9 +119,13 @@ func normalizeCodexLimitAlias(value string) string {
 }
 
 func (decoded codexDecodedHeaderQuota) cacheOutput() (ProviderOutput, bool) {
-	// cache 主额度继续只接受既有已知窗口和非负 used percent，不因 history 放宽协议范围。
 	usage := &CodexUsagePayload{PlanType: decoded.PlanType}
-	usage.RateLimit = codexDecodedCacheRateLimit(decoded.PrimaryWindow, decoded.SecondaryWindow)
+	activeAlias := normalizeCodexLimitAlias(decoded.ActiveLimit)
+	// Active-Limit 命中 Additional 时，无 group 窗口是同一额度的兼容投影，由下方 Additional 行唯一输出。
+	if !decoded.activeLimitMatchesAdditionalGroup(activeAlias) {
+		// 普通、缺失或未知 Active-Limit 仍沿用原 cache 合同，只过滤未支持窗口和负 used percent。
+		usage.RateLimit = codexDecodedCacheRateLimit(decoded.PrimaryWindow, decoded.SecondaryWindow)
+	}
 	// Additional group 按已排序解码顺序投影，保持既有 quota row 稳定顺序。
 	for _, additional := range decoded.Additional {
 		rateLimit := codexDecodedCacheRateLimit(additional.PrimaryWindow, additional.SecondaryWindow)

--- a/internal/quota/codex_quota_history_runner.go
+++ b/internal/quota/codex_quota_history_runner.go
@@ -2,15 +2,12 @@ package quota
 
 import (
 	"context"
-	"math"
-	"sort"
 	"strings"
 	"time"
 
 	"cpa-usage-keeper/internal/entities"
 	repositorydto "cpa-usage-keeper/internal/repository/dto"
 
-	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
@@ -71,6 +68,8 @@ type codexQuotaHistoryCurrentState struct {
 	RemainingPercent int
 	// LastObservedAt 是最近一份被接受 observation 的真实观察 instant。
 	LastObservedAt time.Time
+	// LastMaterializedAt 是本进程最近成功写入该账号角色的墙钟时间，只用于五分钟稳定采样。
+	LastMaterializedAt time.Time
 	// PendingIndex 指向 pending 切片中可继续合并的当前尾段；-1 表示尾段已落库或尚不存在。
 	PendingIndex int
 }
@@ -90,49 +89,7 @@ func newCodexQuotaHistoryTimer(delay time.Duration) (<-chan time.Time, func()) {
 	return timer.C, func() { timer.Stop() }
 }
 
-// runCodexQuotaHistoryRunner 串行拥有状态：Header 等待一分钟聚合，低频可信查询到达时立即执行。
-func (s *Service) runCodexQuotaHistoryRunner() {
-	// done channel 必须只由 runner 关闭，StopRefreshTasks 才能确保数据库关闭前不再有 history 写入。
-	defer close(s.codexQuotaHistoryDoneCh)
-	// 当前状态只保存每个账号角色的最新周期；旧周期待写段由 pending 独立保存。
-	current := make(map[codexQuotaHistoryStateKey]codexQuotaHistoryCurrentState)
-
-	for {
-		select {
-		case <-s.codexQuotaHistoryHeaderWake:
-			// 旧 Header wake 可能对应已被可信来源丢弃的队列，无数据时不启动空窗口。
-			if len(s.codexQuotaHistoryHeaderQueue) == 0 {
-				continue
-			}
-			// Header 第一条只启动固定窗口；可信来源可以中断等待并替代同账号角色的待写 Header。
-			timerC, stopTimer := s.codexQuotaHistoryNewTimer(s.codexQuotaHistoryFlushInterval)
-			select {
-			case <-timerC:
-				stopTimer()
-				// 通知只负责唤醒；到点后原子固定两条队列，避免遗漏尚未发布通知的可信输入。
-				s.processPreferredCodexQuotaHistoryInputs(current)
-			case <-s.codexQuotaHistoryTrustedWake:
-				// 可信来源没有人为等待；先写可信事实，再写未被同账号角色覆盖的 Header。
-				stopTimer()
-				s.processPreferredCodexQuotaHistoryInputs(current)
-			case <-s.codexQuotaHistoryStopCh:
-				// shutdown 不再等待剩余窗口，封住新投递后直接处理队列中已经接收的数据。
-				stopTimer()
-				s.flushQueuedCodexQuotaHistoryOnShutdown(current)
-				return
-			}
-		case <-s.codexQuotaHistoryTrustedWake:
-			// 空闲 runner 收到可信来源后同样立即分流两类事实，不创建一分钟 timer。
-			s.processPreferredCodexQuotaHistoryInputs(current)
-		case <-s.codexQuotaHistoryStopCh:
-			// 空闲时收到 shutdown，同样处理 stop 之前已成功入队的全部元素。
-			s.flushQueuedCodexQuotaHistoryOnShutdown(current)
-			return
-		}
-	}
-}
-
-// takeQueuedCodexQuotaHistoryInputs 在生产者短锁下取出两条来源队列，并清除只属于本批的通知。
+// takeQueuedCodexQuotaHistoryInputs 在生产者短锁下固定两条来源队列的本批数量，并清除对应通知。
 func (s *Service) takeQueuedCodexQuotaHistoryInputs(includeHeader bool, includeTrusted bool) []codexQuotaHistoryInput {
 	s.codexQuotaHistoryMu.Lock()
 	headerCount := 0
@@ -151,7 +108,9 @@ func (s *Service) takeQueuedCodexQuotaHistoryInputs(includeHeader bool, includeT
 		default:
 		}
 	}
-	// Header 满载替换也会短暂读取 channel；所有数据消费都在同一锁内完成，批次边界不会混入后续生产者。
+	s.codexQuotaHistoryMu.Unlock()
+
+	// 锁外只读取已经固定的数量，避免 usage 生产者等待 runner 搬运最多 1024 条 Header。
 	inputs := make([]codexQuotaHistoryInput, 0, headerCount+trustedCount)
 	for range headerCount {
 		inputs = append(inputs, <-s.codexQuotaHistoryHeaderQueue)
@@ -159,18 +118,7 @@ func (s *Service) takeQueuedCodexQuotaHistoryInputs(includeHeader bool, includeT
 	for range trustedCount {
 		inputs = append(inputs, <-s.codexQuotaHistoryTrustedQueue)
 	}
-	s.codexQuotaHistoryMu.Unlock()
 	return inputs
-}
-
-// processPreferredCodexQuotaHistoryInputs 固定两条队列，并让可信事实先于未被覆盖的 Header 独立写入。
-func (s *Service) processPreferredCodexQuotaHistoryInputs(current map[codexQuotaHistoryStateKey]codexQuotaHistoryCurrentState) {
-	inputs := s.takeQueuedCodexQuotaHistoryInputs(true, true)
-	candidates := codexQuotaHistoryCandidates(inputs)
-	trusted, remainingHeaders := splitPreferredCodexQuotaHistoryCandidates(candidates)
-	// 可信来源必须先完成 writer 调用；无关 Header 随后单独写入，不能反向延迟可信校准。
-	s.processCodexQuotaHistoryCandidateBatch(current, trusted)
-	s.processCodexQuotaHistoryCandidateBatch(current, remainingHeaders)
 }
 
 // splitPreferredCodexQuotaHistoryCandidates 只丢弃被同账号、同角色可信事实替代的 Header 候选。
@@ -213,52 +161,6 @@ func codexQuotaHistoryCandidateStateKey(candidate codexQuotaHistoryCandidate) co
 	}
 }
 
-// processCodexQuotaHistoryCandidateBatch 只处理同一来源类别，并按账号、窗口和观察时间恢复内部顺序。
-func (s *Service) processCodexQuotaHistoryCandidateBatch(current map[codexQuotaHistoryStateKey]codexQuotaHistoryCurrentState, candidates []codexQuotaHistoryCandidate) {
-	if len(candidates) == 0 {
-		return
-	}
-	// 同一批某个账号窗口恢复失败后直接跳过余下候选；下一批会重新创建集合并自然重试。
-	failedRecoveries := make(map[codexQuotaHistoryStateKey]struct{})
-	verified := s.verifyCodexQuotaHistoryCandidates(candidates)
-	// Redis inbox ID 和主动刷新完成顺序不保证等于各自观察时间；同类来源内部先恢复真实时序。
-	sort.SliceStable(verified, func(left int, right int) bool {
-		leftObservation := verified[left].Observation
-		rightObservation := verified[right].Observation
-		leftAuthIndex := strings.TrimSpace(leftObservation.AuthIndex)
-		rightAuthIndex := strings.TrimSpace(rightObservation.AuthIndex)
-		if leftAuthIndex != rightAuthIndex {
-			return leftAuthIndex < rightAuthIndex
-		}
-		leftWindowRole := strings.ToLower(strings.TrimSpace(leftObservation.WindowRole))
-		rightWindowRole := strings.ToLower(strings.TrimSpace(rightObservation.WindowRole))
-		if leftWindowRole != rightWindowRole {
-			return leftWindowRole < rightWindowRole
-		}
-		return leftObservation.LastObservedAt.Before(rightObservation.LastObservedAt)
-	})
-	pending := make([]repositorydto.CodexMainQuotaObservation, 0, len(verified))
-	for _, candidate := range verified {
-		// 每条 observation 按账号角色恢复/比较；恢复失败只放弃本批同状态键候选。
-		s.mergeCodexQuotaHistoryObservation(current, failedRecoveries, &pending, candidate.Observation, candidate.Source)
-	}
-	s.flushCodexQuotaHistory(current, &pending, codexQuotaHistoryCandidateSourceSummary(verified))
-}
-
-// codexQuotaHistoryCandidateSourceSummary 为一个来源独立 writer 批次生成稳定、去重的诊断列表。
-func codexQuotaHistoryCandidateSourceSummary(candidates []codexQuotaHistoryCandidate) string {
-	sourceSet := make(map[string]struct{}, len(candidates))
-	for _, candidate := range candidates {
-		sourceSet[refreshSourceLogValue(candidate.Source)] = struct{}{}
-	}
-	sources := make([]string, 0, len(sourceSet))
-	for source := range sourceSet {
-		sources = append(sources, source)
-	}
-	sort.Strings(sources)
-	return strings.Join(sources, ",")
-}
-
 // codexQuotaHistoryCandidates 复制最小 observation，并让输入批次退出作用域后释放完整快照引用。
 func codexQuotaHistoryCandidates(inputs []codexQuotaHistoryInput) []codexQuotaHistoryCandidate {
 	// 每个输入最多两个主窗口，容量上限避免正常 Primary/Secondary 批次重复扩容。
@@ -284,213 +186,6 @@ func codexQuotaHistoryCandidates(inputs []codexQuotaHistoryInput) []codexQuotaHi
 		inputs[index].Observations = nil
 	}
 	return candidates
-}
-
-// verifyCodexQuotaHistoryCandidates 批量确认 Header 来源属于活跃 Codex Auth File。
-func (s *Service) verifyCodexQuotaHistoryCandidates(candidates []codexQuotaHistoryCandidate) []codexQuotaHistoryCandidate {
-	if len(candidates) == 0 {
-		return nil
-	}
-	// 未验证集合只收集非空 auth_index；主动查询已由 Check 的活跃身份读取完成验证。
-	authIndexes := make([]string, 0)
-	seen := make(map[string]struct{})
-	for _, candidate := range candidates {
-		if candidate.IdentityVerified {
-			continue
-		}
-		authIndex := strings.TrimSpace(candidate.Observation.AuthIndex)
-		if authIndex == "" {
-			continue
-		}
-		if _, exists := seen[authIndex]; exists {
-			continue
-		}
-		seen[authIndex] = struct{}{}
-		authIndexes = append(authIndexes, authIndex)
-	}
-
-	// verified 保存真正的 Codex Auth File；查询失败时不猜测身份，主动已验证候选仍可继续。
-	verifiedAuthIndexes := make(map[string]struct{}, len(authIndexes))
-	if len(authIndexes) > 0 {
-		ctx, cancel := context.WithTimeout(context.Background(), codexQuotaHistoryDatabaseTimeout)
-		identities, err := s.codexQuotaHistoryListIdentities(ctx, s.db, authIndexes)
-		cancel()
-		if err != nil {
-			logrus.WithError(err).Warn("codex quota history identity verification failed")
-		} else {
-			for _, identity := range identities {
-				// AuthFile 条件由 repository 保证；这里再限制真实类型为 Codex，排除 provider 文本误判。
-				if !usageHeaderIdentityIsCodex(identity) {
-					continue
-				}
-				authIndex := strings.TrimSpace(identity.Identity)
-				if authIndex != "" {
-					verifiedAuthIndexes[authIndex] = struct{}{}
-				}
-			}
-		}
-	}
-
-	// 保持原队列顺序过滤，确保同一账号的百分比状态按真实观察顺序进入单调状态机。
-	verified := make([]codexQuotaHistoryCandidate, 0, len(candidates))
-	for _, candidate := range candidates {
-		if candidate.IdentityVerified {
-			verified = append(verified, candidate)
-			continue
-		}
-		if _, ok := verifiedAuthIndexes[strings.TrimSpace(candidate.Observation.AuthIndex)]; ok {
-			verified = append(verified, candidate)
-		}
-	}
-	return verified
-}
-
-// mergeCodexQuotaHistoryObservation 把单条候选应用到当前周期缓存和独立 pending 容器。
-func (s *Service) mergeCodexQuotaHistoryObservation(current map[codexQuotaHistoryStateKey]codexQuotaHistoryCurrentState, failedRecoveries map[codexQuotaHistoryStateKey]struct{}, pending *[]repositorydto.CodexMainQuotaObservation, observation repositorydto.CodexMainQuotaObservation, source RefreshSource) bool {
-	// runner 只接受构造层已经规范的两个角色；异常 DTO 留给 repository 前先在内存边界拒绝。
-	key := codexQuotaHistoryStateKey{
-		AuthIndex:  strings.TrimSpace(observation.AuthIndex),
-		WindowRole: strings.ToLower(strings.TrimSpace(observation.WindowRole)),
-	}
-	if key.AuthIndex == "" || (key.WindowRole != "primary" && key.WindowRole != "secondary") {
-		return false
-	}
-	observation.AuthIndex = key.AuthIndex
-	observation.WindowRole = key.WindowRole
-	// 三种专门额度接口的可信度只在本次运行期传给 repository，实体和通用历史表不保存来源。
-	observation.Authoritative = codexQuotaHistorySourceIsAuthoritative(source)
-	// 时间计算、整数百分比和累计次数先做轻量校验，避免异常内部调用破坏缓存状态。
-	if observation.WindowSeconds <= 0 || observation.WindowSeconds > math.MaxInt64/int64(time.Second) ||
-		observation.ResetAt.IsZero() || observation.RemainingPercent < 0 || observation.RemainingPercent > 100 ||
-		observation.ObservationCount < 1 {
-		return false
-	}
-
-	// 缓存首次命中或写失败失效后必须从 writer 恢复当前周期，内存不能无条件建立新基线。
-	state, loaded := current[key]
-	if !loaded {
-		if _, failed := failedRecoveries[key]; failed {
-			return false
-		}
-		recovered, err := s.loadCodexQuotaHistoryCurrentState(key)
-		if err != nil {
-			failedRecoveries[key] = struct{}{}
-			logrus.WithError(err).WithFields(logrus.Fields{
-				"auth_index":  key.AuthIndex,
-				"window_role": key.WindowRole,
-			}).Warn("codex quota history state recovery failed")
-			return false
-		}
-		state = recovered
-		current[key] = state
-	}
-
-	// 所有候选必须有可排序时间；repository 仍会在事务内做最终完整校验。
-	if observation.FirstObservedAt.IsZero() || observation.LastObservedAt.IsZero() || observation.FirstObservedAt.After(observation.LastObservedAt) {
-		return false
-	}
-	// 当前周期存在时，先区分同周期、未来新周期和旧周期迟到三种路径。
-	if state.Found {
-		// 窗口秒数变化优先结束旧周期；Weekly→5h 时不能再用更远的 Weekly reset 阻止切换。
-		if state.WindowSeconds != observation.WindowSeconds {
-			if state.HasTail && observation.LastObservedAt.Before(state.LastObservedAt) {
-				return false
-			}
-			state = codexQuotaHistoryStateFromObservation(observation)
-			*pending = append(*pending, observation)
-			state.PendingIndex = len(*pending) - 1
-			current[key] = state
-			return true
-		}
-
-		sameCycle := codexQuotaHistorySameCycle(state, observation)
-		if !sameCycle {
-			// 相同窗口内，observation 时间早于当前尾段或 reset 早于当前周期都属于迟到旧事实。
-			if (state.HasTail && observation.LastObservedAt.Before(state.LastObservedAt)) || observation.ResetAt.Before(state.ResetAt) {
-				return false
-			}
-			// 同窗口 reset 超出两分钟容差后建立新周期，并允许百分比回到高值。
-			state = codexQuotaHistoryStateFromObservation(observation)
-			*pending = append(*pending, observation)
-			state.PendingIndex = len(*pending) - 1
-			current[key] = state
-			return true
-		}
-
-		// 同周期乱序 observation 不允许重排段；可信主动查询也不能用旧事实反向校准边界。
-		if state.HasTail && observation.LastObservedAt.Before(state.LastObservedAt) {
-			return false
-		}
-		// 可信来源可校准两分钟容差内的任意 Header 边界；普通 Header 仍只允许 relative→absolute 升级。
-		boundaryUpgraded := state.ResetAtSource == "relative" && observation.ResetAtSource == "absolute"
-		trustedBoundaryCalibration := observation.Authoritative &&
-			(state.ResetAtSource != observation.ResetAtSource || !state.ResetAt.Equal(observation.ResetAt))
-		boundaryUpdated := boundaryUpgraded || trustedBoundaryCalibration
-		if boundaryUpdated {
-			state.ResetAtSource = observation.ResetAtSource
-			state.ResetAt = observation.ResetAt
-		}
-		// 同周期可信百分比回升不是新状态段，而是对已接受错误低值尾段的事务纠错。
-		if state.HasTail && observation.RemainingPercent > state.RemainingPercent && observation.Authoritative {
-			*pending = append(*pending, observation)
-			state.RemainingPercent = observation.RemainingPercent
-			state.LastObservedAt = observation.LastObservedAt
-			state.PendingIndex = len(*pending) - 1
-			current[key] = state
-			return true
-		}
-		if state.HasTail && observation.LastObservedAt.Equal(state.LastObservedAt) {
-			if observation.RemainingPercent != state.RemainingPercent {
-				logrus.WithFields(logrus.Fields{
-					"auth_index":       key.AuthIndex,
-					"window_role":      key.WindowRole,
-					"last_observed_at": observation.LastObservedAt,
-				}).Warn("codex quota history observation conflicts at the same timestamp")
-			}
-			if boundaryUpdated {
-				*pending = append(*pending, observation)
-				current[key] = state
-				return true
-			}
-			return false
-		}
-		// Header 或其它非可信来源的同周期回升仍违反单调不增不变量，直接忽略且不推进时间。
-		if state.HasTail && observation.RemainingPercent > state.RemainingPercent {
-			return false
-		}
-		// 相同整数百分比优先合并当前 pending 尾段；已落库尾段则新建一次增量 UPDATE observation。
-		if state.HasTail && observation.RemainingPercent == state.RemainingPercent {
-			if state.PendingIndex >= 0 && state.PendingIndex < len(*pending) {
-				segment := &(*pending)[state.PendingIndex]
-				// 同一待写尾段的边界被允许更新时，把最终值带进 repository，不能只更新内存状态。
-				if boundaryUpdated {
-					segment.ResetAtSource = observation.ResetAtSource
-					segment.ResetAt = observation.ResetAt
-				}
-				segment.LastObservedAt = observation.LastObservedAt
-				segment.ObservationCount += observation.ObservationCount
-			} else {
-				*pending = append(*pending, observation)
-				state.PendingIndex = len(*pending) - 1
-			}
-			state.LastObservedAt = observation.LastObservedAt
-			current[key] = state
-			return true
-		}
-	}
-
-	// 没有当前周期、当前周期没有尾段，或同周期百分比真实下降时追加新状态段。
-	*pending = append(*pending, observation)
-	if !state.Found {
-		state = codexQuotaHistoryStateFromObservation(observation)
-	} else {
-		state.HasTail = true
-		state.RemainingPercent = observation.RemainingPercent
-		state.LastObservedAt = observation.LastObservedAt
-	}
-	state.PendingIndex = len(*pending) - 1
-	current[key] = state
-	return true
 }
 
 // codexQuotaHistorySourceIsAuthoritative 只信任实际调用专门额度接口且低频执行的三种刷新入口。
@@ -557,52 +252,6 @@ func codexQuotaHistoryTimeDistance(left time.Time, right time.Time) time.Duratio
 	return distance
 }
 
-// flushCodexQuotaHistory 用单个两秒 context 写入当前 pending，并按结果维护缓存可信度。
-func (s *Service) flushCodexQuotaHistory(current map[codexQuotaHistoryStateKey]codexQuotaHistoryCurrentState, pending *[]repositorydto.CodexMainQuotaObservation, sources string) {
-	if len(*pending) == 0 {
-		return
-	}
-	// 跨账号保持接收顺序已足够；额外稳定排序只确保同账号角色严格按观察时间进入 repository。
-	sort.SliceStable(*pending, func(left int, right int) bool {
-		leftObservation := (*pending)[left]
-		rightObservation := (*pending)[right]
-		if leftObservation.AuthIndex != rightObservation.AuthIndex {
-			return leftObservation.AuthIndex < rightObservation.AuthIndex
-		}
-		if leftObservation.WindowRole != rightObservation.WindowRole {
-			return leftObservation.WindowRole < rightObservation.WindowRole
-		}
-		return leftObservation.FirstObservedAt.Before(rightObservation.FirstObservedAt)
-	})
-	ctx, cancel := context.WithTimeout(context.Background(), codexQuotaHistoryDatabaseTimeout)
-	err := s.codexQuotaHistoryWrite(ctx, s.db, *pending)
-	cancel()
-	if err != nil {
-		// best-effort 允许丢失本批新鲜度；清空 pending 避免部分提交批次重试造成 count 重复。
-		logrus.WithError(err).WithFields(logrus.Fields{
-			"observation_count": len(*pending),
-			"sources":           sources,
-		}).Warn("codex quota history flush failed")
-		for _, observation := range *pending {
-			// 受影响账号角色全部失效，下一份 observation 必须从 writer 数据库重新加载事实。
-			delete(current, codexQuotaHistoryStateKey{AuthIndex: observation.AuthIndex, WindowRole: observation.WindowRole})
-		}
-		*pending = (*pending)[:0]
-		return
-	}
-	// 写入成功后保留当前周期/百分比缓存，但所有尾段都不再指向已清空 pending。
-	for key, state := range current {
-		state.PendingIndex = -1
-		current[key] = state
-	}
-	*pending = (*pending)[:0]
-}
-
-// flushQueuedCodexQuotaHistoryOnShutdown 固定关闭时的剩余数量，并保持与正常批次相同的处理规则。
-func (s *Service) flushQueuedCodexQuotaHistoryOnShutdown(current map[codexQuotaHistoryStateKey]codexQuotaHistoryCurrentState) {
-	s.processPreferredCodexQuotaHistoryInputs(current)
-}
-
 // tryAppendCodexQuotaHistorySnapshot 把同一不可变 Header 快照指针非阻塞投递到独立 history 队列。
 func (s *Service) tryAppendCodexQuotaHistorySnapshot(snapshot *UsageHeaderSnapshot) bool {
 	if snapshot == nil || len(snapshot.MainQuotaObservations) == 0 {
@@ -660,8 +309,8 @@ func (s *Service) tryAppendCodexQuotaHistoryInput(input codexQuotaHistoryInput) 
 		default:
 		}
 	} else {
-		// Header 队列满时按 ObservedAt 淘汰最旧快照，迟到旧数据不能覆盖已保留的新事实。
-		accepted = tryAppendLatestCodexQuotaHistoryHeaderInput(queue, input)
+		// Header 队列满时直接丢队头并保留后到数据；真实观察时间排序由 runner 批次统一完成。
+		accepted = tryAppendCodexQuotaHistoryHeaderInput(queue, input)
 	}
 	if !accepted {
 		return false
@@ -674,39 +323,31 @@ func (s *Service) tryAppendCodexQuotaHistoryInput(input codexQuotaHistoryInput) 
 	return true
 }
 
-// tryAppendLatestCodexQuotaHistoryHeaderInput 在调用方锁内保留固定容量中 ObservedAt 最新的 Header。
-func tryAppendLatestCodexQuotaHistoryHeaderInput(queue chan codexQuotaHistoryInput, input codexQuotaHistoryInput) bool {
+// tryAppendCodexQuotaHistoryHeaderInput 在调用方锁内 O(1) 写入；满载时 FIFO 淘汰一个队头。
+func tryAppendCodexQuotaHistoryHeaderInput(queue chan codexQuotaHistoryInput, input codexQuotaHistoryInput) bool {
 	if cap(queue) == 0 {
 		return false
 	}
-	if len(queue) < cap(queue) {
-		queue <- input
+	select {
+	case queue <- input:
 		return true
+	default:
 	}
-	// 仅在极端满载时扫描固定上限；正常热路径仍是一次 O(1) channel send。
-	queued := make([]codexQuotaHistoryInput, 0, len(queue))
-	for len(queue) > 0 {
-		queued = append(queued, <-queue)
+	// runner 可能已经在首次发送失败后取走队头；此时无需再丢第二条。
+	select {
+	case <-queue:
+	default:
 	}
-	oldestIndex := 0
-	for index := 1; index < len(queued); index++ {
-		candidateObservedAt := usageHeaderSnapshotObservedAt(queued[index].Snapshot)
-		oldestObservedAt := usageHeaderSnapshotObservedAt(queued[oldestIndex].Snapshot)
-		if usageHeaderObservedAtBefore(candidateObservedAt, oldestObservedAt) {
-			oldestIndex = index
-		}
+	// 所有生产者由同一把锁串行化，runner 只会继续取数据，因此这里仍是非阻塞 O(1) 发送。
+	select {
+	case queue <- input:
+		return true
+	default:
+		return false
 	}
-	accepted := usageHeaderSnapshotIsNewer(input.Snapshot, queued[oldestIndex].Snapshot)
-	if accepted {
-		queued[oldestIndex] = input
-	}
-	for _, queuedInput := range queued {
-		queue <- queuedInput
-	}
-	return accepted
 }
 
-// stopCodexQuotaHistoryRunner 封住新投递并等待 runner 的两秒 best-effort flush 完成。
+// stopCodexQuotaHistoryRunner 封住新投递并等待 runner 完成最后一次 best-effort 处理。
 func (s *Service) stopCodexQuotaHistoryRunner() {
 	if s == nil {
 		return

--- a/internal/quota/codex_quota_history_runner.go
+++ b/internal/quota/codex_quota_history_runner.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	// codexQuotaHistoryFlushInterval 是首条数据入队后、固定本批队列边界前的默认等待时长。
-	codexQuotaHistoryFlushInterval = 10 * time.Second
+	// codexQuotaHistoryFlushInterval 是首条数据入队后、固定本批队列边界前的一分钟默认等待时长。
+	codexQuotaHistoryFlushInterval = time.Minute
 	// codexQuotaHistoryQueueSize 限制 usage 热路径最多持有的不可变快照指针数量。
 	codexQuotaHistoryQueueSize = 1024
 	// codexQuotaHistoryDatabaseTimeout 同时限制身份确认、状态恢复、正常 flush 与 shutdown flush。
@@ -90,7 +90,7 @@ func newCodexQuotaHistoryTimer(delay time.Duration) (<-chan time.Time, func()) {
 	return timer.C, func() { timer.Stop() }
 }
 
-// runCodexQuotaHistoryRunner 串行拥有状态：Header 等待十秒聚合，低频可信查询到达时立即执行。
+// runCodexQuotaHistoryRunner 串行拥有状态：Header 等待一分钟聚合，低频可信查询到达时立即执行。
 func (s *Service) runCodexQuotaHistoryRunner() {
 	// done channel 必须只由 runner 关闭，StopRefreshTasks 才能确保数据库关闭前不再有 history 写入。
 	defer close(s.codexQuotaHistoryDoneCh)
@@ -122,7 +122,7 @@ func (s *Service) runCodexQuotaHistoryRunner() {
 				return
 			}
 		case <-s.codexQuotaHistoryTrustedWake:
-			// 空闲 runner 收到可信来源后同样立即分流两类事实，不创建十秒 timer。
+			// 空闲 runner 收到可信来源后同样立即分流两类事实，不创建一分钟 timer。
 			s.processPreferredCodexQuotaHistoryInputs(current)
 		case <-s.codexQuotaHistoryStopCh:
 			// 空闲时收到 shutdown，同样处理 stop 之前已成功入队的全部元素。
@@ -132,7 +132,7 @@ func (s *Service) runCodexQuotaHistoryRunner() {
 	}
 }
 
-// takeQueuedCodexQuotaHistoryInputs 在生产者短锁下固定两条来源队列边界，并清除只属于本批的通知。
+// takeQueuedCodexQuotaHistoryInputs 在生产者短锁下取出两条来源队列，并清除只属于本批的通知。
 func (s *Service) takeQueuedCodexQuotaHistoryInputs(includeHeader bool, includeTrusted bool) []codexQuotaHistoryInput {
 	s.codexQuotaHistoryMu.Lock()
 	headerCount := 0
@@ -151,9 +151,7 @@ func (s *Service) takeQueuedCodexQuotaHistoryInputs(includeHeader bool, includeT
 		default:
 		}
 	}
-	s.codexQuotaHistoryMu.Unlock()
-
-	// runner 是两条 channel 的唯一消费者；这里仅按固定边界复制，来源优先级由调用方决定。
+	// Header 满载替换也会短暂读取 channel；所有数据消费都在同一锁内完成，批次边界不会混入后续生产者。
 	inputs := make([]codexQuotaHistoryInput, 0, headerCount+trustedCount)
 	for range headerCount {
 		inputs = append(inputs, <-s.codexQuotaHistoryHeaderQueue)
@@ -161,6 +159,7 @@ func (s *Service) takeQueuedCodexQuotaHistoryInputs(includeHeader bool, includeT
 	for range trustedCount {
 		inputs = append(inputs, <-s.codexQuotaHistoryTrustedQueue)
 	}
+	s.codexQuotaHistoryMu.Unlock()
 	return inputs
 }
 
@@ -652,17 +651,59 @@ func (s *Service) tryAppendCodexQuotaHistoryInput(input codexQuotaHistoryInput) 
 		queue = s.codexQuotaHistoryTrustedQueue
 		wake = s.codexQuotaHistoryTrustedWake
 	}
-	select {
-	case queue <- input:
-		// 两条通知都只表达“对应队列非空”；可信通知无等待，Header 通知开启十秒窗口。
+	accepted := false
+	if authoritative {
+		// 可信主动查询保持原有低频独立队列语义；本次只调整 Header 溢出策略。
 		select {
-		case wake <- struct{}{}:
+		case queue <- input:
+			accepted = true
 		default:
 		}
-		return true
-	default:
+	} else {
+		// Header 队列满时按 ObservedAt 淘汰最旧快照，迟到旧数据不能覆盖已保留的新事实。
+		accepted = tryAppendLatestCodexQuotaHistoryHeaderInput(queue, input)
+	}
+	if !accepted {
 		return false
 	}
+	// 两条通知都只表达“对应队列非空”；可信通知无等待，Header 通知开启一分钟窗口。
+	select {
+	case wake <- struct{}{}:
+	default:
+	}
+	return true
+}
+
+// tryAppendLatestCodexQuotaHistoryHeaderInput 在调用方锁内保留固定容量中 ObservedAt 最新的 Header。
+func tryAppendLatestCodexQuotaHistoryHeaderInput(queue chan codexQuotaHistoryInput, input codexQuotaHistoryInput) bool {
+	if cap(queue) == 0 {
+		return false
+	}
+	if len(queue) < cap(queue) {
+		queue <- input
+		return true
+	}
+	// 仅在极端满载时扫描固定上限；正常热路径仍是一次 O(1) channel send。
+	queued := make([]codexQuotaHistoryInput, 0, len(queue))
+	for len(queue) > 0 {
+		queued = append(queued, <-queue)
+	}
+	oldestIndex := 0
+	for index := 1; index < len(queued); index++ {
+		candidateObservedAt := usageHeaderSnapshotObservedAt(queued[index].Snapshot)
+		oldestObservedAt := usageHeaderSnapshotObservedAt(queued[oldestIndex].Snapshot)
+		if usageHeaderObservedAtBefore(candidateObservedAt, oldestObservedAt) {
+			oldestIndex = index
+		}
+	}
+	accepted := usageHeaderSnapshotIsNewer(input.Snapshot, queued[oldestIndex].Snapshot)
+	if accepted {
+		queued[oldestIndex] = input
+	}
+	for _, queuedInput := range queued {
+		queue <- queuedInput
+	}
+	return accepted
 }
 
 // stopCodexQuotaHistoryRunner 封住新投递并等待 runner 的两秒 best-effort flush 完成。

--- a/internal/quota/codex_quota_history_scheduler.go
+++ b/internal/quota/codex_quota_history_scheduler.go
@@ -309,7 +309,19 @@ func (s *Service) mergeCodexQuotaHistoryObservation(state *codexQuotaHistoryRunn
 			if boundaryUpdated {
 				// 先物化此前累计的稳定尾段，再应用同一时刻的边界校准，避免后续被 repository 视为重叠旧数据。
 				s.appendDeferredCodexQuotaHistoryStable(state, key, pending)
-				*pending = append(*pending, observation)
+				if current.PendingIndex >= 0 && current.PendingIndex < len(*pending) {
+					// 尚未落库的同一尾段直接原地升级；后续同值观察会继续合并到这条 absolute 事实。
+					calibrated := &(*pending)[current.PendingIndex]
+					calibrated.ResetAtSource = observation.ResetAtSource
+					calibrated.ResetAt = observation.ResetAt
+					calibrated.ObservationCount += observation.ObservationCount
+					calibrated.Authoritative = calibrated.Authoritative || observation.Authoritative
+				} else {
+					// 已落库尾段无法原地修改；追加校准后必须让 PendingIndex 指向它，不能再引用旧 relative 条目。
+					observation.RemainingPercent = current.RemainingPercent
+					*pending = append(*pending, observation)
+					current.PendingIndex = len(*pending) - 1
+				}
 				state.Current[key] = current
 				return true
 			}

--- a/internal/quota/codex_quota_history_scheduler.go
+++ b/internal/quota/codex_quota_history_scheduler.go
@@ -1,0 +1,491 @@
+package quota
+
+import (
+	"context"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	repositorydto "cpa-usage-keeper/internal/repository/dto"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// codexQuotaHistoryHeartbeatInterval 让稳定百分比的写入频率与 Header/request 数量脱钩。
+	codexQuotaHistoryHeartbeatInterval = 5 * time.Minute
+)
+
+// codexQuotaHistoryDeferredStable 只保存一个账号角色尚未物化的最新稳定尾段。
+type codexQuotaHistoryDeferredStable struct {
+	// Observation 合并相同整数百分比的首尾观察时间与次数。
+	Observation repositorydto.CodexMainQuotaObservation
+	// Immediate 表示可信校准或 reset 边界升级不能等待稳定心跳。
+	Immediate bool
+}
+
+// codexQuotaHistoryRunnerState 由唯一 runner goroutine 串行持有，不需要额外锁或容量限制。
+type codexQuotaHistoryRunnerState struct {
+	// Current 保存每个账号角色最近接受的周期和百分比，用于减少重复数据库恢复。
+	Current map[codexQuotaHistoryStateKey]codexQuotaHistoryCurrentState
+	// Stable 每个账号角色最多一条，保存五分钟内尚未写入的相同百分比累计。
+	Stable map[codexQuotaHistoryStateKey]codexQuotaHistoryDeferredStable
+}
+
+// codexQuotaHistoryCohortKey 标识同一账号在同一次 Header/额度响应中返回的主窗口集合。
+type codexQuotaHistoryCohortKey struct {
+	AuthIndex      string
+	LastObservedAt time.Time
+}
+
+func newCodexQuotaHistoryRunnerState() codexQuotaHistoryRunnerState {
+	return codexQuotaHistoryRunnerState{
+		Current: make(map[codexQuotaHistoryStateKey]codexQuotaHistoryCurrentState),
+		Stable:  make(map[codexQuotaHistoryStateKey]codexQuotaHistoryDeferredStable),
+	}
+}
+
+// runCodexQuotaHistoryRunner 串行处理一分钟 Header 窗口；可信主动查询仍立即触发同一条路径。
+func (s *Service) runCodexQuotaHistoryRunner() {
+	// done 只能由 runner 关闭，App 才能在数据库关闭前确认 history 已经停止。
+	defer close(s.codexQuotaHistoryDoneCh)
+	state := newCodexQuotaHistoryRunnerState()
+
+	for {
+		select {
+		case <-s.codexQuotaHistoryHeaderWake:
+			// 队列和 wake 必须在生产者同一把短锁下观察，避免把并发新数据误判为空通知。
+			s.codexQuotaHistoryMu.Lock()
+			headerQueued := len(s.codexQuotaHistoryHeaderQueue) > 0
+			s.codexQuotaHistoryMu.Unlock()
+			if !headerQueued {
+				continue
+			}
+			// 第一条 Header 固定开启一分钟窗口，后续 Header 只进入同一个有界队列。
+			timerC, stopTimer := s.codexQuotaHistoryNewTimer(s.codexQuotaHistoryFlushInterval)
+			select {
+			case <-timerC:
+				stopTimer()
+				// 一分钟到点后固定本批输入，后续 Header 自然进入下一批。
+				s.processPreferredCodexQuotaHistoryInputs(&state, false)
+			case <-s.codexQuotaHistoryTrustedWake:
+				stopTimer()
+				// 可信查询跳过 Header 等待，并覆盖同账号角色的待处理 Header。
+				s.processPreferredCodexQuotaHistoryInputs(&state, false)
+			case <-s.codexQuotaHistoryStopCh:
+				stopTimer()
+				// shutdown 只尽力处理已经接收的数据，不等待剩余的一分钟窗口。
+				s.processPreferredCodexQuotaHistoryInputs(&state, true)
+				return
+			}
+		case <-s.codexQuotaHistoryTrustedWake:
+			// 空闲 runner 收到可信事实时立即处理，不创建 Header timer。
+			s.processPreferredCodexQuotaHistoryInputs(&state, false)
+		case <-s.codexQuotaHistoryStopCh:
+			// 即使队列为空，shutdown 也会尽力物化内存中的稳定尾段。
+			s.processPreferredCodexQuotaHistoryInputs(&state, true)
+			return
+		}
+	}
+}
+
+// processPreferredCodexQuotaHistoryInputs 固定当前队列，并用一次 writer 调用处理可信事实与未被覆盖的 Header。
+func (s *Service) processPreferredCodexQuotaHistoryInputs(state *codexQuotaHistoryRunnerState, shutdown bool) {
+	// 取得队列后所有状态只由当前 goroutine 持有，生产者可以立即继续投递下一分钟的数据。
+	inputs := s.takeQueuedCodexQuotaHistoryInputs(true, true)
+	candidates := codexQuotaHistoryCandidates(inputs)
+	trusted, headers := splitPreferredCodexQuotaHistoryCandidates(candidates)
+	// 同账号角色 Header 已由可信事实替代；其它账号角色随后按观察时间排序，共享同一次 writer 调用。
+	preferred := append(trusted, headers...)
+	s.processCodexQuotaHistoryCandidateBatch(state, preferred, time.Now(), shutdown)
+}
+
+// processCodexQuotaHistoryCandidateBatch 完成批量身份确认、单调合并和一次低频物化。
+func (s *Service) processCodexQuotaHistoryCandidateBatch(state *codexQuotaHistoryRunnerState, candidates []codexQuotaHistoryCandidate, now time.Time, flushAllStable bool) {
+	verified := s.verifyCodexQuotaHistoryCandidates(candidates)
+	// Redis inbox 与主动查询的完成顺序不等于观察时间；进入状态机前恢复确定顺序。
+	sortCodexQuotaHistoryCandidates(verified)
+
+	// recovery 失败只影响本批同一账号角色；下一批会重新从数据库尝试恢复。
+	failedRecoveries := make(map[codexQuotaHistoryStateKey]struct{})
+	materializedCohorts := make(map[codexQuotaHistoryCohortKey]struct{})
+	pending := make([]repositorydto.CodexMainQuotaObservation, 0, len(verified))
+	for _, candidate := range verified {
+		if s.mergeCodexQuotaHistoryObservation(state, failedRecoveries, &pending, candidate, now) {
+			materializedCohorts[codexQuotaHistoryCandidateCohortKey(candidate)] = struct{}{}
+		}
+	}
+
+	// 任一窗口在本批发生变化时，同一 Header 中仍处于稳定降频的另一窗口也必须一起物化。
+	for key, deferred := range state.Stable {
+		cohort := codexQuotaHistoryCohortKey{AuthIndex: key.AuthIndex, LastObservedAt: deferred.Observation.LastObservedAt}
+		if _, materialized := materializedCohorts[cohort]; materialized {
+			deferred.Immediate = true
+			state.Stable[key] = deferred
+		}
+	}
+
+	// 每次 runner 被唤醒都顺带收集已经到五分钟的稳定尾段；shutdown 则收集全部尾段。
+	stableKeys := s.appendDueCodexQuotaHistoryStable(state, &pending, now, flushAllStable)
+	s.flushCodexQuotaHistory(state, pending, stableKeys, codexQuotaHistoryCandidateSourceSummary(verified), now)
+}
+
+// codexQuotaHistoryCandidateCohortKey 用账号和观察时刻关联同一次响应里的 Primary/Secondary。
+func codexQuotaHistoryCandidateCohortKey(candidate codexQuotaHistoryCandidate) codexQuotaHistoryCohortKey {
+	return codexQuotaHistoryCohortKey{
+		AuthIndex:      strings.TrimSpace(candidate.Observation.AuthIndex),
+		LastObservedAt: candidate.Observation.LastObservedAt,
+	}
+}
+
+// sortCodexQuotaHistoryCandidates 保证同账号角色严格按真实观察时间进入单调状态机。
+func sortCodexQuotaHistoryCandidates(candidates []codexQuotaHistoryCandidate) {
+	sort.SliceStable(candidates, func(left int, right int) bool {
+		leftKey := codexQuotaHistoryCandidateStateKey(candidates[left])
+		rightKey := codexQuotaHistoryCandidateStateKey(candidates[right])
+		if leftKey.AuthIndex != rightKey.AuthIndex {
+			return leftKey.AuthIndex < rightKey.AuthIndex
+		}
+		if leftKey.WindowRole != rightKey.WindowRole {
+			return leftKey.WindowRole < rightKey.WindowRole
+		}
+		return candidates[left].Observation.LastObservedAt.Before(candidates[right].Observation.LastObservedAt)
+	})
+}
+
+// verifyCodexQuotaHistoryCandidates 一次查询确认 Header 属于活跃 Codex Auth File；可信查询已经在 Check 中确认身份。
+func (s *Service) verifyCodexQuotaHistoryCandidates(candidates []codexQuotaHistoryCandidate) []codexQuotaHistoryCandidate {
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	// authIndexes 去重后只产生一次 reader 查询；空账号不会进入数据库条件。
+	authIndexes := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, candidate := range candidates {
+		if candidate.IdentityVerified {
+			continue
+		}
+		authIndex := strings.TrimSpace(candidate.Observation.AuthIndex)
+		if authIndex == "" {
+			continue
+		}
+		if _, exists := seen[authIndex]; exists {
+			continue
+		}
+		seen[authIndex] = struct{}{}
+		authIndexes = append(authIndexes, authIndex)
+	}
+
+	verifiedAuthIndexes := make(map[string]struct{}, len(authIndexes))
+	if len(authIndexes) > 0 {
+		// 身份查询有独立短超时；失败时宁可留下采样缺口，也不猜测 Header 归属。
+		ctx, cancel := context.WithTimeout(context.Background(), codexQuotaHistoryDatabaseTimeout)
+		identities, err := s.codexQuotaHistoryListIdentities(ctx, s.db, authIndexes)
+		cancel()
+		if err != nil {
+			logrus.WithError(err).Warn("codex quota history identity verification failed")
+		} else {
+			for _, identity := range identities {
+				// repository 已限定 Auth File；这里再限定真实 Codex 类型，排除 provider 文本误判。
+				if !usageHeaderIdentityIsCodex(identity) {
+					continue
+				}
+				authIndex := strings.TrimSpace(identity.Identity)
+				if authIndex != "" {
+					verifiedAuthIndexes[authIndex] = struct{}{}
+				}
+			}
+		}
+	}
+
+	// 保持候选原顺序；只有可信查询或本次查询确认的 Header 可以继续。
+	verified := make([]codexQuotaHistoryCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.IdentityVerified {
+			verified = append(verified, candidate)
+			continue
+		}
+		if _, ok := verifiedAuthIndexes[strings.TrimSpace(candidate.Observation.AuthIndex)]; ok {
+			verified = append(verified, candidate)
+		}
+	}
+	return verified
+}
+
+// mergeCodexQuotaHistoryObservation 把一条 observation 合并为语义变化或单个稳定尾段。
+func (s *Service) mergeCodexQuotaHistoryObservation(state *codexQuotaHistoryRunnerState, failedRecoveries map[codexQuotaHistoryStateKey]struct{}, pending *[]repositorydto.CodexMainQuotaObservation, candidate codexQuotaHistoryCandidate, now time.Time) bool {
+	observation := candidate.Observation
+	key := codexQuotaHistoryCandidateStateKey(candidate)
+	// runner 只接受构造层定义的两个主额度角色；repository 仍保留最终完整校验。
+	if key.AuthIndex == "" || (key.WindowRole != "primary" && key.WindowRole != "secondary") {
+		return false
+	}
+	observation.AuthIndex = key.AuthIndex
+	observation.WindowRole = key.WindowRole
+	observation.Authoritative = codexQuotaHistorySourceIsAuthoritative(candidate.Source)
+	// 内部 DTO 必须满足基本范围与时间顺序，异常值不能推进内存状态。
+	if observation.WindowSeconds <= 0 || observation.WindowSeconds > math.MaxInt64/int64(time.Second) ||
+		observation.ResetAt.IsZero() || observation.RemainingPercent < 0 || observation.RemainingPercent > 100 ||
+		observation.ObservationCount < 1 || observation.FirstObservedAt.IsZero() || observation.LastObservedAt.IsZero() ||
+		observation.FirstObservedAt.After(observation.LastObservedAt) {
+		return false
+	}
+
+	current, loaded := state.Current[key]
+	if !loaded {
+		// 同一批第一次恢复失败后不重复打数据库；下一批仍可自然重试。
+		if _, failed := failedRecoveries[key]; failed {
+			return false
+		}
+		recovered, err := s.loadCodexQuotaHistoryCurrentState(key)
+		if err != nil {
+			failedRecoveries[key] = struct{}{}
+			logrus.WithError(err).WithFields(logrus.Fields{
+				"auth_index":  key.AuthIndex,
+				"window_role": key.WindowRole,
+			}).Warn("codex quota history state recovery failed")
+			return false
+		}
+		current = recovered
+		// 已有数据库尾段视为本进程刚确认，避免服务重启后立刻产生无意义稳定 UPDATE。
+		if current.Found && current.HasTail {
+			current.LastMaterializedAt = now
+		}
+		state.Current[key] = current
+	}
+
+	if current.Found {
+		// 窗口变化代表角色切换；先封住旧稳定尾段，再写新周期基线。
+		if current.WindowSeconds != observation.WindowSeconds {
+			if current.HasTail && observation.LastObservedAt.Before(current.LastObservedAt) {
+				return false
+			}
+			s.appendDeferredCodexQuotaHistoryStable(state, key, pending)
+			s.appendCodexQuotaHistoryChange(state, key, &current, pending, observation)
+			return true
+		}
+
+		sameCycle := codexQuotaHistorySameCycle(current, observation)
+		if !sameCycle {
+			// 同窗口只有时间向前且 reset 不倒退时才能建立下一周期。
+			if (current.HasTail && observation.LastObservedAt.Before(current.LastObservedAt)) || observation.ResetAt.Before(current.ResetAt) {
+				return false
+			}
+			s.appendDeferredCodexQuotaHistoryStable(state, key, pending)
+			s.appendCodexQuotaHistoryChange(state, key, &current, pending, observation)
+			return true
+		}
+
+		// 同周期乱序事实不能反向推进百分比或 reset 边界。
+		if current.HasTail && observation.LastObservedAt.Before(current.LastObservedAt) {
+			return false
+		}
+		boundaryUpgraded := current.ResetAtSource == "relative" && observation.ResetAtSource == "absolute"
+		trustedCalibration := observation.Authoritative &&
+			(current.ResetAtSource != observation.ResetAtSource || !current.ResetAt.Equal(observation.ResetAt))
+		boundaryUpdated := boundaryUpgraded || trustedCalibration
+		if boundaryUpdated {
+			current.ResetAtSource = observation.ResetAtSource
+			current.ResetAt = observation.ResetAt
+		}
+
+		// 可信专门额度查询允许纠正错误低尾段；普通 Header 回升仍直接忽略。
+		if current.HasTail && observation.RemainingPercent > current.RemainingPercent && observation.Authoritative {
+			s.appendDeferredCodexQuotaHistoryStable(state, key, pending)
+			s.appendCodexQuotaHistoryChange(state, key, &current, pending, observation)
+			return true
+		}
+		if current.HasTail && observation.LastObservedAt.Equal(current.LastObservedAt) {
+			if observation.RemainingPercent != current.RemainingPercent {
+				logrus.WithFields(logrus.Fields{
+					"auth_index":       key.AuthIndex,
+					"window_role":      key.WindowRole,
+					"last_observed_at": observation.LastObservedAt,
+				}).Warn("codex quota history observation conflicts at the same timestamp")
+			}
+			// reset 校准仍需立即交给 repository；相同时间的百分比冲突不会改变当前尾段。
+			if boundaryUpdated {
+				// 先物化此前累计的稳定尾段，再应用同一时刻的边界校准，避免后续被 repository 视为重叠旧数据。
+				s.appendDeferredCodexQuotaHistoryStable(state, key, pending)
+				*pending = append(*pending, observation)
+				state.Current[key] = current
+				return true
+			}
+			return false
+		}
+		if current.HasTail && observation.RemainingPercent > current.RemainingPercent {
+			return false
+		}
+		if current.HasTail && observation.RemainingPercent == current.RemainingPercent {
+			// 新状态已在本批 pending 时直接合并；否则只保留一个五分钟稳定尾段。
+			materialized := false
+			if current.PendingIndex >= 0 && current.PendingIndex < len(*pending) {
+				merged := &(*pending)[current.PendingIndex]
+				if boundaryUpdated {
+					merged.ResetAtSource = observation.ResetAtSource
+					merged.ResetAt = observation.ResetAt
+				}
+				merged.LastObservedAt = observation.LastObservedAt
+				merged.ObservationCount += observation.ObservationCount
+				merged.Authoritative = merged.Authoritative || observation.Authoritative
+				materialized = true
+			} else {
+				s.mergeDeferredCodexQuotaHistoryStable(state, key, observation, boundaryUpdated || observation.Authoritative)
+			}
+			current.LastObservedAt = observation.LastObservedAt
+			state.Current[key] = current
+			return materialized
+		}
+	}
+
+	// 空状态、空尾段或同周期真实下降都是语义变化，必须在本批立即写入。
+	s.appendDeferredCodexQuotaHistoryStable(state, key, pending)
+	s.appendCodexQuotaHistoryChange(state, key, &current, pending, observation)
+	return true
+}
+
+// appendCodexQuotaHistoryChange 把新周期、真实下降或可信纠错追加到本批，并推进当前比较状态。
+func (s *Service) appendCodexQuotaHistoryChange(state *codexQuotaHistoryRunnerState, key codexQuotaHistoryStateKey, current *codexQuotaHistoryCurrentState, pending *[]repositorydto.CodexMainQuotaObservation, observation repositorydto.CodexMainQuotaObservation) {
+	*pending = append(*pending, observation)
+	if !current.Found || current.WindowSeconds != observation.WindowSeconds || !codexQuotaHistorySameCycle(*current, observation) {
+		*current = codexQuotaHistoryStateFromObservation(observation)
+	} else {
+		current.HasTail = true
+		current.RemainingPercent = observation.RemainingPercent
+		current.LastObservedAt = observation.LastObservedAt
+		current.ResetAtSource = observation.ResetAtSource
+		current.ResetAt = observation.ResetAt
+	}
+	current.PendingIndex = len(*pending) - 1
+	state.Current[key] = *current
+}
+
+// mergeDeferredCodexQuotaHistoryStable 合并同一整数百分比，不创建额外 timer 或每账号缓存队列。
+func (s *Service) mergeDeferredCodexQuotaHistoryStable(state *codexQuotaHistoryRunnerState, key codexQuotaHistoryStateKey, observation repositorydto.CodexMainQuotaObservation, immediate bool) {
+	deferred, exists := state.Stable[key]
+	if !exists {
+		state.Stable[key] = codexQuotaHistoryDeferredStable{Observation: observation, Immediate: immediate}
+		return
+	}
+	// 第一观察时间保持不变；最后时间、累计次数和最终 reset 校准向前推进。
+	deferred.Observation.LastObservedAt = observation.LastObservedAt
+	deferred.Observation.ObservationCount += observation.ObservationCount
+	deferred.Observation.Authoritative = deferred.Observation.Authoritative || observation.Authoritative
+	if observation.Authoritative || deferred.Observation.ResetAtSource == "relative" && observation.ResetAtSource == "absolute" {
+		deferred.Observation.ResetAtSource = observation.ResetAtSource
+		deferred.Observation.ResetAt = observation.ResetAt
+	}
+	deferred.Immediate = deferred.Immediate || immediate
+	state.Stable[key] = deferred
+}
+
+// appendDeferredCodexQuotaHistoryStable 在后续语义变化前先写旧稳定尾段，保持真实观察顺序。
+func (s *Service) appendDeferredCodexQuotaHistoryStable(state *codexQuotaHistoryRunnerState, key codexQuotaHistoryStateKey, pending *[]repositorydto.CodexMainQuotaObservation) {
+	deferred, exists := state.Stable[key]
+	if !exists {
+		return
+	}
+	*pending = append(*pending, deferred.Observation)
+	delete(state.Stable, key)
+}
+
+// appendDueCodexQuotaHistoryStable 收集到期尾段；没有新 Header 时无需为了心跳单独唤醒数据库。
+func (s *Service) appendDueCodexQuotaHistoryStable(state *codexQuotaHistoryRunnerState, pending *[]repositorydto.CodexMainQuotaObservation, now time.Time, all bool) []codexQuotaHistoryStateKey {
+	dueCohorts := make(map[codexQuotaHistoryCohortKey]struct{})
+	for key, deferred := range state.Stable {
+		current := state.Current[key]
+		due := deferred.Immediate || current.LastMaterializedAt.IsZero() || !now.Before(current.LastMaterializedAt.Add(s.codexQuotaHistoryHeartbeatInterval))
+		if all || due {
+			dueCohorts[codexQuotaHistoryCohortKey{AuthIndex: key.AuthIndex, LastObservedAt: deferred.Observation.LastObservedAt}] = struct{}{}
+		}
+	}
+	// 一个窗口到期或被标记立即写入时，把同一响应中存在的另一个主窗口一起收集。
+	keys := make([]codexQuotaHistoryStateKey, 0)
+	for key, deferred := range state.Stable {
+		cohort := codexQuotaHistoryCohortKey{AuthIndex: key.AuthIndex, LastObservedAt: deferred.Observation.LastObservedAt}
+		if _, due := dueCohorts[cohort]; due {
+			keys = append(keys, key)
+		}
+	}
+	// map 遍历无序；账号和角色排序让测试、日志与 repository 输入保持稳定。
+	sort.Slice(keys, func(left int, right int) bool {
+		if keys[left].AuthIndex != keys[right].AuthIndex {
+			return keys[left].AuthIndex < keys[right].AuthIndex
+		}
+		return keys[left].WindowRole < keys[right].WindowRole
+	})
+	for _, key := range keys {
+		*pending = append(*pending, state.Stable[key].Observation)
+	}
+	return keys
+}
+
+// codexQuotaHistoryCandidateSourceSummary 为失败日志生成稳定、去重的来源列表。
+func codexQuotaHistoryCandidateSourceSummary(candidates []codexQuotaHistoryCandidate) string {
+	sourceSet := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		sourceSet[refreshSourceLogValue(candidate.Source)] = struct{}{}
+	}
+	sources := make([]string, 0, len(sourceSet))
+	for source := range sourceSet {
+		sources = append(sources, source)
+	}
+	sort.Strings(sources)
+	return strings.Join(sources, ",")
+}
+
+// flushCodexQuotaHistory 用一次两秒 writer 调用物化本批；失败时丢弃本批并让下一份输入重新恢复数据库事实。
+func (s *Service) flushCodexQuotaHistory(state *codexQuotaHistoryRunnerState, pending []repositorydto.CodexMainQuotaObservation, stableKeys []codexQuotaHistoryStateKey, sources string, now time.Time) {
+	if len(pending) == 0 {
+		return
+	}
+	// 同账号角色必须按观察时间进入 repository；不同账号仅使用稳定排序便于诊断。
+	sort.SliceStable(pending, func(left int, right int) bool {
+		if pending[left].AuthIndex != pending[right].AuthIndex {
+			return pending[left].AuthIndex < pending[right].AuthIndex
+		}
+		if pending[left].WindowRole != pending[right].WindowRole {
+			return pending[left].WindowRole < pending[right].WindowRole
+		}
+		return pending[left].FirstObservedAt.Before(pending[right].FirstObservedAt)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), codexQuotaHistoryDatabaseTimeout)
+	err := s.codexQuotaHistoryWrite(ctx, s.db, pending)
+	cancel()
+	if err != nil {
+		logrus.WithError(err).WithFields(logrus.Fields{
+			"observation_count": len(pending),
+			"sources":           sources,
+		}).Warn("codex quota history flush failed")
+		// history 是低优先级采样：失败允许形成缺口，但不能用未提交内存状态继续推断。
+		for _, observation := range pending {
+			key := codexQuotaHistoryStateKey{AuthIndex: observation.AuthIndex, WindowRole: observation.WindowRole}
+			delete(state.Current, key)
+			delete(state.Stable, key)
+		}
+		return
+	}
+
+	// 成功后稳定尾段才可从内存删除；语义变化也同步刷新五分钟物化时钟。
+	for _, key := range stableKeys {
+		delete(state.Stable, key)
+	}
+	for _, observation := range pending {
+		key := codexQuotaHistoryStateKey{AuthIndex: observation.AuthIndex, WindowRole: observation.WindowRole}
+		current, exists := state.Current[key]
+		if !exists {
+			continue
+		}
+		current.LastMaterializedAt = now
+		current.PendingIndex = -1
+		state.Current[key] = current
+	}
+	// 本批其它状态也不能继续引用已经释放的 pending 切片。
+	for key, current := range state.Current {
+		current.PendingIndex = -1
+		state.Current[key] = current
+	}
+}

--- a/internal/quota/header_cache_worker.go
+++ b/internal/quota/header_cache_worker.go
@@ -20,7 +20,7 @@ import (
 const (
 	// usageHeaderSnapshotFlushInterval 是 usage response header 快照的默认批量落 cache 间隔。
 	usageHeaderSnapshotFlushInterval = time.Minute
-	// usageHeaderPendingIdentityLimit 限制一个窗口内不同身份的内存占用；已有身份仍允许更新。
+	// usageHeaderPendingIdentityLimit 限制一个窗口内不同身份的内存占用；满载只保留 ObservedAt 最新项。
 	usageHeaderPendingIdentityLimit = 1000
 )
 
@@ -48,7 +48,7 @@ func (s *Service) TryAppendUsageHeaderSnapshots(snapshots []*UsageHeaderSnapshot
 	mergePendingUsageHeaderSnapshotPointers(s.usageHeaderPending, snapshots)
 	hasPending := len(s.usageHeaderPending) > 0
 	s.usageHeaderMu.Unlock()
-	// history fan-out 只复制同一快照指针；队列满只丢历史候选，不影响已经接收的 cache latest-map。
+	// history fan-out 只复制同一快照指针；满载淘汰旧候选，不影响已经接收的 cache latest-map。
 	historyRejected := 0
 	for _, snapshot := range snapshots {
 		if !s.tryAppendCodexQuotaHistorySnapshot(snapshot) {
@@ -132,6 +132,7 @@ func (s *Service) flushPendingUsageHeaderSnapshots() {
 
 func mergePendingUsageHeaderSnapshotPointers(pending map[string]*UsageHeaderSnapshot, snapshots []*UsageHeaderSnapshot) {
 	rejected := 0
+	evicted := 0
 	// 遍历本次入队批次，把同一 flush 窗口内的快照合并到 pending map。
 	for _, snapshot := range snapshots {
 		// nil 指针没有任何身份或 cache 输出，直接忽略且不占 pending 容量。
@@ -144,22 +145,70 @@ func mergePendingUsageHeaderSnapshotPointers(pending map[string]*UsageHeaderSnap
 		if authIndex == "" {
 			authIndex = snapshot.Provider + "\x00" + snapshot.AuthType
 		}
-		// 达到上限后只拒绝新身份；已经存在的身份继续按时间覆盖，保证最新进度不会被旧值卡住。
-		if _, exists := pending[authIndex]; !exists && len(pending) >= usageHeaderPendingIdentityLimit {
+		// 已有身份只允许观察时间相同或更新的快照覆盖，迟到数据不能回滚 cache。
+		if existing, exists := pending[authIndex]; exists {
+			if usageHeaderSnapshotIsNewer(snapshot, existing) {
+				pending[authIndex] = snapshot
+			}
+			continue
+		}
+		// 未达到上限时直接接收新身份；硬上限只决定极端溢出时的替换边界。
+		if len(pending) < usageHeaderPendingIdentityLimit {
+			pending[authIndex] = snapshot
+			continue
+		}
+		// 达到上限后比较真实观察时间：新快照只有比全局最旧项更新时才允许替换。
+		oldestKey, oldestSnapshot, found := oldestPendingUsageHeaderSnapshot(pending)
+		if !found || !usageHeaderSnapshotIsNewer(snapshot, oldestSnapshot) {
 			rejected++
 			continue
 		}
-		// 没有旧值或新快照时间更新时覆盖，确保 flush 时使用窗口内最新 header。
-		if existing, ok := pending[authIndex]; !ok || usageHeaderSnapshotIsNewer(snapshot, existing) {
-			pending[authIndex] = snapshot
-		}
+		delete(pending, oldestKey)
+		pending[authIndex] = snapshot
+		evicted++
 	}
-	if rejected > 0 {
+	if rejected > 0 || evicted > 0 {
 		logrus.WithFields(logrus.Fields{
 			"rejected_snapshot_count": rejected,
+			"evicted_snapshot_count":  evicted,
 			"pending_identity_limit":  usageHeaderPendingIdentityLimit,
 		}).Warn("usage header quota pending identity limit reached")
 	}
+}
+
+// oldestPendingUsageHeaderSnapshot 返回当前 map 中观察时间最旧的一项；相同时间按 key 稳定选择。
+func oldestPendingUsageHeaderSnapshot(pending map[string]*UsageHeaderSnapshot) (string, *UsageHeaderSnapshot, bool) {
+	oldestKey := ""
+	var oldestSnapshot *UsageHeaderSnapshot
+	found := false
+	for key, snapshot := range pending {
+		observedAt := usageHeaderSnapshotObservedAt(snapshot)
+		oldestObservedAt := usageHeaderSnapshotObservedAt(oldestSnapshot)
+		if !found || usageHeaderObservedAtBefore(observedAt, oldestObservedAt) || (observedAt.Equal(oldestObservedAt) && key < oldestKey) {
+			oldestKey = key
+			oldestSnapshot = snapshot
+			found = true
+		}
+	}
+	return oldestKey, oldestSnapshot, found
+}
+
+func usageHeaderSnapshotObservedAt(snapshot *UsageHeaderSnapshot) time.Time {
+	if snapshot == nil {
+		return time.Time{}
+	}
+	return snapshot.ObservedAt
+}
+
+// usageHeaderObservedAtBefore 把缺失观察时间视为最旧，避免异常快照挤掉有真实时间的新数据。
+func usageHeaderObservedAtBefore(candidate time.Time, existing time.Time) bool {
+	if candidate.IsZero() {
+		return !existing.IsZero()
+	}
+	if existing.IsZero() {
+		return false
+	}
+	return candidate.Before(existing)
 }
 
 // mergePendingUsageHeaderSnapshots 保留值批次测试入口；生产路径始终使用共享指针版本。

--- a/internal/quota/header_cache_worker.go
+++ b/internal/quota/header_cache_worker.go
@@ -145,12 +145,10 @@ func mergePendingUsageHeaderSnapshotPointers(pending map[string]*UsageHeaderSnap
 		if authIndex == "" {
 			authIndex = snapshot.Provider + "\x00" + snapshot.AuthType
 		}
-		// 已有身份只允许观察时间相同或更新的快照更新，迟到数据不能回滚 cache。
+		// 已有身份按主额度和每个 Additional 分别比较时间；整体迟到不代表其中缺失组件也过期。
 		if existing, exists := pending[authIndex]; exists {
-			if usageHeaderSnapshotIsNewer(snapshot, existing) {
-				// 一分钟内主额度和 Additional 可能来自不同 Header；只合并 cache 投影，不合并 history observation。
-				pending[authIndex] = mergePendingUsageHeaderCacheSnapshot(existing, snapshot)
-			}
+			// 一分钟内主额度和 Additional 可能来自不同 Header；只合并 cache 投影，不合并 history observation。
+			pending[authIndex] = mergePendingUsageHeaderCacheSnapshot(existing, snapshot)
 			continue
 		}
 		// 未达到上限时直接接收新身份；硬上限只决定极端溢出时的替换边界。
@@ -178,61 +176,126 @@ func mergePendingUsageHeaderSnapshotPointers(pending map[string]*UsageHeaderSnap
 }
 
 // mergePendingUsageHeaderCacheSnapshot 把同一账号一分钟内观察到的主额度和 Additional 收敛成一份 cache 快照。
-func mergePendingUsageHeaderCacheSnapshot(existing *UsageHeaderSnapshot, latest *UsageHeaderSnapshot) *UsageHeaderSnapshot {
-	if existing == nil || latest == nil {
-		return latest
+func mergePendingUsageHeaderCacheSnapshot(existing *UsageHeaderSnapshot, candidate *UsageHeaderSnapshot) *UsageHeaderSnapshot {
+	if existing == nil {
+		return candidate
+	}
+	if candidate == nil {
+		return existing
 	}
 	existingUsage := codexUsagePayloadFromProviderOutput(existing.CacheOutput)
-	latestUsage := codexUsagePayloadFromProviderOutput(latest.CacheOutput)
-	if existingUsage == nil || latestUsage == nil {
-		// Header snapshot 当前只有 Codex；未来其它 provider 没有明确合并合同时仍保持 latest 语义。
-		return latest
+	candidateUsage := codexUsagePayloadFromProviderOutput(candidate.CacheOutput)
+	if existingUsage == nil || candidateUsage == nil {
+		// Header snapshot 当前只有 Codex；未来其它 provider 没有明确合并合同时仍保持整体最新语义。
+		if usageHeaderSnapshotIsNewer(candidate, existing) {
+			return candidate
+		}
+		return existing
 	}
 
-	// 以新快照为基底，ObservedAt、身份和 history observation 都保持最新 Header 的原值。
-	mergedSnapshot := *latest
-	mergedUsage := *latestUsage
+	// 整体身份、ObservedAt 和 history observation 仍取最新 Header；cache 组件在下方独立选择。
+	baseSnapshot := existing
+	baseUsage := existingUsage
+	otherUsage := candidateUsage
+	if usageHeaderSnapshotIsNewer(candidate, existing) {
+		baseSnapshot = candidate
+		baseUsage = candidateUsage
+		otherUsage = existingUsage
+	}
+	mergedSnapshot := *baseSnapshot
+	mergedUsage := *baseUsage
 	if strings.TrimSpace(mergedUsage.PlanType) == "" {
 		// 新 Header 未返回套餐时，保留本分钟已观察到的套餐。
-		mergedUsage.PlanType = existingUsage.PlanType
+		mergedUsage.PlanType = otherUsage.PlanType
 	}
-	if mergedUsage.RateLimit == nil {
-		// Active-Limit 命中 Additional 时新快照不含主额度，不能删掉本分钟更早的主 Primary/Secondary。
+
+	existingMainObservedAt := pendingUsageHeaderMainObservedAt(existing, existingUsage)
+	candidateMainObservedAt := pendingUsageHeaderMainObservedAt(candidate, candidateUsage)
+	switch {
+	case candidateUsage.RateLimit != nil && (existingUsage.RateLimit == nil || !usageHeaderObservedAtBefore(candidateMainObservedAt, existingMainObservedAt)):
+		// 主额度 Primary/Secondary 来自同一 Header，必须作为一个整体由较新的主额度观察替换。
+		mergedUsage.RateLimit = candidateUsage.RateLimit
+		mergedSnapshot.pendingMainObservedAt = candidateMainObservedAt
+	case existingUsage.RateLimit != nil:
+		// 即使整体最新 Header 只包含 Spark，也保留主额度自身最近的一次完整观察。
 		mergedUsage.RateLimit = existingUsage.RateLimit
+		mergedSnapshot.pendingMainObservedAt = existingMainObservedAt
+	default:
+		mergedUsage.RateLimit = nil
+		mergedSnapshot.pendingMainObservedAt = time.Time{}
 	}
-	// Additional 按 quota key 所使用的 LimitName 合并：同名 group 用新值，未出现的 group 保留旧值。
-	mergedUsage.AdditionalRateLimits = mergePendingCodexAdditionalRateLimits(existingUsage.AdditionalRateLimits, latestUsage.AdditionalRateLimits)
+
+	// Additional 按 LimitName 独立比较观察时间；同一 group 的 Primary/Secondary 同样保持整体更新。
+	mergedUsage.AdditionalRateLimits, mergedSnapshot.pendingAdditionalObservedAt = mergePendingCodexAdditionalRateLimits(
+		existing,
+		existingUsage.AdditionalRateLimits,
+		candidate,
+		candidateUsage.AdditionalRateLimits,
+	)
 	mergedSnapshot.CacheOutput = ProviderOutput{
-		Provider: latest.CacheOutput.Provider,
+		Provider: baseSnapshot.CacheOutput.Provider,
 		Result:   CodexResult{Usage: &mergedUsage},
 	}
 	return &mergedSnapshot
 }
 
-func mergePendingCodexAdditionalRateLimits(existing []CodexAdditionalRateLimit, latest []CodexAdditionalRateLimit) []CodexAdditionalRateLimit {
-	if len(existing) == 0 {
-		return latest
+func pendingUsageHeaderMainObservedAt(snapshot *UsageHeaderSnapshot, usage *CodexUsagePayload) time.Time {
+	if snapshot == nil || usage == nil || usage.RateLimit == nil {
+		return time.Time{}
 	}
-	if len(latest) == 0 {
-		return existing
+	if !snapshot.pendingMainObservedAt.IsZero() {
+		return snapshot.pendingMainObservedAt
+	}
+	return snapshot.ObservedAt
+}
+
+func pendingUsageHeaderAdditionalObservedAt(snapshot *UsageHeaderSnapshot, limitName string) time.Time {
+	if snapshot == nil {
+		return time.Time{}
+	}
+	if observedAt, exists := snapshot.pendingAdditionalObservedAt[limitName]; exists {
+		return observedAt
+	}
+	return snapshot.ObservedAt
+}
+
+func mergePendingCodexAdditionalRateLimits(
+	existingSnapshot *UsageHeaderSnapshot,
+	existing []CodexAdditionalRateLimit,
+	candidateSnapshot *UsageHeaderSnapshot,
+	candidates []CodexAdditionalRateLimit,
+) ([]CodexAdditionalRateLimit, map[string]time.Time) {
+	if len(existing) == 0 && len(candidates) == 0 {
+		return nil, nil
 	}
 
-	// 沿用旧 cache 的稳定顺序；同名 group 原位替换，本分钟新出现的 group 追加到末尾。
+	// 沿用旧 cache 的稳定顺序；同名 group 只在自身观察时间相同或更新时原位替换。
 	merged := append([]CodexAdditionalRateLimit(nil), existing...)
-	for _, candidate := range latest {
+	observedAtByLimit := make(map[string]time.Time, len(existing)+len(candidates))
+	for _, limit := range existing {
+		observedAtByLimit[limit.LimitName] = pendingUsageHeaderAdditionalObservedAt(existingSnapshot, limit.LimitName)
+	}
+	for _, candidate := range candidates {
+		candidateObservedAt := pendingUsageHeaderAdditionalObservedAt(candidateSnapshot, candidate.LimitName)
 		replaced := false
 		for index := range merged {
-			if merged[index].LimitName == candidate.LimitName {
-				merged[index] = candidate
-				replaced = true
-				break
+			if merged[index].LimitName != candidate.LimitName {
+				continue
 			}
+			existingObservedAt := observedAtByLimit[candidate.LimitName]
+			if !usageHeaderObservedAtBefore(candidateObservedAt, existingObservedAt) {
+				merged[index] = candidate
+				observedAtByLimit[candidate.LimitName] = candidateObservedAt
+			}
+			replaced = true
+			break
 		}
 		if !replaced {
 			merged = append(merged, candidate)
+			observedAtByLimit[candidate.LimitName] = candidateObservedAt
 		}
 	}
-	return merged
+	return merged, observedAtByLimit
 }
 
 // oldestPendingUsageHeaderSnapshot 返回当前 map 中观察时间最旧的一项；相同时间按 key 稳定选择。

--- a/internal/quota/header_cache_worker.go
+++ b/internal/quota/header_cache_worker.go
@@ -34,7 +34,7 @@ func (s *Service) TryAppendUsageHeaderSnapshots(snapshots []*UsageHeaderSnapshot
 	if s == nil || len(snapshots) == 0 {
 		return true
 	}
-	// 快照在 BuildUsageHeaderSnapshot 发布后完全不可变；这里只复制指针，不再深拷贝 Header/map/slice。
+	// 输入快照在 BuildUsageHeaderSnapshot 发布后不可修改；同身份合并可以创建新的派生快照，但不会改写输入对象。
 	// usageHeaderMu 同时保护关闭标记和有界 latest map，避免 Stop 与 Append 并发竞态。
 	s.usageHeaderMu.Lock()
 	if s.usageHeaderClosing {
@@ -44,7 +44,7 @@ func (s *Service) TryAppendUsageHeaderSnapshots(snapshots []*UsageHeaderSnapshot
 	if s.usageHeaderPending == nil {
 		s.usageHeaderPending = make(map[string]*UsageHeaderSnapshot, usageHeaderPendingIdentityLimit)
 	}
-	// 同身份直接覆盖最新值；不同身份总量由同一个 map 的 1000 上限统一约束。
+	// 同身份合并一分钟内最新的 cache 事实；不同身份总量由同一个 map 的 1000 上限统一约束。
 	mergePendingUsageHeaderSnapshotPointers(s.usageHeaderPending, snapshots)
 	hasPending := len(s.usageHeaderPending) > 0
 	s.usageHeaderMu.Unlock()
@@ -145,10 +145,11 @@ func mergePendingUsageHeaderSnapshotPointers(pending map[string]*UsageHeaderSnap
 		if authIndex == "" {
 			authIndex = snapshot.Provider + "\x00" + snapshot.AuthType
 		}
-		// 已有身份只允许观察时间相同或更新的快照覆盖，迟到数据不能回滚 cache。
+		// 已有身份只允许观察时间相同或更新的快照更新，迟到数据不能回滚 cache。
 		if existing, exists := pending[authIndex]; exists {
 			if usageHeaderSnapshotIsNewer(snapshot, existing) {
-				pending[authIndex] = snapshot
+				// 一分钟内主额度和 Additional 可能来自不同 Header；只合并 cache 投影，不合并 history observation。
+				pending[authIndex] = mergePendingUsageHeaderCacheSnapshot(existing, snapshot)
 			}
 			continue
 		}
@@ -174,6 +175,64 @@ func mergePendingUsageHeaderSnapshotPointers(pending map[string]*UsageHeaderSnap
 			"pending_identity_limit":  usageHeaderPendingIdentityLimit,
 		}).Warn("usage header quota pending identity limit reached")
 	}
+}
+
+// mergePendingUsageHeaderCacheSnapshot 把同一账号一分钟内观察到的主额度和 Additional 收敛成一份 cache 快照。
+func mergePendingUsageHeaderCacheSnapshot(existing *UsageHeaderSnapshot, latest *UsageHeaderSnapshot) *UsageHeaderSnapshot {
+	if existing == nil || latest == nil {
+		return latest
+	}
+	existingUsage := codexUsagePayloadFromProviderOutput(existing.CacheOutput)
+	latestUsage := codexUsagePayloadFromProviderOutput(latest.CacheOutput)
+	if existingUsage == nil || latestUsage == nil {
+		// Header snapshot 当前只有 Codex；未来其它 provider 没有明确合并合同时仍保持 latest 语义。
+		return latest
+	}
+
+	// 以新快照为基底，ObservedAt、身份和 history observation 都保持最新 Header 的原值。
+	mergedSnapshot := *latest
+	mergedUsage := *latestUsage
+	if strings.TrimSpace(mergedUsage.PlanType) == "" {
+		// 新 Header 未返回套餐时，保留本分钟已观察到的套餐。
+		mergedUsage.PlanType = existingUsage.PlanType
+	}
+	if mergedUsage.RateLimit == nil {
+		// Active-Limit 命中 Additional 时新快照不含主额度，不能删掉本分钟更早的主 Primary/Secondary。
+		mergedUsage.RateLimit = existingUsage.RateLimit
+	}
+	// Additional 按 quota key 所使用的 LimitName 合并：同名 group 用新值，未出现的 group 保留旧值。
+	mergedUsage.AdditionalRateLimits = mergePendingCodexAdditionalRateLimits(existingUsage.AdditionalRateLimits, latestUsage.AdditionalRateLimits)
+	mergedSnapshot.CacheOutput = ProviderOutput{
+		Provider: latest.CacheOutput.Provider,
+		Result:   CodexResult{Usage: &mergedUsage},
+	}
+	return &mergedSnapshot
+}
+
+func mergePendingCodexAdditionalRateLimits(existing []CodexAdditionalRateLimit, latest []CodexAdditionalRateLimit) []CodexAdditionalRateLimit {
+	if len(existing) == 0 {
+		return latest
+	}
+	if len(latest) == 0 {
+		return existing
+	}
+
+	// 沿用旧 cache 的稳定顺序；同名 group 原位替换，本分钟新出现的 group 追加到末尾。
+	merged := append([]CodexAdditionalRateLimit(nil), existing...)
+	for _, candidate := range latest {
+		replaced := false
+		for index := range merged {
+			if merged[index].LimitName == candidate.LimitName {
+				merged[index] = candidate
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			merged = append(merged, candidate)
+		}
+	}
+	return merged
 }
 
 // oldestPendingUsageHeaderSnapshot 返回当前 map 中观察时间最旧的一项；相同时间按 key 稳定选择。

--- a/internal/quota/header_snapshot.go
+++ b/internal/quota/header_snapshot.go
@@ -34,7 +34,7 @@ type UsageHeaderSnapshot struct {
 	ObservedAt time.Time
 	// CacheOutput 是现有 quota cache 合同的完整只读解析结果，worker 不再解析 Header。
 	CacheOutput ProviderOutput
-	// MainQuotaObservations 只包含无 group Primary/Secondary，供 history runner 在十秒批次到期后消费。
+	// MainQuotaObservations 只包含无 group Primary/Secondary，供 history runner 在一分钟批次到期后消费。
 	MainQuotaObservations []repositorydto.CodexMainQuotaObservation
 }
 

--- a/internal/quota/header_snapshot.go
+++ b/internal/quota/header_snapshot.go
@@ -39,7 +39,7 @@ type UsageHeaderSnapshot struct {
 }
 
 type UsageHeaderSnapshotAppender interface {
-	// TryAppendUsageHeaderSnapshots 接收不可变快照指针；实现只能复制指针，不能修改嵌套对象。
+	// TryAppendUsageHeaderSnapshots 接收不可变快照；实现可以保留指针或创建派生快照，但不能修改输入及其嵌套对象。
 	TryAppendUsageHeaderSnapshots([]*UsageHeaderSnapshot) bool
 }
 

--- a/internal/quota/header_snapshot.go
+++ b/internal/quota/header_snapshot.go
@@ -36,6 +36,10 @@ type UsageHeaderSnapshot struct {
 	CacheOutput ProviderOutput
 	// MainQuotaObservations 只包含无 group Primary/Secondary，供 history runner 在一分钟批次到期后消费。
 	MainQuotaObservations []repositorydto.CodexMainQuotaObservation
+	// pendingMainObservedAt 只供一分钟 cache 合并记录主额度自身的新鲜度；零值表示回退 ObservedAt。
+	pendingMainObservedAt time.Time
+	// pendingAdditionalObservedAt 按 LimitName 记录 Additional 自身的新鲜度，不进入 history 或对外响应。
+	pendingAdditionalObservedAt map[string]time.Time
 }
 
 type UsageHeaderSnapshotAppender interface {

--- a/internal/quota/header_snapshot.go
+++ b/internal/quota/header_snapshot.go
@@ -74,9 +74,12 @@ func (codexUsageHeaderSnapshotProcessor) TryBuildUsageHeaderSnapshot(input Usage
 		return nil, false
 	}
 	cacheOutput, cacheOK := decoded.cacheOutput()
-	// history 复用同一 decoded 主窗口，不读取 cache 已过滤掉的未知窗口结果。
-	historyOutput := decoded.mainQuotaOutput()
-	observations := BuildCodexMainQuotaObservations(authIndex, historyOutput, input.ObservedAt)
+	// history 只在来源可信时复用同一 decoded 主窗口；cache 始终保持原有投影。
+	var observations []repositorydto.CodexMainQuotaObservation
+	if decoded.mainQuotaHistoryAllowed() {
+		historyOutput := decoded.mainQuotaOutput()
+		observations = BuildCodexMainQuotaObservations(authIndex, historyOutput, input.ObservedAt)
+	}
 	// 只有 cache 或 history 至少一个消费者可处理时才创建异步快照。
 	if !cacheOK && len(observations) == 0 {
 		return nil, false
@@ -113,7 +116,7 @@ func codexQuotaSnapshotHeaders(headers http.Header) http.Header {
 }
 
 func isCodexQuotaHeaderKey(key string) bool {
-	if key == "X-Codex-Plan-Type" {
+	if key == "X-Codex-Plan-Type" || key == "X-Codex-Active-Limit" {
 		return true
 	}
 	if !strings.HasPrefix(key, codexHeaderPrefix) {

--- a/internal/quota/service.go
+++ b/internal/quota/service.go
@@ -68,7 +68,7 @@ type Service struct {
 	// refreshWG 跟踪 service 派生的 dispatcher/worker/scheduler goroutine，App 关闭 DB 前会等待它们退出。
 	refreshWG sync.WaitGroup
 
-	// usageHeaderPending 按 auth_index 只保存一分钟窗口内最新的不可变快照指针。
+	// usageHeaderPending 按 auth_index 保存一分钟内合并后的不可变 cache 快照；history 使用独立队列。
 	usageHeaderPending       map[string]*UsageHeaderSnapshot
 	usageHeaderWake          chan struct{}
 	usageHeaderStopCh        chan struct{}

--- a/internal/quota/service.go
+++ b/internal/quota/service.go
@@ -20,7 +20,7 @@ import (
 type ServiceOptions struct {
 	RefreshWorkerLimit               int
 	UsageHeaderSnapshotFlushInterval time.Duration
-	// CodexQuotaHistoryFlushInterval 覆盖独立历史 runner 固定批次边界前的十秒等待，主要供定向测试缩短等待。
+	// CodexQuotaHistoryFlushInterval 覆盖独立历史 runner 固定批次边界前的一分钟等待，主要供定向测试缩短等待。
 	CodexQuotaHistoryFlushInterval time.Duration
 	// CodexQuotaHistoryQueueSize 分别覆盖 Header 与可信主动查询两条有界队列容量，非正值使用生产默认值。
 	CodexQuotaHistoryQueueSize int
@@ -77,13 +77,13 @@ type Service struct {
 	usageHeaderClosing       bool
 	usageHeaderCloseOnce     sync.Once
 
-	// codexQuotaHistoryHeaderQueue 有界保存 Header 快照指针，生产者永不等待。
+	// codexQuotaHistoryHeaderQueue 有界保存 Header 快照指针；满载按 ObservedAt 淘汰最旧项。
 	codexQuotaHistoryHeaderQueue chan codexQuotaHistoryInput
 	// codexQuotaHistoryHeaderWake 只通知 runner“Header 队列已有数据”；容量为一即可合并重复唤醒。
 	codexQuotaHistoryHeaderWake chan struct{}
 	// codexQuotaHistoryTrustedQueue 独立保存低频可信主动查询 observation，不与 Header 共用 writer 批次。
 	codexQuotaHistoryTrustedQueue chan codexQuotaHistoryInput
-	// codexQuotaHistoryTrustedWake 让可信来源跳过 Header 十秒窗口并立即触发 runner。
+	// codexQuotaHistoryTrustedWake 让可信来源跳过 Header 一分钟窗口并立即触发 runner。
 	codexQuotaHistoryTrustedWake chan struct{}
 	// codexQuotaHistoryStopCh 只表达 runner 停止；队列不关闭以避免并发发送 panic。
 	codexQuotaHistoryStopCh chan struct{}
@@ -144,7 +144,7 @@ func NewServiceWithRegistryAndOptions(db *gorm.DB, registry ProviderRegistry, op
 	if usageHeaderFlushInterval <= 0 {
 		usageHeaderFlushInterval = usageHeaderSnapshotFlushInterval
 	}
-	// 独立 history runner 默认每 10 秒合并一次；非正测试覆盖不改变生产语义。
+	// 独立 history runner 默认每一分钟合并一次；非正测试覆盖不改变生产语义。
 	codexHistoryFlushInterval := options.CodexQuotaHistoryFlushInterval
 	if codexHistoryFlushInterval <= 0 {
 		codexHistoryFlushInterval = codexQuotaHistoryFlushInterval

--- a/internal/quota/service.go
+++ b/internal/quota/service.go
@@ -22,6 +22,8 @@ type ServiceOptions struct {
 	UsageHeaderSnapshotFlushInterval time.Duration
 	// CodexQuotaHistoryFlushInterval 覆盖独立历史 runner 固定批次边界前的一分钟等待，主要供定向测试缩短等待。
 	CodexQuotaHistoryFlushInterval time.Duration
+	// CodexQuotaHistoryHeartbeatInterval 覆盖相同整数百分比再次物化的最短间隔，非正值使用五分钟生产默认值。
+	CodexQuotaHistoryHeartbeatInterval time.Duration
 	// CodexQuotaHistoryQueueSize 分别覆盖 Header 与可信主动查询两条有界队列容量，非正值使用生产默认值。
 	CodexQuotaHistoryQueueSize int
 	PricingCatalog             *pricing.Catalog
@@ -77,11 +79,11 @@ type Service struct {
 	usageHeaderClosing       bool
 	usageHeaderCloseOnce     sync.Once
 
-	// codexQuotaHistoryHeaderQueue 有界保存 Header 快照指针；满载按 ObservedAt 淘汰最旧项。
+	// codexQuotaHistoryHeaderQueue 有界保存 Header 快照指针；满载时 FIFO 丢队头并保留后到数据。
 	codexQuotaHistoryHeaderQueue chan codexQuotaHistoryInput
 	// codexQuotaHistoryHeaderWake 只通知 runner“Header 队列已有数据”；容量为一即可合并重复唤醒。
 	codexQuotaHistoryHeaderWake chan struct{}
-	// codexQuotaHistoryTrustedQueue 独立保存低频可信主动查询 observation，不与 Header 共用 writer 批次。
+	// codexQuotaHistoryTrustedQueue 独立保存低频可信主动查询 observation，使它能跳过 Header 等待并覆盖同角色旧候选。
 	codexQuotaHistoryTrustedQueue chan codexQuotaHistoryInput
 	// codexQuotaHistoryTrustedWake 让可信来源跳过 Header 一分钟窗口并立即触发 runner。
 	codexQuotaHistoryTrustedWake chan struct{}
@@ -91,6 +93,8 @@ type Service struct {
 	codexQuotaHistoryDoneCh chan struct{}
 	// codexQuotaHistoryFlushInterval 是首条数据入队后、runner 固定本批队列数量前的等待时长。
 	codexQuotaHistoryFlushInterval time.Duration
+	// codexQuotaHistoryHeartbeatInterval 限制已落库同值状态最多每五分钟物化一次。
+	codexQuotaHistoryHeartbeatInterval time.Duration
 	// codexQuotaHistoryNewTimer 创建一次性窗口 timer，测试可替换但生产默认使用 time.Timer。
 	codexQuotaHistoryNewTimer func(time.Duration) (<-chan time.Time, func())
 	// codexQuotaHistoryWrite 是独立 repository writer；不进入 usage/inbox 事务。
@@ -149,6 +153,11 @@ func NewServiceWithRegistryAndOptions(db *gorm.DB, registry ProviderRegistry, op
 	if codexHistoryFlushInterval <= 0 {
 		codexHistoryFlushInterval = codexQuotaHistoryFlushInterval
 	}
+	// 稳定值与请求量解耦，默认每五分钟最多更新一次父子历史行。
+	codexHistoryHeartbeatInterval := options.CodexQuotaHistoryHeartbeatInterval
+	if codexHistoryHeartbeatInterval <= 0 {
+		codexHistoryHeartbeatInterval = codexQuotaHistoryHeartbeatInterval
+	}
 	// 队列容量只限制内存和丢弃边界，不改变 cache latest-map 的接收能力。
 	codexHistoryQueueSize := options.CodexQuotaHistoryQueueSize
 	if codexHistoryQueueSize <= 0 {
@@ -160,37 +169,38 @@ func NewServiceWithRegistryAndOptions(db *gorm.DB, registry ProviderRegistry, op
 		panic("pricing catalog is required")
 	}
 	service := &Service{
-		db:                              db,
-		registry:                        registry,
-		pricing:                         pricingCatalog,
-		refreshTasks:                    make(map[string]*RefreshTaskRecord),
-		resetInFlight:                   make(map[string]struct{}),
-		refreshWorkerTokens:             make(chan struct{}, workerLimit),
-		refreshTaskTTL:                  RefreshTransientTaskTTL,
-		refreshCooldown:                 time.Sleep,
-		refreshContext:                  refreshContext,
-		refreshCancel:                   refreshCancel,
-		autoRefreshSettingsChanged:      make(chan struct{}, 1),
-		usageHeaderPending:              make(map[string]*UsageHeaderSnapshot, usageHeaderPendingIdentityLimit),
-		usageHeaderWake:                 make(chan struct{}, 1),
-		usageHeaderStopCh:               make(chan struct{}),
-		usageHeaderDoneCh:               make(chan struct{}),
-		usageHeaderFlushInterval:        usageHeaderFlushInterval,
-		usageHeaderNewTimer:             newUsageHeaderTimer,
-		codexQuotaHistoryHeaderQueue:    make(chan codexQuotaHistoryInput, codexHistoryQueueSize),
-		codexQuotaHistoryHeaderWake:     make(chan struct{}, 1),
-		codexQuotaHistoryTrustedQueue:   make(chan codexQuotaHistoryInput, codexHistoryQueueSize),
-		codexQuotaHistoryTrustedWake:    make(chan struct{}, 1),
-		codexQuotaHistoryStopCh:         make(chan struct{}),
-		codexQuotaHistoryDoneCh:         make(chan struct{}),
-		codexQuotaHistoryFlushInterval:  codexHistoryFlushInterval,
-		codexQuotaHistoryNewTimer:       newCodexQuotaHistoryTimer,
-		codexQuotaHistoryWrite:          repository.WriteCodexMainQuotaObservations,
-		codexQuotaHistoryLoad:           repository.LoadLatestCodexQuotaHistoryState,
-		codexQuotaHistoryListIdentities: repository.ListActiveAuthFileUsageIdentitiesByAuthIndexes,
+		db:                                 db,
+		registry:                           registry,
+		pricing:                            pricingCatalog,
+		refreshTasks:                       make(map[string]*RefreshTaskRecord),
+		resetInFlight:                      make(map[string]struct{}),
+		refreshWorkerTokens:                make(chan struct{}, workerLimit),
+		refreshTaskTTL:                     RefreshTransientTaskTTL,
+		refreshCooldown:                    time.Sleep,
+		refreshContext:                     refreshContext,
+		refreshCancel:                      refreshCancel,
+		autoRefreshSettingsChanged:         make(chan struct{}, 1),
+		usageHeaderPending:                 make(map[string]*UsageHeaderSnapshot, usageHeaderPendingIdentityLimit),
+		usageHeaderWake:                    make(chan struct{}, 1),
+		usageHeaderStopCh:                  make(chan struct{}),
+		usageHeaderDoneCh:                  make(chan struct{}),
+		usageHeaderFlushInterval:           usageHeaderFlushInterval,
+		usageHeaderNewTimer:                newUsageHeaderTimer,
+		codexQuotaHistoryHeaderQueue:       make(chan codexQuotaHistoryInput, codexHistoryQueueSize),
+		codexQuotaHistoryHeaderWake:        make(chan struct{}, 1),
+		codexQuotaHistoryTrustedQueue:      make(chan codexQuotaHistoryInput, codexHistoryQueueSize),
+		codexQuotaHistoryTrustedWake:       make(chan struct{}, 1),
+		codexQuotaHistoryStopCh:            make(chan struct{}),
+		codexQuotaHistoryDoneCh:            make(chan struct{}),
+		codexQuotaHistoryFlushInterval:     codexHistoryFlushInterval,
+		codexQuotaHistoryHeartbeatInterval: codexHistoryHeartbeatInterval,
+		codexQuotaHistoryNewTimer:          newCodexQuotaHistoryTimer,
+		codexQuotaHistoryWrite:             repository.WriteCodexMainQuotaObservations,
+		codexQuotaHistoryLoad:              repository.LoadLatestCodexQuotaHistoryState,
+		codexQuotaHistoryListIdentities:    repository.ListActiveAuthFileUsageIdentitiesByAuthIndexes,
 	}
 	go service.runUsageHeaderSnapshotWorker()
-	// history 拥有独立队列、timer 和失败状态，不能复用一分钟 cache worker 的 pending map。
+	// history 拥有独立队列、timer 和稳定尾段，不能复用一分钟 cache worker 的 pending map。
 	go service.runCodexQuotaHistoryRunner()
 	return service
 }

--- a/internal/quota/test/codex_header_test.go
+++ b/internal/quota/test/codex_header_test.go
@@ -127,6 +127,71 @@ func TestBuildCodexUsageHeaderSnapshotCreatesImmutableCacheAndHistoryProjections
 	}
 }
 
+func TestBuildCodexUsageHeaderSnapshotSkipsAdditionalActiveLimitHistory(t *testing.T) {
+	// 生产 Spark 响应会把当前 Additional 额度投影到无 group Primary；cache 仍需保留，但主历史必须拒绝。
+	observedAt := time.Date(2026, 8, 27, 14, 5, 0, 0, time.Local)
+	headers := http.Header{
+		"x-codex-active-limit":                          []string{"codex_bengalfox"},
+		"X-Codex-Primary-Used-Percent":                  []string{"4"},
+		"X-Codex-Primary-Window-Minutes":                []string{"300"},
+		"X-Codex-Primary-Reset-After-Seconds":           []string{"7200"},
+		"X-Codex-Bengalfox-Limit-Name":                  []string{"GPT-5.3-Codex-Spark"},
+		"X-Codex-Bengalfox-Primary-Used-Percent":        []string{"4"},
+		"X-Codex-Bengalfox-Primary-Window-Minutes":      []string{"300"},
+		"X-Codex-Bengalfox-Primary-Reset-After-Seconds": []string{"7200"},
+	}
+	snapshot, ok := BuildUsageHeaderSnapshot(UsageHeaderSnapshotInput{
+		AuthType: "oauth", AuthIndex: "spark-auth", Provider: "codex",
+		ObservedAt: observedAt, Headers: headers,
+	})
+	if !ok || snapshot == nil {
+		t.Fatal("expected Spark header to keep its cache snapshot")
+	}
+	rows := NormalizeQuotaRows(snapshot.CacheOutput)
+	if len(rows) != 2 || rows[0].Key != "rate_limit.primary_window" || rows[1].Key != "additional_rate_limits.GPT-5.3-Codex-Spark.primary_window" {
+		t.Fatalf("unexpected Spark cache rows: %#v", rows)
+	}
+	if len(snapshot.MainQuotaObservations) != 0 {
+		t.Fatalf("expected Spark active Additional header to create no main history, got %+v", snapshot.MainQuotaObservations)
+	}
+}
+
+func TestBuildCodexUsageHeaderSnapshotAcceptsKnownMainAndRejectsUnknownActiveLimit(t *testing.T) {
+	baseHeaders := http.Header{
+		"X-Codex-Primary-Used-Percent":        []string{"22"},
+		"X-Codex-Primary-Window-Minutes":      []string{"10080"},
+		"X-Codex-Primary-Reset-After-Seconds": []string{"604800"},
+	}
+	tests := []struct {
+		name        string
+		activeLimit string
+		wantHistory bool
+	}{
+		{name: "known main", activeLimit: "premium", wantHistory: true},
+		{name: "unknown non-empty", activeLimit: "future_pool", wantHistory: false},
+		{name: "unknown normalized empty", activeLimit: "___", wantHistory: false},
+		{name: "missing compatibility", wantHistory: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			headers := baseHeaders.Clone()
+			if test.activeLimit != "" {
+				headers.Set("X-Codex-Active-Limit", test.activeLimit)
+			}
+			snapshot, ok := BuildUsageHeaderSnapshot(UsageHeaderSnapshotInput{
+				AuthType: "oauth", AuthIndex: "codex-auth", Provider: "codex",
+				ObservedAt: time.Date(2026, 8, 27, 14, 5, 0, 0, time.Local), Headers: headers,
+			})
+			if !ok || snapshot == nil {
+				t.Fatal("expected valid cache snapshot")
+			}
+			if got := len(snapshot.MainQuotaObservations); (got == 1) != test.wantHistory {
+				t.Fatalf("unexpected history eligibility for active limit %q: %+v", test.activeLimit, snapshot.MainQuotaObservations)
+			}
+		})
+	}
+}
+
 func TestBuildCodexUsageHeaderSnapshotKeepsUnknownMainWindowHistoryOnly(t *testing.T) {
 	// 未知 720 分钟窗口不应放宽现有 cache parser，但必须作为合法 Primary 历史 observation 保存。
 	observedAt := time.Date(2026, 8, 20, 8, 0, 0, 0, time.UTC)

--- a/internal/quota/test/codex_header_test.go
+++ b/internal/quota/test/codex_header_test.go
@@ -128,17 +128,24 @@ func TestBuildCodexUsageHeaderSnapshotCreatesImmutableCacheAndHistoryProjections
 }
 
 func TestBuildCodexUsageHeaderSnapshotSkipsAdditionalActiveLimitHistory(t *testing.T) {
-	// 生产 Spark 响应会把当前 Additional 额度投影到无 group Primary；cache 仍需保留，但主历史必须拒绝。
+	// 生产 Spark 响应会把当前 Additional 额度重复投影到无 group Primary。
+	// cache 只保留带 group 的 Spark 行，主历史也不接受这份投影。
 	observedAt := time.Date(2026, 8, 27, 14, 5, 0, 0, time.Local)
 	headers := http.Header{
-		"x-codex-active-limit":                          []string{"codex_bengalfox"},
-		"X-Codex-Primary-Used-Percent":                  []string{"4"},
-		"X-Codex-Primary-Window-Minutes":                []string{"300"},
-		"X-Codex-Primary-Reset-After-Seconds":           []string{"7200"},
-		"X-Codex-Bengalfox-Limit-Name":                  []string{"GPT-5.3-Codex-Spark"},
-		"X-Codex-Bengalfox-Primary-Used-Percent":        []string{"4"},
-		"X-Codex-Bengalfox-Primary-Window-Minutes":      []string{"300"},
-		"X-Codex-Bengalfox-Primary-Reset-After-Seconds": []string{"7200"},
+		"x-codex-active-limit":                            []string{"codex_bengalfox"},
+		"X-Codex-Primary-Used-Percent":                    []string{"4"},
+		"X-Codex-Primary-Window-Minutes":                  []string{"300"},
+		"X-Codex-Primary-Reset-After-Seconds":             []string{"7200"},
+		"X-Codex-Secondary-Used-Percent":                  []string{"6"},
+		"X-Codex-Secondary-Window-Minutes":                []string{"10080"},
+		"X-Codex-Secondary-Reset-After-Seconds":           []string{"3600"},
+		"X-Codex-Bengalfox-Limit-Name":                    []string{"GPT-5.3-Codex-Spark"},
+		"X-Codex-Bengalfox-Primary-Used-Percent":          []string{"4"},
+		"X-Codex-Bengalfox-Primary-Window-Minutes":        []string{"300"},
+		"X-Codex-Bengalfox-Primary-Reset-After-Seconds":   []string{"7200"},
+		"X-Codex-Bengalfox-Secondary-Used-Percent":        []string{"6"},
+		"X-Codex-Bengalfox-Secondary-Window-Minutes":      []string{"10080"},
+		"X-Codex-Bengalfox-Secondary-Reset-After-Seconds": []string{"3600"},
 	}
 	snapshot, ok := BuildUsageHeaderSnapshot(UsageHeaderSnapshotInput{
 		AuthType: "oauth", AuthIndex: "spark-auth", Provider: "codex",
@@ -148,7 +155,7 @@ func TestBuildCodexUsageHeaderSnapshotSkipsAdditionalActiveLimitHistory(t *testi
 		t.Fatal("expected Spark header to keep its cache snapshot")
 	}
 	rows := NormalizeQuotaRows(snapshot.CacheOutput)
-	if len(rows) != 2 || rows[0].Key != "rate_limit.primary_window" || rows[1].Key != "additional_rate_limits.GPT-5.3-Codex-Spark.primary_window" {
+	if len(rows) != 2 || rows[0].Key != "additional_rate_limits.GPT-5.3-Codex-Spark.primary_window" || rows[1].Key != "additional_rate_limits.GPT-5.3-Codex-Spark.secondary_window" {
 		t.Fatalf("unexpected Spark cache rows: %#v", rows)
 	}
 	if len(snapshot.MainQuotaObservations) != 0 {

--- a/internal/quota/test/codex_quota_history_runner_test.go
+++ b/internal/quota/test/codex_quota_history_runner_test.go
@@ -77,7 +77,7 @@ func TestCodexQuotaHistoryRunnerSortsSameBatchByObservationTime(t *testing.T) {
 	resetAt := base.Add(5 * time.Hour)
 	older := codexHistoryPrimarySnapshot("out-of-order-auth", base.Add(time.Minute), 90, resetAt)
 	newer := codexHistoryPrimarySnapshot("out-of-order-auth", base.Add(2*time.Minute), 89, resetAt)
-	// 故意按较新 observation 在前的队列顺序投递；shutdown drain 与正常十秒批次共享同一处理入口。
+	// 故意按较新 observation 在前的队列顺序投递；shutdown drain 与正常一分钟批次共享同一处理入口。
 	if !service.TryAppendUsageHeaderSnapshots(usageHeaderSnapshotPointers(newer, older)) {
 		service.StopRefreshTasks()
 		t.Fatal("expected out-of-order history observations to enter one batch")
@@ -824,7 +824,7 @@ func TestCodexQuotaHistoryRunnerRejectsNonCodexHeaderIdentity(t *testing.T) {
 }
 
 func TestCodexQuotaHistoryQueueFullDoesNotBlockOrDiscardCacheSnapshot(t *testing.T) {
-	// 第一批到点后的 identity 查询被挂起、第二份占满容量一队列，第三份 history 必须被丢弃但 cache 仍接收。
+	// 第一批到点后的 identity 查询被挂起、第二份占满容量一队列，第三份必须淘汰旧 history 且 cache 仍接收。
 	db := openQuotaTestDatabase(t)
 	seedUsageIdentity(t, db, codexHistoryUsageIdentity("queue-auth"))
 	timers := make(chan usageHeaderManualTimer, 1)
@@ -900,15 +900,53 @@ func TestCodexQuotaHistoryQueueFullDoesNotBlockOrDiscardCacheSnapshot(t *testing
 	if task.Quota == nil || len(task.Quota.Quota) != 1 || task.Quota.Quota[0].UsedPercent == nil || *task.Quota.Quota[0].UsedPercent != 13 {
 		t.Fatalf("expected latest third snapshot to reach cache despite full history queue, got %+v", task)
 	}
+	cycles := loadCodexQuotaCycles(t, db, "queue-auth")
+	if len(cycles) != 1 {
+		t.Fatalf("expected one queue-auth history cycle, got %+v", cycles)
+	}
+	segments := loadCodexQuotaSegments(t, db, cycles[0].ID)
+	if len(segments) != 2 || segments[0].RemainingPercent != 90 || segments[1].RemainingPercent != 87 {
+		t.Fatalf("expected full history queue to retain 90 then newest 87 and evict 89, got %+v", segments)
+	}
+}
+
+func TestCodexQuotaHistoryQueueFullDoesNotReplaceNewerSnapshotWithStaleArrival(t *testing.T) {
+	// Header 可能因 inbox 重试乱序到达；容量满时必须比较 ObservedAt，不能仅凭到达顺序覆盖较新事实。
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, codexHistoryUsageIdentity("queue-stale-auth"))
+	service := NewServiceWithRegistryAndOptions(db, NewProviderRegistry(nil), ServiceOptions{
+		UsageHeaderSnapshotFlushInterval: time.Hour,
+		CodexQuotaHistoryFlushInterval:   time.Hour,
+		CodexQuotaHistoryQueueSize:       1,
+		PricingCatalog:                   emptyPricingCatalogForTest(),
+	})
+	base := time.Date(2026, 8, 20, 8, 0, 0, 0, time.UTC)
+	resetAt := base.Add(5 * time.Hour)
+	newer := codexHistoryPrimarySnapshot("queue-stale-auth", base.Add(2*time.Second), 89, resetAt)
+	stale := codexHistoryPrimarySnapshot("queue-stale-auth", base.Add(time.Second), 90, resetAt)
+	if !service.TryAppendUsageHeaderSnapshots(usageHeaderSnapshotPointers(newer, stale)) {
+		service.StopRefreshTasks()
+		t.Fatal("expected cache fan-out to accept the full test batch")
+	}
+	service.StopRefreshTasks()
+
+	cycles := loadCodexQuotaCycles(t, db, "queue-stale-auth")
+	if len(cycles) != 1 {
+		t.Fatalf("expected one stale-order history cycle, got %+v", cycles)
+	}
+	segments := loadCodexQuotaSegments(t, db, cycles[0].ID)
+	if len(segments) != 1 || segments[0].RemainingPercent != 89 {
+		t.Fatalf("expected stale arrival to leave the newer 89 snapshot queued, got %+v", segments)
+	}
 }
 
 func TestCodexQuotaHistoryRunnerSnapshotsQueueOnlyWhenTimerExpires(t *testing.T) {
-	// 第一条只启动十秒窗口；timer 到期时固定当时两条，落库期间到达的第三条必须留给下一轮。
+	// 第一条只启动一分钟窗口；timer 到期时固定当时两条，落库期间到达的第三条必须留给下一轮。
 	db := openQuotaTestDatabase(t)
 	for _, authIndex := range []string{"batch-auth-1", "batch-auth-2", "batch-auth-3"} {
 		seedUsageIdentity(t, db, codexHistoryUsageIdentity(authIndex))
 	}
-	// 手动 timer 让测试精确控制两个十秒窗口，而不依赖 CI 的真实调度时间。
+	// 手动 timer 让测试精确控制两个一分钟窗口，而不依赖 CI 的真实调度时间。
 	timers := make(chan usageHeaderManualTimer, 3)
 	// 第一批在批量 identity 查询处暂停，提供一个确定的“落库期间”并发入队窗口。
 	queryEntered := make(chan struct{}, 1)
@@ -952,8 +990,8 @@ func TestCodexQuotaHistoryRunnerSnapshotsQueueOnlyWhenTimerExpires(t *testing.T)
 		t.Fatal("expected first batch snapshot to enter history queue")
 	}
 	firstTimer := waitForCodexQuotaHistoryManualTimer(t, timers)
-	if firstTimer.delay != 10*time.Second {
-		t.Fatalf("expected first observation to start a ten-second window, got %s", firstTimer.delay)
+	if firstTimer.delay != time.Minute {
+		t.Fatalf("expected first observation to start a one-minute window, got %s", firstTimer.delay)
 	}
 	if queueLength := codexQuotaHistoryHeaderQueueLength(service); queueLength != 1 {
 		t.Fatalf("expected first observation to remain queued before timer expiry, got queue length %d", queueLength)
@@ -961,7 +999,7 @@ func TestCodexQuotaHistoryRunnerSnapshotsQueueOnlyWhenTimerExpires(t *testing.T)
 
 	second := codexHistoryPrimarySnapshot("batch-auth-2", base.Add(time.Second), 89, base.Add(5*time.Hour))
 	if !service.TryAppendUsageHeaderSnapshots(usageHeaderSnapshotPointers(second)) {
-		t.Fatal("expected second observation to join the active ten-second queue window")
+		t.Fatal("expected second observation to join the active one-minute queue window")
 	}
 	if queueLength := codexQuotaHistoryHeaderQueueLength(service); queueLength != 2 {
 		t.Fatalf("expected two observations queued at timer expiry boundary, got %d", queueLength)
@@ -986,7 +1024,7 @@ func TestCodexQuotaHistoryRunnerSnapshotsQueueOnlyWhenTimerExpires(t *testing.T)
 	}
 	release()
 
-	// 第一轮必须只写前两条；runner 随后从残留 wake 启动第二个完整十秒窗口。
+	// 第一轮必须只写前两条；runner 随后从残留 wake 启动第二个完整一分钟窗口。
 	secondTimer := waitForCodexQuotaHistoryManualTimer(t, timers)
 	waitForCodexQuotaCycleCount(t, db, 2)
 	if queueLength := codexQuotaHistoryHeaderQueueLength(service); queueLength != 1 {
@@ -997,7 +1035,7 @@ func TestCodexQuotaHistoryRunnerSnapshotsQueueOnlyWhenTimerExpires(t *testing.T)
 }
 
 func TestCodexQuotaHistoryRunnerUsesDefaultWindowWithoutCountBasedEarlyFlush(t *testing.T) {
-	// 默认生产配置必须等待完整十秒；即使队列超过旧的 256 条阈值也不能提前查询或落库。
+	// 默认生产配置必须等待完整一分钟；即使队列超过旧的 256 条阈值也不能提前查询或落库。
 	db := openQuotaTestDatabase(t)
 	seedUsageIdentity(t, db, codexHistoryUsageIdentity("volume-auth"))
 	timers := make(chan usageHeaderManualTimer, 2)
@@ -1034,8 +1072,8 @@ func TestCodexQuotaHistoryRunnerUsesDefaultWindowWithoutCountBasedEarlyFlush(t *
 		t.Fatal("expected all high-volume snapshots to enter cache/history fan-out")
 	}
 	timer := waitForCodexQuotaHistoryManualTimer(t, timers)
-	if timer.delay != 10*time.Second {
-		t.Fatalf("expected production default history window of ten seconds, got %s", timer.delay)
+	if timer.delay != time.Minute {
+		t.Fatalf("expected production default history window of one minute, got %s", timer.delay)
 	}
 	if queueLength := codexQuotaHistoryHeaderQueueLength(service); queueLength != 257 {
 		t.Fatalf("expected all 257 observations to remain queued before timer expiry, got %d", queueLength)

--- a/internal/quota/test/codex_quota_history_runner_test.go
+++ b/internal/quota/test/codex_quota_history_runner_test.go
@@ -910,8 +910,8 @@ func TestCodexQuotaHistoryQueueFullDoesNotBlockOrDiscardCacheSnapshot(t *testing
 	}
 }
 
-func TestCodexQuotaHistoryQueueFullDoesNotReplaceNewerSnapshotWithStaleArrival(t *testing.T) {
-	// Header 可能因 inbox 重试乱序到达；容量满时必须比较 ObservedAt，不能仅凭到达顺序覆盖较新事实。
+func TestCodexQuotaHistoryQueueFullKeepsLatestArrival(t *testing.T) {
+	// history 队列满时只丢队头并保留后到数据；真实观察时间排序留给 runner 批次处理。
 	db := openQuotaTestDatabase(t)
 	seedUsageIdentity(t, db, codexHistoryUsageIdentity("queue-stale-auth"))
 	service := NewServiceWithRegistryAndOptions(db, NewProviderRegistry(nil), ServiceOptions{
@@ -935,8 +935,8 @@ func TestCodexQuotaHistoryQueueFullDoesNotReplaceNewerSnapshotWithStaleArrival(t
 		t.Fatalf("expected one stale-order history cycle, got %+v", cycles)
 	}
 	segments := loadCodexQuotaSegments(t, db, cycles[0].ID)
-	if len(segments) != 1 || segments[0].RemainingPercent != 89 {
-		t.Fatalf("expected stale arrival to leave the newer 89 snapshot queued, got %+v", segments)
+	if len(segments) != 1 || segments[0].RemainingPercent != 90 {
+		t.Fatalf("expected later arrival to replace the full queue head, got %+v", segments)
 	}
 }
 
@@ -1094,6 +1094,164 @@ func TestCodexQuotaHistoryRunnerUsesDefaultWindowWithoutCountBasedEarlyFlush(t *
 	segments := loadCodexQuotaSegments(t, db, cycles[0].ID)
 	if len(segments) != 1 || segments[0].RemainingPercent != 90 || segments[0].ObservationCount != 257 {
 		t.Fatalf("expected one post-window segment containing all 257 observations, got %+v", segments)
+	}
+}
+
+func TestCodexQuotaHistoryRunnerMaterializesBothHeaderWindowsWhenOneChanges(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, codexHistoryUsageIdentity("paired-window-auth"))
+	timers := make(chan usageHeaderManualTimer, 4)
+	service := NewServiceWithRegistryAndOptions(db, NewProviderRegistry(nil), ServiceOptions{
+		UsageHeaderSnapshotFlushInterval:   time.Hour,
+		CodexQuotaHistoryFlushInterval:     time.Hour,
+		CodexQuotaHistoryHeartbeatInterval: time.Hour,
+		PricingCatalog:                     emptyPricingCatalogForTest(),
+	})
+	defer service.StopRefreshTasks()
+	setCodexQuotaHistoryTimerFactory(service, func(delay time.Duration) (<-chan time.Time, func()) {
+		timer := usageHeaderManualTimer{delay: delay, fire: make(chan time.Time, 1)}
+		timers <- timer
+		return timer.fire, func() {}
+	})
+	writes := make(chan []repositorydto.CodexMainQuotaObservation, 2)
+	setCodexQuotaHistoryWriter(service, func(ctx context.Context, writerDB *gorm.DB, observations []repositorydto.CodexMainQuotaObservation) error {
+		err := repository.WriteCodexMainQuotaObservations(ctx, writerDB, observations)
+		writes <- append([]repositorydto.CodexMainQuotaObservation(nil), observations...)
+		return err
+	})
+
+	base := time.Date(2026, 8, 27, 8, 0, 0, 0, time.UTC)
+	primaryResetAt := base.Add(5 * time.Hour)
+	secondaryResetAt := base.Add(7 * 24 * time.Hour)
+	first := codexHistoryMainWindowsSnapshot("paired-window-auth", base, 90, primaryResetAt, 80, secondaryResetAt)
+	if !service.TryAppendUsageHeaderSnapshots(usageHeaderSnapshotPointers(first)) {
+		t.Fatal("expected first paired-window Header to enter history")
+	}
+	waitForCodexQuotaHistoryManualTimer(t, timers).fire <- time.Now()
+	select {
+	case observations := <-writes:
+		if len(observations) != 2 {
+			t.Fatalf("expected both initial Header windows to materialize, got %+v", observations)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected initial paired-window history write")
+	}
+
+	// Primary 下降而 Secondary 同值时，二者仍代表同一份 Header，必须使用同一观察时刻一起物化。
+	secondObservedAt := base.Add(time.Minute)
+	second := codexHistoryMainWindowsSnapshot("paired-window-auth", secondObservedAt, 89, primaryResetAt, 80, secondaryResetAt)
+	if !service.TryAppendUsageHeaderSnapshots(usageHeaderSnapshotPointers(second)) {
+		t.Fatal("expected changed paired-window Header to enter history")
+	}
+	waitForCodexQuotaHistoryManualTimer(t, timers).fire <- time.Now()
+	select {
+	case observations := <-writes:
+		if len(observations) != 2 {
+			t.Fatalf("expected changed Primary and stable Secondary in one write, got %+v", observations)
+		}
+		byRole := make(map[string]repositorydto.CodexMainQuotaObservation, len(observations))
+		for _, observation := range observations {
+			byRole[observation.WindowRole] = observation
+		}
+		for role, remainingPercent := range map[string]int{"primary": 89, "secondary": 80} {
+			observation, ok := byRole[role]
+			if !ok || observation.RemainingPercent != remainingPercent || !observation.LastObservedAt.Equal(secondObservedAt) {
+				t.Fatalf("unexpected synchronized %s observation: %+v", role, observation)
+			}
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected synchronized paired-window history write")
+	}
+}
+
+func TestCodexQuotaHistoryRunnerMaterializesStablePercentOnNextHeaderAfterHeartbeat(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, codexHistoryUsageIdentity("heartbeat-auth"))
+	timers := make(chan usageHeaderManualTimer, 6)
+	service := NewServiceWithRegistryAndOptions(db, NewProviderRegistry(nil), ServiceOptions{
+		UsageHeaderSnapshotFlushInterval:   time.Hour,
+		CodexQuotaHistoryFlushInterval:     time.Hour,
+		CodexQuotaHistoryHeartbeatInterval: 40 * time.Millisecond,
+		PricingCatalog:                     emptyPricingCatalogForTest(),
+	})
+	defer service.StopRefreshTasks()
+	setCodexQuotaHistoryTimerFactory(service, func(delay time.Duration) (<-chan time.Time, func()) {
+		timer := usageHeaderManualTimer{delay: delay, fire: make(chan time.Time, 1)}
+		timers <- timer
+		return timer.fire, func() {}
+	})
+	writes := make(chan []repositorydto.CodexMainQuotaObservation, 3)
+	setCodexQuotaHistoryWriter(service, func(ctx context.Context, writerDB *gorm.DB, observations []repositorydto.CodexMainQuotaObservation) error {
+		err := repository.WriteCodexMainQuotaObservations(ctx, writerDB, observations)
+		writes <- append([]repositorydto.CodexMainQuotaObservation(nil), observations...)
+		return err
+	})
+
+	base := time.Date(2026, 8, 27, 8, 0, 0, 0, time.UTC)
+	resetAt := base.Add(7 * 24 * time.Hour)
+	first := codexHistoryPrimarySnapshot("heartbeat-auth", base, 90, resetAt)
+	if !service.TryAppendUsageHeaderSnapshots(usageHeaderSnapshotPointers(first)) {
+		t.Fatal("expected first heartbeat observation to enter history")
+	}
+	firstWindow := waitForCodexQuotaHistoryManualTimer(t, timers)
+	firstWindow.fire <- time.Now()
+	select {
+	case observations := <-writes:
+		if len(observations) != 1 || observations[0].ObservationCount != 1 {
+			t.Fatalf("unexpected first materialization: %+v", observations)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected first semantic state to materialize")
+	}
+
+	// 同百分比的高频 Header 先只在内存合并，当前一分钟批次不能产生数据库写入。
+	repeated := make([]UsageHeaderSnapshot, 0, 2)
+	for index := range 2 {
+		repeated = append(repeated, codexHistoryPrimarySnapshot("heartbeat-auth", base.Add(time.Duration(index+1)*time.Second), 90, resetAt))
+	}
+	if !service.TryAppendUsageHeaderSnapshots(usageHeaderSnapshotPointers(repeated...)) {
+		t.Fatal("expected stable heartbeat observations to enter history")
+	}
+	stableWindow := waitForCodexQuotaHistoryManualTimer(t, timers)
+	stableWindow.fire <- time.Now()
+	deadline := time.Now().Add(time.Second)
+	for codexQuotaHistoryHeaderQueueLength(service) != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if queueLength := codexQuotaHistoryHeaderQueueLength(service); queueLength != 0 {
+		t.Fatalf("expected stable batch to leave the Header queue, got %d", queueLength)
+	}
+	select {
+	case observations := <-writes:
+		t.Fatalf("expected no stable write before heartbeat, got %+v", observations)
+	case <-time.After(20 * time.Millisecond):
+	}
+	select {
+	case timer := <-timers:
+		t.Fatalf("expected no dedicated heartbeat timer, got %s", timer.delay)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	// 到达五分钟心跳后不创建独立轮询；下一份 Header 唤醒时把累计尾段一次物化。
+	time.Sleep(50 * time.Millisecond)
+	final := codexHistoryPrimarySnapshot("heartbeat-auth", base.Add(3*time.Second), 90, resetAt)
+	if !service.TryAppendUsageHeaderSnapshots(usageHeaderSnapshotPointers(final)) {
+		t.Fatal("expected post-heartbeat observation to enter history")
+	}
+	nextWindow := waitForCodexQuotaHistoryManualTimer(t, timers)
+	nextWindow.fire <- time.Now()
+	select {
+	case observations := <-writes:
+		if len(observations) != 1 || observations[0].ObservationCount != 3 {
+			t.Fatalf("expected one accumulated stable heartbeat, got %+v", observations)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected accumulated heartbeat write")
+	}
+	cycles := loadCodexQuotaCycles(t, db, "heartbeat-auth")
+	segments := loadCodexQuotaSegments(t, db, cycles[0].ID)
+	if len(segments) != 1 || segments[0].ObservationCount != 4 {
+		t.Fatalf("expected persisted heartbeat count 4, got %+v", segments)
 	}
 }
 
@@ -1341,6 +1499,17 @@ func codexHistoryPrimarySnapshot(authIndex string, observedAt time.Time, remaini
 	})
 }
 
+func codexHistoryMainWindowsSnapshot(authIndex string, observedAt time.Time, primaryRemainingPercent int, primaryResetAt time.Time, secondaryRemainingPercent int, secondaryResetAt time.Time) UsageHeaderSnapshot {
+	return codexUsageHeaderSnapshotWithHeaders(authIndex, observedAt, http.Header{
+		"X-Codex-Primary-Used-Percent":     []string{strconv.Itoa(100 - primaryRemainingPercent)},
+		"X-Codex-Primary-Window-Minutes":   []string{"300"},
+		"X-Codex-Primary-Reset-At":         []string{strconv.FormatInt(primaryResetAt.Unix(), 10)},
+		"X-Codex-Secondary-Used-Percent":   []string{strconv.Itoa(100 - secondaryRemainingPercent)},
+		"X-Codex-Secondary-Window-Minutes": []string{"10080"},
+		"X-Codex-Secondary-Reset-At":       []string{strconv.FormatInt(secondaryResetAt.Unix(), 10)},
+	})
+}
+
 func codexHistoryUsageWindow(usedPercent float64, windowSeconds int64, resetAt time.Time) *CodexUsageWindow {
 	// 主动查询必须通过 presence 标记区分明确零值和字段缺失。
 	return &CodexUsageWindow{
@@ -1396,6 +1565,22 @@ func waitForCodexQuotaCycleCount(t *testing.T, db *gorm.DB, expected int64) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("expected %d Codex quota cycles before deadline", expected)
+}
+
+func waitForCodexQuotaSegmentCount(t *testing.T, db *gorm.DB, cycleID int64, expected int64) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		var count int64
+		if err := db.Model(&entities.QuotaPercentSegment{}).Where("cycle_id = ?", cycleID).Count(&count).Error; err != nil {
+			t.Fatalf("count Codex quota percent segments: %v", err)
+		}
+		if count == expected {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected %d Codex quota percent segments before deadline", expected)
 }
 
 type blockingCodexHistoryProviderHandler struct {

--- a/internal/quota/test/codex_quota_history_runner_test.go
+++ b/internal/quota/test/codex_quota_history_runner_test.go
@@ -302,8 +302,8 @@ func TestCodexQuotaHistoryRunnerRestoresDatabaseTailBeforeComparing(t *testing.T
 	}
 }
 
-func TestCodexQuotaHistoryRunnerCarriesAbsoluteUpgradeIntoMergedPendingSegment(t *testing.T) {
-	// relative 与 absolute 落在同一两分钟容差内且百分比相同，最终父周期仍必须升级到绝对边界。
+func TestCodexQuotaHistoryRunnerKeepsSameTimestampAbsoluteUpgradeDuringStableMerge(t *testing.T) {
+	// 同时刻 absolute 校准后的同值观察必须继续合并到 absolute 条目，不能回写旧 relative pending。
 	db := openQuotaTestDatabase(t)
 	seedUsageIdentity(t, db, codexHistoryUsageIdentity("upgrade-auth"))
 	service := NewServiceWithRegistryAndOptions(db, NewProviderRegistry(nil), ServiceOptions{
@@ -318,8 +318,9 @@ func TestCodexQuotaHistoryRunnerCarriesAbsoluteUpgradeIntoMergedPendingSegment(t
 		"X-Codex-Primary-Reset-After-Seconds": []string{"3600"},
 	})
 	absoluteReset := base.Add(time.Hour + 30*time.Second)
-	absolute := codexHistoryPrimarySnapshot("upgrade-auth", base.Add(time.Minute), 90, absoluteReset)
-	if !service.TryAppendUsageHeaderSnapshots(usageHeaderSnapshotPointers(relative, absolute)) {
+	absolute := codexHistoryPrimarySnapshot("upgrade-auth", base, 90, absoluteReset)
+	followUp := codexHistoryPrimarySnapshot("upgrade-auth", base.Add(time.Minute), 90, absoluteReset)
+	if !service.TryAppendUsageHeaderSnapshots(usageHeaderSnapshotPointers(relative, absolute, followUp)) {
 		t.Fatal("expected relative/absolute upgrade observations to be accepted")
 	}
 	service.StopRefreshTasks()
@@ -329,7 +330,7 @@ func TestCodexQuotaHistoryRunnerCarriesAbsoluteUpgradeIntoMergedPendingSegment(t
 		t.Fatalf("expected one cycle upgraded to the absolute reset, got %+v", cycles)
 	}
 	segments := loadCodexQuotaSegments(t, db, cycles[0].ID)
-	if len(segments) != 1 || segments[0].RemainingPercent != 90 || segments[0].ObservationCount != 2 {
+	if len(segments) != 1 || segments[0].RemainingPercent != 90 || segments[0].ObservationCount != 3 || !segments[0].LastObservedAt.Equal(base.Add(time.Minute)) {
 		t.Fatalf("expected same pending percent to merge count while upgrading boundary, got %+v", segments)
 	}
 }

--- a/internal/quota/test/codex_quota_history_runner_test.go
+++ b/internal/quota/test/codex_quota_history_runner_test.go
@@ -1165,13 +1165,15 @@ func TestCodexQuotaHistoryRunnerMaterializesBothHeaderWindowsWhenOneChanges(t *t
 }
 
 func TestCodexQuotaHistoryRunnerMaterializesStablePercentOnNextHeaderAfterHeartbeat(t *testing.T) {
+	const heartbeatInterval = 500 * time.Millisecond
+
 	db := openQuotaTestDatabase(t)
 	seedUsageIdentity(t, db, codexHistoryUsageIdentity("heartbeat-auth"))
 	timers := make(chan usageHeaderManualTimer, 6)
 	service := NewServiceWithRegistryAndOptions(db, NewProviderRegistry(nil), ServiceOptions{
 		UsageHeaderSnapshotFlushInterval:   time.Hour,
 		CodexQuotaHistoryFlushInterval:     time.Hour,
-		CodexQuotaHistoryHeartbeatInterval: 40 * time.Millisecond,
+		CodexQuotaHistoryHeartbeatInterval: heartbeatInterval,
 		PricingCatalog:                     emptyPricingCatalogForTest(),
 	})
 	defer service.StopRefreshTasks()
@@ -1233,7 +1235,8 @@ func TestCodexQuotaHistoryRunnerMaterializesStablePercentOnNextHeaderAfterHeartb
 	}
 
 	// 到达五分钟心跳后不创建独立轮询；下一份 Header 唤醒时把累计尾段一次物化。
-	time.Sleep(50 * time.Millisecond)
+	// 额外 50ms 只用于跨过测试 heartbeat 边界，500ms 主间隔为 CI 的 SQLite 和调度抖动留出余量。
+	time.Sleep(heartbeatInterval + 50*time.Millisecond)
 	final := codexHistoryPrimarySnapshot("heartbeat-auth", base.Add(3*time.Second), 90, resetAt)
 	if !service.TryAppendUsageHeaderSnapshots(usageHeaderSnapshotPointers(final)) {
 		t.Fatal("expected post-heartbeat observation to enter history")
@@ -1565,22 +1568,6 @@ func waitForCodexQuotaCycleCount(t *testing.T, db *gorm.DB, expected int64) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("expected %d Codex quota cycles before deadline", expected)
-}
-
-func waitForCodexQuotaSegmentCount(t *testing.T, db *gorm.DB, cycleID int64, expected int64) {
-	t.Helper()
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		var count int64
-		if err := db.Model(&entities.QuotaPercentSegment{}).Where("cycle_id = ?", cycleID).Count(&count).Error; err != nil {
-			t.Fatalf("count Codex quota percent segments: %v", err)
-		}
-		if count == expected {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("expected %d Codex quota percent segments before deadline", expected)
 }
 
 type blockingCodexHistoryProviderHandler struct {

--- a/internal/quota/test/header_cache_worker_test.go
+++ b/internal/quota/test/header_cache_worker_test.go
@@ -579,7 +579,7 @@ func TestApplyUsageHeaderSnapshotMergesRowsAndPreservesResetCredits(t *testing.T
 	}
 }
 
-func TestUsageHeaderPendingKeepsMainWeeklySeparateFromActiveSpark(t *testing.T) {
+func TestUsageHeaderPendingMergesOutOfOrderMainAndActiveSparkIndependently(t *testing.T) {
 	db := openQuotaTestDatabase(t)
 	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
 	service := NewServiceWithRegistryAndOptions(db, NewProviderRegistry(nil), ServiceOptions{
@@ -594,9 +594,16 @@ func TestUsageHeaderPendingKeepsMainWeeklySeparateFromActiveSpark(t *testing.T) 
 	sparkPrimaryResetAt := strconv.FormatInt(time.Date(2026, 8, 27, 19, 7, 0, 0, time.Local).Unix(), 10)
 	sparkSecondaryResetAt := strconv.FormatInt(time.Date(2026, 9, 1, 15, 1, 0, 0, time.Local).Unix(), 10)
 	mainHeaders := http.Header{
-		"X-Codex-Primary-Used-Percent":   []string{"8"},
-		"X-Codex-Primary-Window-Minutes": []string{"10080"},
-		"X-Codex-Primary-Reset-At":       []string{mainResetAt},
+		"X-Codex-Primary-Used-Percent":               []string{"8"},
+		"X-Codex-Primary-Window-Minutes":             []string{"10080"},
+		"X-Codex-Primary-Reset-At":                   []string{mainResetAt},
+		"X-Codex-Bengalfox-Limit-Name":               []string{"GPT-5.3-Codex-Spark"},
+		"X-Codex-Bengalfox-Primary-Used-Percent":     []string{"9"},
+		"X-Codex-Bengalfox-Primary-Window-Minutes":   []string{"300"},
+		"X-Codex-Bengalfox-Primary-Reset-At":         []string{sparkPrimaryResetAt},
+		"X-Codex-Bengalfox-Secondary-Used-Percent":   []string{"9"},
+		"X-Codex-Bengalfox-Secondary-Window-Minutes": []string{"10080"},
+		"X-Codex-Bengalfox-Secondary-Reset-At":       []string{sparkSecondaryResetAt},
 	}
 	sparkHeaders := http.Header{
 		"X-Codex-Active-Limit":                       []string{"codex_bengalfox"},
@@ -614,10 +621,10 @@ func TestUsageHeaderPendingKeepsMainWeeklySeparateFromActiveSpark(t *testing.T) 
 		"X-Codex-Bengalfox-Secondary-Window-Minutes": []string{"10080"},
 		"X-Codex-Bengalfox-Secondary-Reset-At":       []string{sparkSecondaryResetAt},
 	}
-	// 复现生产一分钟窗口：先收到主 Weekly，最后一份是只输出 Additional 的 Spark Header。
-	mainSnapshot := codexUsageHeaderSnapshotWithHeaders("codex-auth", base, mainHeaders)
+	// 复现生产乱序：较新的 Spark 先处理；随后旧 Header 的 Weekly 应补入，但其中较旧 Spark 不能回滚。
+	mainSnapshot := codexUsageHeaderSnapshotWithHeaders("codex-auth", base.Add(30*time.Second), mainHeaders)
 	sparkSnapshot := codexUsageHeaderSnapshotWithHeaders("codex-auth", base.Add(59*time.Second), sparkHeaders)
-	if !service.TryAppendUsageHeaderSnapshots(usageHeaderSnapshotPointers(mainSnapshot, sparkSnapshot)) {
+	if !service.TryAppendUsageHeaderSnapshots(usageHeaderSnapshotPointers(sparkSnapshot, mainSnapshot)) {
 		t.Fatal("expected production Header pending path to accept snapshots")
 	}
 	// Stop 会立即 flush 已接收的 pending，测试无需真实等待一分钟。

--- a/internal/quota/test/header_cache_worker_test.go
+++ b/internal/quota/test/header_cache_worker_test.go
@@ -579,6 +579,76 @@ func TestApplyUsageHeaderSnapshotMergesRowsAndPreservesResetCredits(t *testing.T
 	}
 }
 
+func TestUsageHeaderPendingKeepsMainWeeklySeparateFromActiveSpark(t *testing.T) {
+	db := openQuotaTestDatabase(t)
+	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})
+	service := NewServiceWithRegistryAndOptions(db, NewProviderRegistry(nil), ServiceOptions{
+		UsageHeaderSnapshotFlushInterval: time.Hour,
+		CodexQuotaHistoryFlushInterval:   time.Hour,
+		PricingCatalog:                   emptyPricingCatalogForTest(),
+	})
+	defer service.StopRefreshTasks()
+
+	base := time.Date(2026, 8, 27, 14, 0, 0, 0, time.Local)
+	mainResetAt := strconv.FormatInt(time.Date(2026, 9, 1, 22, 28, 0, 0, time.Local).Unix(), 10)
+	sparkPrimaryResetAt := strconv.FormatInt(time.Date(2026, 8, 27, 19, 7, 0, 0, time.Local).Unix(), 10)
+	sparkSecondaryResetAt := strconv.FormatInt(time.Date(2026, 9, 1, 15, 1, 0, 0, time.Local).Unix(), 10)
+	mainHeaders := http.Header{
+		"X-Codex-Primary-Used-Percent":   []string{"8"},
+		"X-Codex-Primary-Window-Minutes": []string{"10080"},
+		"X-Codex-Primary-Reset-At":       []string{mainResetAt},
+	}
+	sparkHeaders := http.Header{
+		"X-Codex-Active-Limit":                       []string{"codex_bengalfox"},
+		"X-Codex-Primary-Used-Percent":               []string{"1"},
+		"X-Codex-Primary-Window-Minutes":             []string{"300"},
+		"X-Codex-Primary-Reset-At":                   []string{sparkPrimaryResetAt},
+		"X-Codex-Secondary-Used-Percent":             []string{"1"},
+		"X-Codex-Secondary-Window-Minutes":           []string{"10080"},
+		"X-Codex-Secondary-Reset-At":                 []string{sparkSecondaryResetAt},
+		"X-Codex-Bengalfox-Limit-Name":               []string{"GPT-5.3-Codex-Spark"},
+		"X-Codex-Bengalfox-Primary-Used-Percent":     []string{"1"},
+		"X-Codex-Bengalfox-Primary-Window-Minutes":   []string{"300"},
+		"X-Codex-Bengalfox-Primary-Reset-At":         []string{sparkPrimaryResetAt},
+		"X-Codex-Bengalfox-Secondary-Used-Percent":   []string{"1"},
+		"X-Codex-Bengalfox-Secondary-Window-Minutes": []string{"10080"},
+		"X-Codex-Bengalfox-Secondary-Reset-At":       []string{sparkSecondaryResetAt},
+	}
+	// 复现生产一分钟窗口：先收到主 Weekly，最后一份是只输出 Additional 的 Spark Header。
+	mainSnapshot := codexUsageHeaderSnapshotWithHeaders("codex-auth", base, mainHeaders)
+	sparkSnapshot := codexUsageHeaderSnapshotWithHeaders("codex-auth", base.Add(59*time.Second), sparkHeaders)
+	if !service.TryAppendUsageHeaderSnapshots(usageHeaderSnapshotPointers(mainSnapshot, sparkSnapshot)) {
+		t.Fatal("expected production Header pending path to accept snapshots")
+	}
+	// Stop 会立即 flush 已接收的 pending，测试无需真实等待一分钟。
+	service.StopRefreshTasks()
+
+	task := refreshTaskRecord(service, "codex-auth")
+	if task == nil || task.Quota == nil {
+		t.Fatalf("expected completed quota cache, got %+v", task)
+	}
+	wantKeys := []string{
+		"rate_limit.primary_window",
+		"additional_rate_limits.GPT-5.3-Codex-Spark.primary_window",
+		"additional_rate_limits.GPT-5.3-Codex-Spark.secondary_window",
+	}
+	if len(task.Quota.Quota) != len(wantKeys) {
+		t.Fatalf("expected main Weekly and two Spark rows, got %#v", task.Quota.Quota)
+	}
+	for index, key := range wantKeys {
+		if task.Quota.Quota[index].Key != key {
+			t.Fatalf("unexpected quota row order: %#v", task.Quota.Quota)
+		}
+	}
+	wantPercents := []float64{8, 1, 1}
+	for index, wantPercent := range wantPercents {
+		row := task.Quota.Quota[index]
+		if row.UsedPercent == nil || *row.UsedPercent != wantPercent {
+			t.Fatalf("expected %s used percent %.0f, got %#v", row.Key, wantPercent, row)
+		}
+	}
+}
+
 func TestApplyUsageHeaderSnapshotDoesNotBackfillAdditionalLimitUsageStats(t *testing.T) {
 	db := openQuotaTestDatabase(t)
 	seedUsageIdentity(t, db, entities.UsageIdentity{Identity: "codex-auth", Provider: "codex", Type: "codex", AuthType: entities.UsageIdentityAuthTypeAuthFile})

--- a/internal/quota/test/header_cache_worker_test.go
+++ b/internal/quota/test/header_cache_worker_test.go
@@ -825,7 +825,7 @@ func TestUsageHeaderWorkerStaysSilentWithoutSnapshotsAndDoesNotResetActiveWindow
 		t.Fatalf("expected second Header not to reset timer, got delay=%s", timer.delay)
 	case <-time.After(30 * time.Millisecond):
 	}
-	// 独立 history runner 会等待自己的十秒批次窗口；一分钟 cache 仍不得在自己的 timer 前应用结果。
+	// 独立 history runner 会等待自己的一分钟批次窗口；一分钟 cache 仍不得在自己的 timer 前应用结果。
 	if refreshTaskCount(service) != 0 {
 		t.Fatalf("expected pending cache window to remain unapplied, got %+v", refreshTasks(service))
 	}
@@ -1076,19 +1076,19 @@ func TestTryAppendUsageHeaderSnapshotsKeepsLatestPendingSnapshotPerAuthIndex(t *
 	}
 }
 
-func TestUsageHeaderPendingKeepsOneThousandIdentitiesAndStillUpdatesExistingOnes(t *testing.T) {
-	// 一分钟内身份种类异常增长时内存必须有硬上限；已接收身份仍允许更新到最新 Header。
+func TestUsageHeaderPendingKeepsNewestOneThousandIdentities(t *testing.T) {
+	// 一分钟内身份种类异常增长时内存必须有硬上限，并按真实观察时间保留最新身份。
 	pending := make(map[string]UsageHeaderSnapshot)
 	firstBatch := make([]UsageHeaderSnapshot, 0, 1000)
 	baseTime := time.Date(2026, 6, 22, 11, 0, 0, 0, time.Local)
 	for index := 0; index < 1000; index++ {
 		firstBatch = append(firstBatch, UsageHeaderSnapshot{
-			AuthType: "oauth", AuthIndex: fmt.Sprintf("bounded-auth-%04d", index), Provider: "codex", ObservedAt: baseTime,
+			AuthType: "oauth", AuthIndex: fmt.Sprintf("bounded-auth-%04d", index), Provider: "codex", ObservedAt: baseTime.Add(time.Duration(index) * time.Second),
 		})
 	}
 	mergePendingUsageHeaderSnapshots(pending, firstBatch)
-	newerExisting := UsageHeaderSnapshot{AuthType: "oauth", AuthIndex: "bounded-auth-0000", Provider: "codex", ObservedAt: baseTime.Add(time.Minute)}
-	overflow := UsageHeaderSnapshot{AuthType: "oauth", AuthIndex: "bounded-auth-overflow", Provider: "codex", ObservedAt: baseTime.Add(2 * time.Minute)}
+	newerExisting := UsageHeaderSnapshot{AuthType: "oauth", AuthIndex: "bounded-auth-0000", Provider: "codex", ObservedAt: baseTime.Add(1000 * time.Second)}
+	overflow := UsageHeaderSnapshot{AuthType: "oauth", AuthIndex: "bounded-auth-overflow", Provider: "codex", ObservedAt: baseTime.Add(1001 * time.Second)}
 	mergePendingUsageHeaderSnapshots(pending, []UsageHeaderSnapshot{newerExisting, overflow})
 
 	if len(pending) != 1000 {
@@ -1097,8 +1097,18 @@ func TestUsageHeaderPendingKeepsOneThousandIdentitiesAndStillUpdatesExistingOnes
 	if got := pending["bounded-auth-0000"].ObservedAt; !got.Equal(newerExisting.ObservedAt) {
 		t.Fatalf("expected existing identity to update at cap, got %s", got)
 	}
-	if _, ok := pending["bounded-auth-overflow"]; ok {
-		t.Fatal("expected a new identity beyond the cap to be rejected")
+	if _, ok := pending["bounded-auth-0001"]; ok {
+		t.Fatal("expected the oldest identity to be evicted at the cap")
+	}
+	if got, ok := pending["bounded-auth-overflow"]; !ok || !got.ObservedAt.Equal(overflow.ObservedAt) {
+		t.Fatalf("expected the newest identity to be retained at the cap, got %+v", got)
+	}
+
+	// 迟到但观察时间更旧的新身份不能反向挤掉已经保留的更新数据。
+	stale := UsageHeaderSnapshot{AuthType: "oauth", AuthIndex: "bounded-auth-stale", Provider: "codex", ObservedAt: baseTime.Add(-time.Second)}
+	mergePendingUsageHeaderSnapshots(pending, []UsageHeaderSnapshot{stale})
+	if _, ok := pending["bounded-auth-stale"]; ok {
+		t.Fatal("expected an out-of-order stale identity not to evict newer pending data")
 	}
 }
 

--- a/internal/quota/test/internal_access_test.go
+++ b/internal/quota/test/internal_access_test.go
@@ -137,7 +137,7 @@ func setUsageHeaderTimerFactory(service *quota.Service, factory func(time.Durati
 }
 
 func setCodexQuotaHistoryTimerFactory(service *quota.Service, factory func(time.Duration) (<-chan time.Time, func())) {
-	// history runner 的手动 timer 只用于锁定十秒批次边界，不依赖真实墙钟调度。
+	// history runner 的手动 timer 只用于锁定一分钟批次边界，不依赖真实墙钟调度。
 	quotaServiceField(service, "codexQuotaHistoryNewTimer").Set(reflect.ValueOf(factory))
 }
 

--- a/internal/repository/codex_quota_efficiency.go
+++ b/internal/repository/codex_quota_efficiency.go
@@ -359,18 +359,20 @@ func buildCodexQuotaEfficiencyCyclePeriods(cycles []entities.QuotaCycle, current
 		return ordered[left].ID < ordered[right].ID
 	})
 	periods := make(map[int64]codexQuotaEfficiencyCyclePeriod, len(ordered))
-	for index, cycle := range ordered {
-		period := codexQuotaEfficiencyCyclePeriod{start: cycle.WindowStartedAt, end: cycle.ResetAt}
-		if index > 0 {
-			previousCycle := ordered[index-1]
-			previousPeriod := periods[previousCycle.ID]
-			// 无论窗口长度是否变化，重叠部分都以新周期的理论起点切分。
-			if cycle.WindowStartedAt.Before(previousPeriod.end) {
-				previousPeriod.end = cycle.WindowStartedAt
-				periods[previousCycle.ID] = previousPeriod
-			}
+	// 反向维护所有后续周期中最早的理论起点；这样一次线性扫描就能覆盖多个连续 detour。
+	var earliestLaterStart time.Time
+	for index := len(ordered) - 1; index >= 0; index-- {
+		cycle := ordered[index]
+		periodEnd := cycle.ResetAt
+		// 后续观察到的周期从其理论起点接管；此前周期只能保留到该起点之前。
+		if !earliestLaterStart.IsZero() && earliestLaterStart.Before(periodEnd) {
+			periodEnd = earliestLaterStart
 		}
-		periods[cycle.ID] = period
+		periods[cycle.ID] = codexQuotaEfficiencyCyclePeriod{start: cycle.WindowStartedAt, end: periodEnd}
+		// 更早周期需要同时避开当前周期和已经处理过的所有后续周期，因此只保留最早起点。
+		if earliestLaterStart.IsZero() || cycle.WindowStartedAt.Before(earliestLaterStart) {
+			earliestLaterStart = cycle.WindowStartedAt
+		}
 	}
 	if len(ordered) == 0 {
 		return periods

--- a/internal/repository/codex_quota_efficiency.go
+++ b/internal/repository/codex_quota_efficiency.go
@@ -141,7 +141,11 @@ func BuildCodexQuotaEfficiencyHistory(ctx context.Context, db *gorm.DB, query re
 	if len(selectedCycles) == 0 {
 		return result, nil
 	}
-	periods := buildCodexQuotaEfficiencyCyclePeriods(selectedCycles, selected.HasCurrentCycle, query.Now)
+	currentCycleID := int64(0)
+	if selected.HasCurrentCycle {
+		currentCycleID = latestCodexQuotaEfficiencyCycleID(selectedCycles)
+	}
+	periods := buildCodexQuotaEfficiencyCyclePeriods(selectedCycles, currentCycleID, query.Now)
 
 	// 所有子段用一次 IN 查询读出；每周期最多 101 个整数桶，不允许对父周期逐条 Preload。
 	var segments []entities.QuotaPercentSegment
@@ -334,12 +338,23 @@ func selectCodexQuotaEfficiencyWindow(windows []repositorydto.CodexQuotaEfficien
 	return selected
 }
 
-func buildCodexQuotaEfficiencyCyclePeriods(cycles []entities.QuotaCycle, roleHasCurrentCycle bool, now time.Time) map[int64]codexQuotaEfficiencyCyclePeriod {
-	// 观察顺序表达角色真实演进；复制后排序，避免扰动调用方用于历史倒序展示的父周期切片。
+// latestCodexQuotaEfficiencyCycleID 与窗口标题共享 LastObservedAt 口径，返回该角色最近被确认的父周期。
+func latestCodexQuotaEfficiencyCycleID(cycles []entities.QuotaCycle) int64 {
+	var latest entities.QuotaCycle
+	for _, cycle := range cycles {
+		if latest.ID == 0 || cycle.LastObservedAt.After(latest.LastObservedAt) || (cycle.LastObservedAt.Equal(latest.LastObservedAt) && cycle.ID > latest.ID) {
+			latest = cycle
+		}
+	}
+	return latest.ID
+}
+
+func buildCodexQuotaEfficiencyCyclePeriods(cycles []entities.QuotaCycle, currentCycleID int64, now time.Time) map[int64]codexQuotaEfficiencyCyclePeriod {
+	// 最近观察顺序表达角色当前演进；复用旧父行后它必须排到中间错误周期之后。
 	ordered := append([]entities.QuotaCycle(nil), cycles...)
 	sort.SliceStable(ordered, func(left, right int) bool {
-		if !ordered[left].FirstObservedAt.Equal(ordered[right].FirstObservedAt) {
-			return ordered[left].FirstObservedAt.Before(ordered[right].FirstObservedAt)
+		if !ordered[left].LastObservedAt.Equal(ordered[right].LastObservedAt) {
+			return ordered[left].LastObservedAt.Before(ordered[right].LastObservedAt)
 		}
 		return ordered[left].ID < ordered[right].ID
 	})
@@ -360,10 +375,15 @@ func buildCodexQuotaEfficiencyCyclePeriods(cycles []entities.QuotaCycle, roleHas
 	if len(ordered) == 0 {
 		return periods
 	}
-	latestCycle := ordered[len(ordered)-1]
-	latestPeriod := periods[latestCycle.ID]
-	latestPeriod.current = roleHasCurrentCycle && !now.Before(latestPeriod.start) && now.Before(latestPeriod.end)
-	periods[latestCycle.ID] = latestPeriod
+	if currentCycleID == 0 {
+		return periods
+	}
+	currentPeriod, found := periods[currentCycleID]
+	if !found {
+		return periods
+	}
+	currentPeriod.current = !now.Before(currentPeriod.start) && now.Before(currentPeriod.end)
+	periods[currentCycleID] = currentPeriod
 	return periods
 }
 

--- a/internal/repository/codex_quota_history.go
+++ b/internal/repository/codex_quota_history.go
@@ -165,22 +165,31 @@ func normalizeCodexMainQuotaObservation(observation repositorydto.CodexMainQuota
 
 func applyCodexMainQuotaObservation(tx *gorm.DB, observation repositorydto.CodexMainQuotaObservation) error {
 	quotaKey, _ := codexQuotaKey(observation.WindowRole)
-	cycle, found, err := loadCurrentQuotaCycle(tx, observation.AuthIndex, quotaKey)
+	latestCycle, latestFound, err := loadCurrentQuotaCycle(tx, observation.AuthIndex, quotaKey)
 	if err != nil {
 		return err
 	}
-	if found && cycle.WindowSeconds != observation.WindowSeconds {
-		// 窗口变化优先于 reset；只有观察时间更旧时才把它视为切换前的迟到事实。
-		if observation.LastObservedAt.Before(cycle.LastObservedAt) {
-			return nil
+	// 正常连续观察直接复用最近父行，只保留原来的一次查询。
+	cycle := latestCycle
+	found := latestFound && latestCycle.WindowSeconds == observation.WindowSeconds && quotaResetTimesMatch(latestCycle.ResetAt, observation.ResetAt)
+	if latestFound && !found {
+		// 只有窗口绕行或 reset 变化时才回查旧父行；Weekly 经 5h 绕行后由这里复用原周期。
+		cycle, found, err = loadMatchingQuotaCycle(tx, observation.AuthIndex, quotaKey, observation.WindowSeconds, observation.ResetAt)
+		if err != nil {
+			return err
 		}
-		found = false
-	} else if found && !quotaResetTimesMatch(cycle.ResetAt, observation.ResetAt) {
-		// 相同窗口仍按观察时间与 reset 顺序拒绝旧事实，超过两分钟的未来 reset 建立新周期。
-		if observation.LastObservedAt.Before(cycle.LastObservedAt) || observation.ResetAt.Before(cycle.ResetAt) {
-			return nil
-		}
-		found = false
+	}
+	if latestFound && observation.LastObservedAt.Before(latestCycle.LastObservedAt) {
+		// 无论能否匹配旧父行，真实观察时间更旧的迟到事实都不能反向切换当前周期。
+		return nil
+	}
+	if found && latestFound && cycle.ID != latestCycle.ID && cycle.WindowSeconds == latestCycle.WindowSeconds {
+		// 同一种窗口已经进入更新 reset 时，不能仅因迟到数据匹配旧父行而回写；跨窗口恢复才允许复用。
+		return nil
+	}
+	if !found && latestFound && latestCycle.WindowSeconds == observation.WindowSeconds && observation.ResetAt.Before(latestCycle.ResetAt) {
+		// 同窗口没有落入容差且 reset 更早，只可能属于已经结束的旧周期。
+		return nil
 	}
 
 	created := false
@@ -264,6 +273,41 @@ func applyCodexMainQuotaObservation(tx *gorm.DB, observation repositorydto.Codex
 		}
 	}
 	return updateQuotaCycleObservedTimes(tx, cycle, observation)
+}
+
+// loadMatchingQuotaCycle 在同账号角色和窗口内选择 reset 距离最近的已有父行，支持周期恢复复用。
+func loadMatchingQuotaCycle(tx *gorm.DB, authIndex string, quotaKey string, windowSeconds int64, resetAt time.Time) (entities.QuotaCycle, bool, error) {
+	// reset 查询边界与写入状态机共用固定两分钟容差，避免两处周期身份规则漂移。
+	resetLower := timeutil.FormatSortableStorageTime(resetAt.Add(-codexQuotaResetTolerance))
+	resetUpper := timeutil.FormatSortableStorageTime(resetAt.Add(codexQuotaResetTolerance))
+	var candidates []entities.QuotaCycle
+	err := tx.Where(
+		"provider = ? AND auth_index = ? AND quota_key = ? AND window_seconds = ? AND reset_at >= ? AND reset_at <= ?",
+		codexQuotaProvider, authIndex, quotaKey, windowSeconds, resetLower, resetUpper,
+	).Order("last_observed_at DESC, id DESC").Find(&candidates).Error
+	if err != nil {
+		return entities.QuotaCycle{}, false, fmt.Errorf("load matching quota cycle: %w", err)
+	}
+	if len(candidates) == 0 {
+		return entities.QuotaCycle{}, false, nil
+	}
+	// 正常只有一个候选；若历史抖动曾产生多个父行，则复用 reset 距离本次事实最近的一行。
+	selected := candidates[0]
+	selectedDistance := selected.ResetAt.Sub(resetAt)
+	if selectedDistance < 0 {
+		selectedDistance = -selectedDistance
+	}
+	for _, candidate := range candidates[1:] {
+		distance := candidate.ResetAt.Sub(resetAt)
+		if distance < 0 {
+			distance = -distance
+		}
+		if distance < selectedDistance {
+			selected = candidate
+			selectedDistance = distance
+		}
+	}
+	return selected, true, nil
 }
 
 func correctQuotaPercentTail(tx *gorm.DB, cycle entities.QuotaCycle, observation repositorydto.CodexMainQuotaObservation) error {

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -1,7 +1,7 @@
 package repository
 
 import (
-	"cpa-usage-keeper/internal/repository/dto"
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -9,11 +9,14 @@ import (
 	"strings"
 	"time"
 
+	"cpa-usage-keeper/internal/backup"
 	"cpa-usage-keeper/internal/config"
 	"cpa-usage-keeper/internal/entities"
 	"cpa-usage-keeper/internal/logging"
+	"cpa-usage-keeper/internal/repository/dto"
 	"cpa-usage-keeper/internal/repository/migration"
 	"cpa-usage-keeper/internal/timeutil"
+	"github.com/sirupsen/logrus"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	"gorm.io/plugin/dbresolver"
@@ -147,7 +150,17 @@ func OpenDatabase(cfg config.Config) (*gorm.DB, error) {
 	}
 
 	// 已有业务表的数据库必须走显式迁移，确保旧库按版本顺序补齐结构和索引。
-	if err := migration.Run(db); err != nil {
+	// 破坏性 migration 直接复用定时任务的 Writer，生成相同目录和 database_*.db 文件名。
+	migrationBackupWriter := backup.NewWriter(cfg.BackupDir)
+	if err := migration.Run(db, migration.RunOptions{BeforeDestructiveMigration: func(ctx context.Context, version string) error {
+		// 在线 SQLite backup 读取唯一 writer 的一致快照；失败会原样返回并阻止 migration 进入清表事务。
+		backupPath, err := migrationBackupWriter.WriteDatabase(ctx, sqlDB, time.Now())
+		if err != nil {
+			return err
+		}
+		logrus.WithFields(logrus.Fields{"version": version, "backup_path": backupPath}).Info("database backed up before destructive migration")
+		return nil
+	}}); err != nil {
 		return nil, fmt.Errorf("run schema migrations: %w", err)
 	}
 

--- a/internal/repository/migration/20260827_reset_quota_history.go
+++ b/internal/repository/migration/20260827_reset_quota_history.go
@@ -1,0 +1,21 @@
+package migration
+
+import (
+	"fmt"
+
+	"cpa-usage-keeper/internal/entities"
+
+	"gorm.io/gorm"
+)
+
+// resetQuotaHistoryMigration 只清空无法验证来源的旧历史；父子 schema 与其它业务数据保持不变。
+func resetQuotaHistoryMigration(tx *gorm.DB) error {
+	// 外键是 RESTRICT，必须先清子表；AllowGlobalUpdate 明确表达本版本有意执行全表 DELETE。
+	if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&entities.QuotaPercentSegment{}).Error; err != nil {
+		return fmt.Errorf("clear quota percent segments: %w", err)
+	}
+	if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&entities.QuotaCycle{}).Error; err != nil {
+		return fmt.Errorf("clear quota cycles: %w", err)
+	}
+	return nil
+}

--- a/internal/repository/migration/migration.go
+++ b/internal/repository/migration/migration.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -87,6 +88,8 @@ const (
 	migrationRebuildQuotaHistory = "20260822_rebuild_quota_history"
 	// migrationAddAuthSessionAlias 保存单个管理员会话的可选辨识名称。
 	migrationAddAuthSessionAlias = "20260824_add_auth_session_alias"
+	// migrationResetQuotaHistory 在新来源判定生效后清空无法证明 provenance 的旧额度历史。
+	migrationResetQuotaHistory = "20260827_reset_quota_history"
 )
 
 type schemaMigration struct {
@@ -102,15 +105,30 @@ type databaseMigration struct {
 	version            string
 	run                func(*gorm.DB) error
 	disableTransaction bool
+	// destructive 要求在默认事务开始前完成一份通用数据库快照，失败时不得执行 migration。
+	destructive bool
 }
 
-func Run(db *gorm.DB) error {
+// RunOptions 为生产启动注入通用 migration 安全边界；测试可按目标替换备份实现。
+type RunOptions struct {
+	// BeforeDestructiveMigration 在破坏性 migration 事务前执行，version 仅用于日志和诊断。
+	BeforeDestructiveMigration func(context.Context, string) error
+}
+
+func Run(db *gorm.DB, optionValues ...RunOptions) error {
+	if len(optionValues) > 1 {
+		return fmt.Errorf("run schema migrations: expected at most one options value")
+	}
+	options := RunOptions{}
+	if len(optionValues) == 1 {
+		options = optionValues[0]
+	}
 	if err := createSchemaMigrationsTable(db); err != nil {
 		return err
 	}
 
 	for _, migration := range orderedMigrations() {
-		if err := runSchemaMigration(db, migration); err != nil {
+		if err := runSchemaMigration(db, migration, options); err != nil {
 			return err
 		}
 	}
@@ -211,16 +229,54 @@ func orderedMigrations() []databaseMigration {
 		// 破坏性清空与通用表创建必须和版本标记处于同一个默认事务。
 		{version: migrationRebuildQuotaHistory, run: rebuildQuotaHistoryMigration},
 		{version: migrationAddAuthSessionAlias, run: addAuthSessionAliasMigration},
+		// 清表前必须先在事务外完成通用数据库备份；DELETE 与版本标记仍使用默认单事务。
+		{version: migrationResetQuotaHistory, run: resetQuotaHistoryMigration, destructive: true},
 	}
 }
 
-func runSchemaMigration(db *gorm.DB, migration databaseMigration) error {
+func runSchemaMigration(db *gorm.DB, migration databaseMigration, optionValues ...RunOptions) error {
+	if len(optionValues) > 1 {
+		return fmt.Errorf("run schema migration %s: expected at most one options value", migration.version)
+	}
+	options := RunOptions{}
+	if len(optionValues) == 1 {
+		options = optionValues[0]
+	}
+	if migration.destructive {
+		// 先检查版本，已经成功执行过的清表迁移不能在每次启动时重复生成备份。
+		applied, err := schemaMigrationApplied(db, migration.version)
+		if err != nil {
+			return err
+		}
+		if !applied {
+			// 没有备份实现时直接终止启动，不能以“尽力而为”方式继续执行不可逆 DELETE。
+			if options.BeforeDestructiveMigration == nil {
+				return fmt.Errorf("run schema migration %s: destructive migration backup is required", migration.version)
+			}
+			logger := logrus.WithField("version", migration.version)
+			logger.Info("schema migration backup started")
+			// 备份必须先在 migration 事务外完成；回调成功返回后才允许进入下面的默认单事务。
+			if err := options.BeforeDestructiveMigration(context.Background(), migration.version); err != nil {
+				logger.WithError(err).Error("schema migration backup failed")
+				return fmt.Errorf("backup before schema migration %s: %w", migration.version, err)
+			}
+			logger.Info("schema migration backup completed")
+		}
+	}
 	if migration.disableTransaction {
 		return runSchemaMigrationWithoutTransaction(db, migration)
 	}
 	return db.Transaction(func(tx *gorm.DB) error {
 		return runSchemaMigrationBody(tx, migration)
 	})
+}
+
+func schemaMigrationApplied(db *gorm.DB, version string) (bool, error) {
+	var count int64
+	if err := db.Table("schema_migrations").Where("version = ?", version).Count(&count).Error; err != nil {
+		return false, fmt.Errorf("check schema migration %s: %w", version, err)
+	}
+	return count > 0, nil
 }
 
 func runSchemaMigrationWithoutTransaction(db *gorm.DB, migration databaseMigration) error {

--- a/internal/repository/migration/migration_support_test.go
+++ b/internal/repository/migration/migration_support_test.go
@@ -2,6 +2,7 @@ package migration
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
 
@@ -46,7 +47,7 @@ func openMigratedDatabase(t *testing.T, dbPath string) *gorm.DB {
 	if err != nil {
 		t.Fatalf("open migrated database: %v", err)
 	}
-	if err := Run(db); err != nil {
+	if err := Run(db, RunOptions{BeforeDestructiveMigration: func(context.Context, string) error { return nil }}); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
 	return db

--- a/internal/repository/migration/migration_test.go
+++ b/internal/repository/migration/migration_test.go
@@ -85,6 +85,7 @@ func TestOrderedMigrationsPreservesExecutionOrder(t *testing.T) {
 		"20260820_codex_quota_history",
 		"20260822_rebuild_quota_history",
 		"20260824_add_auth_session_alias",
+		"20260827_reset_quota_history",
 	}
 	assertStringSlicesEqual(t, want, got)
 }

--- a/internal/repository/migration/test/quota_history_reset_test.go
+++ b/internal/repository/migration/test/quota_history_reset_test.go
@@ -1,0 +1,156 @@
+package test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/backup"
+	"cpa-usage-keeper/internal/config"
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+	"cpa-usage-keeper/internal/repository/migration"
+
+	_ "github.com/mattn/go-sqlite3"
+	"gorm.io/gorm"
+)
+
+const quotaHistoryResetMigrationVersion = "20260827_reset_quota_history"
+
+func TestQuotaHistoryResetMigrationBacksUpThenClearsHistory(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Config{
+		SQLitePath: filepath.Join(root, "app.db"),
+		BackupDir:  filepath.Join(root, "backups"),
+	}
+	db, err := repository.OpenDatabase(cfg)
+	if err != nil {
+		t.Fatalf("open seed database: %v", err)
+	}
+	seedQuotaHistoryResetRows(t, db)
+	markQuotaHistoryResetPending(t, db)
+	closeQuotaHistoryResetDatabase(t, db)
+
+	upgraded, err := repository.OpenDatabase(cfg)
+	if err != nil {
+		t.Fatalf("open upgraded database: %v", err)
+	}
+	defer closeQuotaHistoryResetDatabase(t, upgraded)
+	assertQuotaHistoryResetRows(t, upgraded, 0, 0)
+	assertQuotaHistoryResetVersion(t, upgraded, 1)
+
+	files, err := backup.ListFiles(cfg.BackupDir)
+	if err != nil {
+		t.Fatalf("list migration backups: %v", err)
+	}
+	if len(files) != 1 || !strings.HasPrefix(filepath.Base(files[0]), "database_") || filepath.Ext(files[0]) != ".db" {
+		t.Fatalf("expected one standard database backup, got %+v", files)
+	}
+	assertQuotaHistoryResetBackupRows(t, files[0], 1, 1)
+}
+
+func TestQuotaHistoryResetMigrationStopsWhenBackupFails(t *testing.T) {
+	root := t.TempDir()
+	db, err := repository.OpenDatabase(config.Config{SQLitePath: filepath.Join(root, "app.db")})
+	if err != nil {
+		t.Fatalf("open seed database: %v", err)
+	}
+	defer closeQuotaHistoryResetDatabase(t, db)
+	seedQuotaHistoryResetRows(t, db)
+	markQuotaHistoryResetPending(t, db)
+
+	backupFailure := errors.New("expected backup failure")
+	err = migration.Run(db, migration.RunOptions{
+		BeforeDestructiveMigration: func(context.Context, string) error { return backupFailure },
+	})
+	if !errors.Is(err, backupFailure) {
+		t.Fatalf("expected backup failure, got %v", err)
+	}
+	assertQuotaHistoryResetRows(t, db, 1, 1)
+	assertQuotaHistoryResetVersion(t, db, 0)
+}
+
+func seedQuotaHistoryResetRows(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	now := time.Now()
+	cycle := entities.QuotaCycle{
+		Provider: "codex", AuthIndex: "codex-auth", QuotaKey: "rate_limit.primary_window",
+		WindowSeconds: 604_800, ResetAtSource: entities.QuotaResetAtSourceAbsolute,
+		WindowStartedAt: now.Add(-24 * time.Hour), ResetAt: now.Add(6 * 24 * time.Hour),
+		FirstObservedAt: now.Add(-time.Hour), LastObservedAt: now.Add(-time.Minute),
+	}
+	if err := db.Create(&cycle).Error; err != nil {
+		t.Fatalf("seed quota cycle: %v", err)
+	}
+	segment := entities.QuotaPercentSegment{
+		CycleID: cycle.ID, RemainingPercent: 77, FirstObservedAt: cycle.FirstObservedAt,
+		LastObservedAt: cycle.LastObservedAt, ObservationCount: 2,
+	}
+	if err := db.Create(&segment).Error; err != nil {
+		t.Fatalf("seed quota percent segment: %v", err)
+	}
+}
+
+func markQuotaHistoryResetPending(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	if err := db.Exec("DELETE FROM schema_migrations WHERE version = ?", quotaHistoryResetMigrationVersion).Error; err != nil {
+		t.Fatalf("mark quota history reset pending: %v", err)
+	}
+}
+
+func assertQuotaHistoryResetRows(t *testing.T, db *gorm.DB, cycles, segments int64) {
+	t.Helper()
+	for table, want := range map[string]int64{"quota_cycles": cycles, "quota_percent_segments": segments} {
+		var got int64
+		if err := db.Table(table).Count(&got).Error; err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if got != want {
+			t.Fatalf("expected %s row count %d, got %d", table, want, got)
+		}
+	}
+}
+
+func assertQuotaHistoryResetVersion(t *testing.T, db *gorm.DB, want int64) {
+	t.Helper()
+	var got int64
+	if err := db.Table("schema_migrations").Where("version = ?", quotaHistoryResetMigrationVersion).Count(&got).Error; err != nil {
+		t.Fatalf("count reset migration version: %v", err)
+	}
+	if got != want {
+		t.Fatalf("expected migration version count %d, got %d", want, got)
+	}
+}
+
+func assertQuotaHistoryResetBackupRows(t *testing.T, path string, cycles, segments int64) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open migration backup: %v", err)
+	}
+	defer db.Close()
+	for table, want := range map[string]int64{"quota_cycles": cycles, "quota_percent_segments": segments} {
+		var got int64
+		if err := db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&got); err != nil {
+			t.Fatalf("count backup %s: %v", table, err)
+		}
+		if got != want {
+			t.Fatalf("expected backup %s row count %d, got %d", table, want, got)
+		}
+	}
+}
+
+func closeQuotaHistoryResetDatabase(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sql database: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close sql database: %v", err)
+	}
+}

--- a/internal/repository/test/codex_quota_efficiency_test.go
+++ b/internal/repository/test/codex_quota_efficiency_test.go
@@ -190,6 +190,41 @@ func TestBuildCodexQuotaEfficiencyHistoryUsesLatestWindowPerRoleAndCutsOverlappi
 	assertCodexQuotaEfficiencyUsage(t, result.Cycles[0].Usage, 300, 0.0003, true)
 }
 
+func TestBuildCodexQuotaEfficiencyHistoryMarksReusedWeeklyCurrentAfterFiveHourDetour(t *testing.T) {
+	// 复用父行会保留 Weekly 较早的 FirstObservedAt；current 必须由最新 LastObservedAt 决定。
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	db := openTestDatabase(t)
+	weeklyStart := now.Add(-24 * time.Hour)
+	weeklyReset := weeklyStart.Add(7 * 24 * time.Hour)
+	weekly := seedCodexQuotaEfficiencyCycle(t, db, "codex-auth", weeklyStart, weeklyReset, []codexQuotaEfficiencySegmentSeed{
+		{remaining: 90, first: now.Add(-3 * time.Hour), last: now.Add(-3 * time.Hour)},
+	})
+	fiveHour := seedCodexQuotaEfficiencyCycle(t, db, "codex-auth", now.Add(-4*time.Hour), now.Add(time.Hour), []codexQuotaEfficiencySegmentSeed{
+		{remaining: 50, first: now.Add(-2 * time.Hour), last: now.Add(-2 * time.Hour)},
+	})
+	restored := repositorydto.CodexMainQuotaObservation{
+		AuthIndex: "codex-auth", WindowRole: "primary", WindowSeconds: int64((7 * 24 * time.Hour) / time.Second),
+		ResetAtSource: "absolute", ResetAt: weeklyReset, RemainingPercent: 89,
+		FirstObservedAt: now.Add(-time.Hour), LastObservedAt: now.Add(-time.Hour), ObservationCount: 1,
+	}
+	if err := repository.WriteCodexMainQuotaObservations(context.Background(), db, []repositorydto.CodexMainQuotaObservation{restored}); err != nil {
+		t.Fatalf("reuse Weekly cycle: %v", err)
+	}
+
+	result, err := repository.BuildCodexQuotaEfficiencyHistory(context.Background(), db, repositorydto.CodexQuotaEfficiencyQuery{
+		AuthIndex: "codex-auth", Now: now, RangeStart: now.Add(-30 * 24 * time.Hour),
+	}, codexQuotaEfficiencyPricingResolver(t))
+	if err != nil {
+		t.Fatalf("BuildCodexQuotaEfficiencyHistory returned error: %v", err)
+	}
+	if result.SelectedWindow == nil || result.SelectedWindow.WindowSeconds != int64((7*24*time.Hour)/time.Second) || !result.SelectedWindow.HasCurrentCycle {
+		t.Fatalf("expected restored Weekly window selection, got %+v", result.SelectedWindow)
+	}
+	if len(result.Cycles) != 1 || result.Cycles[0].ID != weekly.ID || result.Cycles[0].Status != "current" {
+		t.Fatalf("expected reused Weekly current and intermediate 5h %d hidden, got %+v", fiveHour.ID, result.Cycles)
+	}
+}
+
 func TestBuildCodexQuotaEfficiencyHistoryClassifiesSingleWindowKindsByDuration(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/repository/test/codex_quota_efficiency_test.go
+++ b/internal/repository/test/codex_quota_efficiency_test.go
@@ -190,17 +190,20 @@ func TestBuildCodexQuotaEfficiencyHistoryUsesLatestWindowPerRoleAndCutsOverlappi
 	assertCodexQuotaEfficiencyUsage(t, result.Cycles[0].Usage, 300, 0.0003, true)
 }
 
-func TestBuildCodexQuotaEfficiencyHistoryMarksReusedWeeklyCurrentAfterFiveHourDetour(t *testing.T) {
-	// 复用父行会保留 Weekly 较早的 FirstObservedAt；current 必须由最新 LastObservedAt 决定。
+func TestBuildCodexQuotaEfficiencyHistoryMarksReusedWeeklyCurrentAfterMultipleFiveHourDetours(t *testing.T) {
+	// 复用父行会把 Weekly 移到多个错误 5h 周期之后；所有被其理论区间覆盖的 detour 都必须隐藏。
 	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
 	db := openTestDatabase(t)
 	weeklyStart := now.Add(-24 * time.Hour)
 	weeklyReset := weeklyStart.Add(7 * 24 * time.Hour)
 	weekly := seedCodexQuotaEfficiencyCycle(t, db, "codex-auth", weeklyStart, weeklyReset, []codexQuotaEfficiencySegmentSeed{
-		{remaining: 90, first: now.Add(-3 * time.Hour), last: now.Add(-3 * time.Hour)},
+		{remaining: 90, first: now.Add(-4 * time.Hour), last: now.Add(-4 * time.Hour)},
 	})
-	fiveHour := seedCodexQuotaEfficiencyCycle(t, db, "codex-auth", now.Add(-4*time.Hour), now.Add(time.Hour), []codexQuotaEfficiencySegmentSeed{
-		{remaining: 50, first: now.Add(-2 * time.Hour), last: now.Add(-2 * time.Hour)},
+	firstFiveHour := seedCodexQuotaEfficiencyCycle(t, db, "codex-auth", now.Add(-6*time.Hour), now.Add(-time.Hour), []codexQuotaEfficiencySegmentSeed{
+		{remaining: 50, first: now.Add(-3 * time.Hour), last: now.Add(-3 * time.Hour)},
+	})
+	secondFiveHour := seedCodexQuotaEfficiencyCycle(t, db, "codex-auth", now.Add(-5*time.Hour), now, []codexQuotaEfficiencySegmentSeed{
+		{remaining: 40, first: now.Add(-2 * time.Hour), last: now.Add(-2 * time.Hour)},
 	})
 	restored := repositorydto.CodexMainQuotaObservation{
 		AuthIndex: "codex-auth", WindowRole: "primary", WindowSeconds: int64((7 * 24 * time.Hour) / time.Second),
@@ -210,6 +213,10 @@ func TestBuildCodexQuotaEfficiencyHistoryMarksReusedWeeklyCurrentAfterFiveHourDe
 	if err := repository.WriteCodexMainQuotaObservations(context.Background(), db, []repositorydto.CodexMainQuotaObservation{restored}); err != nil {
 		t.Fatalf("reuse Weekly cycle: %v", err)
 	}
+	seedCodexQuotaEfficiencyUsage(t, db,
+		usageEventForQuotaEfficiency("during-first-detour", "oauth", "codex-auth", now.Add(-11*time.Hour/2), 100),
+		usageEventForQuotaEfficiency("during-second-detour", "oauth", "codex-auth", now.Add(-9*time.Hour/2), 200),
+	)
 
 	result, err := repository.BuildCodexQuotaEfficiencyHistory(context.Background(), db, repositorydto.CodexQuotaEfficiencyQuery{
 		AuthIndex: "codex-auth", Now: now, RangeStart: now.Add(-30 * 24 * time.Hour),
@@ -221,8 +228,9 @@ func TestBuildCodexQuotaEfficiencyHistoryMarksReusedWeeklyCurrentAfterFiveHourDe
 		t.Fatalf("expected restored Weekly window selection, got %+v", result.SelectedWindow)
 	}
 	if len(result.Cycles) != 1 || result.Cycles[0].ID != weekly.ID || result.Cycles[0].Status != "current" {
-		t.Fatalf("expected reused Weekly current and intermediate 5h %d hidden, got %+v", fiveHour.ID, result.Cycles)
+		t.Fatalf("expected reused Weekly current and intermediate 5h cycles %d/%d hidden, got %+v", firstFiveHour.ID, secondFiveHour.ID, result.Cycles)
 	}
+	assertCodexQuotaEfficiencyUsage(t, result.Cycles[0].Usage, 300, 0.0003, true)
 }
 
 func TestBuildCodexQuotaEfficiencyHistoryClassifiesSingleWindowKindsByDuration(t *testing.T) {

--- a/internal/repository/test/codex_quota_history_test.go
+++ b/internal/repository/test/codex_quota_history_test.go
@@ -169,6 +169,43 @@ func TestWriteCodexMainQuotaObservationsSwitchesWindowBeforeComparingReset(t *te
 	}
 }
 
+func TestWriteCodexMainQuotaObservationsReusesMatchingCycleAfterWindowDetour(t *testing.T) {
+	// Weekly 中间出现错误 5h 后再次观察同一 Weekly，必须回到原父行而不是触发唯一键或创建重复周期。
+	db := openCodexQuotaHistoryRepositoryDatabase(t, "reuse-window-cycle.db")
+	base := time.Date(2026, 8, 27, 8, 0, 0, 0, time.UTC)
+	weeklyReset := base.Add(7 * 24 * time.Hour)
+	fiveHourReset := base.Add(5 * time.Hour)
+	weekly := codexQuotaHistoryObservation("codex-auth", "primary", 604_800, weeklyReset, 90, base)
+	fiveHour := codexQuotaHistoryObservation("codex-auth", "primary", 18_000, fiveHourReset, 50, base.Add(time.Minute))
+	restoredWeekly := codexQuotaHistoryObservation("codex-auth", "primary", 604_800, weeklyReset, 89, base.Add(2*time.Minute))
+
+	if err := repository.WriteCodexMainQuotaObservations(context.Background(), db, []repositorydto.CodexMainQuotaObservation{weekly, fiveHour, restoredWeekly}); err != nil {
+		t.Fatalf("write restored Weekly observations: %v", err)
+	}
+
+	var cycles []entities.QuotaCycle
+	if err := db.Where("provider = ? AND auth_index = ? AND quota_key = ?", "codex", "codex-auth", "rate_limit.primary_window").Order("window_seconds desc").Find(&cycles).Error; err != nil {
+		t.Fatalf("load restored Weekly cycles: %v", err)
+	}
+	if len(cycles) != 2 || cycles[0].WindowSeconds != 604_800 || cycles[1].WindowSeconds != 18_000 {
+		t.Fatalf("expected one reused Weekly and one intermediate 5h cycle, got %+v", cycles)
+	}
+	weeklySegments := loadCodexQuotaHistorySegments(t, db, cycles[0].ID)
+	if len(weeklySegments) != 2 || weeklySegments[0].RemainingPercent != 90 || weeklySegments[1].RemainingPercent != 89 {
+		t.Fatalf("expected restored Weekly observation on the original parent, got %+v", weeklySegments)
+	}
+	if !cycles[0].LastObservedAt.Equal(restoredWeekly.LastObservedAt) {
+		t.Fatalf("expected reused Weekly to become latest observed cycle, got %+v", cycles[0])
+	}
+	state, err := repository.LoadLatestCodexQuotaHistoryState(context.Background(), db, "codex-auth", "primary")
+	if err != nil {
+		t.Fatalf("load restored Weekly state: %v", err)
+	}
+	if !state.Found || state.WindowSeconds != 604_800 || !state.HasTail || state.TailRemainingPercent != 89 {
+		t.Fatalf("expected state recovery to select reused Weekly, got %+v", state)
+	}
+}
+
 func TestWriteCodexMainQuotaObservationsMergesRelativeResetAndUpgradesAbsoluteBoundary(t *testing.T) {
 	// 准备：relative-only 候选相差 30 秒，随后官方 absolute 边界在两分钟容差内到达。
 	db := openCodexQuotaHistoryRepositoryDatabase(t, "relative-upgrade.db")


### PR DESCRIPTION
## Summary

- isolate Codex main quota history from Spark/Additional projections and keep main and Additional progress rows distinct in the minute Header cache
- batch Header history independently from usage persistence, write semantic changes immediately, and coalesce stable percentages at a five-minute cadence
- reuse matching quota cycles after window detours and select the latest observed cycle for the current history display
- create a standard database backup before clearing legacy quota history so post-upgrade observations rebuild from a clean state

Closes #477

## Validation

- `verify-local.sh backend`
- `go test ./internal/quota/test -run "^TestCodexQuotaHistoryRunnerMaterializesStablePercentOnNextHeaderAfterHeartbeat$" -count=10`
- `git diff --check`