### PR TITLE
fix(metadata): sync after ingest connection

### DIFF
--- a/internal/app/metadata_sync.go
+++ b/internal/app/metadata_sync.go
@@ -24,6 +24,8 @@ type MetadataSyncRunner struct {
 	refreshDebounce time.Duration
 	// refreshRequests 用单元素缓冲合并密集 refresh 通知。
 	refreshRequests chan struct{}
+	// connectedRequests 用单元素缓冲接收 ingest 连接成功信号，避免连接建立时阻塞 ingest。
+	connectedRequests chan struct{}
 	// onStart 只给测试确认后台 runner 已启动，生产逻辑不依赖它。
 	onStart func()
 	// now 允许测试控制 debounce 时间判断，生产使用 time.Now。
@@ -35,6 +37,8 @@ type MetadataSyncRunner struct {
 	running bool
 	// notificationMode 表示 CPA 已支持通知，周期 tick 应该 no-op。
 	notificationMode bool
+	// activated 表示 ingest 至少成功建立过一次连接；首次连接前周期 tick 不执行同步。
+	activated bool
 	// lastRefreshRequestedAt 记录最后一条 refresh=true 的收到时间。
 	lastRefreshRequestedAt time.Time
 }
@@ -42,15 +46,16 @@ type MetadataSyncRunner struct {
 func NewMetadataSyncRunner(syncer MetadataSyncer, interval time.Duration) *MetadataSyncRunner {
 	// 构造阶段只保存依赖，不主动访问 CPA 或数据库。
 	return &MetadataSyncRunner{
-		syncer:          syncer,
-		interval:        interval,
-		refreshDebounce: metadataSyncRefreshDebounceDefault,
-		refreshRequests: make(chan struct{}, 1),
-		now:             time.Now,
+		syncer:            syncer,
+		interval:          interval,
+		refreshDebounce:   metadataSyncRefreshDebounceDefault,
+		refreshRequests:   make(chan struct{}, 1),
+		connectedRequests: make(chan struct{}, 1),
+		now:               time.Now,
 	}
 }
 
-// Run 启动独立 metadata 同步任务：默认轮询；收到 CPA 控制消息后进入通知模式，周期 tick 只保持空转。
+// Run 启动独立 metadata 同步任务：等待 ingest 首次连接后激活；默认轮询，收到 CPA 控制消息后进入通知模式。
 func (r *MetadataSyncRunner) Run(ctx context.Context) error {
 	// 启动前统一校验依赖和补齐测试可能清空的可选字段。
 	if err := r.validate(); err != nil {
@@ -66,13 +71,6 @@ func (r *MetadataSyncRunner) Run(ctx context.Context) error {
 	if r.onStart != nil {
 		r.onStart()
 	}
-
-	// 如果应用启动后立刻取消，就不再执行首次同步。
-	if ctx.Err() != nil {
-		return nil
-	}
-	// 无论后续是否进入通知模式，启动时先同步一次 metadata。
-	r.runSync(ctx)
 
 	// periodic 负责默认轮询模式的固定周期 tick。
 	periodic := time.NewTimer(r.interval)
@@ -94,13 +92,25 @@ func (r *MetadataSyncRunner) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			// 应用关闭是正常退出，不返回错误。
 			return nil
+		case <-r.connectedRequests:
+			// 连接成功是首次同步的门闩；无论当前是否通知模式，都执行一次。
+			// 关停优先于连接触发的同步，避免应用退出时再发起外部请求。
+			if ctx.Err() != nil {
+				return nil
+			}
+			// 首次消费连接信号后解锁周期同步和后续 refresh debounce。
+			r.markActivated()
+			// 连接事件只触发一次同步，失败由后续连接、周期或 refresh 调度再次处理。
+			r.runSync(ctx)
+			// 连接触发的同步完成后重新开始周期计时，避免紧接着又执行一次轮询。
+			resetTimer(periodic, r.interval)
 		case <-periodic.C:
 			// 周期 tick 到达后再检查一次 context，避免关停时多同步。
 			if ctx.Err() != nil {
 				return nil
 			}
-			// 通知模式下周期 tick 完全 no-op，避免继续轮询 CPA。
-			if !r.isNotificationMode() {
+			// 首次连接前不访问 metadata；非订阅（轮询）模式继续按 interval 同步。
+			if r.isActivated() && !r.isNotificationMode() {
 				r.runSync(ctx)
 			}
 			// 无论是否 no-op，都继续维持 tick，方便降级回轮询后恢复节奏。
@@ -149,11 +159,15 @@ func (r *MetadataSyncRunner) RequestMetadataRefresh() {
 	if r == nil {
 		return
 	}
-	// refresh=true 同时证明通知可用，并刷新 trailing debounce 的起点。
-	changed := r.recordRefreshRequest()
+	// refresh=true 同时证明通知可用；只有 runner 已经激活时才进入 trailing debounce。
+	changed, activated := r.recordRefreshRequest()
 	if changed {
 		// refresh=true 也能证明 CPA 通知可用，首次进入通知模式时记录。
 		logrus.WithField("source", "refresh").Info("metadata sync switched to notification mode")
+	}
+	if !activated {
+		// 首次连接同步会读取最新 metadata，连接信号消费前无需再排队一次 refresh。
+		return
 	}
 	// channel 已满时说明已有 refresh 待处理，时间戳已更新即可。
 	select {
@@ -191,6 +205,10 @@ func (r *MetadataSyncRunner) validate() error {
 	if r.refreshRequests == nil {
 		r.refreshRequests = make(chan struct{}, 1)
 	}
+	// 测试可能清空连接信号 channel，运行前恢复单缓冲队列。
+	if r.connectedRequests == nil {
+		r.connectedRequests = make(chan struct{}, 1)
+	}
 	// 测试可能清空时钟函数，运行前恢复生产时钟。
 	if r.now == nil {
 		r.now = time.Now
@@ -198,10 +216,22 @@ func (r *MetadataSyncRunner) validate() error {
 	return nil
 }
 
+func (r *MetadataSyncRunner) NotifyIngestConnected() {
+	// nil runner 保护只为防御异常 wiring，正常路径不会触发。
+	if r == nil {
+		return
+	}
+	// 连接恢复期间多个事件合并为一个待执行同步，避免同步请求堆积。
+	select {
+	case r.connectedRequests <- struct{}{}:
+	default:
+	}
+}
+
 func (r *MetadataSyncRunner) runSync(ctx context.Context) {
 	// 所有 metadata 同步都从这里串行调用 SyncMetadata。
 	if err := r.syncer.SyncMetadata(ctx); err != nil {
-		// 单次同步失败不退出 runner，下一次 tick 或 refresh 继续尝试。
+		// 单次同步失败不退出 runner，下一次连接信号、tick 或 refresh 再按既有调度尝试。
 		logrus.WithError(err).Error("metadata sync failed")
 	}
 }
@@ -211,6 +241,20 @@ func (r *MetadataSyncRunner) setRunning(running bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.running = running
+}
+
+func (r *MetadataSyncRunner) markActivated() {
+	// activated 只需记录一次，后续连接恢复仍然通过同一 channel 触发同步。
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.activated = true
+}
+
+func (r *MetadataSyncRunner) isActivated() bool {
+	// 周期 tick 读取 activated 时需要加锁，避免和连接事件竞争。
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.activated
 }
 
 func (r *MetadataSyncRunner) setNotificationMode(enabled bool) bool {
@@ -226,14 +270,19 @@ func (r *MetadataSyncRunner) setNotificationMode(enabled bool) bool {
 	return changed
 }
 
-func (r *MetadataSyncRunner) recordRefreshRequest() bool {
-	// refresh 请求需要在同一把锁内更新通知模式和最后请求时间。
+func (r *MetadataSyncRunner) recordRefreshRequest() (changed, activated bool) {
+	// refresh 请求需要在同一把锁内更新通知模式、激活状态和 debounce 时间。
+	// changed 表示通知模式是否切换；activated 表示首次连接信号是否已被消费。
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	changed := !r.notificationMode
+	changed = !r.notificationMode
 	r.notificationMode = true
-	r.lastRefreshRequestedAt = r.currentTimeLocked()
-	return changed
+	activated = r.activated
+	if activated {
+		// 激活前的 refresh 由首次连接同步覆盖，不污染后续 debounce 起点。
+		r.lastRefreshRequestedAt = r.currentTimeLocked()
+	}
+	return changed, activated
 }
 
 func (r *MetadataSyncRunner) isNotificationMode() bool {

--- a/internal/app/metadata_sync_test.go
+++ b/internal/app/metadata_sync_test.go
@@ -74,7 +74,7 @@ func (c *metadataSyncErrContext) CloseDone() {
 	close(c.done)
 }
 
-func TestMetadataSyncRunnerRunsImmediatelyThenAtInterval(t *testing.T) {
+func TestMetadataSyncRunnerRunsOnConnectionThenAtInterval(t *testing.T) {
 	syncer := &metadataSyncStub{}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -84,12 +84,13 @@ func TestMetadataSyncRunnerRunsImmediatelyThenAtInterval(t *testing.T) {
 		}
 	}
 	runner := NewMetadataSyncRunner(syncer, time.Millisecond)
+	runner.NotifyIngestConnected()
 
 	if err := runner.Run(ctx); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
 	if got := syncer.CallCount(); got != 2 {
-		t.Fatalf("expected two metadata sync calls, got %d", got)
+		t.Fatalf("expected connection sync plus periodic sync, got %d", got)
 	}
 }
 
@@ -104,6 +105,7 @@ func TestMetadataSyncRunnerLogsFailureAndContinues(t *testing.T) {
 		}
 	}
 	runner := NewMetadataSyncRunner(syncer, time.Millisecond)
+	runner.NotifyIngestConnected()
 
 	if err := runner.Run(ctx); err != nil {
 		t.Fatalf("Run returned error: %v", err)
@@ -137,6 +139,7 @@ func TestMetadataSyncRunnerDefaultsRefreshDebounceToOneSecond(t *testing.T) {
 func TestMetadataSyncRunnerRefreshSupportMakesPeriodicTickNoop(t *testing.T) {
 	syncer := &metadataSyncStub{}
 	runner := NewMetadataSyncRunner(syncer, time.Millisecond)
+	runner.NotifyIngestConnected()
 	runner.MarkRefreshSupported()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -153,7 +156,7 @@ func TestMetadataSyncRunnerRefreshSupportMakesPeriodicTickNoop(t *testing.T) {
 		t.Fatalf("Run returned error: %v", err)
 	}
 	if got := syncer.CallCount(); got != 1 {
-		t.Fatalf("expected only startup sync in notification mode, got %d", got)
+		t.Fatalf("expected only connection-triggered sync in notification mode, got %d", got)
 	}
 }
 
@@ -180,10 +183,11 @@ func TestMetadataSyncRunnerLogsModeSwitches(t *testing.T) {
 	}
 }
 
-func TestMetadataSyncRunnerRefreshSupportDoesNotSyncWithoutRefreshRequest(t *testing.T) {
+func TestMetadataSyncRunnerRefreshSupportDoesNotAddExtraSyncWithoutRefreshRequest(t *testing.T) {
 	syncer := &metadataSyncStub{}
 	runner := NewMetadataSyncRunner(syncer, time.Millisecond)
 	runner.refreshDebounce = time.Millisecond
+	runner.NotifyIngestConnected()
 	runner.MarkRefreshSupported()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -200,7 +204,7 @@ func TestMetadataSyncRunnerRefreshSupportDoesNotSyncWithoutRefreshRequest(t *tes
 		t.Fatalf("Run returned error: %v", err)
 	}
 	if got := syncer.CallCount(); got != 1 {
-		t.Fatalf("expected support-only notification mode not to sync without refresh, got %d", got)
+		t.Fatalf("expected support-only notification mode not to add a sync without refresh, got %d", got)
 	}
 }
 
@@ -208,21 +212,40 @@ func TestMetadataSyncRunnerRefreshRequestDebounces(t *testing.T) {
 	syncer := &metadataSyncStub{}
 	runner := NewMetadataSyncRunner(syncer, time.Hour)
 	runner.refreshDebounce = 5 * time.Millisecond
-	runner.RequestMetadataRefresh()
-	runner.RequestMetadataRefresh()
+	runner.NotifyIngestConnected()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	firstCall := make(chan struct{}, 1)
 	syncer.onCall = func(call int) {
+		if call == 1 {
+			firstCall <- struct{}{}
+		}
 		if call >= 2 {
 			cancel()
 		}
 	}
 
-	if err := runner.Run(ctx); err != nil {
-		t.Fatalf("Run returned error: %v", err)
+	done := make(chan error, 1)
+	go func() {
+		done <- runner.Run(ctx)
+	}()
+	select {
+	case <-firstCall:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for connection sync")
+	}
+	runner.RequestMetadataRefresh()
+	runner.RequestMetadataRefresh()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for metadata runner to stop")
 	}
 	if got := syncer.CallCount(); got != 2 {
-		t.Fatalf("expected startup sync plus one debounced refresh sync, got %d", got)
+		t.Fatalf("expected connection sync plus one debounced refresh sync, got %d", got)
 	}
 }
 
@@ -230,6 +253,7 @@ func TestMetadataSyncRunnerRefreshRequestUsesTrailingDebounce(t *testing.T) {
 	syncer := &metadataSyncStub{}
 	runner := NewMetadataSyncRunner(syncer, time.Hour)
 	runner.refreshDebounce = 150 * time.Millisecond
+	runner.NotifyIngestConnected()
 	calls := make(chan time.Time, 3)
 	syncer.onCall = func(int) {
 		calls <- time.Now()
@@ -243,7 +267,7 @@ func TestMetadataSyncRunnerRefreshRequestUsesTrailingDebounce(t *testing.T) {
 	select {
 	case <-calls:
 	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for startup sync")
+		t.Fatal("timed out waiting for connection sync")
 	}
 
 	runner.RequestMetadataRefresh()
@@ -270,7 +294,7 @@ func TestMetadataSyncRunnerRefreshRequestUsesTrailingDebounce(t *testing.T) {
 		t.Fatalf("expected debounce to wait after the last refresh request, elapsed %s", elapsed)
 	}
 	if got := syncer.CallCount(); got != 2 {
-		t.Fatalf("expected startup sync plus one trailing refresh sync, got %d", got)
+		t.Fatalf("expected connection sync plus one trailing refresh sync, got %d", got)
 	}
 }
 
@@ -278,6 +302,7 @@ func TestMetadataSyncRunnerSkipsDebouncedRefreshAfterContextError(t *testing.T) 
 	syncer := &metadataSyncStub{}
 	runner := NewMetadataSyncRunner(syncer, time.Hour)
 	runner.refreshDebounce = time.Millisecond
+	runner.NotifyIngestConnected()
 	ctx := newMetadataSyncErrContext()
 	syncer.onCall = func(call int) {
 		if call == 1 {
@@ -310,6 +335,7 @@ func TestMetadataSyncRunnerFallbackRestoresPolling(t *testing.T) {
 	runner := NewMetadataSyncRunner(syncer, time.Millisecond)
 	runner.MarkRefreshSupported()
 	runner.MarkRefreshPollingRequired("redis_degraded_http")
+	runner.NotifyIngestConnected()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	syncer.onCall = func(call int) {
@@ -322,6 +348,6 @@ func TestMetadataSyncRunnerFallbackRestoresPolling(t *testing.T) {
 		t.Fatalf("Run returned error: %v", err)
 	}
 	if got := syncer.CallCount(); got != 2 {
-		t.Fatalf("expected startup sync plus restored periodic sync, got %d", got)
+		t.Fatalf("expected connection sync plus restored periodic sync, got %d", got)
 	}
 }

--- a/internal/app/test/metadata_sync_connection_test.go
+++ b/internal/app/test/metadata_sync_connection_test.go
@@ -1,0 +1,115 @@
+package test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	keeperapp "cpa-usage-keeper/internal/app"
+)
+
+type metadataConnectionSyncer struct {
+	mu     sync.Mutex
+	calls  int
+	called chan struct{}
+}
+
+func newMetadataConnectionSyncer() *metadataConnectionSyncer {
+	return &metadataConnectionSyncer{called: make(chan struct{}, 8)}
+}
+
+func (s *metadataConnectionSyncer) SyncMetadata(context.Context) error {
+	s.mu.Lock()
+	s.calls++
+	s.mu.Unlock()
+	select {
+	case s.called <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (s *metadataConnectionSyncer) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+func TestMetadataSyncRunnerWaitsForConnectionAndKeepsPolling(t *testing.T) {
+	syncer := newMetadataConnectionSyncer()
+	runner := keeperapp.NewMetadataSyncRunner(syncer, 20*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- runner.Run(ctx)
+	}()
+
+	select {
+	case <-syncer.called:
+		t.Fatal("metadata sync ran before ingest connected")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	runner.NotifyIngestConnected()
+	select {
+	case <-syncer.called:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for connection-triggered metadata sync")
+	}
+	select {
+	case <-syncer.called:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for periodic metadata sync")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for metadata runner to stop")
+	}
+	if got := syncer.callCount(); got < 2 {
+		t.Fatalf("expected connection-triggered sync plus periodic sync, got %d calls", got)
+	}
+}
+
+func TestMetadataSyncRunnerIgnoresRefreshBeforeConnectionActivation(t *testing.T) {
+	syncer := newMetadataConnectionSyncer()
+	runner := keeperapp.NewMetadataSyncRunner(syncer, time.Hour)
+	runner.RequestMetadataRefresh()
+	runner.NotifyIngestConnected()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- runner.Run(ctx)
+	}()
+
+	select {
+	case <-syncer.called:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for connection-triggered metadata sync")
+	}
+	select {
+	case <-syncer.called:
+		t.Fatal("refresh received before activation triggered an extra metadata sync")
+	case <-time.After(1100 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for metadata runner to stop")
+	}
+	if got := syncer.callCount(); got != 1 {
+		t.Fatalf("expected only connection-triggered sync, got %d calls", got)
+	}
+}

--- a/internal/benchmark/legacy/redis_process_benchmark_test.go
+++ b/internal/benchmark/legacy/redis_process_benchmark_test.go
@@ -215,7 +215,8 @@ func redisProcessBenchmarkAuthIndex(i int) string {
 
 type redisProcessBenchmarkRefreshObserver struct{}
 
-func (o *redisProcessBenchmarkRefreshObserver) MarkRefreshSupported() {}
+func (o *redisProcessBenchmarkRefreshObserver) NotifyIngestConnected() {}
+func (o *redisProcessBenchmarkRefreshObserver) MarkRefreshSupported()  {}
 
 func (o *redisProcessBenchmarkRefreshObserver) RequestMetadataRefresh() {}
 

--- a/internal/poller/redis_ingest_runner.go
+++ b/internal/poller/redis_ingest_runner.go
@@ -110,6 +110,46 @@ func (r *RedisIngestRunner) SetControlMessageObserver(observer RedisControlMessa
 	r.controlObserver = observer
 }
 
+func (r *RedisIngestRunner) onConnectionEstablished() {
+	// 所有首次连接、重试恢复和降级连接都从这里分发通知，便于未来扩展其它 runner。
+	// 先复制 observer，避免回调 metadata runner 时持有 ingest 状态锁。
+	r.mu.Lock()
+	observer := r.controlObserver
+	r.mu.Unlock()
+	if observer != nil {
+		// 每次连接建立都分发一次事件；具体同步由 metadata runner 串行执行。
+		observer.NotifyIngestConnected()
+	}
+}
+
+// redisIngestConnectionSource 表示当前实际用于拉取 usage 的远端来源。
+type redisIngestConnectionSource uint8
+
+const (
+	// redisIngestConnectionNone 表示当前来源不可用，下一次成功需要重新通知。
+	redisIngestConnectionNone redisIngestConnectionSource = iota
+	// redisIngestConnectionRedis 表示最近一次成功使用 Redis pull。
+	redisIngestConnectionRedis
+	// redisIngestConnectionHTTP 表示最近一次成功使用 HTTP pull。
+	redisIngestConnectionHTTP
+)
+
+func (r *RedisIngestRunner) markConnectionEstablished(current *redisIngestConnectionSource, source redisIngestConnectionSource) {
+	// 同一来源持续健康时不重复通知；只有来源切换或失败恢复才分发事件。
+	if current == nil || *current == source {
+		return
+	}
+	*current = source
+	r.onConnectionEstablished()
+}
+
+func markConnectionUnavailable(current *redisIngestConnectionSource, source redisIngestConnectionSource) {
+	// 只清除当前实际使用的来源，探测其它来源失败不能影响仍健康的 fallback。
+	if current != nil && *current == source {
+		*current = redisIngestConnectionNone
+	}
+}
+
 func (r *RedisIngestRunner) Run(ctx context.Context) error {
 	// 先校验依赖，避免后台 goroutine 运行后才暴露 nil source/writer。
 	if err := r.validate(); err != nil {
@@ -132,6 +172,8 @@ func (r *RedisIngestRunner) Run(ctx context.Context) error {
 		if subErr == nil {
 			// 任一启动入口恢复后，下一次整体故障重新从 10s 开始。
 			r.startupAllFailedBackoff.Reset()
+			// 首次 subscribe 握手成功后通知 metadata runner，允许执行一次同步。
+			r.onConnectionEstablished()
 			// 订阅连上后先进入 backfill 阶段，补订阅建立前可能遗漏的队列数据。
 			r.recordState(RedisIngestSyncModeSubscribe, RedisIngestSubStateSubscribeBackfill, "subscribe_connected", "", "")
 			// subscribe 模式内部会处理断线、降级轮询和固定间隔重连。
@@ -151,6 +193,8 @@ func (r *RedisIngestRunner) Run(ctx context.Context) error {
 			r.startupAllFailedBackoff.Reset()
 			// 成功拉取说明远端恢复，清掉连续失败退避。
 			r.failureBackoff.Reset()
+			// 首次 Redis pull 成功后通知 metadata runner；空批次同样代表连接可用。
+			r.onConnectionEstablished()
 			// 记录 redis_pull 长期模式，message_count 不进 status，避免状态字符串频繁变化。
 			r.recordState(RedisIngestSyncModeRedisPull, RedisIngestSubStateRedisPullActive, pullStatus(redisCount), "", "")
 			// redis_pull 模式内部负责 Redis 失败后的 HTTP 降级和 Redis 恢复。
@@ -176,6 +220,8 @@ func (r *RedisIngestRunner) Run(ctx context.Context) error {
 			r.startupAllFailedBackoff.Reset()
 			// HTTP 成功说明兜底链路可用，重置连续失败退避。
 			r.failureBackoff.Reset()
+			// 首次 HTTP pull 成功后通知 metadata runner；空批次同样代表连接可用。
+			r.onConnectionEstablished()
 			// 记录 http_pull 固定模式；该模式不再尝试 Redis/subscribe，符合启动选择规则。
 			r.recordState(RedisIngestSyncModeHTTPPull, RedisIngestSubStateHTTPPullActive, pullStatus(httpCount), "", "")
 			// http_pull 模式只按 HTTP 拉取，失败时用指数退避。
@@ -372,6 +418,8 @@ func (r *RedisIngestRunner) receiveSubscribeBatches(ctx context.Context, sub Usa
 func (r *RedisIngestRunner) runSubscribeDegradedPolling(ctx context.Context) (UsageSubscription, error) {
 	// 订阅断开后不是立即重连，而是 固定间隔后探测，避免断线时高频打 Redis。
 	nextSubscribeRetryAt := r.now().Add(redisIngestRecoveryRetryInterval)
+	// fallbackSource 记录降级轮询当前实际使用的来源，避免健康 pull 重复通知。
+	fallbackSource := redisIngestConnectionNone
 	// 降级轮询会持续运行，直到 subscribe 恢复或应用关闭。
 	for {
 		// 每轮先检查关停，避免关停时继续拉取远端数据。
@@ -387,6 +435,8 @@ func (r *RedisIngestRunner) runSubscribeDegradedPolling(ctx context.Context) (Us
 			if err == nil {
 				// 重连成功后回到 backfill 阶段，补断线期间可能遗漏的数据。
 				r.recordState(RedisIngestSyncModeSubscribe, RedisIngestSubStateSubscribeBackfill, "subscribe_reconnected", "", "")
+				// subscribe 恢复后通知 metadata runner，再由其串行执行一次同步。
+				r.onConnectionEstablished()
 				// 恢复细节放 debug；子状态切换已经输出 info。
 				logrus.Debug("redis ingest subscribe reconnected")
 				return sub, nil
@@ -399,6 +449,8 @@ func (r *RedisIngestRunner) runSubscribeDegradedPolling(ctx context.Context) (Us
 		// 降级期间优先 Redis pull，尽量走原 Redis 队列路径。
 		count, err := r.serialPullAndWrite(ctx, RedisIngestSourceRedisPull, r.redisSource)
 		if err == nil {
+			// 降级 Redis 首次建立或从其它 fallback 切换后通知 metadata runner。
+			r.markConnectionEstablished(&fallbackSource, redisIngestConnectionRedis)
 			// Redis pull 成功表示降级拉取链路健康，清掉状态快照中的旧失败。
 			r.recordAvailable(RedisIngestSyncModeSubscribe, RedisIngestSubStateSubscribeDegradedPolling, pullStatus(count), count)
 			// Redis pull 成功表示降级拉取链路健康，清掉连续失败退避。
@@ -421,11 +473,15 @@ func (r *RedisIngestRunner) runSubscribeDegradedPolling(ctx context.Context) (Us
 		}
 		// Redis pull 失败后保留错误，后面如果 HTTP 也失败要一起上报。
 		redisErr := err
+		// Redis fallback 已不可用；后续 HTTP 成功需要重新发一次连接事件。
+		markConnectionUnavailable(&fallbackSource, redisIngestConnectionRedis)
 		// 记录 Redis 降级失败，日志中能看到正在从 Redis 继续降到 HTTP。
 		r.recordWarning("subscribe_degraded_redis_failed", redisErr)
 		// Redis 降级失败后尝试 HTTP pull，保证最终仍可从 CPA 管理接口取数。
 		count, err = r.serialPullAndWrite(ctx, RedisIngestSourceHTTPPull, r.httpSource)
 		if err == nil {
+			// 降级 HTTP 首次建立或从其它 fallback 切换后通知 metadata runner。
+			r.markConnectionEstablished(&fallbackSource, redisIngestConnectionHTTP)
 			// HTTP 成功表示兜底链路健康，清掉状态快照中的旧失败。
 			r.recordAvailable(RedisIngestSyncModeSubscribe, RedisIngestSubStateSubscribeDegradedPolling, pullStatus(count), count)
 			// HTTP 成功表示兜底链路健康，清掉失败退避。
@@ -448,6 +504,8 @@ func (r *RedisIngestRunner) runSubscribeDegradedPolling(ctx context.Context) (Us
 		}
 		// HTTP 也失败时保留错误，与 Redis 错误合并后上报。
 		httpErr := err
+		// 降级 HTTP 已不可用，下一次成功需要重新发连接事件。
+		markConnectionUnavailable(&fallbackSource, redisIngestConnectionHTTP)
 		// 连续失败使用指数退避，避免订阅断线且 CPA 故障时高频刷日志。
 		delay := r.failureBackoff.NextDelay()
 		// 同时记录 Redis 和 HTTP 两个失败原因，方便判断是局部还是整体故障。
@@ -462,6 +520,8 @@ func (r *RedisIngestRunner) runSubscribeDegradedPolling(ctx context.Context) (Us
 func (r *RedisIngestRunner) runRedisPullMode(ctx context.Context) error {
 	// 固定 redis_pull 模式不会主动尝试 subscribe，只负责 Redis pull 与 HTTP 降级恢复。
 	degraded := false
+	// connectionSource 记录当前实际使用的来源，避免健康 pull 重复通知。
+	connectionSource := redisIngestConnectionRedis
 	// nextRedisRetryAt 只在 HTTP 降级阶段生效，用于 Redis 恢复探测。
 	nextRedisRetryAt := time.Time{}
 	for {
@@ -480,6 +540,8 @@ func (r *RedisIngestRunner) runRedisPullMode(ctx context.Context) error {
 					r.failureBackoff.Reset()
 					degraded = false
 					r.recordState(RedisIngestSyncModeRedisPull, RedisIngestSubStateRedisPullActive, pullStatus(count), "", "")
+					// Redis 重试从失败恢复后通知 metadata runner；普通健康 pull 不会走这里。
+					r.markConnectionEstablished(&connectionSource, redisIngestConnectionRedis)
 					if r.pulledFullBatch(count) {
 						continue
 					}
@@ -501,6 +563,8 @@ func (r *RedisIngestRunner) runRedisPullMode(ctx context.Context) error {
 			// 恢复点未到或恢复失败时，继续 HTTP pull 作为兜底。
 			count, err := r.serialPullAndWrite(ctx, RedisIngestSourceHTTPPull, r.httpSource)
 			if err == nil {
+				// 降级 HTTP 首次建立或从其它来源切换后通知 metadata runner。
+				r.markConnectionEstablished(&connectionSource, redisIngestConnectionHTTP)
 				// HTTP 成功后清掉状态快照中的旧失败。
 				r.recordAvailable(RedisIngestSyncModeRedisPull, RedisIngestSubStateRedisPullDegradedHTTP, pullStatus(count), count)
 				// HTTP 成功后清退避。
@@ -521,6 +585,8 @@ func (r *RedisIngestRunner) runRedisPullMode(ctx context.Context) error {
 				}
 				continue
 			}
+			// 降级 HTTP 已不可用，下一次成功需要重新发连接事件。
+			markConnectionUnavailable(&connectionSource, redisIngestConnectionHTTP)
 			delay := r.failureBackoff.NextDelay()
 			r.recordError("redis_degraded_http_failed", err)
 			// HTTP 失败退避不能睡过 Redis 恢复探测点。
@@ -537,6 +603,8 @@ func (r *RedisIngestRunner) runRedisPullMode(ctx context.Context) error {
 		if err == nil {
 			// Redis 成功表示固定 redis_pull 链路恢复，清掉状态快照中的旧失败。
 			r.recordAvailable(RedisIngestSyncModeRedisPull, RedisIngestSubStateRedisPullActive, pullStatus(count), count)
+			// Redis 请求从失败恢复后通知 metadata runner；普通健康 pull 不会走这里。
+			r.markConnectionEstablished(&connectionSource, redisIngestConnectionRedis)
 			// Redis 成功后清掉失败退避。
 			r.failureBackoff.Reset()
 			if r.pulledFullBatch(count) {
@@ -557,11 +625,15 @@ func (r *RedisIngestRunner) runRedisPullMode(ctx context.Context) error {
 			continue
 		}
 		redisErr := err
+		// Redis 已经不可用，清除当前来源；后续 HTTP 接管或 Redis 恢复会重新通知。
+		markConnectionUnavailable(&connectionSource, redisIngestConnectionRedis)
 		// 记录 Redis pull 失败，日志能看到准备降级到 HTTP。
 		r.recordWarning("redis_pull_failed", redisErr)
 		// Redis 失败时立即尝试 HTTP，不让 ingest 完全中断。
 		count, err = r.serialPullAndWrite(ctx, RedisIngestSourceHTTPPull, r.httpSource)
 		if err == nil {
+			// Redis 失败后的 HTTP 降级连接建立后通知 metadata runner。
+			r.markConnectionEstablished(&connectionSource, redisIngestConnectionHTTP)
 			// HTTP 成功后清退避，并进入 redis_pull 的 HTTP 降级子状态。
 			r.failureBackoff.Reset()
 			degraded = true
@@ -599,6 +671,8 @@ func (r *RedisIngestRunner) runRedisPullMode(ctx context.Context) error {
 
 func (r *RedisIngestRunner) runHTTPPullMode(ctx context.Context) error {
 	// 固定 http_pull 模式是启动时 Redis/subscribe 都不可用后的兜底模式。
+	// connectionSource 记录 HTTP 当前是否可用，避免健康 pull 重复通知。
+	connectionSource := redisIngestConnectionHTTP
 	for {
 		// 每轮先响应应用关闭。
 		if err := ctx.Err(); err != nil {
@@ -609,6 +683,8 @@ func (r *RedisIngestRunner) runHTTPPullMode(ctx context.Context) error {
 		// HTTP 模式只调用 HTTP source，不再尝试 Redis 或 subscribe。
 		count, err := r.serialPullAndWrite(ctx, RedisIngestSourceHTTPPull, r.httpSource)
 		if err == nil {
+			// HTTP 重试从失败恢复后通知 metadata runner；健康轮询不会重复触发。
+			r.markConnectionEstablished(&connectionSource, redisIngestConnectionHTTP)
 			// HTTP 成功后如果之前记录过失败，需要打一条恢复 info。
 			r.recordRecovery(RedisIngestSyncModeHTTPPull, RedisIngestSubStateHTTPPullActive, "http_pull_recovered", count)
 			// HTTP 成功后清掉连续失败退避。
@@ -624,6 +700,10 @@ func (r *RedisIngestRunner) runHTTPPullMode(ctx context.Context) error {
 			continue
 		}
 		// HTTP 连续失败按指数退避增长到上限。
+		if !errors.Is(err, errRedisIngestInboxWrite) {
+			// 本地 inbox 写入失败不清除 HTTP 来源，避免把本地 sink 故障误判为远端断开。
+			markConnectionUnavailable(&connectionSource, redisIngestConnectionHTTP)
+		}
 		delay := r.failureBackoff.NextDelay()
 		// HTTP 是本模式唯一链路，每次失败都记录 error。
 		r.recordError("http_pull_failed", err)

--- a/internal/poller/redis_ingest_sources.go
+++ b/internal/poller/redis_ingest_sources.go
@@ -36,8 +36,10 @@ type RedisInboxWriter interface {
 	Insert(ctx context.Context, source string, messages []string, receivedAt time.Time) (int, error)
 }
 
-// RedisControlMessageObserver 接收 usage 通道里的 metadata 控制信号。
+// RedisControlMessageObserver 接收 usage ingest 的连接和 metadata 控制信号。
 type RedisControlMessageObserver interface {
+	// NotifyIngestConnected 表示 usage ingest 已成功建立或恢复一条 CPA 连接。
+	NotifyIngestConnected()
 	// MarkRefreshSupported 表示 CPA 已支持 metadata refresh 通知，周期轮询可以 no-op。
 	MarkRefreshSupported()
 	// RequestMetadataRefresh 表示 CPA metadata 配置已变化，需要 debounce 后同步。

--- a/internal/poller/test/redis_inbox_writer_test.go
+++ b/internal/poller/test/redis_inbox_writer_test.go
@@ -3,6 +3,7 @@ package poller_test
 import (
 	"context"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -111,7 +112,8 @@ func TestControlAwareRedisInboxWriterFiltersControlMessages(t *testing.T) {
 	if inserted != 2 {
 		t.Fatalf("expected two usage rows, got %d", inserted)
 	}
-	if observer.support != 2 || observer.refresh != 1 {
+	_, support, refresh, _ := observer.counts()
+	if support != 2 || refresh != 1 {
 		t.Fatalf("unexpected observer calls: %+v", observer)
 	}
 
@@ -136,7 +138,8 @@ func TestControlAwareRedisInboxWriterSkipsControlOnlyBatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Insert returned error: %v", err)
 	}
-	if inserted != 0 || observer.refresh != 1 {
+	_, _, refresh, _ := observer.counts()
+	if inserted != 0 || refresh != 1 {
 		t.Fatalf("expected filtered refresh only, inserted=%d observer=%+v", inserted, observer)
 	}
 
@@ -164,7 +167,8 @@ func TestControlAwareRedisInboxWriterSkipsEmptyAndNullPayloads(t *testing.T) {
 	if inserted != 1 {
 		t.Fatalf("expected one usage row, got %d", inserted)
 	}
-	if observer.support != 0 || observer.refresh != 0 {
+	_, support, refresh, _ := observer.counts()
+	if support != 0 || refresh != 0 {
 		t.Fatalf("expected empty/null payloads not to trigger control observer, got %+v", observer)
 	}
 
@@ -178,21 +182,41 @@ func TestControlAwareRedisInboxWriterSkipsEmptyAndNullPayloads(t *testing.T) {
 }
 
 type controlObserverStub struct {
-	support int
-	refresh int
-	polling int
+	mu        sync.Mutex
+	connected int
+	support   int
+	refresh   int
+	polling   int
+}
+
+func (s *controlObserverStub) NotifyIngestConnected() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.connected++
 }
 
 func (s *controlObserverStub) MarkRefreshSupported() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.support++
 }
 
 func (s *controlObserverStub) RequestMetadataRefresh() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.refresh++
 }
 
 func (s *controlObserverStub) MarkRefreshPollingRequired(string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.polling++
+}
+
+func (s *controlObserverStub) counts() (connected, support, refresh, polling int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.connected, s.support, s.refresh, s.polling
 }
 
 func openPollerTestDB(t *testing.T) *gorm.DB {

--- a/internal/poller/test/redis_ingest_runner_test.go
+++ b/internal/poller/test/redis_ingest_runner_test.go
@@ -34,6 +34,75 @@ func TestRedisIngestRunnerStartupFallsBackToHTTPPull(t *testing.T) {
 	}
 }
 
+func TestRedisIngestRunnerNotifiesMetadataOnInitialConnectionOnce(t *testing.T) {
+	observer := &controlObserverStub{}
+	writer := newFakeInboxWriter()
+	runner := poller.NewRedisIngestRunner(
+		fakeSubscribeSource{err: errors.New("subscribe unavailable")},
+		&fakePullSource{err: errors.New("redis unavailable")},
+		&fakePullSource{batches: [][]string{{`{"request_id":"http"}`}}},
+		writer,
+		poller.RedisIngestRunnerConfig{IdleInterval: time.Millisecond, BatchSize: 10, HTTPBackoffInitial: time.Millisecond, HTTPBackoffMax: time.Millisecond},
+	)
+	runner.SetControlMessageObserver(observer)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		_ = runner.Run(ctx)
+		close(done)
+	}()
+
+	_ = writer.waitForInsert(t)
+	// 健康 HTTP 轮询会持续成功，但不能把每次 pull 都当作一次连接事件。
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runner to stop")
+	}
+	connected := waitForConnected(t, observer, 1)
+	if connected != 1 {
+		t.Fatalf("expected one initial connection notification, got %d", connected)
+	}
+}
+
+func TestRedisIngestRunnerNotifiesMetadataAfterHTTPRecovery(t *testing.T) {
+	observer := &controlObserverStub{}
+	writer := newFakeInboxWriter()
+	httpSource := &fakePullSource{
+		errs:    []error{nil, errors.New("http unavailable"), nil},
+		batches: [][]string{{`{"request_id":"initial"}`}, {`{"request_id":"recovered"}`}},
+	}
+	runner := poller.NewRedisIngestRunner(
+		fakeSubscribeSource{err: errors.New("subscribe unavailable")},
+		&fakePullSource{err: errors.New("redis unavailable")},
+		httpSource,
+		writer,
+		poller.RedisIngestRunnerConfig{IdleInterval: time.Millisecond, BatchSize: 10, HTTPBackoffInitial: time.Millisecond, HTTPBackoffMax: time.Millisecond},
+	)
+	runner.SetControlMessageObserver(observer)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		_ = runner.Run(ctx)
+		close(done)
+	}()
+
+	_ = writer.waitForInsert(t)
+	_ = writer.waitForInsert(t)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runner to stop")
+	}
+	connected := waitForConnected(t, observer, 2)
+	if connected != 2 {
+		t.Fatalf("expected initial and recovery connection notifications, got %d", connected)
+	}
+}
+
 func TestRedisIngestRunnerStartupAllFailedUsesTenSecondInitialRetry(t *testing.T) {
 	logs := capturePollerLogs(t, logrus.DebugLevel)
 	runner := poller.NewRedisIngestRunner(
@@ -64,6 +133,7 @@ func TestRedisIngestRunnerStartupAllFailedUsesTenSecondInitialRetry(t *testing.T
 }
 
 func TestRedisIngestRunnerSubscribeBackfillsBeforeReceiving(t *testing.T) {
+	observer := &controlObserverStub{}
 	writer := newFakeInboxWriter()
 	sub := &blockingSubscription{messages: make(chan string)}
 	runner := poller.NewRedisIngestRunner(
@@ -73,6 +143,7 @@ func TestRedisIngestRunnerSubscribeBackfillsBeforeReceiving(t *testing.T) {
 		writer,
 		poller.RedisIngestRunnerConfig{IdleInterval: 10 * time.Millisecond, BatchSize: 10, HTTPBackoffInitial: 10 * time.Millisecond, HTTPBackoffMax: 10 * time.Millisecond},
 	)
+	runner.SetControlMessageObserver(observer)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() { _ = runner.Run(ctx) }()
@@ -81,6 +152,10 @@ func TestRedisIngestRunnerSubscribeBackfillsBeforeReceiving(t *testing.T) {
 	cancel()
 	if entry.source != poller.RedisIngestSourceRedisPull {
 		t.Fatalf("expected Redis backfill source, got %q", entry.source)
+	}
+	connected := waitForConnected(t, observer, 1)
+	if connected != 1 {
+		t.Fatalf("expected one initial subscribe connection notification, got %d", connected)
 	}
 }
 
@@ -304,6 +379,7 @@ func TestRedisIngestRunnerSubscribeReceivingReportsSyncRunning(t *testing.T) {
 }
 
 func TestRedisIngestRunnerRedisPullRecoveryClearsStatusError(t *testing.T) {
+	observer := &controlObserverStub{}
 	writer := newFakeInboxWriter()
 	redisSource := &fakePullSource{
 		errs: []error{
@@ -323,6 +399,7 @@ func TestRedisIngestRunnerRedisPullRecoveryClearsStatusError(t *testing.T) {
 		writer,
 		poller.RedisIngestRunnerConfig{IdleInterval: 10 * time.Millisecond, BatchSize: 10, HTTPBackoffInitial: 10 * time.Millisecond, HTTPBackoffMax: 10 * time.Millisecond},
 	)
+	runner.SetControlMessageObserver(observer)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() { _ = runner.Run(ctx) }()
@@ -340,18 +417,24 @@ func TestRedisIngestRunnerRedisPullRecoveryClearsStatusError(t *testing.T) {
 	_ = waitForStatus(t, runner, func(status poller.Status) bool {
 		return status.LastError == "" && status.LastWarning == "" && status.SyncRunning
 	})
+	connected := waitForConnected(t, observer, 2)
+	if connected != 2 {
+		t.Fatalf("expected initial and Redis recovery connection notifications, got %d", connected)
+	}
 	cancel()
 }
 
 func TestRedisIngestRunnerDegradedHTTPSuccessClearsStatusError(t *testing.T) {
+	observer := &controlObserverStub{}
 	writer := newFakeInboxWriter()
 	runner := poller.NewRedisIngestRunner(
 		fakeSubscribeSource{sub: failingSubscription{err: io.EOF}},
-		&fakePullSource{errs: []error{nil, errors.New("redis unavailable")}},
+		&fakePullSource{errs: []error{nil, errors.New("redis unavailable"), errors.New("redis unavailable"), errors.New("redis unavailable")}},
 		&fakePullSource{batches: [][]string{{`{"request_id":"http-fallback"}`}}},
 		writer,
 		poller.RedisIngestRunnerConfig{IdleInterval: 10 * time.Millisecond, BatchSize: 10, HTTPBackoffInitial: 10 * time.Millisecond, HTTPBackoffMax: 10 * time.Millisecond},
 	)
+	runner.SetControlMessageObserver(observer)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() { _ = runner.Run(ctx) }()
@@ -363,7 +446,51 @@ func TestRedisIngestRunnerDegradedHTTPSuccessClearsStatusError(t *testing.T) {
 	_ = waitForStatus(t, runner, func(status poller.Status) bool {
 		return status.LastError == "" && status.LastWarning == "" && status.SyncRunning
 	})
+	connected := waitForConnected(t, observer, 2)
+	if connected != 2 {
+		t.Fatalf("expected initial and degraded connection notifications, got %d", connected)
+	}
 	cancel()
+}
+
+func TestRedisIngestRunnerNotifiesMetadataAfterHTTPFallbackRecovery(t *testing.T) {
+	observer := &controlObserverStub{}
+	writer := newFakeInboxWriter()
+	redisSource := &fakePullSource{
+		errs:    []error{nil, errors.New("redis failed"), errors.New("redis failed")},
+		batches: [][]string{{`{"request_id":"redis-initial"}`}},
+	}
+	httpSource := &fakePullSource{
+		errs:    []error{nil, errors.New("http degraded failure"), nil},
+		batches: [][]string{{`{"request_id":"http-fallback"}`}, {`{"request_id":"http-recovered"}`}},
+	}
+	runner := poller.NewRedisIngestRunner(
+		fakeSubscribeSource{err: errors.New("subscribe unavailable")},
+		redisSource,
+		httpSource,
+		writer,
+		poller.RedisIngestRunnerConfig{IdleInterval: time.Millisecond, BatchSize: 10, HTTPBackoffInitial: time.Millisecond, HTTPBackoffMax: time.Millisecond},
+	)
+	runner.SetControlMessageObserver(observer)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		_ = runner.Run(ctx)
+		close(done)
+	}()
+
+	_ = writer.waitForInsert(t)
+	_ = writer.waitForInsert(t)
+	connected := waitForConnected(t, observer, 3)
+	if connected != 3 {
+		t.Fatalf("expected initial, fallback, and fallback recovery notifications, got %d", connected)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runner to stop")
+	}
 }
 
 func TestRedisIngestRunnerMarksMetadataPollingRequiredOnSubscribeDisconnect(t *testing.T) {
@@ -392,7 +519,8 @@ func TestRedisIngestRunnerMarksMetadataPollingRequiredOnSubscribeDisconnect(t *t
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for runner to stop")
 	}
-	if observer.polling == 0 {
+	_, _, _, polling := observer.counts()
+	if polling == 0 {
 		t.Fatal("expected subscribe disconnect to restore metadata polling")
 	}
 }
@@ -599,6 +727,25 @@ func waitForStatus(t *testing.T, runner *poller.RedisIngestRunner, match func(po
 		case <-deadline:
 			t.Fatalf("timed out waiting for status, got: %+v", status)
 			return status
+		case <-tick.C:
+		}
+	}
+}
+
+func waitForConnected(t *testing.T, observer *controlObserverStub, expected int) int {
+	t.Helper()
+	deadline := time.After(time.Second)
+	tick := time.NewTicker(time.Millisecond)
+	defer tick.Stop()
+	for {
+		connected, _, _, _ := observer.counts()
+		if connected >= expected {
+			return connected
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d connection notifications, got %d", expected, connected)
+			return connected
 		case <-tick.C:
 		}
 	}


### PR DESCRIPTION
## Summary
- gate the initial metadata sync on an ingest connection and notify on initial, recovered, and fallback connections
- suppress pre-activation refresh debounce while preserving post-activation refresh and non-subscription polling
- track connection-source edges to avoid duplicate notifications and add coverage for recovery paths

## Validation
- `go test ./internal/app ./internal/app/test`
- `go test -race ./internal/app ./internal/app/test`
- targeted Redis ingest tests and race checks
- `go test ./... -run '^$' -count=1`
- `git diff --check`

The complete `internal/poller/test` suite remains blocked in this sandbox by an existing `tcp6` httptest listener restriction.