### PR TITLE
test(quota): cover suspend-aware timer contract

### DIFF
--- a/internal/quota/suspend_timer_linux.go
+++ b/internal/quota/suspend_timer_linux.go
@@ -9,6 +9,14 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func suspendAwareTimerParameters(delay time.Duration) (int, int, int, unix.ItimerSpec) {
+	// 使用相对的一次性 CLOCK_BOOTTIME timer，让系统休眠时间计入自动刷新等待周期。
+	return unix.CLOCK_BOOTTIME,
+		unix.TFD_CLOEXEC | unix.TFD_NONBLOCK,
+		0,
+		unix.ItimerSpec{Value: unix.NsecToTimespec(delay.Nanoseconds())}
+}
+
 func newSuspendAwareTimer(delay time.Duration) (<-chan time.Time, func(), error) {
 	if delay <= 0 {
 		ch := make(chan time.Time, 1)
@@ -16,15 +24,13 @@ func newSuspendAwareTimer(delay time.Duration) (<-chan time.Time, func(), error)
 		return ch, func() {}, nil
 	}
 
-	fd, err := unix.TimerfdCreate(unix.CLOCK_BOOTTIME, unix.TFD_CLOEXEC|unix.TFD_NONBLOCK)
+	clockID, createFlags, settimeFlags, spec := suspendAwareTimerParameters(delay)
+	fd, err := unix.TimerfdCreate(clockID, createFlags)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	spec := unix.ItimerSpec{
-		Value: unix.NsecToTimespec(delay.Nanoseconds()),
-	}
-	if err := unix.TimerfdSettime(fd, 0, &spec, nil); err != nil {
+	if err := unix.TimerfdSettime(fd, settimeFlags, &spec, nil); err != nil {
 		_ = unix.Close(fd)
 		return nil, nil, err
 	}

--- a/internal/quota/test/suspend_timer_linux_test.go
+++ b/internal/quota/test/suspend_timer_linux_test.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package test
+
+import (
+	"testing"
+	"time"
+	_ "unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+//go:linkname suspendAwareTimerParameters cpa-usage-keeper/internal/quota.suspendAwareTimerParameters
+func suspendAwareTimerParameters(delay time.Duration) (int, int, int, unix.ItimerSpec)
+
+func TestSuspendAwareTimerParametersUseBootTimeOneShot(t *testing.T) {
+	delay := 90*time.Minute + 123*time.Millisecond
+	clockID, createFlags, settimeFlags, spec := suspendAwareTimerParameters(delay)
+
+	if clockID != unix.CLOCK_BOOTTIME {
+		t.Fatalf("expected CLOCK_BOOTTIME, got %d", clockID)
+	}
+	wantCreateFlags := unix.TFD_CLOEXEC | unix.TFD_NONBLOCK
+	if createFlags != wantCreateFlags {
+		t.Fatalf("expected timerfd create flags %d, got %d", wantCreateFlags, createFlags)
+	}
+	if settimeFlags != 0 {
+		t.Fatalf("expected relative timerfd settime flags, got %d", settimeFlags)
+	}
+	if got := unix.TimespecToNsec(spec.Value); got != delay.Nanoseconds() {
+		t.Fatalf("expected timer delay %s, got %s", delay, time.Duration(got))
+	}
+	if got := unix.TimespecToNsec(spec.Interval); got != 0 {
+		t.Fatalf("expected one-shot timer interval, got %s", time.Duration(got))
+	}
+}

--- a/internal/quota/test/suspend_timer_test.go
+++ b/internal/quota/test/suspend_timer_test.go
@@ -38,10 +38,16 @@ func TestSuspendAwareTimerFiresAfterDelay(t *testing.T) {
 	}
 }
 
-func TestSuspendAwareTimerStopPreventsLeak(t *testing.T) {
-	_, stop, err := newSuspendAwareTimer(10 * time.Second)
+func TestSuspendAwareTimerStopCancelsDelivery(t *testing.T) {
+	ch, stop, err := newSuspendAwareTimer(time.Second)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	stop()
+
+	select {
+	case <-ch:
+		t.Fatal("expected stopped timer not to deliver an event")
+	case <-time.After(1250 * time.Millisecond):
+	}
 }


### PR DESCRIPTION
## Summary

- centralize the Linux timerfd clock, flags, and one-shot specification so the suspend-aware contract is directly testable
- assert CLOCK_BOOTTIME, nonblocking close-on-exec creation, relative scheduling, and a zero repeat interval
- replace the no-assertion stop test with coverage that verifies a stopped timer does not deliver after its deadline

## Validation

- go test ./internal/quota/test -run TestStartAutoRefreshWakesWhenSettingsChange\|TestSuspendAwareTimer -count=3
- go test -race ./internal/quota/test -run TestStartAutoRefreshWakesWhenSettingsChange\|TestSuspendAwareTimer -count=1
- .codex/skills/cpa-usage-keeper/scripts/verify-local.sh backend

Follow-up to #497.