### PR TITLE
feat(request-events): compact token metrics in detail histories

### DIFF
--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -30,6 +30,7 @@ import type { UsageEvent, UsageEventRequestLogResponse, UsageSourceFilterOption 
 import { useScrollBoundaryContainment } from '@/hooks/useScrollBoundaryContainment';
 import {
   calculateCacheReadRate,
+  formatCompactTokenValue,
   formatDurationMs,
   formatUsd,
   LATENCY_SOURCE_FIELD,
@@ -149,6 +150,12 @@ type RequestEventRow = {
   cacheReadTokensLabel: string;
   cacheCreationTokensLabel: string;
   totalTokensLabel: string;
+  inputTokensDisplayLabel: string;
+  outputTokensDisplayLabel: string;
+  reasoningTokensDisplayLabel: string;
+  cacheReadTokensDisplayLabel: string;
+  cacheCreationTokensDisplayLabel: string;
+  totalTokensDisplayLabel: string;
   cacheReadRate: string;
   cost: number | null;
   costAvailable: boolean;
@@ -175,17 +182,19 @@ function RequestEventsTokenMetric({
   direction,
   label,
   value,
+  accessibleValue = value,
 }: {
   direction: 'input' | 'output';
   label: string;
   value: string;
+  accessibleValue?: string;
 }) {
   const Icon = direction === 'input' ? IconArrowUpFromLine : IconArrowDownToLine;
   return (
     <span
       className={`${styles.requestEventsTokenMetric} ${direction === 'input' ? styles.requestEventsTokenMetricInput : styles.requestEventsTokenMetricOutput}`}
       role="img"
-      aria-label={`${label}: ${value}`}
+      aria-label={`${label}: ${accessibleValue}`}
       data-token-direction={direction}
       data-token-flow={direction === 'input' ? 'upload' : 'download'}
     >
@@ -197,12 +206,12 @@ function RequestEventsTokenMetric({
   );
 }
 
-function RequestEventsReasoningMetric({ label, value }: { label: string; value: string }) {
+function RequestEventsReasoningMetric({ label, value, accessibleValue = value }: { label: string; value: string; accessibleValue?: string }) {
   return (
     <span
       className={`${styles.requestEventsTokenMetric} ${styles.requestEventsTokenMetricReasoning}`}
       role="img"
-      aria-label={`${label}: ${value}`}
+      aria-label={`${label}: ${accessibleValue}`}
       data-token-direction="reasoning"
     >
       <span className={styles.requestEventsMetricIconSlot} aria-hidden="true">
@@ -217,17 +226,19 @@ function RequestEventsCacheMetric({
   operation,
   label,
   value,
+  accessibleValue = value,
 }: {
   operation: 'read' | 'write';
   label: string;
   value: string;
+  accessibleValue?: string;
 }) {
   const Icon = operation === 'read' ? IconDatabaseArrowUp : IconDatabaseArrowDown;
   return (
     <span
       className={`${styles.requestEventsCacheMetric} ${operation === 'read' ? styles.requestEventsCacheMetricRead : styles.requestEventsCacheMetricWrite}`}
       role="img"
-      aria-label={`${label}: ${value}`}
+      aria-label={`${label}: ${accessibleValue}`}
       data-cache-operation={operation}
       data-cache-flow={operation === 'read' ? 'upload' : 'download'}
     >
@@ -626,6 +637,12 @@ export function RequestEventsDetailsCard({
         cacheReadTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(cacheReadTokens),
         cacheCreationTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(cacheCreationTokens),
         totalTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(totalTokens),
+        inputTokensDisplayLabel: formatCompactTokenValue(inputTokens),
+        outputTokensDisplayLabel: formatCompactTokenValue(outputTokens),
+        reasoningTokensDisplayLabel: formatCompactTokenValue(reasoningTokens),
+        cacheReadTokensDisplayLabel: formatCompactTokenValue(cacheReadTokens),
+        cacheCreationTokensDisplayLabel: formatCompactTokenValue(cacheCreationTokens),
+        totalTokensDisplayLabel: formatCompactTokenValue(totalTokens),
         cacheReadRate: formatCacheReadRate(cacheReadTokens, inputTokens),
         cost,
         costAvailable,
@@ -929,23 +946,26 @@ export function RequestEventsDetailsCard({
               onFocus={(event) => handleRequestEventsTooltipFocus(tooltipLines, event.currentTarget)}
               onBlur={(event) => handleRequestEventsTooltipBlur(event.currentTarget)}
             >
-              <span className={styles.requestEventsStackedPrimary}>{row.totalTokensLabel}</span>
+              <span className={styles.requestEventsStackedPrimary}>{row.totalTokensDisplayLabel}</span>
               <div className={styles.requestEventsTokenMetricRow}>
                 <RequestEventsTokenMetric
                   direction="input"
                   label={t('usage_stats.input_tokens')}
-                  value={row.inputTokensLabel}
+                  value={row.inputTokensDisplayLabel}
+                  accessibleValue={row.inputTokensLabel}
                 />
               </div>
               <div className={styles.requestEventsTokenMetricRow}>
                 <RequestEventsTokenMetric
                   direction="output"
                   label={t('usage_stats.output_tokens')}
-                  value={row.outputTokensLabel}
+                  value={row.outputTokensDisplayLabel}
+                  accessibleValue={row.outputTokensLabel}
                 />
                 <RequestEventsReasoningMetric
                   label={t('usage_stats.reasoning_tokens')}
-                  value={row.reasoningTokensLabel}
+                  value={row.reasoningTokensDisplayLabel}
+                  accessibleValue={row.reasoningTokensLabel}
                 />
               </div>
             </td>
@@ -975,12 +995,14 @@ export function RequestEventsDetailsCard({
                 <RequestEventsCacheMetric
                   operation="read"
                   label={t('usage_stats.cache_read_tokens')}
-                  value={row.cacheReadTokensLabel}
+                  value={row.cacheReadTokensDisplayLabel}
+                  accessibleValue={row.cacheReadTokensLabel}
                 />
                 <RequestEventsCacheMetric
                   operation="write"
                   label={t('usage_stats.cache_creation_tokens')}
-                  value={row.cacheCreationTokensLabel}
+                  value={row.cacheCreationTokensDisplayLabel}
+                  accessibleValue={row.cacheCreationTokensLabel}
                 />
               </div>
             </td>

--- a/web/src/components/usage/RequestEventsDetailsCard.tsx
+++ b/web/src/components/usage/RequestEventsDetailsCard.tsx
@@ -30,8 +30,8 @@ import type { UsageEvent, UsageEventRequestLogResponse, UsageSourceFilterOption 
 import { useScrollBoundaryContainment } from '@/hooks/useScrollBoundaryContainment';
 import {
   calculateCacheReadRate,
-  formatCompactTokenValue,
   formatDurationMs,
+  formatCompactTokenValue,
   formatUsd,
   LATENCY_SOURCE_FIELD,
   normalizeAuthIndex,
@@ -144,18 +144,18 @@ type RequestEventRow = {
   cacheReadTokens: number;
   cacheCreationTokens: number;
   totalTokens: number;
-  inputTokensLabel: string;
-  outputTokensLabel: string;
-  reasoningTokensLabel: string;
-  cacheReadTokensLabel: string;
-  cacheCreationTokensLabel: string;
-  totalTokensLabel: string;
   inputTokensDisplayLabel: string;
   outputTokensDisplayLabel: string;
   reasoningTokensDisplayLabel: string;
   cacheReadTokensDisplayLabel: string;
   cacheCreationTokensDisplayLabel: string;
   totalTokensDisplayLabel: string;
+  inputTokensLabel: string;
+  outputTokensLabel: string;
+  reasoningTokensLabel: string;
+  cacheReadTokensLabel: string;
+  cacheCreationTokensLabel: string;
+  totalTokensLabel: string;
   cacheReadRate: string;
   cost: number | null;
   costAvailable: boolean;
@@ -182,19 +182,19 @@ function RequestEventsTokenMetric({
   direction,
   label,
   value,
-  accessibleValue = value,
+  fullValue,
 }: {
   direction: 'input' | 'output';
   label: string;
   value: string;
-  accessibleValue?: string;
+  fullValue: string;
 }) {
   const Icon = direction === 'input' ? IconArrowUpFromLine : IconArrowDownToLine;
   return (
     <span
       className={`${styles.requestEventsTokenMetric} ${direction === 'input' ? styles.requestEventsTokenMetricInput : styles.requestEventsTokenMetricOutput}`}
       role="img"
-      aria-label={`${label}: ${accessibleValue}`}
+      aria-label={`${label}: ${fullValue}`}
       data-token-direction={direction}
       data-token-flow={direction === 'input' ? 'upload' : 'download'}
     >
@@ -206,12 +206,12 @@ function RequestEventsTokenMetric({
   );
 }
 
-function RequestEventsReasoningMetric({ label, value, accessibleValue = value }: { label: string; value: string; accessibleValue?: string }) {
+function RequestEventsReasoningMetric({ label, value, fullValue }: { label: string; value: string; fullValue: string }) {
   return (
     <span
       className={`${styles.requestEventsTokenMetric} ${styles.requestEventsTokenMetricReasoning}`}
       role="img"
-      aria-label={`${label}: ${accessibleValue}`}
+      aria-label={`${label}: ${fullValue}`}
       data-token-direction="reasoning"
     >
       <span className={styles.requestEventsMetricIconSlot} aria-hidden="true">
@@ -226,19 +226,19 @@ function RequestEventsCacheMetric({
   operation,
   label,
   value,
-  accessibleValue = value,
+  fullValue,
 }: {
   operation: 'read' | 'write';
   label: string;
   value: string;
-  accessibleValue?: string;
+  fullValue: string;
 }) {
   const Icon = operation === 'read' ? IconDatabaseArrowUp : IconDatabaseArrowDown;
   return (
     <span
       className={`${styles.requestEventsCacheMetric} ${operation === 'read' ? styles.requestEventsCacheMetricRead : styles.requestEventsCacheMetricWrite}`}
       role="img"
-      aria-label={`${label}: ${accessibleValue}`}
+      aria-label={`${label}: ${fullValue}`}
       data-cache-operation={operation}
       data-cache-flow={operation === 'read' ? 'upload' : 'download'}
     >
@@ -631,18 +631,18 @@ export function RequestEventsDetailsCard({
         cacheReadTokens,
         cacheCreationTokens,
         totalTokens,
-        inputTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(inputTokens),
-        outputTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(outputTokens),
-        reasoningTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(reasoningTokens),
-        cacheReadTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(cacheReadTokens),
-        cacheCreationTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(cacheCreationTokens),
-        totalTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(totalTokens),
         inputTokensDisplayLabel: formatCompactTokenValue(inputTokens),
         outputTokensDisplayLabel: formatCompactTokenValue(outputTokens),
         reasoningTokensDisplayLabel: formatCompactTokenValue(reasoningTokens),
         cacheReadTokensDisplayLabel: formatCompactTokenValue(cacheReadTokens),
         cacheCreationTokensDisplayLabel: formatCompactTokenValue(cacheCreationTokens),
         totalTokensDisplayLabel: formatCompactTokenValue(totalTokens),
+        inputTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(inputTokens),
+        outputTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(outputTokens),
+        reasoningTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(reasoningTokens),
+        cacheReadTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(cacheReadTokens),
+        cacheCreationTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(cacheCreationTokens),
+        totalTokensLabel: REQUEST_EVENT_INTEGER_FORMATTER.format(totalTokens),
         cacheReadRate: formatCacheReadRate(cacheReadTokens, inputTokens),
         cost,
         costAvailable,
@@ -952,7 +952,7 @@ export function RequestEventsDetailsCard({
                   direction="input"
                   label={t('usage_stats.input_tokens')}
                   value={row.inputTokensDisplayLabel}
-                  accessibleValue={row.inputTokensLabel}
+                  fullValue={row.inputTokensLabel}
                 />
               </div>
               <div className={styles.requestEventsTokenMetricRow}>
@@ -960,12 +960,12 @@ export function RequestEventsDetailsCard({
                   direction="output"
                   label={t('usage_stats.output_tokens')}
                   value={row.outputTokensDisplayLabel}
-                  accessibleValue={row.outputTokensLabel}
+                  fullValue={row.outputTokensLabel}
                 />
                 <RequestEventsReasoningMetric
                   label={t('usage_stats.reasoning_tokens')}
                   value={row.reasoningTokensDisplayLabel}
-                  accessibleValue={row.reasoningTokensLabel}
+                  fullValue={row.reasoningTokensLabel}
                 />
               </div>
             </td>
@@ -996,13 +996,13 @@ export function RequestEventsDetailsCard({
                   operation="read"
                   label={t('usage_stats.cache_read_tokens')}
                   value={row.cacheReadTokensDisplayLabel}
-                  accessibleValue={row.cacheReadTokensLabel}
+                  fullValue={row.cacheReadTokensLabel}
                 />
                 <RequestEventsCacheMetric
                   operation="write"
                   label={t('usage_stats.cache_creation_tokens')}
                   value={row.cacheCreationTokensDisplayLabel}
-                  accessibleValue={row.cacheCreationTokensLabel}
+                  fullValue={row.cacheCreationTokensLabel}
                 />
               </div>
             </td>

--- a/web/src/components/usage/credentials/CredentialRequestEventsList.module.scss
+++ b/web/src/components/usage/credentials/CredentialRequestEventsList.module.scss
@@ -195,6 +195,96 @@
   font-variant-numeric: tabular-nums;
 }
 
+.requestEventsTokenMetricRow,
+.requestEventsCacheMetrics {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 3px;
+  min-height: 18px;
+}
+
+.requestEventsCacheMetrics {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+  min-height: 0;
+}
+
+.requestEventsTokenMetric,
+.requestEventsCacheMetric {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: none;
+  overflow: visible;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.25;
+  white-space: nowrap;
+}
+
+.requestEventsMetricIconSlot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  overflow: visible;
+}
+
+.requestEventsCacheIcon {
+  transform: scale(0.9);
+  transform-origin: center;
+}
+
+.requestEventsTokenMetricInput {
+  color: #0284c7;
+}
+
+.requestEventsTokenMetricOutput {
+  color: #16a34a;
+}
+
+.requestEventsTokenMetricReasoning {
+  color: #8b5cf6;
+}
+
+.requestEventsCacheMetricRead {
+  color: #d97706;
+}
+
+.requestEventsCacheMetricWrite {
+  color: #db2777;
+}
+
+.requestEventsCacheMetric {
+  gap: 5px;
+  padding: 1px 3px;
+}
+
+.requestEventsCacheRate {
+  display: block;
+  max-width: 240px;
+  overflow: hidden;
+  color: var(--text-primary);
+  text-overflow: ellipsis;
+  font-size: 12px;
+  font-weight: 750;
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.requestEventsMetricCell {
+  cursor: default;
+
+  &:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: -3px;
+  }
+}
+
 .detailRow {
   td {
     overflow: hidden;

--- a/web/src/components/usage/credentials/CredentialRequestEventsList.tsx
+++ b/web/src/components/usage/credentials/CredentialRequestEventsList.tsx
@@ -12,16 +12,25 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 import { useTranslation } from 'react-i18next'
 import { EmptyState } from '@/components/ui/EmptyState'
 import { PortalTooltip, usePortalTooltip } from '@/components/ui/PortalTooltip'
-import { IconChevronDown, IconChevronRight } from '@/components/ui/icons'
+import {
+  IconArrowDownToLine,
+  IconArrowUpFromLine,
+  IconBrain,
+  IconChevronDown,
+  IconChevronRight,
+  IconDatabaseArrowDown,
+  IconDatabaseArrowUp,
+} from '@/components/ui/icons'
 import { useScrollBoundaryContainment } from '@/hooks/useScrollBoundaryContainment'
 import type { UsageEvent } from '@/lib/types'
-import { calculateCacheReadRate, formatDurationMs, formatUsd } from '@/utils/usage'
+import { calculateCacheReadRate, formatCompactTokenValue, formatDurationMs, formatUsd } from '@/utils/usage'
 import { RequestEventResultBadge } from '@/components/usage/RequestEventResultBadge'
 import styles from './CredentialRequestEventsList.module.scss'
 
 const LOAD_MORE_THRESHOLD_PX = 320
 const VIRTUALIZATION_THRESHOLD = 50
-const VIRTUAL_ROW_HEIGHT = 70
+// 折叠行包含三行 Token/Cache 指标，基准高度取略高于实际 CSS 高度，避免离屏行缓存被低估。
+const VIRTUAL_ROW_HEIGHT = 80
 const VIRTUAL_OVERSCAN = 8
 const VIRTUAL_INITIAL_VIEWPORT_HEIGHT = 600
 const INTEGER_FORMATTER = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 })
@@ -56,12 +65,18 @@ interface CredentialRequestEventRow {
   endpoint: string
   failed: boolean
   inputTokens: string
+  inputTokensFull: string
   outputTokens: string
+  outputTokensFull: string
   reasoningTokens: string
+  reasoningTokensFull: string
   cacheReadTokens: string
+  cacheReadTokensFull: string
   cacheCreationTokens: string
+  cacheCreationTokensFull: string
   cacheReadRate: string
   totalTokens: string
+  totalTokensFull: string
   latency: string
   ttft: string
   speed: string
@@ -150,6 +165,117 @@ function OverflowTooltipText({
   return <span ref={anchorRef} {...sharedProps}>{children}</span>
 }
 
+function CredentialRequestEventsTokenMetric({
+  direction,
+  label,
+  value,
+  accessibleValue = value,
+}: {
+  direction: 'input' | 'output'
+  label: string
+  value: string
+  accessibleValue?: string
+}) {
+  const Icon = direction === 'input' ? IconArrowUpFromLine : IconArrowDownToLine
+  return (
+    <span
+      className={`${styles.requestEventsTokenMetric} ${direction === 'input' ? styles.requestEventsTokenMetricInput : styles.requestEventsTokenMetricOutput}`}
+      role="img"
+      aria-label={`${label}: ${accessibleValue}`}
+      data-token-direction={direction}
+      data-token-flow={direction === 'input' ? 'upload' : 'download'}
+    >
+      <span className={styles.requestEventsMetricIconSlot} aria-hidden="true">
+        <Icon size={14} aria-hidden="true" />
+      </span>
+      <span>{value}</span>
+    </span>
+  )
+}
+
+function CredentialRequestEventsReasoningMetric({ label, value, accessibleValue = value }: { label: string; value: string; accessibleValue?: string }) {
+  return (
+    <span
+      className={`${styles.requestEventsTokenMetric} ${styles.requestEventsTokenMetricReasoning}`}
+      role="img"
+      aria-label={`${label}: ${accessibleValue}`}
+      data-token-direction="reasoning"
+    >
+      <span className={styles.requestEventsMetricIconSlot} aria-hidden="true">
+        <IconBrain size={12} aria-hidden="true" />
+      </span>
+      <span>{value}</span>
+    </span>
+  )
+}
+
+function CredentialRequestEventsCacheMetric({
+  operation,
+  label,
+  value,
+  accessibleValue = value,
+}: {
+  operation: 'read' | 'write'
+  label: string
+  value: string
+  accessibleValue?: string
+}) {
+  const Icon = operation === 'read' ? IconDatabaseArrowUp : IconDatabaseArrowDown
+  return (
+    <span
+      className={`${styles.requestEventsCacheMetric} ${operation === 'read' ? styles.requestEventsCacheMetricRead : styles.requestEventsCacheMetricWrite}`}
+      role="img"
+      aria-label={`${label}: ${accessibleValue}`}
+      data-cache-operation={operation}
+      data-cache-flow={operation === 'read' ? 'upload' : 'download'}
+    >
+      <span className={styles.requestEventsMetricIconSlot} aria-hidden="true">
+        <Icon className={styles.requestEventsCacheIcon} size={14} aria-hidden="true" />
+      </span>
+      <span>{value}</span>
+    </span>
+  )
+}
+
+function CredentialRequestEventsMetricCell({
+  className,
+  tooltipLines,
+  tooltipActions,
+  children,
+}: {
+  className: string
+  tooltipLines: string[]
+  tooltipActions: OverflowTooltipActions
+  children: ReactNode
+}) {
+  const cellRef = useRef<HTMLTableCellElement | null>(null)
+
+  useEffect(() => {
+    const cell = cellRef.current
+    return () => {
+      if (!cell) return
+      // 虚拟行卸载时同步清理整格指标 Tooltip，避免浮层保留已不存在的锚点。
+      tooltipActions.hideOnMouseLeave(cell)
+      tooltipActions.hideOnBlur(cell)
+    }
+  }, [tooltipActions])
+
+  return (
+    <td
+      ref={cellRef}
+      className={className}
+      tabIndex={0}
+      aria-label={tooltipLines.join('; ')}
+      onMouseEnter={(event) => tooltipActions.showOnMouseEnter(tooltipLines, event.currentTarget)}
+      onMouseLeave={(event) => tooltipActions.hideOnMouseLeave(event.currentTarget)}
+      onFocus={(event) => tooltipActions.showOnFocus(tooltipLines, event.currentTarget)}
+      onBlur={(event) => tooltipActions.hideOnBlur(event.currentTarget)}
+    >
+      {children}
+    </td>
+  )
+}
+
 const SPEED_MODE_LABEL_KEYS: Record<string, string> = {
   auto: 'usage_stats.speed_mode_auto',
   default: 'usage_stats.speed_mode_standard',
@@ -189,6 +315,31 @@ const formatCacheRate = (inputTokens: number, cacheReadTokens: number): string =
   const rate = calculateCacheReadRate({ inputTokens, cacheReadTokens })
   return rate === null ? '-' : `${rate.toFixed(2)}%`
 }
+
+const formatCredentialRequestMetricTooltipLine = (
+  label: string,
+  value: string,
+  t: (key: string, options?: Record<string, string>) => string,
+): string => t('usage_stats.request_events_metric_tooltip_line', { label, value })
+
+const buildCredentialRequestTokenTooltipLines = (
+  row: CredentialRequestEventRow,
+  t: (key: string, options?: Record<string, string>) => string,
+): string[] => [
+  formatCredentialRequestMetricTooltipLine(t('usage_stats.total_tokens'), row.totalTokensFull, t),
+  formatCredentialRequestMetricTooltipLine(t('usage_stats.input_tokens'), row.inputTokensFull, t),
+  formatCredentialRequestMetricTooltipLine(t('usage_stats.output_tokens'), row.outputTokensFull, t),
+  formatCredentialRequestMetricTooltipLine(t('usage_stats.reasoning_tokens'), row.reasoningTokensFull, t),
+]
+
+const buildCredentialRequestCacheTooltipLines = (
+  row: CredentialRequestEventRow,
+  t: (key: string, options?: Record<string, string>) => string,
+): string[] => [
+  formatCredentialRequestMetricTooltipLine(t('usage_stats.cache_rate'), row.cacheReadRate, t),
+  formatCredentialRequestMetricTooltipLine(t('usage_stats.cache_read_tokens'), row.cacheReadTokensFull, t),
+  formatCredentialRequestMetricTooltipLine(t('usage_stats.cache_creation_tokens'), row.cacheCreationTokensFull, t),
+]
 
 const optionalText = (value: unknown): string => String(value ?? '').trim() || '-'
 
@@ -249,13 +400,19 @@ const buildRow = (
     requestType: endpoint.requestType,
     endpoint: endpoint.endpoint,
     failed: event.failed === true,
-    inputTokens: INTEGER_FORMATTER.format(inputTokens),
-    outputTokens: INTEGER_FORMATTER.format(toNumber(event.tokens?.output_tokens)),
-    reasoningTokens: INTEGER_FORMATTER.format(toNumber(event.tokens?.reasoning_tokens)),
-    cacheReadTokens: INTEGER_FORMATTER.format(cacheReadTokens),
-    cacheCreationTokens: INTEGER_FORMATTER.format(toNumber(event.tokens?.cache_creation_tokens)),
+    inputTokens: formatCompactTokenValue(inputTokens),
+    inputTokensFull: INTEGER_FORMATTER.format(inputTokens),
+    outputTokens: formatCompactTokenValue(toNumber(event.tokens?.output_tokens)),
+    outputTokensFull: INTEGER_FORMATTER.format(toNumber(event.tokens?.output_tokens)),
+    reasoningTokens: formatCompactTokenValue(toNumber(event.tokens?.reasoning_tokens)),
+    reasoningTokensFull: INTEGER_FORMATTER.format(toNumber(event.tokens?.reasoning_tokens)),
+    cacheReadTokens: formatCompactTokenValue(cacheReadTokens),
+    cacheReadTokensFull: INTEGER_FORMATTER.format(cacheReadTokens),
+    cacheCreationTokens: formatCompactTokenValue(toNumber(event.tokens?.cache_creation_tokens)),
+    cacheCreationTokensFull: INTEGER_FORMATTER.format(toNumber(event.tokens?.cache_creation_tokens)),
     cacheReadRate: formatCacheRate(inputTokens, cacheReadTokens),
-    totalTokens: INTEGER_FORMATTER.format(toNumber(event.tokens?.total_tokens)),
+    totalTokens: formatCompactTokenValue(toNumber(event.tokens?.total_tokens)),
+    totalTokensFull: INTEGER_FORMATTER.format(toNumber(event.tokens?.total_tokens)),
     latency: formatDurationMs(latencyMs),
     ttft: ttftMs && ttftMs > 0 ? formatDurationMs(ttftMs) : '-',
     speed: formatSpeed(event.speed_tps),
@@ -429,6 +586,8 @@ export function CredentialRequestEventsList({
     const canOpenLog = Boolean(requestLogAccessEnabled && row.requestId && onRequestLogOpen)
     const logLoading = requestLogLoadingEventId === row.id
     const expanded = expandedRowId === row.id
+    const tokenTooltipLines = buildCredentialRequestTokenTooltipLines(row, t)
+    const cacheTooltipLines = buildCredentialRequestCacheTooltipLines(row, t)
     return (
       <tbody
         key={row.id}
@@ -501,19 +660,55 @@ export function CredentialRequestEventsList({
               size="compact"
             />
           </td>
-          <td className={`${styles.stackedCell} ${styles.tokens}`.trim()}>
-            {renderOverflowText('strong', row.totalTokens)}
-            {renderLabeledOverflowText(t('usage_stats.input_tokens'), row.inputTokens)}
-            {renderLabeledOverflowText(
-              t('usage_stats.output_tokens'),
-              `${row.outputTokens} (${t('usage_stats.reasoning_tokens')} ${row.reasoningTokens})`,
-            )}
-          </td>
-          <td className={`${styles.stackedCell} ${styles.cache}`.trim()}>
-            {renderOverflowText('strong', row.cacheReadRate)}
-            {renderLabeledOverflowText(t('usage_stats.credentials_detail_cache_read'), row.cacheReadTokens)}
-            {renderLabeledOverflowText(t('usage_stats.credentials_detail_cache_write'), row.cacheCreationTokens)}
-          </td>
+          <CredentialRequestEventsMetricCell
+            className={`${styles.stackedCell} ${styles.tokens} ${styles.requestEventsMetricCell}`.trim()}
+            tooltipLines={tokenTooltipLines}
+            tooltipActions={tooltipActions}
+          >
+            <strong>{row.totalTokens}</strong>
+            <div className={styles.requestEventsTokenMetricRow}>
+              <CredentialRequestEventsTokenMetric
+                direction="input"
+                label={t('usage_stats.input_tokens')}
+                value={row.inputTokens}
+                accessibleValue={row.inputTokensFull}
+              />
+            </div>
+            <div className={styles.requestEventsTokenMetricRow}>
+              <CredentialRequestEventsTokenMetric
+                direction="output"
+                label={t('usage_stats.output_tokens')}
+                value={row.outputTokens}
+                accessibleValue={row.outputTokensFull}
+              />
+              <CredentialRequestEventsReasoningMetric
+                label={t('usage_stats.reasoning_tokens')}
+                value={row.reasoningTokens}
+                accessibleValue={row.reasoningTokensFull}
+              />
+            </div>
+          </CredentialRequestEventsMetricCell>
+          <CredentialRequestEventsMetricCell
+            className={`${styles.stackedCell} ${styles.cache} ${styles.requestEventsMetricCell}`.trim()}
+            tooltipLines={cacheTooltipLines}
+            tooltipActions={tooltipActions}
+          >
+            <span className={styles.requestEventsCacheRate}>{row.cacheReadRate}</span>
+            <div className={styles.requestEventsCacheMetrics}>
+              <CredentialRequestEventsCacheMetric
+                operation="read"
+                label={t('usage_stats.cache_read_tokens')}
+                value={row.cacheReadTokens}
+                accessibleValue={row.cacheReadTokensFull}
+              />
+              <CredentialRequestEventsCacheMetric
+                operation="write"
+                label={t('usage_stats.cache_creation_tokens')}
+                value={row.cacheCreationTokens}
+                accessibleValue={row.cacheCreationTokensFull}
+              />
+            </div>
+          </CredentialRequestEventsMetricCell>
           <td className={`${styles.stackedCell} ${styles.performance}`.trim()}>
             {renderOverflowText('strong', row.latency)}
             {renderLabeledOverflowText(t('usage_stats.ttft'), row.ttft)}

--- a/web/src/components/usage/credentials/test/CredentialRequestEventsList.styles.test.ts
+++ b/web/src/components/usage/credentials/test/CredentialRequestEventsList.styles.test.ts
@@ -22,6 +22,17 @@ describe('CredentialRequestEventsList compact table styles', () => {
     expect(styles).toMatch(/\.subDataLabel\s*\{[\s\S]*?color:\s*var\(--text-secondary\);/)
   })
 
+  it('uses the Request Event Log token and cache metric treatment in credential details', () => {
+    expect(styles).toMatch(/\.requestEventsTokenMetricRow\s*,\s*\.requestEventsCacheMetrics\s*\{[\s\S]*?display:\s*flex;/)
+    expect(styles).toMatch(/\.requestEventsTokenMetricInput\s*\{[\s\S]*?color:\s*#0284c7;/)
+    expect(styles).toMatch(/\.requestEventsTokenMetricOutput\s*\{[\s\S]*?color:\s*#16a34a;/)
+    expect(styles).toMatch(/\.requestEventsTokenMetricReasoning\s*\{[\s\S]*?color:\s*#8b5cf6;/)
+    expect(styles).toMatch(/\.requestEventsCacheMetricRead\s*\{[\s\S]*?color:\s*#d97706;/)
+    expect(styles).toMatch(/\.requestEventsCacheMetricWrite\s*\{[\s\S]*?color:\s*#db2777;/)
+    expect(styles).toMatch(/\.requestEventsMetricIconSlot\s*\{[\s\S]*?width:\s*16px;[\s\S]*?height:\s*16px;/)
+    expect(styles).toMatch(/\.requestEventsMetricCell\s*\{[\s\S]*?cursor:\s*default;[\s\S]*?&:\s*focus-visible\s*\{[\s\S]*?outline:\s*2px solid var\(--primary-color\);/)
+  })
+
   it('uses the spare client-context row for a two-line User Agent value', () => {
     expect(styles).toMatch(/\.detailUserAgentValue\s*\{[\s\S]*?display:\s*-webkit-box;[\s\S]*?-webkit-line-clamp:\s*2;[\s\S]*?overflow-wrap:\s*anywhere;[\s\S]*?white-space:\s*normal;/)
   })

--- a/web/src/components/usage/credentials/test/CredentialRequestEventsList.test.tsx
+++ b/web/src/components/usage/credentials/test/CredentialRequestEventsList.test.tsx
@@ -12,7 +12,11 @@ import {
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => undefined },
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) => options
+      ? `${options.label}: ${options.value}`
+      : key,
+  }),
 }))
 
 const event: UsageEvent = {
@@ -46,6 +50,8 @@ const event: UsageEvent = {
     total_tokens: 1_300,
   },
 }
+
+const CREDENTIAL_REQUEST_TEST_ROW_HEIGHT = 80
 
 const buildEvent = (index: number): UsageEvent => ({
   ...event,
@@ -139,7 +145,7 @@ describe('CredentialRequestEventsList', () => {
       if (this.dataset.credentialRequestEventsScroller === 'true') return rect(920, 600)
       if (this.dataset.credentialRequestEventGroup) {
         const expanded = this.querySelector('[data-credential-request-event-details]') !== null
-        return rect(920, expanded ? 220 : 70)
+        return rect(920, expanded ? 220 : CREDENTIAL_REQUEST_TEST_ROW_HEIGHT)
       }
       if (this instanceof HTMLTableRowElement) {
         const spacerHeight = Number.parseFloat(this.style.height)
@@ -186,13 +192,16 @@ describe('CredentialRequestEventsList', () => {
     expect(container.textContent).toContain('SSE')
     expect(container.textContent).not.toContain('usage_stats.speed_mode_fast')
     expect(container.textContent).not.toContain('usage_stats.speed_mode_flex')
-    expect(container.textContent).toContain('1,300')
-    expect(container.textContent).toContain('usage_stats.reasoning_tokens 80')
+    expect(container.textContent).toContain('1.30K')
+    expect(container.textContent).toContain('1.00K')
+    expect(container.textContent).toContain('300')
+    expect(container.textContent).toContain('80')
     expect(container.textContent).toContain('60.00%')
-    expect(container.textContent).toContain('usage_stats.credentials_detail_cache_read 600')
-    expect(container.textContent).toContain('usage_stats.credentials_detail_cache_write 100')
-    expect(container.textContent).not.toContain('usage_stats.cache_read_tokens')
-    expect(container.textContent).not.toContain('usage_stats.cache_creation_tokens')
+    expect(container.textContent).toContain('600')
+    expect(container.textContent).toContain('100')
+    expect(container.textContent).not.toContain('usage_stats.credentials_detail_cache_read')
+    expect(container.textContent).not.toContain('usage_stats.credentials_detail_cache_write')
+    expect(container.textContent).not.toContain('usage_stats.reasoning_tokens 80')
     expect(container.textContent).toContain('42.5 t/s')
     expect(container.textContent).toContain('usage_stats.credentials_detail_pricing_style_openai')
     expect(container.textContent).not.toContain('usage_stats.model_price_style usage_stats.model_price_style_openai')
@@ -204,13 +213,21 @@ describe('CredentialRequestEventsList', () => {
     expect(container.querySelector('[data-credential-request-model="1"]')?.getAttribute('title')).toBeNull()
     expect(Array.from(container.querySelectorAll('[data-credential-request-sub-label]')).map((label) => label.textContent)).toEqual([
       'usage_stats.reasoning_effort',
-      'usage_stats.input_tokens',
-      'usage_stats.output_tokens',
-      'usage_stats.credentials_detail_cache_read',
-      'usage_stats.credentials_detail_cache_write',
       'usage_stats.ttft',
       'usage_stats.speed',
     ])
+    const metricCells = container.querySelectorAll<HTMLTableCellElement>('tbody tr:first-child td')
+    const tokenCell = metricCells[4]
+    const cacheCell = metricCells[5]
+    expect(tokenCell.tabIndex).toBe(0)
+    expect(cacheCell.tabIndex).toBe(0)
+    expect(tokenCell.getAttribute('aria-label')).toContain('usage_stats.total_tokens: 1,300')
+    expect(cacheCell.getAttribute('aria-label')).toContain('usage_stats.cache_rate: 60.00%')
+    expect(container.querySelectorAll('[data-token-direction="input"]')).toHaveLength(1)
+    expect(container.querySelectorAll('[data-token-direction="output"]')).toHaveLength(1)
+    expect(container.querySelectorAll('[data-token-direction="reasoning"]')).toHaveLength(1)
+    expect(container.querySelectorAll('[data-cache-operation="read"]')).toHaveLength(1)
+    expect(container.querySelectorAll('[data-cache-operation="write"]')).toHaveLength(1)
     expect(Array.from(container.querySelectorAll('thead th')).map((cell) => cell.textContent)).toEqual([
       'usage_stats.request_events_timestamp',
       'usage_stats.model_name',
@@ -227,6 +244,62 @@ describe('CredentialRequestEventsList', () => {
     expect(container.textContent).not.toContain('usage_stats.request_events_filter_model')
     expect(container.textContent).not.toContain('usage_stats.request_events_filter_source')
     expect(container.textContent).not.toContain('usage_stats.request_events_filter_result')
+  })
+
+  it('uses compact token units in details while keeping full values in the metric tooltip', async () => {
+    const largeEvent: UsageEvent = {
+      ...event,
+      tokens: {
+        input_tokens: 1_234_567,
+        output_tokens: 2_345_678,
+        reasoning_tokens: 12_345,
+        cache_read_tokens: 3_456_789,
+        cache_creation_tokens: 4_567_890,
+        total_tokens: 5_678_901,
+      },
+    }
+
+    await act(async () => root.render(
+      <CredentialRequestEventsList
+        events={[largeEvent]}
+        loading={false}
+        hasMore={false}
+        loadingMore={false}
+        autoLoadMore
+        onLoadMore={() => undefined}
+      />,
+    ))
+
+    const cells = container.querySelectorAll<HTMLTableCellElement>('tbody tr:first-child td')
+    const tokenCell = cells[4]
+    const cacheCell = cells[5]
+    expect(tokenCell.textContent).toContain('5.68M')
+    expect(tokenCell.textContent).toContain('1.23M')
+    expect(tokenCell.textContent).toContain('2.35M')
+    expect(tokenCell.textContent).toContain('12.35K')
+    expect(cacheCell.textContent).toContain('3.46M')
+    expect(cacheCell.textContent).toContain('4.57M')
+    expect(tokenCell.getAttribute('aria-label')).toBe(
+      'usage_stats.total_tokens: 5,678,901; usage_stats.input_tokens: 1,234,567; usage_stats.output_tokens: 2,345,678; usage_stats.reasoning_tokens: 12,345',
+    )
+    expect(cacheCell.getAttribute('aria-label')).toBe(
+      'usage_stats.cache_rate: 280.00%; usage_stats.cache_read_tokens: 3,456,789; usage_stats.cache_creation_tokens: 4,567,890',
+    )
+    expect(container.querySelector('[data-token-direction="input"]')?.getAttribute('aria-label'))
+      .toBe('usage_stats.input_tokens: 1,234,567')
+    expect(container.querySelector('[data-cache-operation="read"]')?.getAttribute('aria-label'))
+      .toBe('usage_stats.cache_read_tokens: 3,456,789')
+
+    await act(async () => tokenCell.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })))
+    expect(Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="tooltip"] span'),
+      (line) => line.textContent,
+    )).toEqual([
+      'usage_stats.total_tokens: 5,678,901',
+      'usage_stats.input_tokens: 1,234,567',
+      'usage_stats.output_tokens: 2,345,678',
+      'usage_stats.reasoning_tokens: 12,345',
+    ])
   })
 
   it('expands only metadata that is absent from the compact row', async () => {
@@ -445,7 +518,7 @@ describe('CredentialRequestEventsList', () => {
       container.querySelector<HTMLButtonElement>('[data-credential-request-event-toggle="1"]')?.click()
     })
     await act(async () => TestResizeObserver.flush())
-    expect(readVirtualContentHeight(scroller)).toBe(3_650)
+    expect(readVirtualContentHeight(scroller)).toBe(4_140)
 
     scroller.scrollTop = 2_800
     await act(async () => {
@@ -461,7 +534,7 @@ describe('CredentialRequestEventsList', () => {
       root.render(renderList(secondPage))
       await Promise.resolve()
     })
-    expect(readVirtualContentHeight(scroller)).toBe(7_150)
+    expect(readVirtualContentHeight(scroller)).toBe(8_140)
     expect(scroller.scrollTop).toBe(scrollTopBeforeAppend)
   })
 
@@ -557,6 +630,41 @@ describe('CredentialRequestEventsList', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
+  it('clears a token or cache tooltip when its virtual row leaves the window', async () => {
+    const events = Array.from({ length: 100 }, (_, index) => buildEvent(index))
+
+    await act(async () => {
+      root.render(
+        <CredentialRequestEventsList
+          events={events}
+          loading={false}
+          hasMore={false}
+          loadingMore={false}
+          autoLoadMore
+          onLoadMore={() => undefined}
+        />,
+      )
+      await Promise.resolve()
+    })
+
+    const tokenCell = container.querySelector('[data-token-direction="input"]')?.closest('td')
+    expect(tokenCell).not.toBeNull()
+    await act(async () => tokenCell?.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })))
+    expect(document.body.querySelector('[role="tooltip"]')).not.toBeNull()
+
+    const scroller = container.querySelector<HTMLElement>('[data-credential-request-events-scroller="true"]')!
+    scroller.scrollTop = 3_500
+    await act(async () => {
+      scroller.dispatchEvent(new Event('scroll'))
+      const { promise, resolve } = Promise.withResolvers<void>()
+      window.setTimeout(resolve, 0)
+      await promise
+    })
+
+    expect(tokenCell?.isConnected).toBe(false)
+    expect(document.body.querySelector('[role="tooltip"]')).toBeNull()
+  })
+
   it('drops the stale height of an expanded row after it leaves the virtual window', async () => {
     const events = Array.from({ length: 100 }, (_, index) => buildEvent(index))
     await act(async () => {
@@ -583,7 +691,7 @@ describe('CredentialRequestEventsList', () => {
     await act(async () => {
       TestResizeObserver.flush()
     })
-    expect(readVirtualContentHeight(scroller)).toBe(7_150)
+    expect(readVirtualContentHeight(scroller)).toBe(8_140)
 
     scroller.scrollTop = 3_500
     await act(async () => {
@@ -605,8 +713,8 @@ describe('CredentialRequestEventsList', () => {
     await act(async () => {
       TestResizeObserver.flush()
     })
-    expect(readVirtualContentHeight(scroller)).toBe(7_150)
-    expect(scroller.scrollTop).toBe(scrollTopBeforeSwitch - 150)
+    expect(readVirtualContentHeight(scroller)).toBe(8_140)
+    expect(scroller.scrollTop).toBe(scrollTopBeforeSwitch - 140)
   })
 
   it('fully renders a small event page without virtual spacer rows', async () => {

--- a/web/src/components/usage/test/RequestEventsDetailsCardCacheTokens.test.tsx
+++ b/web/src/components/usage/test/RequestEventsDetailsCardCacheTokens.test.tsx
@@ -94,4 +94,29 @@ describe('RequestEventsDetailsCard cache token columns', () => {
     expect(html).toContain('data-cache-flow="download"');
     expect(html).not.toContain('data-cache-rate-tone=');
   });
+
+  it('uses compact token units in cells while keeping full values in the cell labels', () => {
+    const html = renderCard({
+      events: [{
+        ...event,
+        tokens: {
+          input_tokens: 1_234_567,
+          output_tokens: 2_345_678,
+          reasoning_tokens: 12_345,
+          cache_read_tokens: 3_456_789,
+          cache_creation_tokens: 4_567_890,
+          total_tokens: 5_678_901,
+        },
+      }],
+    });
+    const headers = extractTableHeaders(html);
+    const cells = extractFirstTableRowCells(html);
+    const tokensIndex = headers.indexOf('Tokens');
+    const cacheIndex = headers.indexOf('Cache');
+
+    expect(cells[tokensIndex]).toBe('5.68M1.23M2.35M12.35K');
+    expect(cells[cacheIndex]).toBe('280.00%3.46M4.57M');
+    expect(html).toContain('aria-label="Total Tokens: 5,678,901; Input: 1,234,567; Output: 2,345,678; Reasoning: 12,345"');
+    expect(html).toContain('aria-label="Cache Rate: 280.00%; Cache Read: 3,456,789; Cache Write: 4,567,890"');
+  });
 });

--- a/web/src/components/usage/test/RequestEventsDetailsCardMetricsTooltip.test.tsx
+++ b/web/src/components/usage/test/RequestEventsDetailsCardMetricsTooltip.test.tsx
@@ -32,6 +32,19 @@ const baseEvent: UsageEvent = {
   pricing_style: 'openai',
 };
 
+const largeTokenEvent: UsageEvent = {
+  ...baseEvent,
+  id: 'metrics-tooltip-large-event',
+  tokens: {
+    input_tokens: 73_893_802,
+    output_tokens: 280_802,
+    reasoning_tokens: 160_430,
+    cache_read_tokens: 69_897_984,
+    cache_creation_tokens: 0,
+    total_tokens: 74_174_604,
+  },
+};
+
 const renderCardElement = (events: UsageEvent[]) => (
   <RequestEventsDetailsCard
     events={events}
@@ -140,36 +153,41 @@ describe('RequestEventsDetailsCard token and cache tooltips', () => {
     }
   });
 
-  it('keeps full token values in the tooltip when cells use compact units', async () => {
-    const mounted = await mountCard([{
-      ...baseEvent,
-      tokens: {
-        input_tokens: 1_234_567,
-        output_tokens: 2_345_678,
-        reasoning_tokens: 12_345,
-        cache_read_tokens: 3_456_789,
-        cache_creation_tokens: 4_567_890,
-        total_tokens: 5_678_901,
-      },
-    }]);
+  it('compacts list values while keeping complete token and cache values in the tooltip', async () => {
+    const mounted = await mountCard([largeTokenEvent]);
 
     try {
       const cells = mounted.container.querySelectorAll<HTMLTableCellElement>('tbody td');
       const tokensCell = cells[0];
       const cacheCell = cells[1];
-      expect(tokensCell.textContent).toContain('5.68M');
-      expect(tokensCell.textContent).toContain('1.23M');
-      expect(cacheCell.textContent).toContain('3.46M');
-      expect(cacheCell.textContent).toContain('4.57M');
+      expect(tokensCell.textContent).toContain('74.17M');
+      expect(tokensCell.textContent).toContain('73.89M');
+      expect(tokensCell.textContent).toContain('280.80K');
+      expect(tokensCell.textContent).toContain('160.43K');
+      expect(cacheCell.textContent).toContain('94.59%');
+      expect(cacheCell.textContent).toContain('69.90M');
+      expect(cacheCell.textContent).toContain('0');
+      expect(tokensCell.getAttribute('aria-label')).toContain('Total Tokens: 74,174,604');
+      expect(cacheCell.getAttribute('aria-label')).toContain('Cache Read: 69,897,984');
 
       await act(async () => {
         tokensCell.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
       });
       expect(tooltipLines()).toEqual([
-        'Total Tokens: 5,678,901',
-        'Input: 1,234,567',
-        'Output: 2,345,678',
-        'Reasoning: 12,345',
+        'Total Tokens: 74,174,604',
+        'Input: 73,893,802',
+        'Output: 280,802',
+        'Reasoning: 160,430',
+      ]);
+
+      await act(async () => {
+        tokensCell.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
+        cacheCell.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      });
+      expect(tooltipLines()).toEqual([
+        'Cache Rate: 94.59%',
+        'Cache Read: 69,897,984',
+        'Cache Write: 0',
       ]);
     } finally {
       await mounted.unmount();

--- a/web/src/components/usage/test/RequestEventsDetailsCardMetricsTooltip.test.tsx
+++ b/web/src/components/usage/test/RequestEventsDetailsCardMetricsTooltip.test.tsx
@@ -139,4 +139,40 @@ describe('RequestEventsDetailsCard token and cache tooltips', () => {
       await i18n.changeLanguage('en');
     }
   });
+
+  it('keeps full token values in the tooltip when cells use compact units', async () => {
+    const mounted = await mountCard([{
+      ...baseEvent,
+      tokens: {
+        input_tokens: 1_234_567,
+        output_tokens: 2_345_678,
+        reasoning_tokens: 12_345,
+        cache_read_tokens: 3_456_789,
+        cache_creation_tokens: 4_567_890,
+        total_tokens: 5_678_901,
+      },
+    }]);
+
+    try {
+      const cells = mounted.container.querySelectorAll<HTMLTableCellElement>('tbody td');
+      const tokensCell = cells[0];
+      const cacheCell = cells[1];
+      expect(tokensCell.textContent).toContain('5.68M');
+      expect(tokensCell.textContent).toContain('1.23M');
+      expect(cacheCell.textContent).toContain('3.46M');
+      expect(cacheCell.textContent).toContain('4.57M');
+
+      await act(async () => {
+        tokensCell.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      });
+      expect(tooltipLines()).toEqual([
+        'Total Tokens: 5,678,901',
+        'Input: 1,234,567',
+        'Output: 2,345,678',
+        'Reasoning: 12,345',
+      ]);
+    } finally {
+      await mounted.unmount();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- compact visible token metrics in Request Event Log and credential detail histories
- keep full token values in localized tooltips and accessible labels
- align credential detail virtualization with the metric row height

## Validation
- npm --prefix ./web run test (150 files, 1238 tests)
- npm --prefix ./web run typecheck
- npm --prefix ./web run lint
- npm --prefix ./web run build