### PR TITLE
fix: support Codex Agent Identity credentials in Keeper

### DIFF
--- a/internal/cpa/client.go
+++ b/internal/cpa/client.go
@@ -11,12 +11,14 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"cpa-usage-keeper/internal/cpa/dto/apicall"
+	"cpa-usage-keeper/internal/cpa/dto/authfiles"
 	"cpa-usage-keeper/internal/cpa/dto/providerconfig"
 	"cpa-usage-keeper/internal/cpa/dto/response"
 )
@@ -54,6 +56,14 @@ type authFileStatusRequest struct {
 type authFilesDeleteRequest struct {
 	Names []string `json:"names"`
 }
+
+type codexAuthFileClassification uint8
+
+const (
+	codexAuthFileUnknown codexAuthFileClassification = iota
+	codexAuthFileNative
+	codexAuthFileSidecar
+)
 
 func (c *Client) doJSONRequest(ctx context.Context, path string, target any, kind string, configure func(*http.Request)) (int, []byte, error) {
 	return c.doJSONRequestWithBody(ctx, http.MethodGet, path, nil, target, kind, configure)
@@ -432,12 +442,23 @@ func (c *Client) FetchModels(ctx context.Context) (*response.ModelsResult, error
 }
 
 func (c *Client) FetchAuthFiles(ctx context.Context) (*response.AuthFilesResult, error) {
+	return c.fetchAuthFiles(ctx, true)
+}
+
+func (c *Client) fetchAuthFiles(ctx context.Context, enrichCodexMetadata bool) (*response.AuthFilesResult, error) {
 	result := &response.AuthFilesResult{}
 	statusCode, body, err := c.doManagementJSONRequest(ctx, cpaManagementAuthFilesEndpoint, &result.Payload, "auth files")
 	result.StatusCode = statusCode
 	result.Body = body
 	if err != nil {
 		return result, err
+	}
+	if enrichCodexMetadata {
+		// CPA versions before plugin metadata projection only expose the runtime
+		// provider and email in this list. Fill the Codex-specific account/team
+		// fields from clearly sidecar-managed files without returning their raw
+		// credential JSON to callers.
+		c.enrichCodexAuthFileMetadata(ctx, &result.Payload)
 	}
 	return result, nil
 }
@@ -456,12 +477,495 @@ func (c *Client) DeleteAuthFiles(ctx context.Context, names []string) error {
 }
 
 func (c *Client) CallManagementAPI(ctx context.Context, request apicall.Request) (*apicall.Response, error) {
-	result := &apicall.Response{}
-	_, _, err := c.doManagementJSONPostRequest(ctx, cpaManagementAPICallEndpoint, request, result, "api call")
-	if err != nil {
+	if !isCodexQuotaRequest(request) {
+		result, _, err := c.callManagementAPIAt(ctx, cpaManagementAPICallEndpoint, request, "api call")
 		return result, err
 	}
-	return result, nil
+
+	// CPA reserves /v0/management/api-call before plugin routes are mounted.
+	// Send Codex quota/reset calls through the plugin-owned route so a
+	// sidecar-managed auth file is converted to the correct AgentAssertion or
+	// PAT bearer token instead of leaking its opaque cais_* client key upstream.
+	result, statusCode, err := c.callManagementAPIAt(ctx, cpaManagementCodexAgentIdentityAPICallEndpoint, request, "codex api call")
+	if err == nil {
+		return result, nil
+	}
+	if !isManagementRouteUnavailable(statusCode) {
+		return result, err
+	}
+
+	// Keep native OAuth working on CPA deployments where the plugin is not
+	// installed yet. Only fall back after positively identifying the auth file
+	// as a native credential; an unknown or sidecar-managed file must never be
+	// sent through CPA's native route with cais_* as a Bearer token.
+	classification, classifyErr := c.classifyCodexAuthIndex(ctx, request.AuthIndex)
+	if classifyErr != nil {
+		return result, fmt.Errorf("codex agent identity bridge unavailable; refusing unsafe native fallback: %w", classifyErr)
+	}
+	if classification != codexAuthFileNative {
+		return result, fmt.Errorf("codex agent identity bridge unavailable for this auth file; install or enable the Codex Agent Identity plugin")
+	}
+
+	nativeResult, _, nativeErr := c.callManagementAPIAt(ctx, cpaManagementAPICallEndpoint, request, "api call")
+	return nativeResult, nativeErr
+}
+
+func (c *Client) callManagementAPIAt(ctx context.Context, path string, request apicall.Request, kind string) (*apicall.Response, int, error) {
+	result := &apicall.Response{}
+	statusCode, _, err := c.doManagementJSONPostRequest(ctx, path, request, result, kind)
+	return result, statusCode, err
+}
+
+func isManagementRouteUnavailable(statusCode int) bool {
+	return statusCode == http.StatusNotFound || statusCode == http.StatusMethodNotAllowed
+}
+
+func isCodexQuotaRequest(request apicall.Request) bool {
+	method := strings.ToUpper(strings.TrimSpace(request.Method))
+	parsed, err := url.Parse(strings.TrimSpace(request.URL))
+	if err != nil || parsed.Scheme == "" || parsed.Hostname() == "" {
+		return false
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") || !strings.EqualFold(parsed.Hostname(), "chatgpt.com") || parsed.Port() != "" {
+		return false
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.RawPath != "" || parsed.Opaque != "" {
+		return false
+	}
+
+	switch parsed.Path {
+	case "/backend-api/wham/usage", "/backend-api/wham/rate-limit-reset-credits":
+		return method == http.MethodGet
+	case "/backend-api/wham/rate-limit-reset-credits/consume":
+		return method == http.MethodPost
+	default:
+		return false
+	}
+}
+
+func (c *Client) classifyCodexAuthIndex(ctx context.Context, authIndex string) (codexAuthFileClassification, error) {
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex == "" {
+		// No auth index means there is no opaque sidecar key that this client
+		// could accidentally forward. Native CPA resolution remains safe.
+		return codexAuthFileNative, nil
+	}
+
+	files, err := c.fetchAuthFiles(ctx, false)
+	if err != nil {
+		return codexAuthFileUnknown, fmt.Errorf("inspect CPA auth files: %w", err)
+	}
+	found := false
+	for _, file := range files.Payload.Files {
+		if strings.TrimSpace(file.AuthIndex) != authIndex {
+			continue
+		}
+		found = true
+		if isSidecarCodexAuthFile(file) {
+			return codexAuthFileSidecar, nil
+		}
+		if len(authFileDownloadNames(file.Name, file.Path)) == 0 {
+			return codexAuthFileUnknown, fmt.Errorf("CPA auth file name is unavailable")
+		}
+		raw, exists, err := c.downloadAuthFileRaw(ctx, file.Name, file.Path)
+		if err != nil {
+			return codexAuthFileUnknown, fmt.Errorf("inspect CPA auth file: %w", err)
+		}
+		if !exists {
+			continue
+		}
+		switch classifyCodexAuthFile(raw) {
+		case codexAuthFileSidecar:
+			return codexAuthFileSidecar, nil
+		case codexAuthFileNative:
+			return codexAuthFileNative, nil
+		}
+	}
+	if !found {
+		return codexAuthFileUnknown, nil
+	}
+	return codexAuthFileUnknown, nil
+}
+
+func authFileDownloadName(name, filePath string) string {
+	names := authFileDownloadNames(name, filePath)
+	if len(names) == 0 {
+		return ""
+	}
+	return names[0]
+}
+
+func authFileDownloadNames(name, filePath string) []string {
+	candidates := make([]string, 0, 2)
+	seen := make(map[string]struct{}, 2)
+	for _, raw := range []string{name, filePath} {
+		candidate := authFileDownloadCandidate(raw)
+		if candidate == "" {
+			continue
+		}
+		if _, exists := seen[candidate]; exists {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		candidates = append(candidates, candidate)
+	}
+	return candidates
+}
+
+func authFileDownloadCandidate(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.ContainsAny(value, "\r\n\x00") {
+		return ""
+	}
+	normalized := strings.ReplaceAll(value, "\\", "/")
+	for _, segment := range strings.Split(normalized, "/") {
+		if segment == ".." {
+			return ""
+		}
+	}
+	candidate := path.Base(normalized)
+	if candidate == "" || candidate == "." || candidate == "/" || strings.ContainsAny(candidate, "/\\\r\n\x00") {
+		return ""
+	}
+	if len(candidate) <= len(".json") || !strings.EqualFold(path.Ext(candidate), ".json") {
+		return ""
+	}
+	return candidate
+}
+
+// enrichCodexAuthFileMetadata performs a best-effort, in-memory metadata
+// projection for the sidecar files emitted by cpa-codex-agent-identity. The
+// CPA list endpoint is intentionally not assumed to expose plugin Metadata or
+// Attributes, so Keeper reads only the small set of non-secret identity fields
+// needed for display and ChatGPT-Account-Id routing.
+func (c *Client) enrichCodexAuthFileMetadata(ctx context.Context, payload *authfiles.AuthFilesResponse) {
+	if c == nil || payload == nil {
+		return
+	}
+	for index := range payload.Files {
+		file := &payload.Files[index]
+		if !shouldInspectCodexAuthFile(*file) {
+			continue
+		}
+		if len(authFileDownloadNames(file.Name, file.Path)) == 0 {
+			continue
+		}
+		raw, exists, err := c.downloadAuthFileRaw(ctx, file.Name, file.Path)
+		if err != nil || !exists {
+			// Metadata enrichment must not turn a successful auth-files list into
+			// an all-or-nothing failure. The normal bridge path still refuses an
+			// unsafe fallback if it cannot classify the credential later.
+			continue
+		}
+		metadata, classification, ok := parseCodexAuthFileMetadata(raw)
+		if !ok || classification != codexAuthFileSidecar {
+			continue
+		}
+		mergeCodexAuthFileMetadata(file, metadata)
+	}
+}
+
+func shouldInspectCodexAuthFile(file authfiles.AuthFile) bool {
+	typeName := strings.ToLower(strings.TrimSpace(file.Type))
+	providerName := strings.ToLower(strings.TrimSpace(file.Provider))
+	if typeName != "codex" && typeName != "codex-agent-identity" && providerName != "codex" && providerName != "codex-agent-identity" {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(file.AuthMode), "agent_identity_sidecar") || strings.TrimSpace(file.AgentIdentityID) != "" {
+		return true
+	}
+	for _, name := range authFileDownloadNames(file.Name, file.Path) {
+		name = strings.ToLower(name)
+		if strings.HasSuffix(name, "-agent-identity.json") || strings.HasPrefix(name, "codex-agent-identity-") {
+			return true
+		}
+	}
+	return false
+}
+
+func isSidecarCodexAuthFile(file authfiles.AuthFile) bool {
+	return strings.EqualFold(strings.TrimSpace(file.AuthMode), "agent_identity_sidecar") || strings.TrimSpace(file.AgentIdentityID) != ""
+}
+
+type codexAuthFileMetadata struct {
+	Type                  string
+	AuthMode              string
+	CredentialKind        string
+	AgentIdentityID       string
+	Email                 string
+	AccountID             string
+	ChatGPTAccountID      string
+	ChatGPTAccountIDCamel string
+	ChatGPTUserID         string
+	ChatGPTUserIDCamel    string
+	PlanType              string
+	PlanTypeCamel         string
+}
+
+func parseCodexAuthFileMetadata(raw []byte) (codexAuthFileMetadata, codexAuthFileClassification, bool) {
+	var metadata codexAuthFileMetadata
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var object map[string]any
+	if err := decoder.Decode(&object); err != nil || object == nil {
+		return metadata, codexAuthFileUnknown, false
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return metadata, codexAuthFileUnknown, false
+	}
+	populateCodexAuthFileMetadata(&metadata, object)
+	metadata.Type = strings.ToLower(strings.TrimSpace(metadata.Type))
+	metadata.AuthMode = strings.ToLower(strings.TrimSpace(metadata.AuthMode))
+	if metadata.Type != "codex" && metadata.Type != "codex-agent-identity" {
+		return metadata, codexAuthFileUnknown, false
+	}
+
+	credentialObjects := codexAuthCredentialObjects(object)
+	accessToken := firstCodexAuthString(credentialObjects, "access_token")
+	if metadata.AuthMode == "agent_identity_sidecar" ||
+		strings.HasPrefix(accessToken, "cais_") ||
+		metadata.AgentIdentityID != "" {
+		return metadata, codexAuthFileSidecar, true
+	}
+
+	// A native Codex OAuth file has an id_token plus at least one OAuth token.
+	// Do not classify an arbitrary type=codex JSON file as native: doing so
+	// could make the Keeper fallback send an opaque plugin credential through
+	// CPA's native route.
+	idToken := strings.TrimSpace(firstCodexAuthString(credentialObjects, "id_token"))
+	refreshToken := strings.TrimSpace(firstCodexAuthString(credentialObjects, "refresh_token"))
+	if metadata.Type == "codex" && idToken != "" && (refreshToken != "" || accessToken != "") {
+		return metadata, codexAuthFileNative, true
+	}
+	return metadata, codexAuthFileUnknown, true
+}
+
+func populateCodexAuthFileMetadata(metadata *codexAuthFileMetadata, object map[string]any) {
+	if metadata == nil {
+		return
+	}
+	setCodexAuthString(&metadata.Type, object, "type")
+	setCodexAuthString(&metadata.AuthMode, object, "auth_mode")
+	setCodexAuthString(&metadata.CredentialKind, object, "credential_kind")
+	setCodexAuthString(&metadata.AgentIdentityID, object, "agent_identity_id")
+	setCodexAuthString(&metadata.Email, object, "email")
+	setCodexAuthString(&metadata.AccountID, object, "account_id")
+	setCodexAuthString(&metadata.ChatGPTAccountID, object, "chatgpt_account_id")
+	setCodexAuthString(&metadata.ChatGPTAccountIDCamel, object, "chatgptAccountId")
+	setCodexAuthString(&metadata.ChatGPTUserID, object, "chatgpt_user_id")
+	setCodexAuthString(&metadata.ChatGPTUserIDCamel, object, "chatgptUserId")
+	setCodexAuthString(&metadata.PlanType, object, "plan_type")
+	setCodexAuthString(&metadata.PlanTypeCamel, object, "planType")
+	populateCodexAuthIDTokenMetadataMissing(metadata, object)
+
+	// A few CPA/plugin revisions wrap provider metadata under metadata or
+	// attributes. Read only the same allowlisted fields and never retain the
+	// wrapper or any access/refresh token value.
+	for _, key := range []string{"metadata", "attributes"} {
+		nested, ok := object[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		populateCodexAuthFileMetadataMissing(metadata, nested)
+		populateCodexAuthIDTokenMetadataMissing(metadata, nested)
+	}
+}
+
+func populateCodexAuthFileMetadataMissing(metadata *codexAuthFileMetadata, object map[string]any) {
+	if metadata == nil {
+		return
+	}
+	setCodexAuthStringMissing(&metadata.Type, object, "type")
+	setCodexAuthStringMissing(&metadata.AuthMode, object, "auth_mode")
+	setCodexAuthStringMissing(&metadata.CredentialKind, object, "credential_kind")
+	setCodexAuthStringMissing(&metadata.AgentIdentityID, object, "agent_identity_id")
+	setCodexAuthStringMissing(&metadata.Email, object, "email")
+	setCodexAuthStringMissing(&metadata.AccountID, object, "account_id")
+	setCodexAuthStringMissing(&metadata.ChatGPTAccountID, object, "chatgpt_account_id")
+	setCodexAuthStringMissing(&metadata.ChatGPTAccountIDCamel, object, "chatgptAccountId")
+	setCodexAuthStringMissing(&metadata.ChatGPTUserID, object, "chatgpt_user_id")
+	setCodexAuthStringMissing(&metadata.ChatGPTUserIDCamel, object, "chatgptUserId")
+	setCodexAuthStringMissing(&metadata.PlanType, object, "plan_type")
+	setCodexAuthStringMissing(&metadata.PlanTypeCamel, object, "planType")
+	setCodexAuthStringMissing(&metadata.PlanType, object, "chatgpt_plan_type")
+	setCodexAuthStringMissing(&metadata.PlanTypeCamel, object, "chatgptPlanType")
+}
+
+func populateCodexAuthIDTokenMetadataMissing(metadata *codexAuthFileMetadata, object map[string]any) {
+	if metadata == nil {
+		return
+	}
+	idToken, ok := object["id_token"].(map[string]any)
+	if !ok {
+		return
+	}
+	populateCodexAuthFileMetadataMissing(metadata, idToken)
+	for _, key := range []string{"auth", "https://api.openai.com/auth", "profile", "https://api.openai.com/profile"} {
+		nested, ok := idToken[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		populateCodexAuthFileMetadataMissing(metadata, nested)
+	}
+}
+
+func codexAuthCredentialObjects(object map[string]any) []map[string]any {
+	objects := make([]map[string]any, 0, 3)
+	if object == nil {
+		return objects
+	}
+	objects = append(objects, object)
+	for _, key := range []string{"metadata", "attributes"} {
+		if nested, ok := object[key].(map[string]any); ok {
+			objects = append(objects, nested)
+		}
+	}
+	return objects
+}
+
+func firstCodexAuthString(objects []map[string]any, key string) string {
+	for _, object := range objects {
+		if value := strings.TrimSpace(codexAuthString(object[key])); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func setCodexAuthString(target *string, object map[string]any, key string) {
+	if target == nil {
+		return
+	}
+	*target = strings.TrimSpace(codexAuthString(object[key]))
+}
+
+func setCodexAuthStringMissing(target *string, object map[string]any, key string) {
+	if target == nil || strings.TrimSpace(*target) != "" {
+		return
+	}
+	setCodexAuthString(target, object, key)
+}
+
+func codexAuthString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case json.Number:
+		return typed.String()
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	default:
+		return ""
+	}
+}
+
+func mergeCodexAuthFileMetadata(file *authfiles.AuthFile, metadata codexAuthFileMetadata) {
+	if file == nil {
+		return
+	}
+	if strings.TrimSpace(file.Email) == "" {
+		file.Email = strings.TrimSpace(metadata.Email)
+	}
+	if strings.TrimSpace(file.AuthMode) == "" {
+		file.AuthMode = strings.TrimSpace(metadata.AuthMode)
+	}
+	if strings.TrimSpace(file.CredentialKind) == "" {
+		file.CredentialKind = strings.TrimSpace(metadata.CredentialKind)
+	}
+	if strings.TrimSpace(file.AgentIdentityID) == "" {
+		file.AgentIdentityID = strings.TrimSpace(metadata.AgentIdentityID)
+	}
+	file.AccountID = firstNonEmpty(metadata.AccountID, metadata.ChatGPTAccountID, metadata.ChatGPTAccountIDCamel, file.AccountID)
+	file.ChatGPTAccountID = firstNonEmpty(metadata.ChatGPTAccountID, metadata.AccountID, file.ChatGPTAccountID)
+	file.ChatGPTAccountIDCamel = firstNonEmpty(metadata.ChatGPTAccountIDCamel, file.ChatGPTAccountIDCamel)
+	file.ChatGPTUserID = firstNonEmpty(metadata.ChatGPTUserID, file.ChatGPTUserID)
+	file.ChatGPTUserIDCamel = firstNonEmpty(metadata.ChatGPTUserIDCamel, file.ChatGPTUserIDCamel)
+	file.PlanType = firstNonEmpty(metadata.PlanType, metadata.PlanTypeCamel, file.PlanType)
+	file.PlanTypeCamel = firstNonEmpty(metadata.PlanTypeCamel, file.PlanTypeCamel)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+const authFileDownloadMaxBytes int64 = 2 * 1024 * 1024
+
+func (c *Client) downloadAuthFileRaw(ctx context.Context, name, filePath string) ([]byte, bool, error) {
+	candidates := authFileDownloadNames(name, filePath)
+	if len(candidates) == 0 {
+		return nil, false, fmt.Errorf("auth file name is invalid")
+	}
+	for _, candidate := range candidates {
+		body, statusCode, err := c.downloadAuthFileCandidate(ctx, candidate)
+		if statusCode == http.StatusNotFound {
+			continue
+		}
+		if err != nil {
+			return nil, false, err
+		}
+		return body, true, nil
+	}
+	return nil, false, nil
+}
+
+func (c *Client) downloadAuthFileCandidate(ctx context.Context, name string) ([]byte, int, error) {
+	if c == nil {
+		return nil, 0, fmt.Errorf("cpa client is nil")
+	}
+	if c.baseURL == "" {
+		return nil, 0, fmt.Errorf("cpa base url is required")
+	}
+	if c.managementKey == "" {
+		return nil, 0, fmt.Errorf("cpa management key is required")
+	}
+	name = authFileDownloadCandidate(name)
+	if name == "" {
+		return nil, 0, fmt.Errorf("auth file name is invalid")
+	}
+	requestPath := cpaManagementAuthFilesDownloadEndpoint + "?name=" + url.QueryEscape(name)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+requestPath, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("build management auth file download request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.managementKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("request management auth file download: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, resp.StatusCode, nil
+	}
+	if resp.ContentLength > authFileDownloadMaxBytes {
+		return nil, resp.StatusCode, fmt.Errorf("auth file download response exceeds %d bytes", authFileDownloadMaxBytes)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, authFileDownloadMaxBytes+1))
+	if err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("read management auth file download response: %w", err)
+	}
+	if int64(len(body)) > authFileDownloadMaxBytes {
+		return nil, resp.StatusCode, fmt.Errorf("auth file download response exceeds %d bytes", authFileDownloadMaxBytes)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, resp.StatusCode, fmt.Errorf("management auth file download request returned status %d", resp.StatusCode)
+	}
+	return body, resp.StatusCode, nil
+}
+
+func classifyCodexAuthFile(raw []byte) codexAuthFileClassification {
+	_, classification, ok := parseCodexAuthFileMetadata(raw)
+	if !ok {
+		return codexAuthFileUnknown
+	}
+	return classification
 }
 
 func (c *Client) FetchGeminiAPIKeys(ctx context.Context) (*response.ProviderKeyConfigResult, error) {

--- a/internal/cpa/client_test.go
+++ b/internal/cpa/client_test.go
@@ -1,6 +1,7 @@
 package cpa
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"encoding/json"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"cpa-usage-keeper/internal/cpa/dto/apicall"
+	"cpa-usage-keeper/internal/cpa/dto/authfiles"
 )
 
 func TestBlankJSONResponseBodyCheckDoesNotAllocate(t *testing.T) {
@@ -351,6 +353,186 @@ func TestFetchAuthFilesParsesCodexIDTokenFields(t *testing.T) {
 	}
 }
 
+func TestFetchAuthFilesEnrichesSidecarAccountAndTeamMetadata(t *testing.T) {
+	const sharedEmail = "same-user@example.invalid"
+	var downloadCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer management-secret" {
+			t.Errorf("expected management Authorization header, got %q", got)
+		}
+		switch r.URL.Path {
+		case cpaManagementAuthFilesEndpoint:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"files":[
+				{"name":"codex-account-a-same-user@example.invalid-team-agent-identity.json","auth_index":"agent-auth-a","type":"codex","email":"` + sharedEmail + `"},
+				{"name":"codex-account-b-same-user@example.invalid-team-agent-identity.json","auth_index":"agent-auth-b","type":"codex","email":"` + sharedEmail + `"},
+				{"name":"codex-native.json","auth_index":"native-auth","type":"codex","email":"native@example.invalid"}
+			]}`))
+		case cpaManagementAuthFilesDownloadEndpoint:
+			downloadCalls++
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Query().Get("name") {
+			case "codex-account-a-same-user@example.invalid-team-agent-identity.json":
+				_, _ = w.Write([]byte(`{"type":"codex","auth_mode":"agent_identity_sidecar","credential_kind":"agent_identity","agent_identity_id":"agent-aabb0011","email":"` + sharedEmail + `","account_id":"team-account-a","chatgpt_user_id":"chatgpt-user-a","plan_type":"team","access_token":"cais_secret_a_do_not_return"}`))
+			case "codex-account-b-same-user@example.invalid-team-agent-identity.json":
+				_, _ = w.Write([]byte(`{"type":"codex","auth_mode":"agent_identity_sidecar","credential_kind":"personal_access_token","agent_identity_id":"agent-ccdd2233","email":"` + sharedEmail + `","account_id":"team-account-b","chatgpt_user_id":"chatgpt-user-b","plan_type":"team","access_token":"cais_secret_b_do_not_return"}`))
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "management-secret", 2*time.Second, false)
+	result, err := client.FetchAuthFiles(context.Background())
+	if err != nil {
+		t.Fatalf("FetchAuthFiles returned error: %v", err)
+	}
+	if len(result.Payload.Files) != 3 {
+		t.Fatalf("expected three auth files, got %#v", result.Payload.Files)
+	}
+	if downloadCalls != 2 {
+		t.Fatalf("expected only sidecar candidates to be downloaded, got %d calls", downloadCalls)
+	}
+	if bytes.Contains(result.Body, []byte("cais_secret_a_do_not_return")) || bytes.Contains(result.Body, []byte("cais_secret_b_do_not_return")) {
+		t.Fatalf("auth-files response body contains a sidecar credential")
+	}
+
+	filesByIndex := make(map[string]authfiles.AuthFile, len(result.Payload.Files))
+	for _, file := range result.Payload.Files {
+		filesByIndex[file.AuthIndex] = file
+	}
+	first := filesByIndex["agent-auth-a"]
+	second := filesByIndex["agent-auth-b"]
+	if first.AccountID != "team-account-a" || first.ChatGPTUserID != "chatgpt-user-a" || first.PlanType != "team" || first.AuthMode != "agent_identity_sidecar" {
+		t.Fatalf("first sidecar metadata = %+v", first)
+	}
+	if second.AccountID != "team-account-b" || second.ChatGPTUserID != "chatgpt-user-b" || second.PlanType != "team" || second.CredentialKind != "personal_access_token" {
+		t.Fatalf("second sidecar metadata = %+v", second)
+	}
+	if first.Email != sharedEmail || second.Email != sharedEmail || first.AccountID == second.AccountID {
+		t.Fatalf("same-email sidecars were not kept distinct: first=%+v second=%+v", first, second)
+	}
+	if native := filesByIndex["native-auth"]; native.AccountID != "" || native.PlanType != "" || native.AuthMode != "" {
+		t.Fatalf("native OAuth file was unexpectedly enriched: %+v", native)
+	}
+}
+
+func TestClassifyCodexAuthFileRejectsUnknownShape(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want codexAuthFileClassification
+	}{
+		{name: "native oauth", raw: `{"type":"codex","access_token":"oauth-access","refresh_token":"oauth-refresh","id_token":"header.payload.signature"}`, want: codexAuthFileNative},
+		{name: "sidecar", raw: `{"type":"codex","auth_mode":"agent_identity_sidecar","agent_identity_id":"agent-aabb0011","access_token":"cais_fake_for_test_only"}`, want: codexAuthFileSidecar},
+		{name: "unknown codex", raw: `{"type":"codex","access_token":"opaque-but-unclassified"}`, want: codexAuthFileUnknown},
+		{name: "plugin type without marker", raw: `{"type":"codex-agent-identity","access_token":"opaque-but-unclassified"}`, want: codexAuthFileUnknown},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := classifyCodexAuthFile([]byte(test.raw)); got != test.want {
+				t.Fatalf("classifyCodexAuthFile() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestFetchAuthFilesUsesPathBasenameAndNestedCodexMetadata(t *testing.T) {
+	var downloadNames []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer management-secret" {
+			t.Errorf("expected management Authorization header, got %q", got)
+		}
+		switch r.URL.Path {
+		case cpaManagementAuthFilesEndpoint:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"files":[{"name":"auth-record.json","path":"/var/lib/cpa/auths/codex-agent-identity-team.json","auth_index":"team-auth","type":"codex-agent-identity","email":"team-user@example.invalid"}]}`))
+		case cpaManagementAuthFilesDownloadEndpoint:
+			name := r.URL.Query().Get("name")
+			downloadNames = append(downloadNames, name)
+			if name == "auth-record.json" {
+				http.NotFound(w, r)
+				return
+			}
+			if name != "codex-agent-identity-team.json" {
+				t.Errorf("unexpected download candidate %q", name)
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"metadata":{"type":"codex-agent-identity","auth_mode":"agent_identity_sidecar","agent_identity_id":"agent-aabb0011","account_id":"team-from-path","plan_type":"team","id_token":{"chatgpt_account_id":"team-from-id-token"}},"attributes":{"chatgpt_user_id":"chatgpt-user-from-attributes"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "management-secret", 2*time.Second, false)
+	result, err := client.FetchAuthFiles(context.Background())
+	if err != nil {
+		t.Fatalf("FetchAuthFiles returned error: %v", err)
+	}
+	if len(downloadNames) != 2 || downloadNames[0] != "auth-record.json" || downloadNames[1] != "codex-agent-identity-team.json" {
+		t.Fatalf("expected safe name/path candidate order, got %#v", downloadNames)
+	}
+	if len(result.Payload.Files) != 1 {
+		t.Fatalf("expected one auth file, got %#v", result.Payload.Files)
+	}
+	file := result.Payload.Files[0]
+	if file.Type != "codex-agent-identity" || file.AuthMode != "agent_identity_sidecar" || file.AgentIdentityID != "agent-aabb0011" {
+		t.Fatalf("nested sidecar classification metadata = %+v", file)
+	}
+	if file.AccountID != "team-from-path" || file.ChatGPTAccountID != "team-from-id-token" || file.PlanType != "team" || file.ChatGPTUserID != "chatgpt-user-from-attributes" {
+		t.Fatalf("nested sidecar routing metadata = %+v", file)
+	}
+	if file.IDToken != nil {
+		t.Fatalf("downloaded sidecar id_token claims must not be promoted to a raw credential field: %+v", file.IDToken)
+	}
+}
+
+func TestAuthFileDownloadNamesRejectTraversalAndUseJSONBasenames(t *testing.T) {
+	if got := authFileDownloadNames("../secret.json", `C:\\data\\safe.json`); len(got) != 1 || got[0] != "safe.json" {
+		t.Fatalf("unexpected sanitized auth file candidates: %#v", got)
+	}
+	if got := authFileDownloadNames("auth-record.txt", "/data/auths/real.json"); len(got) != 1 || got[0] != "real.json" {
+		t.Fatalf("expected invalid name to fall back to path basename, got %#v", got)
+	}
+	if got := authFileDownloadNames("nested/auth.json", "/data/auths/auth.json"); len(got) != 1 || got[0] != "auth.json" {
+		t.Fatalf("expected duplicate basenames to be deduplicated, got %#v", got)
+	}
+	if got := authFileDownloadNames("../secret.json", "../also-secret.json"); len(got) != 0 {
+		t.Fatalf("expected traversal candidates to be rejected, got %#v", got)
+	}
+}
+
+func TestDownloadAuthFileRawLimitsResponseWithoutReturningCredentialBody(t *testing.T) {
+	const sentinel = "cais_secret_should_not_escape"
+	body := strings.Repeat("x", int(authFileDownloadMaxBytes)-len(sentinel)+1) + sentinel
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != cpaManagementAuthFilesDownloadEndpoint {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "management-secret", 2*time.Second, false)
+	_, exists, err := client.downloadAuthFileRaw(context.Background(), "oversized.json", "")
+	if err == nil {
+		t.Fatal("expected oversized auth file response error")
+	}
+	if exists {
+		t.Fatal("oversized auth file must not be reported as existing")
+	}
+	if strings.Contains(err.Error(), sentinel) {
+		t.Fatalf("oversized response leaked credential content in error: %v", err)
+	}
+}
+
 func TestUpdateAuthFileStatusPatchesManagementEndpoint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPatch {
@@ -495,6 +677,204 @@ func TestCallManagementAPIParsesSnakeCaseResponse(t *testing.T) {
 	}
 	if result.StatusCode != http.StatusCreated || result.BodyText != "created" || string(result.Body) != `{"ok":true}` {
 		t.Fatalf("unexpected snake case api-call response: %+v", result)
+	}
+}
+
+func TestCallManagementAPICodexQuotaUsesPluginBridge(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		url    string
+		data   any
+	}{
+		{
+			name:   "usage",
+			method: http.MethodGet,
+			url:    "https://chatgpt.com/backend-api/wham/usage",
+		},
+		{
+			name:   "reset credit details",
+			method: http.MethodGet,
+			url:    "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits",
+		},
+		{
+			name:   "reset credit consume",
+			method: http.MethodPost,
+			url:    "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume",
+			data:   map[string]string{"redeem_request_id": "redeem-test"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST method, got %s", r.Method)
+				}
+				if r.URL.Path != cpaManagementCodexAgentIdentityAPICallEndpoint {
+					t.Errorf("expected plugin bridge path %q, got %q", cpaManagementCodexAgentIdentityAPICallEndpoint, r.URL.Path)
+				}
+				if got := r.Header.Get("Authorization"); got != "Bearer management-secret" {
+					t.Errorf("expected management Authorization header, got %q", got)
+				}
+				if got := r.Header.Get("Content-Type"); got != "application/json" {
+					t.Errorf("expected JSON content type, got %q", got)
+				}
+
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decode bridge request body: %v", err)
+				}
+				if body["authIndex"] != "codex-auth" || body["method"] != test.method || body["url"] != test.url {
+					t.Errorf("unexpected bridge request body: %#v", body)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"statusCode":200,"bodyText":"bridge-ok","body":{"bridge":true}}`))
+			}))
+			defer server.Close()
+
+			client := NewClient(server.URL, "management-secret", 2*time.Second, false)
+			result, err := client.CallManagementAPI(context.Background(), apicall.Request{
+				AuthIndex: "codex-auth",
+				Method:    test.method,
+				URL:       test.url,
+				Header:    map[string]string{"Chatgpt-Account-Id": "acct-test"},
+				Data:      test.data,
+			})
+			if err != nil {
+				t.Fatalf("CallManagementAPI returned error: %v", err)
+			}
+			if result.StatusCode != http.StatusOK || result.BodyText != "bridge-ok" || string(result.Body) != `{"bridge":true}` {
+				t.Fatalf("unexpected bridge response: %+v", result)
+			}
+		})
+	}
+}
+
+func TestIsCodexQuotaRequestMatchesOnlySupportedEndpoints(t *testing.T) {
+	tests := []struct {
+		name    string
+		method  string
+		url     string
+		expects bool
+	}{
+		{name: "usage", method: http.MethodGet, url: "https://chatgpt.com/backend-api/wham/usage", expects: true},
+		{name: "reset details", method: http.MethodGet, url: "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits", expects: true},
+		{name: "reset consume", method: http.MethodPost, url: "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume", expects: true},
+		{name: "lowercase method", method: "get", url: "https://chatgpt.com/backend-api/wham/usage", expects: true},
+		{name: "wrong method", method: http.MethodPost, url: "https://chatgpt.com/backend-api/wham/usage", expects: false},
+		{name: "query string", method: http.MethodGet, url: "https://chatgpt.com/backend-api/wham/usage?account=1", expects: false},
+		{name: "fragment", method: http.MethodGet, url: "https://chatgpt.com/backend-api/wham/usage#fragment", expects: false},
+		{name: "trailing slash", method: http.MethodGet, url: "https://chatgpt.com/backend-api/wham/usage/", expects: false},
+		{name: "wrong scheme", method: http.MethodGet, url: "http://chatgpt.com/backend-api/wham/usage", expects: false},
+		{name: "wrong host", method: http.MethodGet, url: "https://chat.openai.com/backend-api/wham/usage", expects: false},
+		{name: "host suffix", method: http.MethodGet, url: "https://chatgpt.com.evil.example/backend-api/wham/usage", expects: false},
+		{name: "explicit port", method: http.MethodGet, url: "https://chatgpt.com:443/backend-api/wham/usage", expects: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := isCodexQuotaRequest(apicall.Request{Method: test.method, URL: test.url})
+			if got != test.expects {
+				t.Fatalf("isCodexQuotaRequest(%q, %q) = %v, want %v", test.method, test.url, got, test.expects)
+			}
+		})
+	}
+}
+
+func TestCallManagementAPIFallsBackToNativeForKnownOAuthWhenBridgeIsMissing(t *testing.T) {
+	var bridgeBody, nativeBody []byte
+	var bridgeCalls, nativeCalls, listCalls, downloadCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer management-secret" {
+			t.Errorf("expected management Authorization header, got %q", got)
+		}
+		switch r.URL.Path {
+		case cpaManagementCodexAgentIdentityAPICallEndpoint:
+			bridgeCalls++
+			bridgeBody, _ = io.ReadAll(r.Body)
+			http.NotFound(w, r)
+		case cpaManagementAuthFilesEndpoint:
+			listCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"files":[{"name":"codex-native-agent-identity.json","auth_index":"oauth-auth","type":"codex"}]}`))
+		case cpaManagementAuthFilesDownloadEndpoint:
+			downloadCalls++
+			if got := r.URL.Query().Get("name"); got != "codex-native-agent-identity.json" {
+				t.Errorf("unexpected auth file download name %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"type":"codex","access_token":"oauth-token","refresh_token":"oauth-refresh-token","id_token":"header.payload.signature"}`))
+		case cpaManagementAPICallEndpoint:
+			nativeCalls++
+			nativeBody, _ = io.ReadAll(r.Body)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"statusCode":200,"bodyText":"native-ok","body":{"oauth":true}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "management-secret", 2*time.Second, false)
+	result, err := client.CallManagementAPI(context.Background(), apicall.Request{
+		AuthIndex: "oauth-auth",
+		Method:    http.MethodGet,
+		URL:       "https://chatgpt.com/backend-api/wham/usage",
+		Header:    map[string]string{"User-Agent": "keeper-test"},
+	})
+	if err != nil {
+		t.Fatalf("CallManagementAPI returned error: %v", err)
+	}
+	if result.StatusCode != http.StatusOK || result.BodyText != "native-ok" || string(result.Body) != `{"oauth":true}` {
+		t.Fatalf("unexpected native fallback response: %+v", result)
+	}
+	if bridgeCalls != 1 || nativeCalls != 1 || listCalls != 1 || downloadCalls != 1 {
+		t.Fatalf("unexpected fallback calls: bridge=%d native=%d list=%d download=%d", bridgeCalls, nativeCalls, listCalls, downloadCalls)
+	}
+	if len(bridgeBody) == 0 || !bytes.Equal(bridgeBody, nativeBody) {
+		t.Fatalf("bridge and native request bodies differ: bridge=%s native=%s", bridgeBody, nativeBody)
+	}
+}
+
+func TestCallManagementAPINeverFallsBackForSidecarAuthWhenBridgeIsMissing(t *testing.T) {
+	var nativeCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case cpaManagementCodexAgentIdentityAPICallEndpoint:
+			http.NotFound(w, r)
+		case cpaManagementAuthFilesEndpoint:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"files":[{"name":"codex-agent.json","auth_index":"agent-auth","type":"codex"}]}`))
+		case cpaManagementAuthFilesDownloadEndpoint:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"type":"codex","auth_mode":"agent_identity_sidecar","agent_identity_id":"agent-aabb0011","access_token":"cais_fake_for_test_only"}`))
+		case cpaManagementAPICallEndpoint:
+			nativeCalls++
+			http.Error(w, "native route must not receive sidecar auth", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "management-secret", 2*time.Second, false)
+	_, err := client.CallManagementAPI(context.Background(), apicall.Request{
+		AuthIndex: "agent-auth",
+		Method:    http.MethodGet,
+		URL:       "https://chatgpt.com/backend-api/wham/usage",
+	})
+	if err == nil {
+		t.Fatal("expected bridge-unavailable error")
+	}
+	if !strings.Contains(err.Error(), "install or enable the Codex Agent Identity plugin") {
+		t.Fatalf("unexpected bridge-unavailable error: %v", err)
+	}
+	if strings.Contains(err.Error(), "cais_fake_for_test_only") {
+		t.Fatalf("error leaked an opaque credential: %v", err)
+	}
+	if nativeCalls != 0 {
+		t.Fatalf("native route received a sidecar request %d time(s)", nativeCalls)
 	}
 }
 

