### PR TITLE
fix(quota): use suspend-aware timer for auto refresh schedule

### DIFF
--- a/internal/quota/auto_refresh.go
+++ b/internal/quota/auto_refresh.go
@@ -297,14 +297,22 @@ func (s *Service) sleepAutoRefreshDelay(ctx context.Context, delay time.Duration
 		}
 		return autoRefreshWakeElapsed
 	}
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
+
+	timerCh, stopTimer, err := newSuspendAwareTimer(delay)
+	if err != nil {
+		logrus.WithError(err).Warn("failed to create suspend-aware timer, falling back to standard timer")
+		timer := time.NewTimer(delay)
+		timerCh = timer.C
+		stopTimer = func() { timer.Stop() }
+	}
+	defer stopTimer()
+
 	select {
 	case <-ctx.Done():
 		return autoRefreshWakeCanceled
 	case <-s.autoRefreshSettingsChanged:
 		return autoRefreshWakeSettingsChanged
-	case <-timer.C:
+	case <-timerCh:
 		return autoRefreshWakeElapsed
 	}
 }

--- a/internal/quota/suspend_timer_linux.go
+++ b/internal/quota/suspend_timer_linux.go
@@ -1,0 +1,50 @@
+//go:build linux
+
+package quota
+
+import (
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func newSuspendAwareTimer(delay time.Duration) (<-chan time.Time, func(), error) {
+	if delay <= 0 {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch, func() {}, nil
+	}
+
+	fd, err := unix.TimerfdCreate(unix.CLOCK_BOOTTIME, unix.TFD_CLOEXEC|unix.TFD_NONBLOCK)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	spec := unix.ItimerSpec{
+		Value: unix.NsecToTimespec(delay.Nanoseconds()),
+	}
+	if err := unix.TimerfdSettime(fd, 0, &spec, nil); err != nil {
+		_ = unix.Close(fd)
+		return nil, nil, err
+	}
+
+	file := os.NewFile(uintptr(fd), "suspend-aware-timer")
+	ch := make(chan time.Time, 1)
+	go func() {
+		var buf [8]byte
+		n, err := file.Read(buf[:])
+		if err == nil && n == 8 {
+			select {
+			case ch <- time.Now():
+			default:
+			}
+		}
+	}()
+
+	stop := func() {
+		_ = file.Close()
+	}
+
+	return ch, stop, nil
+}

--- a/internal/quota/suspend_timer_unsupported.go
+++ b/internal/quota/suspend_timer_unsupported.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package quota
+
+import (
+	"time"
+)
+
+func newSuspendAwareTimer(delay time.Duration) (<-chan time.Time, func(), error) {
+	timer := time.NewTimer(delay)
+	return timer.C, func() { timer.Stop() }, nil
+}

--- a/internal/quota/test/internal_access_test.go
+++ b/internal/quota/test/internal_access_test.go
@@ -47,6 +47,9 @@ func nextAutoRefreshDelay(service *quota.Service, settings quota.AutoRefreshSett
 //go:linkname sleepAutoRefreshDelay cpa-usage-keeper/internal/quota.(*Service).sleepAutoRefreshDelay
 func sleepAutoRefreshDelay(service *quota.Service, ctx context.Context, delay time.Duration) int
 
+//go:linkname newSuspendAwareTimer cpa-usage-keeper/internal/quota.newSuspendAwareTimer
+func newSuspendAwareTimer(delay time.Duration) (<-chan time.Time, func(), error)
+
 //go:linkname resetInspectionCompletedAt cpa-usage-keeper/internal/quota.(*Service).resetInspectionCompletedAt
 func resetInspectionCompletedAt(service *quota.Service)
 

--- a/internal/quota/test/suspend_timer_test.go
+++ b/internal/quota/test/suspend_timer_test.go
@@ -1,0 +1,47 @@
+package test
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSuspendAwareTimerZeroDelayFiresImmediately(t *testing.T) {
+	ch, stop, err := newSuspendAwareTimer(0)
+	if err != nil {
+		t.Fatalf("unexpected error for 0 delay: %v", err)
+	}
+	defer stop()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("expected 0 delay timer to fire immediately")
+	}
+}
+
+func TestSuspendAwareTimerFiresAfterDelay(t *testing.T) {
+	start := time.Now()
+	ch, stop, err := newSuspendAwareTimer(50 * time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer stop()
+
+	select {
+	case <-ch:
+		elapsed := time.Since(start)
+		if elapsed < 40*time.Millisecond {
+			t.Fatalf("timer fired too early: %v", elapsed)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected timer to fire after delay")
+	}
+}
+
+func TestSuspendAwareTimerStopPreventsLeak(t *testing.T) {
+	_, stop, err := newSuspendAwareTimer(10 * time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	stop()
+}


### PR DESCRIPTION
Standard Go runtime timers rely on CLOCK_MONOTONIC on Linux, which halts during system suspend. This caused scheduled auto-refreshes to be delayed by the duration of the suspend after waking up.

Use Linux timerfd with CLOCK_BOOTTIME so that system sleep time is properly accounted for and scheduled refreshes trigger promptly upon wake.