### PR TITLE
fix(quota): repair missing quota history index

### DIFF
--- a/internal/repository/migration/20260902_repair_usage_event_quota_window_index.go
+++ b/internal/repository/migration/20260902_repair_usage_event_quota_window_index.go
@@ -1,0 +1,26 @@
+package migration
+
+import (
+	"fmt"
+
+	"cpa-usage-keeper/internal/entities"
+
+	"gorm.io/gorm"
+)
+
+const usageEventQuotaWindowIndexName = "idx_usage_events_auth_index_timestamp_id"
+
+// repairUsageEventQuotaWindowIndexMigration 修复旧 migration 已记录完成、物理索引却缺失的 schema 漂移。
+func repairUsageEventQuotaWindowIndexMigration(tx *gorm.DB) error {
+	if !tx.Migrator().HasTable(&entities.UsageEvent{}) {
+		return fmt.Errorf("repair usage event quota window index: usage_events table is missing")
+	}
+	if tx.Migrator().HasIndex(&entities.UsageEvent{}, usageEventQuotaWindowIndexName) {
+		return nil
+	}
+	// 复用 UsageEvent 的复合索引声明，避免修复 migration 与当前实体列顺序发生漂移。
+	if err := tx.Migrator().CreateIndex(&entities.UsageEvent{}, usageEventQuotaWindowIndexName); err != nil {
+		return fmt.Errorf("repair usage event quota window index: %w", err)
+	}
+	return nil
+}

--- a/internal/repository/migration/migration.go
+++ b/internal/repository/migration/migration.go
@@ -90,6 +90,8 @@ const (
 	migrationAddAuthSessionAlias = "20260824_add_auth_session_alias"
 	// migrationResetQuotaHistory 在新来源判定生效后清空无法证明 provenance 的旧额度历史。
 	migrationResetQuotaHistory = "20260827_reset_quota_history"
+	// migrationRepairUsageEventQuotaWindowIndex 修复旧 migration 记录与物理索引不一致的数据库。
+	migrationRepairUsageEventQuotaWindowIndex = "20260902_repair_usage_event_quota_window_index"
 )
 
 type schemaMigration struct {
@@ -231,6 +233,8 @@ func orderedMigrations() []databaseMigration {
 		{version: migrationAddAuthSessionAlias, run: addAuthSessionAliasMigration},
 		// 清表前必须先在事务外完成通用数据库备份；DELETE 与版本标记仍使用默认单事务。
 		{version: migrationResetQuotaHistory, run: resetQuotaHistoryMigration, destructive: true},
+		// 历史 migration 不会重跑；用新版本幂等补齐额度历史查询强制依赖的索引。
+		{version: migrationRepairUsageEventQuotaWindowIndex, run: repairUsageEventQuotaWindowIndexMigration},
 	}
 }
 

--- a/internal/repository/migration/migration_test.go
+++ b/internal/repository/migration/migration_test.go
@@ -86,6 +86,7 @@ func TestOrderedMigrationsPreservesExecutionOrder(t *testing.T) {
 		"20260822_rebuild_quota_history",
 		"20260824_add_auth_session_alias",
 		"20260827_reset_quota_history",
+		"20260902_repair_usage_event_quota_window_index",
 	}
 	assertStringSlicesEqual(t, want, got)
 }