--- a/internal/cpa/dto/authfiles/auth_files.go
+++ b/internal/cpa/dto/authfiles/auth_files.go
@@ -17,46 +17,74 @@ type AuthFilesResponse struct {
 
 // AuthFile 是 CPA /management/auth-files 中单个 auth file 的原始响应 DTO。
 type AuthFile struct {
-	AuthIndex   string                  `json:"auth_index"`
-	Name        string                  `json:"name"`
-	Path        string                  `json:"path"`
-	Email       string                  `json:"email"`
-	Type        string                  `json:"type"`
-	Provider    string                  `json:"provider"`
-	Label       string                  `json:"label"`
-	Status      string                  `json:"status"`
-	Source      string                  `json:"source"`
-	Prefix      string                  `json:"prefix"`
-	Priority    *int                    `json:"priority"`
-	Disabled    *bool                   `json:"disabled"`
-	Note        *string                 `json:"note"`
-	Unavailable bool                    `json:"unavailable"`
-	RuntimeOnly bool                    `json:"runtime_only"`
-	Account     string                  `json:"account,omitempty"`
-	ProjectID   string                  `json:"project_id,omitempty"`
-	Sub         *AuthFileXAIUserIDValue `json:"sub,omitempty"`
-	Subject     *AuthFileXAIUserIDValue `json:"subject,omitempty"`
-	UserID      *AuthFileXAIUserIDValue `json:"user_id,omitempty"`
-	UserIDCamel *AuthFileXAIUserIDValue `json:"userId,omitempty"`
-	Metadata    *AuthFileClaims         `json:"metadata,omitempty"`
-	Attributes  *AuthFileClaims         `json:"attributes,omitempty"`
-	OAuth       *AuthFileOAuth          `json:"oauth,omitempty"`
-	User        *AuthFileUser           `json:"user,omitempty"`
-	IDToken     *AuthFileIDToken        `json:"id_token"`
-	xaiOAuthSet bool
-	xaiUserSet  bool
+	AuthIndex   string  `json:"auth_index"`
+	Name        string  `json:"name"`
+	Path        string  `json:"path"`
+	Email       string  `json:"email"`
+	Type        string  `json:"type"`
+	Provider    string  `json:"provider"`
+	Label       string  `json:"label"`
+	Status      string  `json:"status"`
+	Source      string  `json:"source"`
+	Prefix      string  `json:"prefix"`
+	Priority    *int    `json:"priority"`
+	Disabled    *bool   `json:"disabled"`
+	Note        *string `json:"note"`
+	Unavailable bool    `json:"unavailable"`
+	RuntimeOnly bool    `json:"runtime_only"`
+	Account     string  `json:"account,omitempty"`
+	// The CPA auth-files list does not expose plugin-owned metadata on every
+	// release. These non-secret fields are populated from the sidecar auth file
+	// by the Keeper client when the list entry is clearly Codex Agent Identity.
+	AuthMode              string                  `json:"auth_mode,omitempty"`
+	CredentialKind        string                  `json:"credential_kind,omitempty"`
+	AgentIdentityID       string                  `json:"agent_identity_id,omitempty"`
+	AccountID             string                  `json:"account_id,omitempty"`
+	ChatGPTAccountID      string                  `json:"chatgpt_account_id,omitempty"`
+	ChatGPTAccountIDCamel string                  `json:"chatgptAccountId,omitempty"`
+	ChatGPTUserID         string                  `json:"chatgpt_user_id,omitempty"`
+	ChatGPTUserIDCamel    string                  `json:"chatgptUserId,omitempty"`
+	PlanType              string                  `json:"plan_type,omitempty"`
+	PlanTypeCamel         string                  `json:"planType,omitempty"`
+	ProjectID             string                  `json:"project_id,omitempty"`
+	Sub                   *AuthFileXAIUserIDValue `json:"sub,omitempty"`
+	Subject               *AuthFileXAIUserIDValue `json:"subject,omitempty"`
+	UserID                *AuthFileXAIUserIDValue `json:"user_id,omitempty"`
+	UserIDCamel           *AuthFileXAIUserIDValue `json:"userId,omitempty"`
+	Metadata              *AuthFileClaims         `json:"metadata,omitempty"`
+	Attributes            *AuthFileClaims         `json:"attributes,omitempty"`
+	OAuth                 *AuthFileOAuth          `json:"oauth,omitempty"`
+	User                  *AuthFileUser           `json:"user,omitempty"`
+	IDToken               *AuthFileIDToken        `json:"id_token"`
+	xaiOAuthSet           bool
+	xaiUserSet            bool
 }
 
 // AuthFileClaims 是 CPA auth file 中可能携带身份 subject 的通用 claims DTO。
 type AuthFileClaims struct {
-	Sub         *AuthFileXAIUserIDValue `json:"sub,omitempty"`
-	Subject     *AuthFileXAIUserIDValue `json:"subject,omitempty"`
-	UserID      *AuthFileXAIUserIDValue `json:"user_id,omitempty"`
-	UserIDCamel *AuthFileXAIUserIDValue `json:"userId,omitempty"`
-	OAuth       *AuthFileOAuth          `json:"oauth,omitempty"`
-	User        *AuthFileUser           `json:"user,omitempty"`
-	xaiOAuthSet bool
-	xaiUserSet  bool
+	Type                  string                  `json:"type,omitempty"`
+	Provider              string                  `json:"provider,omitempty"`
+	AuthMode              string                  `json:"auth_mode,omitempty"`
+	CredentialKind        string                  `json:"credential_kind,omitempty"`
+	AgentIdentityID       string                  `json:"agent_identity_id,omitempty"`
+	Email                 string                  `json:"email,omitempty"`
+	AccountID             string                  `json:"account_id,omitempty"`
+	ChatGPTAccountID      string                  `json:"chatgpt_account_id,omitempty"`
+	ChatGPTAccountIDCamel string                  `json:"chatgptAccountId,omitempty"`
+	ChatGPTUserID         string                  `json:"chatgpt_user_id,omitempty"`
+	ChatGPTUserIDCamel    string                  `json:"chatgptUserId,omitempty"`
+	PlanType              string                  `json:"plan_type,omitempty"`
+	PlanTypeCamel         string                  `json:"planType,omitempty"`
+	ProjectID             string                  `json:"project_id,omitempty"`
+	IDToken               *AuthFileIDToken        `json:"id_token,omitempty"`
+	Sub                   *AuthFileXAIUserIDValue `json:"sub,omitempty"`
+	Subject               *AuthFileXAIUserIDValue `json:"subject,omitempty"`
+	UserID                *AuthFileXAIUserIDValue `json:"user_id,omitempty"`
+	UserIDCamel           *AuthFileXAIUserIDValue `json:"userId,omitempty"`
+	OAuth                 *AuthFileOAuth          `json:"oauth,omitempty"`
+	User                  *AuthFileUser           `json:"user,omitempty"`
+	xaiOAuthSet           bool
+	xaiUserSet            bool
 }
 
 // AuthFileOAuth 是 CPA auth file 中 oauth 身份字段的最小 DTO。
@@ -88,6 +116,7 @@ func (file *AuthFile) UnmarshalJSON(data []byte) error {
 		Attributes  json.RawMessage `json:"attributes"`
 		OAuth       json.RawMessage `json:"oauth"`
 		User        json.RawMessage `json:"user"`
+		IDToken     json.RawMessage `json:"id_token"`
 	}{authFileAlias: &decoded}
 	if err := json.Unmarshal(data, &shadow); err != nil {
 		return fmt.Errorf("decode auth file: %w", err)
@@ -105,7 +134,10 @@ func (file *AuthFile) UnmarshalJSON(data []byte) error {
 	decoded.Attributes = authFileClaims(object["attributes"])
 	decoded.OAuth, decoded.xaiOAuthSet = authFileOAuth(object["oauth"])
 	decoded.User, decoded.xaiUserSet = authFileUser(object["user"])
+	decoded.IDToken = authFileIDToken(object["id_token"])
 	*file = AuthFile(decoded)
+	mergeAuthFileCodexClaims(file, file.Metadata)
+	mergeAuthFileCodexClaims(file, file.Attributes)
 	return nil
 }
 
@@ -154,14 +186,151 @@ func authFileClaims(data json.RawMessage) *AuthFileClaims {
 		return nil
 	}
 	claims := &AuthFileClaims{
-		Sub:         authFileXAIUserIDValue(object["sub"]),
-		Subject:     authFileXAIUserIDValue(object["subject"]),
-		UserID:      authFileXAIUserIDValue(object["user_id"]),
-		UserIDCamel: authFileXAIUserIDValue(object["userId"]),
+		Type:                  authFileString(object["type"]),
+		Provider:              authFileString(object["provider"]),
+		AuthMode:              authFileString(object["auth_mode"]),
+		CredentialKind:        authFileString(object["credential_kind"]),
+		AgentIdentityID:       authFileString(object["agent_identity_id"]),
+		Email:                 authFileString(object["email"]),
+		AccountID:             authFileString(object["account_id"]),
+		ChatGPTAccountID:      authFileString(object["chatgpt_account_id"]),
+		ChatGPTAccountIDCamel: authFileString(object["chatgptAccountId"]),
+		ChatGPTUserID:         authFileString(object["chatgpt_user_id"]),
+		ChatGPTUserIDCamel:    authFileString(object["chatgptUserId"]),
+		PlanType:              authFileString(object["plan_type"]),
+		PlanTypeCamel:         authFileString(object["planType"]),
+		ProjectID:             authFileString(object["project_id"]),
+		IDToken:               authFileIDToken(object["id_token"]),
+		Sub:                   authFileXAIUserIDValue(object["sub"]),
+		Subject:               authFileXAIUserIDValue(object["subject"]),
+		UserID:                authFileXAIUserIDValue(object["user_id"]),
+		UserIDCamel:           authFileXAIUserIDValue(object["userId"]),
 	}
 	claims.OAuth, claims.xaiOAuthSet = authFileOAuth(object["oauth"])
 	claims.User, claims.xaiUserSet = authFileUser(object["user"])
 	return claims
+}
+
+func authFileString(data json.RawMessage) string {
+	if len(data) == 0 {
+		return ""
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case json.Number:
+		return strings.TrimSpace(typed.String())
+	default:
+		return ""
+	}
+}
+
+func authFileStringPointer(data json.RawMessage) *string {
+	value := authFileString(data)
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func authFileTime(data json.RawMessage) *time.Time {
+	value := authFileString(data)
+	if value == "" {
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return nil
+	}
+	return &parsed
+}
+
+func authFileIDToken(data json.RawMessage) *AuthFileIDToken {
+	object := authFileObject(data)
+	if object == nil {
+		return nil
+	}
+	return &AuthFileIDToken{
+		AccountID:        authFileStringPointer(object["chatgpt_account_id"]),
+		AccountIDCamel:   authFileStringPointer(object["chatgptAccountId"]),
+		ActiveStart:      authFileTime(object["chatgpt_subscription_active_start"]),
+		ActiveStartCamel: authFileTime(object["chatgptSubscriptionActiveStart"]),
+		ActiveUntil:      authFileTime(object["chatgpt_subscription_active_until"]),
+		ActiveUntilCamel: authFileTime(object["chatgptSubscriptionActiveUntil"]),
+		PlanType:         authFileStringPointer(object["plan_type"]),
+		PlanTypeCamel:    authFileStringPointer(object["planType"]),
+	}
+}
+
+func mergeAuthFileCodexClaims(file *AuthFile, claims *AuthFileClaims) {
+	if file == nil || claims == nil {
+		return
+	}
+	file.Type = authFileFirstNonEmpty(file.Type, claims.Type)
+	file.Provider = authFileFirstNonEmpty(file.Provider, claims.Provider)
+	file.AuthMode = authFileFirstNonEmpty(file.AuthMode, claims.AuthMode)
+	file.CredentialKind = authFileFirstNonEmpty(file.CredentialKind, claims.CredentialKind)
+	file.AgentIdentityID = authFileFirstNonEmpty(file.AgentIdentityID, claims.AgentIdentityID)
+	file.Email = authFileFirstNonEmpty(file.Email, claims.Email)
+	file.AccountID = authFileFirstNonEmpty(file.AccountID, claims.AccountID, claims.ChatGPTAccountID, claims.ChatGPTAccountIDCamel)
+	file.ChatGPTAccountID = authFileFirstNonEmpty(file.ChatGPTAccountID, claims.ChatGPTAccountID, claims.AccountID)
+	file.ChatGPTAccountIDCamel = authFileFirstNonEmpty(file.ChatGPTAccountIDCamel, claims.ChatGPTAccountIDCamel)
+	file.ChatGPTUserID = authFileFirstNonEmpty(file.ChatGPTUserID, claims.ChatGPTUserID)
+	file.ChatGPTUserIDCamel = authFileFirstNonEmpty(file.ChatGPTUserIDCamel, claims.ChatGPTUserIDCamel)
+	file.PlanType = authFileFirstNonEmpty(file.PlanType, claims.PlanType, claims.PlanTypeCamel)
+	file.PlanTypeCamel = authFileFirstNonEmpty(file.PlanTypeCamel, claims.PlanTypeCamel)
+	file.ProjectID = authFileFirstNonEmpty(file.ProjectID, claims.ProjectID)
+	if file.IDToken == nil {
+		file.IDToken = claims.IDToken
+		return
+	}
+	if claims.IDToken == nil {
+		return
+	}
+	file.IDToken.AccountID = authFileFirstNonEmptyPointer(file.IDToken.AccountID, claims.IDToken.AccountID)
+	file.IDToken.AccountIDCamel = authFileFirstNonEmptyPointer(file.IDToken.AccountIDCamel, claims.IDToken.AccountIDCamel)
+	file.IDToken.ActiveStart = authFileFirstNonEmptyTime(file.IDToken.ActiveStart, claims.IDToken.ActiveStart)
+	file.IDToken.ActiveStartCamel = authFileFirstNonEmptyTime(file.IDToken.ActiveStartCamel, claims.IDToken.ActiveStartCamel)
+	file.IDToken.ActiveUntil = authFileFirstNonEmptyTime(file.IDToken.ActiveUntil, claims.IDToken.ActiveUntil)
+	file.IDToken.ActiveUntilCamel = authFileFirstNonEmptyTime(file.IDToken.ActiveUntilCamel, claims.IDToken.ActiveUntilCamel)
+	file.IDToken.PlanType = authFileFirstNonEmptyPointer(file.IDToken.PlanType, claims.IDToken.PlanType)
+	file.IDToken.PlanTypeCamel = authFileFirstNonEmptyPointer(file.IDToken.PlanTypeCamel, claims.IDToken.PlanTypeCamel)
+}
+
+func authFileFirstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func authFileFirstNonEmptyPointer(values ...*string) *string {
+	for _, value := range values {
+		if value == nil {
+			continue
+		}
+		if trimmed := strings.TrimSpace(*value); trimmed != "" {
+			return &trimmed
+		}
+	}
+	return nil
+}
+
+func authFileFirstNonEmptyTime(values ...*time.Time) *time.Time {
+	for _, value := range values {
+		if value != nil && !value.IsZero() {
+			return value
+		}
+	}
+	return nil
 }
 
 func authFileOAuth(data json.RawMessage) (*AuthFileOAuth, bool) {

--- a/internal/cpa/endpoints.go
+++ b/internal/cpa/endpoints.go
@@ -2,6 +2,7 @@ package cpa
 
 const (
 	cpaManagementAuthFilesEndpoint           = "/v0/management/auth-files"
+	cpaManagementAuthFilesDownloadEndpoint   = "/v0/management/auth-files/download"
 	cpaManagementAuthFilesStatusEndpoint     = "/v0/management/auth-files/status"
 	cpaManagementAPIKeysEndpoint             = "/v0/management/api-keys"
 	cpaManagementVertexAPIKeyEndpoint        = "/v0/management/vertex-api-key"
@@ -12,8 +13,13 @@ const (
 	cpaManagementOpenAICompatibilityEndpoint = "/v0/management/openai-compatibility"
 	cpaManagementUsageQueueEndpoint          = "/v0/management/usage-queue"
 	cpaManagementAPICallEndpoint             = "/v0/management/api-call"
-	cpaManagementRequestLogByIDEndpoint      = "/v0/management/request-log-by-id"
-	cpaModelsEndpoint                        = "/v1/models"
+	// The plugin host cannot replace CPA's reserved api-call route. Codex
+	// quota/reset requests therefore use the plugin-owned bridge, which then
+	// applies AgentAssertion/PAT auth for sidecar credentials and forwards
+	// ordinary OAuth credentials back to CPA's native route.
+	cpaManagementCodexAgentIdentityAPICallEndpoint = "/v0/management/codex-agent-identity/api-call"
+	cpaManagementRequestLogByIDEndpoint            = "/v0/management/request-log-by-id"
+	cpaModelsEndpoint                              = "/v1/models"
 
 	cpaManagementRedisNetwork       = "tcp"
 	ManagementRedisDefaultPort      = "8317"

--- a/internal/quota/test/codex_test.go
+++ b/internal/quota/test/codex_test.go
@@ -84,6 +84,45 @@ func TestCodexProviderUsesAccountIDForUsageRequest(t *testing.T) {
 	}
 }
 
+func TestCodexProviderKeepsSameEmailTeamsSeparatedByIdentityAndAccountHeader(t *testing.T) {
+	const usageJSON = `{"plan_type":"team","rate_limit":{"allowed":true,"limit_reached":false,"primary_window":{"used_percent":12,"limit_window_seconds":18000,"reset_after_seconds":60},"secondary_window":{"used_percent":4,"limit_window_seconds":604800,"reset_after_seconds":120}}}`
+	caller := &recordingManagementCaller{responses: []*apicall.Response{
+		{StatusCode: 200, BodyText: usageJSON, Body: json.RawMessage(usageJSON)},
+		{StatusCode: 200, BodyText: usageJSON, Body: json.RawMessage(usageJSON)},
+	}}
+	provider := quota.NewCodexProvider(caller, quota.DefaultProviderConfigs().Codex)
+	identities := []entities.UsageIdentity{
+		{Name: "same-user@example.invalid", Identity: "codex-team-a-auth", AccountID: stringPtr("team-account-a")},
+		{Name: "same-user@example.invalid", Identity: "codex-team-b-auth", AccountID: stringPtr("team-account-b")},
+	}
+	for _, identity := range identities {
+		if _, err := provider.Check(context.Background(), quota.ProviderInput{Identity: identity}); err != nil {
+			t.Fatalf("Check for %s returned error: %v", identity.Identity, err)
+		}
+	}
+	if len(caller.requests) != 2 {
+		t.Fatalf("expected one request per Codex team, got %d", len(caller.requests))
+	}
+	for index, want := range []struct {
+		authIndex string
+		accountID string
+	}{
+		{authIndex: "codex-team-a-auth", accountID: "team-account-a"},
+		{authIndex: "codex-team-b-auth", accountID: "team-account-b"},
+	} {
+		request := caller.requests[index]
+		if request.AuthIndex != want.authIndex {
+			t.Fatalf("request %d used wrong auth index %q, want %q", index, request.AuthIndex, want.authIndex)
+		}
+		if got := request.Header["Chatgpt-Account-Id"]; got != want.accountID {
+			t.Fatalf("request %d used wrong Chatgpt-Account-Id %q, want %q", index, got, want.accountID)
+		}
+	}
+	if caller.requests[0].Header["Chatgpt-Account-Id"] == caller.requests[1].Header["Chatgpt-Account-Id"] {
+		t.Fatal("same-email Codex teams unexpectedly shared Chatgpt-Account-Id")
+	}
+}
+
 func TestCodexProviderParsesZeroRateLimitResetCredits(t *testing.T) {
 	codexUsageJSON := `{"plan_type":"plus","rate_limit":{"allowed":true,"limit_reached":false},"rate_limit_reset_credits":{"available_count":0}}`
 	caller := &recordingManagementCaller{responses: []*apicall.Response{{

--- a/internal/service/auth_file_identity_test.go
+++ b/internal/service/auth_file_identity_test.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"testing"
+
+	"cpa-usage-keeper/internal/cpa/dto/authfiles"
+)
+
+func TestAuthFileUsageIdentityUsesCodexProviderWhenTypeIsMissing(t *testing.T) {
+	accountID := "team-account-from-provider"
+	planType := "team"
+	identity := authFileUsageIdentity(authfiles.AuthFile{
+		AuthIndex: "codex-provider-only-auth",
+		Email:     "same-user@example.invalid",
+		Provider:  "codex-agent-identity",
+		IDToken: &authfiles.AuthFileIDToken{
+			AccountID: &accountID,
+			PlanType:  &planType,
+		},
+	})
+	if identity.AccountID == nil || *identity.AccountID != accountID || identity.PlanType == nil || *identity.PlanType != planType {
+		t.Fatalf("provider-only Codex auth file was not extended: %+v", identity)
+	}
+}

--- a/internal/service/auth_file_to_usage_identity_fields.go
+++ b/internal/service/auth_file_to_usage_identity_fields.go
@@ -24,6 +24,9 @@ func resolveCodexAccountID(file authfiles.AuthFile) *string {
 		idTokenAccountIDCamel = file.IDToken.AccountIDCamel
 	}
 	return firstNonEmptyStringPtr(
+		stringValue(file.AccountID),
+		stringValue(file.ChatGPTAccountID),
+		stringValue(file.ChatGPTAccountIDCamel),
 		idTokenAccountID,
 		idTokenAccountIDCamel,
 	)
@@ -37,6 +40,8 @@ func resolveCodexPlanType(file authfiles.AuthFile) *string {
 		idTokenPlanTypeCamel = file.IDToken.PlanTypeCamel
 	}
 	return firstNonEmptyStringPtr(
+		stringValue(file.PlanType),
+		stringValue(file.PlanTypeCamel),
 		idTokenPlanType,
 		idTokenPlanTypeCamel,
 	)

--- a/internal/service/metadata_auth_files.go
+++ b/internal/service/metadata_auth_files.go
@@ -52,7 +52,8 @@ type authFileUsageIdentityExtension func(authfiles.AuthFile, *entities.UsageIden
 // authFileUsageIdentityExtensions 按规范化 Auth File type 选择既有专属解析逻辑。
 var authFileUsageIdentityExtensions = map[string]authFileUsageIdentityExtension{
 	// Codex 解析 ChatGPT id_token 的账户、窗口和套餐字段。
-	"codex": extendCodexAuthFileUsageIdentity,
+	"codex":                extendCodexAuthFileUsageIdentity,
+	"codex-agent-identity": extendCodexAuthFileUsageIdentity,
 	// xAI 解析 CPA claims 中的稳定 user id 候选。
 	"xai": extendXAIAuthFileUsageIdentity,
 }
@@ -62,8 +63,14 @@ func authFileUsageIdentity(file authfiles.AuthFile) entities.UsageIdentity {
 	// identity 从所有 Auth Files 共用字段开始构造。
 	identity := baseAuthFileUsageIdentity(file)
 	// type 只用于选择专属字段解析，原始 Type 字段仍保存在 identity。
-	if extend, ok := authFileUsageIdentityExtensions[strings.ToLower(strings.TrimSpace(file.Type))]; ok {
-		// 专属扩展只修改自己负责的 nullable 字段。
+	extensionName := strings.ToLower(strings.TrimSpace(file.Type))
+	extend, ok := authFileUsageIdentityExtensions[extensionName]
+	if !ok {
+		extensionName = strings.ToLower(strings.TrimSpace(file.Provider))
+		extend, ok = authFileUsageIdentityExtensions[extensionName]
+	}
+	if ok {
+		// The extension only updates the nullable fields it owns.
 		extend(file, &identity)
 	}
 	// ProjectID 继续按既有 Gemini 家族规则解析，unsupported type 返回 nil。

--- a/internal/service/test/metadata_sync_test.go
+++ b/internal/service/test/metadata_sync_test.go
@@ -460,3 +460,77 @@ func TestSyncMetadataInteractionsRestoreCatchesUpOnlyNewHistoricalEvents(t *test
 		t.Fatalf("repeated Interactions stats = %+v", repeated)
 	}
 }
+
+func TestSyncMetadataKeepsSameEmailCodexTeamsDistinct(t *testing.T) {
+	db := openMetadataTestDatabase(t, "codex-same-email-teams.db")
+	const sharedEmail = "same-codex-user@example.invalid"
+	currentNow := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+	fetcher := newMetadataTestFetcher()
+	fetcher.setAuthFiles([]authfiles.AuthFile{
+		{
+			AuthIndex: "codex-team-a-auth",
+			Name:      "team-a.json",
+			Email:     sharedEmail,
+			Type:      "codex-agent-identity",
+			Provider:  "codex-agent-identity",
+			AccountID: "team-account-a",
+			PlanType:  "team",
+		},
+		{
+			AuthIndex: "codex-team-b-auth",
+			Name:      "team-b.json",
+			Email:     sharedEmail,
+			Type:      "codex",
+			Provider:  "codex",
+			AccountID: "team-account-b",
+			PlanType:  "team",
+		},
+	})
+	syncer := service.NewSyncServiceWithOptions(db, service.SyncServiceOptions{
+		BaseURL:         "https://cpa.example.com",
+		MetadataFetcher: fetcher,
+		Now:             func() time.Time { return currentNow },
+	})
+
+	if err := syncer.SyncMetadata(context.Background()); err != nil {
+		t.Fatalf("initial Codex team metadata sync returned error: %v", err)
+	}
+	rows := loadMetadataIdentityMap(t, db)
+	teamA := rows[metadataIdentityKey(entities.UsageIdentityAuthTypeAuthFile, "codex-team-a-auth")]
+	teamB := rows[metadataIdentityKey(entities.UsageIdentityAuthTypeAuthFile, "codex-team-b-auth")]
+	if teamA.ID == 0 || teamB.ID == 0 || teamA.ID == teamB.ID {
+		t.Fatalf("same-email Codex teams were merged: teamA=%+v teamB=%+v", teamA, teamB)
+	}
+	if teamA.Name != sharedEmail || teamB.Name != sharedEmail || teamA.AccountID == nil || *teamA.AccountID != "team-account-a" || teamB.AccountID == nil || *teamB.AccountID != "team-account-b" {
+		t.Fatalf("same-email Codex team metadata was not preserved: teamA=%+v teamB=%+v", teamA, teamB)
+	}
+	if teamA.Type != "codex-agent-identity" || teamB.Type != "codex" || teamA.AuthTypeName != "oauth" || teamB.AuthTypeName != "oauth" {
+		t.Fatalf("unexpected Codex team identity types: teamA=%+v teamB=%+v", teamA, teamB)
+	}
+
+	var activeRows []entities.UsageIdentity
+	if err := db.Where("auth_type = ? AND is_deleted = ?", entities.UsageIdentityAuthTypeAuthFile, false).Find(&activeRows).Error; err != nil {
+		t.Fatalf("list active Codex team identities: %v", err)
+	}
+	if len(activeRows) != 2 {
+		t.Fatalf("expected exactly two active Codex team identities, got %d: %+v", len(activeRows), activeRows)
+	}
+
+	currentNow = currentNow.Add(time.Hour)
+	if err := syncer.SyncMetadata(context.Background()); err != nil {
+		t.Fatalf("repeated Codex team metadata sync returned error: %v", err)
+	}
+	rowsAfterRepeat := loadMetadataIdentityMap(t, db)
+	teamAAfterRepeat := rowsAfterRepeat[metadataIdentityKey(entities.UsageIdentityAuthTypeAuthFile, "codex-team-a-auth")]
+	teamBAfterRepeat := rowsAfterRepeat[metadataIdentityKey(entities.UsageIdentityAuthTypeAuthFile, "codex-team-b-auth")]
+	if teamAAfterRepeat.ID != teamA.ID || teamBAfterRepeat.ID != teamB.ID || teamAAfterRepeat.AccountID == nil || *teamAAfterRepeat.AccountID != "team-account-a" || teamBAfterRepeat.AccountID == nil || *teamBAfterRepeat.AccountID != "team-account-b" {
+		t.Fatalf("repeated sync changed or merged Codex teams: teamA=%+v teamB=%+v", teamAAfterRepeat, teamBAfterRepeat)
+	}
+	var total int64
+	if err := db.Model(&entities.UsageIdentity{}).Where("auth_type = ?", entities.UsageIdentityAuthTypeAuthFile).Count(&total).Error; err != nil {
+		t.Fatalf("count all auth-file identities after repeat: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("repeated sync created duplicate auth-file rows: %d", total)
+	}
+}


### PR DESCRIPTION
## Summary
- bridge Codex Agent Identity quota/reset-credit requests through the CPA plugin route
- only fall back to native CPA Codex OAuth auth files when the bridge is unavailable
- prevent `cais_*` sidecar keys from being treated as normal Bearer tokens
- preserve team/account identity separation and enrich non-sensitive auth metadata
- add bounded auth-file downloads, DTO compatibility, and regression tests

## Validation
- `go test -p 1 -vet=off ./internal/cpa/... ./internal/service/... ./internal/quota/... -count=1 -timeout 30m`
- `go build -p 1 ./...`
- `go vet ./internal/cpa/... ./internal/service/... ./internal/quota/...`

The local branch is based on `696a4659ce1d5d6f2d2d0530e3205eb51fbce889` and contains commit `406c018`.