### PR TITLE
fix(key-viewer): unify dashboard tabs and time range

### DIFF
--- a/web/src/features/key-viewer/KeyViewerShell.module.scss
+++ b/web/src/features/key-viewer/KeyViewerShell.module.scss
@@ -89,6 +89,7 @@
 .themeSwitcher {
   display: inline-flex;
   align-items: stretch;
+  gap: 4px;
   min-height: var(--keeper-toolbar-control-height, 42px);
   padding: 4px;
   border-radius: 999px;
@@ -131,7 +132,7 @@
   padding: 8px 12px;
   border-radius: 999px;
   cursor: pointer;
-  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 
   &:hover:not(:disabled) {
     color: var(--text-primary);
@@ -155,11 +156,10 @@
 }
 
 .loadingOverlaySpinner {
-  width: 12px;
-  height: 12px;
   border-width: 2px;
   border-color: rgba($primary-color, 0.25);
   border-top-color: var(--primary-color);
+  box-shadow: 0 0 10px rgba($primary-color, 0.25);
 }
 
 .contentColumn {
@@ -245,18 +245,80 @@
     0 4px 12px rgba($primary-color, 0.14);
 }
 
+// API Key 只读页与管理页使用同一组连接式导航标签。
+.tabBarConnected {
+  display: inline-flex;
+  align-items: stretch;
+  width: max-content;
+  max-width: 100%;
+  min-height: 40px;
+  padding: 4px;
+  gap: 0;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--bg-secondary) 78%, transparent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--text-primary) 12%, transparent);
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+:global([data-theme='dark']) .tabBarConnected {
+  border-color: transparent;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.tabBarConnected .tabPill {
+  flex: 0 0 auto;
+  min-height: 32px;
+  padding: 7px 12px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.tabBarConnected:lang(zh) .tabPill {
+  padding-inline: 16px;
+}
+
+.tabBarConnected .tabPill:not(.tabPillActive):hover {
+  color: var(--text-primary);
+  background: color-mix(in srgb, var(--bg-primary) 58%, transparent);
+}
+
+.tabBarConnected .tabPillActive {
+  border: 0;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  box-shadow: 0 6px 16px color-mix(in srgb, var(--text-primary) 10%, transparent);
+}
+
 .toolbarActionsRight {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  column-gap: 10px;
   gap: 10px;
-  flex-wrap: wrap;
   width: 100%;
   min-width: 0;
+
+  // Ranking 无本地排名权限时仍将刷新按钮靠右，与管理页保持同一列边界。
+  > :only-child {
+    grid-column: 2;
+  }
 
   @include mobile {
     align-items: stretch;
     justify-content: flex-start;
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: 0;
+
+    > :only-child {
+      grid-column: 1;
+    }
   }
 }
 
@@ -272,6 +334,13 @@
   opacity: 1;
   overflow: hidden;
   transform: translateY(0);
+
+  @include mobile {
+    width: 100%;
+    justify-content: flex-start;
+    max-height: none;
+    overflow: visible;
+  }
 }
 
 .usageRefreshSlot {
@@ -288,14 +357,35 @@
   flex: 0 0 auto;
 }
 
+@media (max-width: #{$breakpoint-tablet}) {
+  .toolbarActionsRight {
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
+
+  .usageFilterBar {
+    width: 100%;
+    justify-content: flex-start;
+    max-height: none;
+    overflow: visible;
+  }
+
+  .usageRefreshSlot {
+    margin-left: auto;
+  }
+
+  .usageFilterActions {
+    margin-left: 0;
+  }
+}
+
 .errorBox {
-  padding: 12px 14px;
-  border-radius: 16px;
-  border: 1px solid rgba($error-color, 0.28);
-  background: rgba($error-color, 0.1);
-  color: var(--danger-color);
-  font-size: 13px;
-  line-height: 1.6;
+  padding: 10px;
+  background-color: rgba($error-color, 0.1);
+  border: 1px solid var(--error-color);
+  border-radius: $radius-sm;
+  color: var(--error-color);
+  font-size: 12px;
 }
 
 .errorBoxWithAction {
@@ -326,12 +416,13 @@
   position: absolute;
   inset: 0;
   z-index: 5;
-  display: grid;
-  place-items: center;
-  min-height: 280px;
-  border-radius: 24px;
-  background: color-mix(in srgb, var(--bg-secondary) 68%, transparent);
-  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  --glass-blur: 6px;
+  background: var(--glass-bg-secondary);
+  backdrop-filter: var(--glass-backdrop-filter);
+  -webkit-backdrop-filter: var(--glass-backdrop-filter);
 }
 
 .loadingOverlayContent {
@@ -339,16 +430,16 @@
   align-items: center;
   gap: 10px;
   padding: 12px 16px;
-  border-radius: 999px;
+  border-radius: $radius-lg;
   border: 1px solid var(--border-color);
   background: var(--bg-primary);
-  box-shadow: var(--floating-shadow);
+  box-shadow: var(--shadow-lg);
 }
 
 .loadingOverlayText {
   color: var(--text-secondary);
   font-size: 13px;
-  font-weight: 700;
+  font-weight: 600;
 }
 
 @include mobile {
@@ -356,10 +447,19 @@
     white-space: nowrap;
   }
 
+  .toolbarActionsRight,
+  .usageFilterBar,
   .usageRefreshSlot,
   .usageFilterActions,
   .refreshMainActionShell {
     width: 100%;
+  }
+
+  .usageFilterBar {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 8px;
+    margin-bottom: 10px;
   }
 
   .refreshMainActionButton {

--- a/web/src/features/key-viewer/KeyViewerShell.tsx
+++ b/web/src/features/key-viewer/KeyViewerShell.tsx
@@ -42,7 +42,7 @@ export function KeyViewerShell({
   onNavigate,
   onAuthRequired,
 }: KeyViewerShellProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const theme = useThemeStore((state) => state.theme);
   const setTheme = useThemeStore((state) => state.setTheme);
   const [loggingOut, setLoggingOut] = useState(false);
@@ -116,7 +116,12 @@ export function KeyViewerShell({
             )}
 
             <div className={styles.toolbarRow}>
-              <div className={styles.tabBar} role="tablist" aria-label={t('key_overview.tabs_aria_label')}>
+              <div
+                className={`${styles.tabBar} ${styles.tabBarConnected}`.trim()}
+                role="tablist"
+                aria-label={t('key_overview.tabs_aria_label')}
+                lang={i18n.resolvedLanguage || i18n.language}
+              >
                 {(Object.keys(KEY_VIEWER_PAGE_PATHS) as KeyViewerPage[]).map((page) => {
                   const active = page === activePage;
                   return (

--- a/web/src/features/key-viewer/test/KeyViewerShell.styles.test.ts
+++ b/web/src/features/key-viewer/test/KeyViewerShell.styles.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const styles = readFileSync(new URL('../KeyViewerShell.module.scss', import.meta.url), 'utf8');
+const source = readFileSync(new URL('../KeyViewerShell.tsx', import.meta.url), 'utf8');
 
 describe('KeyViewerShell loading layer', () => {
   it('keeps the viewer toolbar above the page loading overlay', () => {
@@ -9,5 +10,13 @@ describe('KeyViewerShell loading layer', () => {
 
     expect(toolbarBlock).toContain('position: relative;');
     expect(toolbarBlock).toContain('z-index: 6;');
+  });
+
+  it('uses the same connected tab treatment and toolbar grid as the management page', () => {
+    expect(source).toContain('styles.tabBarConnected');
+    expect(source).toContain('lang={i18n.resolvedLanguage || i18n.language}');
+    expect(styles).toMatch(/\.tabBarConnected\s*\{[\s\S]*?border-radius:\s*999px;/);
+    expect(styles).toMatch(/\.tabBarConnected \.tabPill\s*\{[\s\S]*?font-weight:\s*700;/);
+    expect(styles).toMatch(/\.toolbarActionsRight\s*\{[\s\S]*?display:\s*grid;[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) auto;/);
   });
 });

--- a/web/src/features/key-viewer/test/timeRange.test.ts
+++ b/web/src/features/key-viewer/test/timeRange.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import type { StoredUsageRangeState } from '@/utils/usage/customRange';
+import {
+  KEY_VIEWER_TIME_RANGE_STORAGE_KEY,
+  loadKeyViewerTimeRange,
+  persistKeyViewerTimeRange,
+} from '../timeRange';
+
+type MemoryStorage = {
+  values: Map<string, string>;
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+};
+
+const createStorage = (): MemoryStorage => {
+  const values = new Map<string, string>();
+  return {
+    values,
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+  };
+};
+
+describe('API Key viewer time range persistence', () => {
+  it('uses one storage entry for Overview and Analysis', () => {
+    const storage = createStorage();
+    const selected: StoredUsageRangeState = { range: '7d' };
+
+    persistKeyViewerTimeRange(selected, storage);
+
+    expect(storage.values.has(KEY_VIEWER_TIME_RANGE_STORAGE_KEY)).toBe(true);
+    expect(loadKeyViewerTimeRange(storage)).toEqual(selected);
+  });
+
+  it('ignores page-specific storage entries when the shared entry is absent', () => {
+    const storage = createStorage();
+    storage.setItem('cli-proxy-key-overview-range-v1', JSON.stringify({ range: '7d' }));
+
+    expect(loadKeyViewerTimeRange(storage)).toEqual({ range: 'today' });
+    expect(storage.values.has(KEY_VIEWER_TIME_RANGE_STORAGE_KEY)).toBe(false);
+  });
+});

--- a/web/src/features/key-viewer/test/timeRange.test.ts
+++ b/web/src/features/key-viewer/test/timeRange.test.ts
@@ -39,4 +39,25 @@ describe('API Key viewer time range persistence', () => {
     expect(loadKeyViewerTimeRange(storage)).toEqual({ range: 'today' });
     expect(storage.values.has(KEY_VIEWER_TIME_RANGE_STORAGE_KEY)).toBe(false);
   });
+
+  it('falls back safely when the browser blocks localStorage access', () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get: () => {
+        throw new Error('storage blocked');
+      },
+    });
+
+    try {
+      expect(loadKeyViewerTimeRange()).toEqual({ range: 'today' });
+      expect(() => persistKeyViewerTimeRange({ range: '7d' })).not.toThrow();
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(globalThis, 'localStorage', originalDescriptor);
+      } else {
+        delete (globalThis as { localStorage?: unknown }).localStorage;
+      }
+    }
+  });
 });

--- a/web/src/features/key-viewer/timeRange.ts
+++ b/web/src/features/key-viewer/timeRange.ts
@@ -1,0 +1,50 @@
+import {
+  parseStoredUsageRangeState,
+  serializeUsageRangeState,
+  type StoredUsageRangeState,
+} from '@/utils/usage/customRange';
+
+export const KEY_VIEWER_TIME_RANGE_STORAGE_KEY = 'cli-proxy-key-viewer-time-range-v1';
+
+interface StorageLike {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+}
+
+const resolveStorage = (storage?: StorageLike): StorageLike | undefined => {
+  if (storage) return storage;
+  if (typeof localStorage === 'undefined') return undefined;
+  return localStorage;
+};
+
+const defaultRangeState = (): StoredUsageRangeState => ({ range: 'today' });
+
+/** API Key 的各个只读页面共用同一时间范围。 */
+export const loadKeyViewerTimeRange = (
+  storage?: StorageLike,
+  nowMs = Date.now(),
+): StoredUsageRangeState => {
+  const target = resolveStorage(storage);
+  if (!target) return defaultRangeState();
+
+  try {
+    const sharedRaw = target.getItem(KEY_VIEWER_TIME_RANGE_STORAGE_KEY);
+    if (sharedRaw) return parseStoredUsageRangeState(sharedRaw, { nowMs });
+  } catch {
+    // 忽略浏览器存储不可用；页面仍使用默认范围。
+  }
+  return defaultRangeState();
+};
+
+export const persistKeyViewerTimeRange = (
+  state: StoredUsageRangeState,
+  storage?: StorageLike,
+): void => {
+  const target = resolveStorage(storage);
+  if (!target) return;
+  try {
+    target.setItem(KEY_VIEWER_TIME_RANGE_STORAGE_KEY, serializeUsageRangeState(state));
+  } catch {
+    // 忽略浏览器存储不可用；页面仍使用当前内存状态。
+  }
+};

--- a/web/src/features/key-viewer/timeRange.ts
+++ b/web/src/features/key-viewer/timeRange.ts
@@ -13,8 +13,13 @@ interface StorageLike {
 
 const resolveStorage = (storage?: StorageLike): StorageLike | undefined => {
   if (storage) return storage;
-  if (typeof localStorage === 'undefined') return undefined;
-  return localStorage;
+  try {
+    if (typeof localStorage === 'undefined') return undefined;
+    return localStorage;
+  } catch {
+    // sandbox iframe 或隐私模式可能在读取 localStorage 时直接抛出异常。
+    return undefined;
+  }
 };
 
 const defaultRangeState = (): StoredUsageRangeState => ({ range: 'today' });

--- a/web/src/pages/KeyAnalysisPage.tsx
+++ b/web/src/pages/KeyAnalysisPage.tsx
@@ -11,24 +11,15 @@ import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { useThemeStore } from '@/stores';
 import {
   clampStoredUsageRangeStateToCurrentBounds,
-  parseStoredUsageRangeState,
   resolveUsageRangeRecoveryTimeZone,
-  serializeUsageRangeState,
   type StoredUsageRangeState,
 } from '@/utils/usage/customRange';
 import { buildUsageRangeQuery } from '@/utils/usage/rangeQuery';
+import { loadKeyViewerTimeRange, persistKeyViewerTimeRange } from '@/features/key-viewer/timeRange';
 import styles from '@/features/key-viewer/KeyViewerShell.module.scss';
 
-const KEY_ANALYSIS_RANGE_STORAGE_KEY = 'cli-proxy-key-analysis-range-v1';
-const DEFAULT_TIME_RANGE: UsageTimeRange = 'today';
-
 const loadTimeRange = (): StoredUsageRangeState => {
-  try {
-    if (typeof localStorage === 'undefined') return { range: DEFAULT_TIME_RANGE };
-    return parseStoredUsageRangeState(localStorage.getItem(KEY_ANALYSIS_RANGE_STORAGE_KEY), { nowMs: Date.now() });
-  } catch {
-    return { range: DEFAULT_TIME_RANGE };
-  }
+  return loadKeyViewerTimeRange();
 };
 
 export interface KeyAnalysisPageProps {
@@ -75,12 +66,16 @@ export function KeyAnalysisPage({ apiKey, onNavigate, onAuthRequired }: KeyAnaly
   }, [timeRangeState]);
 
   const handleTimeRangeChange = useCallback((range: UsageTimeRange, nextCustomRange?: UsageCustomRange) => {
+    let nextState: StoredUsageRangeState;
     if (range === 'custom' && nextCustomRange) {
-      setTimeRangeState({ range, customRange: nextCustomRange, timeZone: rangeTimeZone });
-      return;
+      nextState = { range, customRange: nextCustomRange, timeZone: rangeTimeZone };
+    } else {
+      nextState = { ...timeRangeState, range };
     }
-    setTimeRangeState((current) => ({ ...current, range }));
-  }, [rangeTimeZone]);
+    setTimeRangeState(nextState);
+    // 切换页面可能紧接着发生，先同步写入共享缓存，再等待状态 effect。
+    persistKeyViewerTimeRange(nextState);
+  }, [rangeTimeZone, timeRangeState]);
 
   const loadAnalysis = useCallback(async () => {
     if (!usageRangeQuery.valid) return;
@@ -140,11 +135,7 @@ export function KeyAnalysisPage({ apiKey, onNavigate, onAuthRequired }: KeyAnaly
   }, [loadAnalysis]);
 
   useEffect(() => {
-    try {
-      localStorage.setItem(KEY_ANALYSIS_RANGE_STORAGE_KEY, serializeUsageRangeState(timeRangeState));
-    } catch {
-      // 忽略浏览器存储不可用；页面仍使用当前内存状态。
-    }
+    persistKeyViewerTimeRange(timeRangeState);
   }, [timeRangeState]);
 
   const handleManualRefresh = useCallback(async () => {

--- a/web/src/pages/KeyOverviewPage.styles.test.ts
+++ b/web/src/pages/KeyOverviewPage.styles.test.ts
@@ -6,7 +6,7 @@ const styles = readFileSync(new URL('../features/key-viewer/KeyViewerShell.modul
 const shellSource = readFileSync(new URL('../features/key-viewer/KeyViewerShell.tsx', import.meta.url), 'utf8')
 
 describe('KeyOverviewPage layout', () => {
-  it('keeps the viewer page on independent styles while matching the admin overview toolbar structure', () => {
+  it('keeps the viewer page data-specific while matching the admin overview toolbar structure', () => {
     expect(source).not.toContain('UsagePage.module.scss')
     expect(source).toContain("import { KeyViewerShell } from '@/features/key-viewer/KeyViewerShell';")
     expect(shellSource).toContain('className={styles.themeSwitcher}')
@@ -16,9 +16,10 @@ describe('KeyOverviewPage layout', () => {
     expect(shellSource).not.toContain('styles.logoutSwitcher')
     expect(shellSource).not.toContain('styles.logoutPill')
     expect(source).not.toContain('check_updates')
-    expect(shellSource.indexOf('className={styles.tabBar}')).toBeLessThan(shellSource.indexOf('className={styles.toolbarActionsRight}'))
+    expect(shellSource).toContain('styles.tabBarConnected')
+    expect(shellSource).toContain('className={styles.toolbarActionsRight}')
     expect(source).toContain('<TimeRangeControl')
-    expect(source).toContain('parseStoredUsageRangeState')
+    expect(source).toContain('loadKeyViewerTimeRange')
     expect(source).not.toContain('className={styles.timeRangeGroup}')
     expect(source).toContain('className={styles.usageRefreshSlot}')
     expect(source).not.toContain('className={styles.toolbarMetaRow}')

--- a/web/src/pages/KeyOverviewPage.tsx
+++ b/web/src/pages/KeyOverviewPage.tsx
@@ -19,24 +19,18 @@ import {
 } from '@/components/usage';
 import type { UsageOverviewPayload } from '@/components/usage/hooks/useUsageData';
 import { getCurrentOverviewUsage, getDailyAverageCardUsage, getOverviewDisplayLoading, isDailyAverageRange } from '@/utils/usage/overview';
-import { clampStoredUsageRangeStateToCurrentBounds, parseStoredUsageRangeState, resolveUsageRangeRecoveryTimeZone, serializeUsageRangeState, type StoredUsageRangeState } from '@/utils/usage/customRange';
+import { clampStoredUsageRangeStateToCurrentBounds, resolveUsageRangeRecoveryTimeZone, type StoredUsageRangeState } from '@/utils/usage/customRange';
 import { buildUsageRangeQuery } from '@/utils/usage/rangeQuery';
+import { loadKeyViewerTimeRange, persistKeyViewerTimeRange } from '@/features/key-viewer/timeRange';
 import styles from '@/features/key-viewer/KeyViewerShell.module.scss';
 
-const KEY_OVERVIEW_RANGE_STORAGE_KEY = 'cli-proxy-key-overview-range-v1';
 const OVERVIEW_REALTIME_WINDOW_STORAGE_KEY = 'cli-proxy-usage-overview-realtime-window-v1';
-const DEFAULT_TIME_RANGE: UsageTimeRange = 'today';
 const DEFAULT_REALTIME_WINDOW: OverviewRealtimeWindow = '15m';
 const KEY_OVERVIEW_REALTIME_VISIBLE_DIMENSIONS = ['models'] as const;
 const KEY_OVERVIEW_AUTO_REFRESH_INTERVAL_MS = 10_000;
 
 const loadTimeRange = (): StoredUsageRangeState => {
-  try {
-    if (typeof localStorage === 'undefined') return { range: DEFAULT_TIME_RANGE };
-    return parseStoredUsageRangeState(localStorage.getItem(KEY_OVERVIEW_RANGE_STORAGE_KEY), { nowMs: Date.now() });
-  } catch {
-    return { range: DEFAULT_TIME_RANGE };
-  }
+  return loadKeyViewerTimeRange();
 };
 
 const isOverviewRealtimeWindow = (value: unknown): value is OverviewRealtimeWindow => (
@@ -202,12 +196,16 @@ export function KeyOverviewPage({ apiKey, onNavigate, onAuthRequired }: KeyOverv
     return true;
   }, [rangeRecoveryTimeZone, timeRangeState]);
   const handleTimeRangeChange = useCallback((range: UsageTimeRange, nextCustomRange?: UsageCustomRange) => {
+    let nextState: StoredUsageRangeState;
     if (range === 'custom' && nextCustomRange) {
-      setTimeRangeState({ range, customRange: nextCustomRange, timeZone: rangeTimeZone });
-      return;
+      nextState = { range, customRange: nextCustomRange, timeZone: rangeTimeZone };
+    } else {
+      nextState = { ...timeRangeState, range };
     }
-    setTimeRangeState((current) => ({ ...current, range }));
-  }, [rangeTimeZone]);
+    setTimeRangeState(nextState);
+    // 切换页面可能紧接着发生，先同步写入共享缓存，再等待状态 effect。
+    persistKeyViewerTimeRange(nextState);
+  }, [rangeTimeZone, timeRangeState]);
 
   const loadOverview = useCallback(async (options: KeyOverviewLoadOptions = {}) => {
     if (!usageRangeQuery.valid) return;
@@ -306,11 +304,7 @@ export function KeyOverviewPage({ apiKey, onNavigate, onAuthRequired }: KeyOverv
   }), [handleAutoRefreshError, refreshKeyOverview]);
 
   useEffect(() => {
-    try {
-      localStorage.setItem(KEY_OVERVIEW_RANGE_STORAGE_KEY, serializeUsageRangeState(timeRangeState));
-    } catch {
-      // ignore storage failures
-    }
+    persistKeyViewerTimeRange(timeRangeState);
   }, [timeRangeState]);
 
   useEffect(() => {

--- a/web/src/pages/test/KeyAnalysisPage.logic.test.tsx
+++ b/web/src/pages/test/KeyAnalysisPage.logic.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiError } from '@/lib/api';
 import type { AnalysisLatencyDiagnostics, AnalysisResponse } from '@/lib/types';
 import { serializeUsageRangeState } from '@/utils/usage/customRange';
+import { KEY_VIEWER_TIME_RANGE_STORAGE_KEY } from '@/features/key-viewer/timeRange';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -145,7 +146,7 @@ describe('KeyAnalysisPage requests', () => {
   });
 
   it('does not reload when the response timezone replaces a stored custom-range timezone', async () => {
-    localStorage.setItem('cli-proxy-key-analysis-range-v1', serializeUsageRangeState({
+    localStorage.setItem(KEY_VIEWER_TIME_RANGE_STORAGE_KEY, serializeUsageRangeState({
       range: 'custom',
       customRange: { unit: 'day', start: '2026-08-20', end: '2026-08-21' },
       timeZone: 'America/New_York',

--- a/web/src/pages/test/UsagePage.styles.test.ts
+++ b/web/src/pages/test/UsagePage.styles.test.ts
@@ -9,6 +9,7 @@ const usagePageStyles = readSource(new URL('../UsagePage.module.scss', import.me
 const usagePageSource = readSource(new URL('../UsagePage.tsx', import.meta.url))
 const keyOverviewPageStyles = readSource(new URL('../../features/key-viewer/KeyViewerShell.module.scss', import.meta.url))
 const keyOverviewPageSource = readSource(new URL('../KeyOverviewPage.tsx', import.meta.url))
+const keyAnalysisPageSource = readSource(new URL('../KeyAnalysisPage.tsx', import.meta.url))
 const keyViewerShellSource = readSource(new URL('../../features/key-viewer/KeyViewerShell.tsx', import.meta.url))
 const requestEventsSource = readSource(new URL('../../components/usage/RequestEventsDetailsCard.tsx', import.meta.url))
 const requestEventLogSource = readSource(new URL('../../components/usage/RequestEventLogModal.tsx', import.meta.url))
@@ -254,7 +255,8 @@ describe('UsagePage toolbar styles', () => {
     expect(usagePageSource).not.toContain('TimeRangeControlPrototype')
     expect(keyOverviewPageSource).not.toContain('TimeRangeControlPrototype')
     expect(usagePageSource).toContain('parseStoredUsageRangeState')
-    expect(keyOverviewPageSource).toContain('parseStoredUsageRangeState')
+    expect(keyOverviewPageSource).toContain('loadKeyViewerTimeRange')
+    expect(keyAnalysisPageSource).toContain('loadKeyViewerTimeRange')
     expect(timeRangeControlSource).toContain('data-time-range-trigger="desktop"')
     expect(timeRangeControlSource).toContain('data-time-range-trigger="mobile"')
   })
@@ -276,6 +278,13 @@ describe('UsagePage toolbar styles', () => {
     expect(keyOverviewPageSource).toContain('customRange={customRange}')
     expect(keyOverviewPageSource).toContain('onChange={handleTimeRangeChange}')
     expect(keyOverviewPageSource).toContain('fetchKeyOverview(usageRangeQuery, controller.signal)')
+  })
+
+  it('persists one time range across API Key viewer pages', () => {
+    expect(keyOverviewPageSource).toContain('persistKeyViewerTimeRange(timeRangeState)')
+    expect(keyAnalysisPageSource).toContain('persistKeyViewerTimeRange(timeRangeState)')
+    expect(keyOverviewPageSource).not.toContain('cli-proxy-key-overview-range-v1')
+    expect(keyAnalysisPageSource).not.toContain('cli-proxy-key-analysis-range-v1')
   })
 
   it('shows a dedicated notice when Usage Events export capacity is full', () => {
@@ -921,10 +930,11 @@ describe('UsagePage toolbar styles', () => {
     expect(connectedActiveTab).not.toContain('border-color:')
   })
 
-  it('keeps the connected shell out of CPAMC embed and Key Overview', () => {
+  it('keeps the connected shell out of CPAMC embed while sharing it with Key Overview', () => {
     expect(usagePageSource).toContain("${!isEmbeddedInCPAMC ? styles.tabBarConnected : ''}")
-    expect(keyOverviewPageSource).not.toContain('tabBarConnected')
-    expect(keyOverviewPageStyles).not.toContain('.tabBarConnected')
+    expect(keyViewerShellSource).toContain('styles.tabBarConnected')
+    expect(keyOverviewPageSource).toContain('KeyViewerShell')
+    expect(keyOverviewPageStyles).toContain('.tabBarConnected')
   })
 
   it('lets API Key Settings content scroll inside the card instead of being clipped', () => {


### PR DESCRIPTION
## Summary

Align the API Key viewer dashboard shell with the management dashboard and use one shared time-range selection across its read-only pages.

## Changes

- Use the connected tab treatment and responsive toolbar layout for Overview, Analysis, and Ranking.
- Share one API Key viewer time-range storage entry between Overview and Analysis.
- Remove page-specific legacy cache compatibility as the new version does not need it.
- Add regression coverage for shared persistence and the shell style contract.

## Verification

- `rtk vitest run` (1221 tests)
- `rtk npm run lint`
- `rtk npm run typecheck`
- `rtk npm run build`