--- a/internal/repository/migration/test/usage_event_quota_window_index_repair_test.go
+++ b/internal/repository/migration/test/usage_event_quota_window_index_repair_test.go
@@ -1,0 +1,92 @@
+package test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"cpa-usage-keeper/internal/repository/migration"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const (
+	usageEventQuotaWindowIndexName            = "idx_usage_events_auth_index_timestamp_id"
+	usageEventQuotaWindowIndexRepairMigration = "20260902_repair_usage_event_quota_window_index"
+)
+
+func TestUsageEventQuotaWindowIndexRepairMigrationReconcilesPhysicalIndex(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		seedIndex    bool
+		indexOutcome string
+	}{
+		{name: "missing index", indexOutcome: "repaired"},
+		{name: "existing index", seedIndex: true, indexOutcome: "preserved"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "existing.db")), &gorm.Config{})
+			if err != nil {
+				t.Fatalf("open existing database: %v", err)
+			}
+			closeMigrationTestDatabase(t, db)
+
+			if err := db.Exec(`CREATE TABLE usage_events (
+				id INTEGER PRIMARY KEY,
+				auth_index TEXT NOT NULL,
+				timestamp DATETIME NOT NULL
+			)`).Error; err != nil {
+				t.Fatalf("create usage_events table: %v", err)
+			}
+			if test.seedIndex {
+				if err := db.Exec(`CREATE INDEX idx_usage_events_auth_index_timestamp_id
+					ON usage_events(auth_index, timestamp, id)`).Error; err != nil {
+					t.Fatalf("seed quota window index: %v", err)
+				}
+			}
+			if err := db.Exec(`INSERT INTO usage_events (id, auth_index, timestamp)
+				VALUES (1, 'codex-auth', '2026-09-02T00:00:00Z')`).Error; err != nil {
+				t.Fatalf("seed usage event: %v", err)
+			}
+			// 模拟生产事故：旧建索引 migration 已记录完成，新修复版本仍待执行。
+			if err := migration.MarkAllAsApplied(db); err != nil {
+				t.Fatalf("mark historical migrations applied: %v", err)
+			}
+			if err := db.Table("schema_migrations").Where("version = ?", usageEventQuotaWindowIndexRepairMigration).Delete(nil).Error; err != nil {
+				t.Fatalf("make quota window index repair migration pending: %v", err)
+			}
+
+			if err := migration.Run(db); err != nil {
+				t.Fatalf("Run returned error: %v", err)
+			}
+
+			if !db.Migrator().HasIndex("usage_events", usageEventQuotaWindowIndexName) {
+				t.Fatalf("expected %s index %s", test.indexOutcome, usageEventQuotaWindowIndexName)
+			}
+			var eventIDs []int64
+			if err := db.Raw(`SELECT id
+				FROM usage_events INDEXED BY idx_usage_events_auth_index_timestamp_id
+				WHERE auth_index = ? AND timestamp >= ? AND timestamp < ?
+				ORDER BY timestamp ASC, id ASC`,
+				"codex-auth", "2026-09-01T00:00:00Z", "2026-09-03T00:00:00Z").Scan(&eventIDs).Error; err != nil {
+				t.Fatalf("query usage events through repaired quota window index: %v", err)
+			}
+			if len(eventIDs) != 1 || eventIDs[0] != 1 {
+				t.Fatalf("expected repaired quota window query to return event 1, got %v", eventIDs)
+			}
+			var count int64
+			if err := db.Table("usage_events").Where("id = ? AND auth_index = ?", 1, "codex-auth").Count(&count).Error; err != nil {
+				t.Fatalf("count preserved usage event: %v", err)
+			}
+			if count != 1 {
+				t.Fatalf("expected migration to preserve usage event, got %d rows", count)
+			}
+			if err := db.Table("schema_migrations").Where("version = ?", usageEventQuotaWindowIndexRepairMigration).Count(&count).Error; err != nil {
+				t.Fatalf("count quota window index repair migration: %v", err)
+			}
+			if count != 1 {
+				t.Fatalf("expected one quota window index repair migration record, got %d", count)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add a follow-up schema migration that repairs the missing quota-history usage event index
- preserve existing indexes and usage data while reconciling migration-record/schema drift
- cover missing-index repair, existing-index no-op, forced-index queries, and migration recording

## Validation

- `go test ./internal/repository/migration/test -run TestUsageEventQuotaWindowIndexRepairMigrationReconcilesPhysicalIndex -count=1`
- `go test ./internal/repository/migration/... -count=1`
- `verify-local.sh backend`
- `git diff --check`