### PR TITLE
fix(request-events): compact token values in event log

### DIFF
--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -31,6 +31,7 @@ import { useScrollBoundaryContainment } from '@/hooks/useScrollBoundaryContainme
 import {
   calculateCacheReadRate,
   formatDurationMs,
+  formatCompactTokenValue,
   formatUsd,
   LATENCY_SOURCE_FIELD,
   normalizeAuthIndex,
@@ -143,6 +144,12 @@ type RequestEventRow = {
   cacheReadTokens: number;
   cacheCreationTokens: number;
   totalTokens: number;
+  inputTokensDisplayLabel: string;
+  outputTokensDisplayLabel: string;
+  reasoningTokensDisplayLabel: string;
+  cacheReadTokensDisplayLabel: string;
+  cacheCreationTokensDisplayLabel: string;
+  totalTokensDisplayLabel: string;
   inputTokensLabel: string;
   outputTokensLabel: string;
   reasoningTokensLabel: string;
@@ -175,17 +182,19 @@ function RequestEventsTokenMetric({
   direction,
   label,
   value,
+  fullValue,
 }: {
   direction: 'input' | 'output';
   label: string;
   value: string;
+  fullValue: string;
 }) {
   const Icon = direction === 'input' ? IconArrowUpFromLine : IconArrowDownToLine;
   return (
     <span
       className={`${styles.requestEventsTokenMetric} ${direction === 'input' ? styles.requestEventsTokenMetricInput : styles.requestEventsTokenMetricOutput}`}
       role="img"
-      aria-label={`${label}: ${value}`}
+      aria-label={`${label}: ${fullValue}`}
       data-token-direction={direction}
       data-token-flow={direction === 'input' ? 'upload' : 'download'}
     >
@@ -197,12 +206,12 @@ function RequestEventsTokenMetric({
   );
 }
 
-function RequestEventsReasoningMetric({ label, value }: { label: string; value: string }) {
+function RequestEventsReasoningMetric({ label, value, fullValue }: { label: string; value: string; fullValue: string }) {
   return (
     <span
       className={`${styles.requestEventsTokenMetric} ${styles.requestEventsTokenMetricReasoning}`}
       role="img"
-      aria-label={`${label}: ${value}`}
+      aria-label={`${label}: ${fullValue}`}
       data-token-direction="reasoning"
     >
       <span className={styles.requestEventsMetricIconSlot} aria-hidden="true">
@@ -217,17 +226,19 @@ function RequestEventsCacheMetric({
   operation,
   label,
   value,
+  fullValue,
 }: {
   operation: 'read' | 'write';
   label: string;
   value: string;
+  fullValue: string;
 }) {
   const Icon = operation === 'read' ? IconDatabaseArrowUp : IconDatabaseArrowDown;
   return (
     <span
       className={`${styles.requestEventsCacheMetric} ${operation === 'read' ? styles.requestEventsCacheMetricRead : styles.requestEventsCacheMetricWrite}`}
       role="img"
-      aria-label={`${label}: ${value}`}
+      aria-label={`${label}: ${fullValue}`}
       data-cache-operation={operation}
       data-cache-flow={operation === 'read' ? 'upload' : 'download'}
     >
@@ -620,6 +631,12 @@ export function RequestEventsDetailsCard({
         cacheReadTokens,
         cacheCreationTokens,
         totalTokens,
+        inputTokensDisplayLabel: formatCompactTokenValue(inputTokens),
+        outputTokensDisplayLabel: formatCompactTokenValue(outputTokens),
+        reasoningTokensDisplayLabel: formatCompactTokenValue(reasoningTokens),
+        cacheReadTokensDisplayLabel: formatCompactTokenValue(cacheReadTokens),
+        cacheCreationTokensDisplayLabel: formatCompactTokenValue(cacheCreationTokens),
+        totalTokensDisplayLabel: formatCompactTokenValue(totalTokens),
         inputTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(inputTokens),
         outputTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(outputTokens),
         reasoningTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(reasoningTokens),
@@ -929,23 +946,26 @@ export function RequestEventsDetailsCard({
               onFocus={(event) => handleRequestEventsTooltipFocus(tooltipLines, event.currentTarget)}
               onBlur={(event) => handleRequestEventsTooltipBlur(event.currentTarget)}
             >
-              <span className={styles.requestEventsStackedPrimary}>{row.totalTokensLabel}</span>
+              <span className={styles.requestEventsStackedPrimary}>{row.totalTokensDisplayLabel}</span>
               <div className={styles.requestEventsTokenMetricRow}>
                 <RequestEventsTokenMetric
                   direction="input"
                   label={t('usage_stats.input_tokens')}
-                  value={row.inputTokensLabel}
+                  value={row.inputTokensDisplayLabel}
+                  fullValue={row.inputTokensLabel}
                 />
               </div>
               <div className={styles.requestEventsTokenMetricRow}>
                 <RequestEventsTokenMetric
                   direction="output"
                   label={t('usage_stats.output_tokens')}
-                  value={row.outputTokensLabel}
+                  value={row.outputTokensDisplayLabel}
+                  fullValue={row.outputTokensLabel}
                 />
                 <RequestEventsReasoningMetric
                   label={t('usage_stats.reasoning_tokens')}
-                  value={row.reasoningTokensLabel}
+                  value={row.reasoningTokensDisplayLabel}
+                  fullValue={row.reasoningTokensLabel}
                 />
               </div>
             </td>
@@ -975,12 +995,14 @@ export function RequestEventsDetailsCard({
                 <RequestEventsCacheMetric
                   operation="read"
                   label={t('usage_stats.cache_read_tokens')}
-                  value={row.cacheReadTokensLabel}
+                  value={row.cacheReadTokensDisplayLabel}
+                  fullValue={row.cacheReadTokensLabel}
                 />
                 <RequestEventsCacheMetric
                   operation="write"
                   label={t('usage_stats.cache_creation_tokens')}
-                  value={row.cacheCreationTokensLabel}
+                  value={row.cacheCreationTokensDisplayLabel}
+                  fullValue={row.cacheCreationTokensLabel}
                 />
               </div>
             </td>

--- a/web/src/components/usage/test/RequestEventsDetailsCardMetricsTooltip.test.tsx
+++ b/web/src/components/usage/test/RequestEventsDetailsCardMetricsTooltip.test.tsx
@@ -32,6 +32,19 @@ const baseEvent: UsageEvent = {
   pricing_style: 'openai',
 };
 
+const largeTokenEvent: UsageEvent = {
+  ...baseEvent,
+  id: 'metrics-tooltip-large-event',
+  tokens: {
+    input_tokens: 73_893_802,
+    output_tokens: 280_802,
+    reasoning_tokens: 160_430,
+    cache_read_tokens: 69_897_984,
+    cache_creation_tokens: 0,
+    total_tokens: 74_174_604,
+  },
+};
+
 const renderCardElement = (events: UsageEvent[]) => (
   <RequestEventsDetailsCard
     events={events}
@@ -137,6 +150,47 @@ describe('RequestEventsDetailsCard token and cache tooltips', () => {
     } finally {
       await mounted.unmount();
       await i18n.changeLanguage('en');
+    }
+  });
+
+  it('compacts list values while keeping complete token and cache values in the tooltip', async () => {
+    const mounted = await mountCard([largeTokenEvent]);
+
+    try {
+      const cells = mounted.container.querySelectorAll<HTMLTableCellElement>('tbody td');
+      const tokensCell = cells[0];
+      const cacheCell = cells[1];
+      expect(tokensCell.textContent).toContain('74.17M');
+      expect(tokensCell.textContent).toContain('73.89M');
+      expect(tokensCell.textContent).toContain('280.80K');
+      expect(tokensCell.textContent).toContain('160.43K');
+      expect(cacheCell.textContent).toContain('94.59%');
+      expect(cacheCell.textContent).toContain('69.90M');
+      expect(cacheCell.textContent).toContain('0');
+      expect(tokensCell.getAttribute('aria-label')).toContain('Total Tokens: 74,174,604');
+      expect(cacheCell.getAttribute('aria-label')).toContain('Cache Read: 69,897,984');
+
+      await act(async () => {
+        tokensCell.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      });
+      expect(tooltipLines()).toEqual([
+        'Total Tokens: 74,174,604',
+        'Input: 73,893,802',
+        'Output: 280,802',
+        'Reasoning: 160,430',
+      ]);
+
+      await act(async () => {
+        tokensCell.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
+        cacheCell.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      });
+      expect(tooltipLines()).toEqual([
+        'Cache Rate: 94.59%',
+        'Cache Read: 69,897,984',
+        'Cache Write: 0',
+      ]);
+    } finally {
+      await mounted.unmount();
     }
   });
 });


### PR DESCRIPTION
## Summary

- Use the shared token formatter for Tokens and Cache values in the Request Event Log list.
- Keep complete token counts in hover tooltips and accessible labels.
- Add regression coverage for compact large values and exact tooltip values.

## Verification

- `verify-local.sh frontend` (150 test files, 1234 tests, lint, typecheck, production build)