### PR TITLE
fix(credentials): base quota estimate on settled usage

### DIFF
--- a/web/src/components/usage/credentials/CodexQuotaHistoryPanel.tsx
+++ b/web/src/components/usage/credentials/CodexQuotaHistoryPanel.tsx
@@ -341,17 +341,21 @@ function QuotaSummaryMetric({
 }
 
 function calculateFullQuotaEstimate(cycle: CodexQuotaHistoryCycle): QuotaSummaryMetrics | null {
-  const remainingPercent = cycle.last_remaining_percent
-  if (remainingPercent == null || !Number.isFinite(remainingPercent)) return null
-  const usedPercent = 100 - Math.min(100, Math.max(0, remainingPercent))
-  if (usedPercent <= 0 || cycle.usage.requests <= 0 || cycle.usage.total_tokens <= 0) return null
-  // 与认证文件列表 Estimated 口径一致：当前用量除以已用比例，外推到 100% 额度。
-  const ratio = usedPercent / 100
+  // 只使用已经被相邻百分比观察夹住的事件；周期总量还包含首段前和尾段后的未结算用量。
+  const settled = cycle.transitions.reduce((total, transition) => ({
+    percentagePoints: total.percentagePoints + transition.percentage_points,
+    requests: total.requests + transition.usage.requests,
+    tokens: total.tokens + transition.usage.total_tokens,
+    cost: total.cost + transition.usage.total_cost_usd,
+    costAvailable: total.costAvailable && transition.cost_per_point_available,
+  }), { percentagePoints: 0, requests: 0, tokens: 0, cost: 0, costAvailable: true })
+  if (settled.percentagePoints <= 0 || settled.requests <= 0 || settled.tokens <= 0) return null
+  const ratio = 100 / settled.percentagePoints
   return {
-    requests: cycle.usage.requests / ratio,
-    tokens: cycle.usage.total_tokens / ratio,
-    cost: cycle.usage.total_cost_usd / ratio,
-    costAvailable: cycle.usage.cost_available,
+    requests: settled.requests * ratio,
+    tokens: settled.tokens * ratio,
+    cost: settled.cost * ratio,
+    costAvailable: settled.costAvailable,
   }
 }
 

--- a/web/src/components/usage/credentials/test/CodexQuotaHistoryPanel.test.tsx
+++ b/web/src/components/usage/credentials/test/CodexQuotaHistoryPanel.test.tsx
@@ -59,6 +59,19 @@ const usage = (tokens: number, cost: number, available = true, requests = 1) => 
   cost_available: available,
 })
 
+const completedTransition = (costAvailable = true) => ({
+  from_remaining_percent: 93,
+  to_remaining_percent: 92,
+  percentage_points: 1,
+  is_direct: true,
+  interval_started_at: '2026-08-16T22:00:00Z',
+  interval_ended_at: '2026-08-16T22:10:00Z',
+  usage: usage(1000, 1, costAvailable, 10),
+  tokens_per_point: 1000,
+  cost_per_point: 1,
+  cost_per_point_available: costAvailable,
+})
+
 const response: CodexQuotaHistoryResponse = {
   generated_at: '2026-08-21T12:00:00Z',
   range_start: '2026-07-22T12:00:00Z',
@@ -80,7 +93,7 @@ const response: CodexQuotaHistoryResponse = {
     first_remaining_percent: 90,
     last_remaining_percent: 86,
     observation_count: 3,
-    usage: usage(5000, 5, true, 14),
+    usage: usage(5000, 5, true, 80),
     transitions: [
       {
         from_remaining_percent: 90,
@@ -120,7 +133,7 @@ const response: CodexQuotaHistoryResponse = {
     first_remaining_percent: 93,
     last_remaining_percent: 93,
     observation_count: 2,
-    usage: usage(2000, 2),
+    usage: usage(2000, 2, true, 12),
     transitions: [],
   }],
 }
@@ -219,7 +232,7 @@ describe('CodexQuotaHistoryPanel', () => {
     expect([...document.body.querySelectorAll('[data-codex-quota-chart-summary] > [data-codex-quota-summary]')]
       .map((summary) => summary.getAttribute('data-codex-quota-summary'))).toEqual(['median', 'used', 'full-estimate'])
     expect(usedSummary?.textContent).toContain('usage_stats.credentials_quota_history_used')
-    expect(usedSummary?.querySelector('[data-codex-quota-summary-metric="requests"]')?.textContent).toBe('14')
+    expect(usedSummary?.querySelector('[data-codex-quota-summary-metric="requests"]')?.textContent).toBe('80')
     expect(usedSummary?.querySelector('[data-codex-quota-summary-metric="tokens"]')?.textContent).toBe('5.00K')
     expect(usedSummary?.querySelector('[data-codex-quota-summary-metric="cost"]')?.textContent).toBe('$5.00')
     expect(fullEstimateSummary?.textContent).toContain('usage_stats.credentials_quota_history_full_estimate')
@@ -306,7 +319,7 @@ describe('CodexQuotaHistoryPanel', () => {
     expect(medianRequestMetric?.getAttribute('aria-label')).toBe('usage_stats.total_requests: 20')
     expect(currentSummary?.querySelector('[data-codex-quota-summary="median"] [data-codex-quota-summary-metric="tokens"]')?.textContent).toBe('1.00K')
     expect(currentSummary?.querySelector('[data-codex-quota-summary="median"] [data-codex-quota-summary-metric="cost"]')?.textContent).toBe('$1.00')
-    expect(currentSummary?.querySelector('[data-codex-quota-summary="used"] [data-codex-quota-summary-metric="requests"]')?.textContent).toBe('14')
+    expect(currentSummary?.querySelector('[data-codex-quota-summary="used"] [data-codex-quota-summary-metric="requests"]')?.textContent).toBe('80')
     expect(currentSummary?.querySelector('[data-codex-quota-summary="full-estimate"] [data-codex-quota-summary-metric="tokens"]')?.textContent).toBe('100.00K')
     expect(currentSummary?.querySelector('[data-codex-quota-summary="estimated-unused"]')).toBeNull()
 
@@ -330,18 +343,7 @@ describe('CodexQuotaHistoryPanel', () => {
 
   it('derives completed full-quota and unused estimates from settled transitions', async () => {
     const completedEstimateResponse = cloneResponse()
-    completedEstimateResponse.cycles[1].transitions = [{
-      from_remaining_percent: 93,
-      to_remaining_percent: 92,
-      percentage_points: 1,
-      is_direct: true,
-      interval_started_at: '2026-08-16T22:00:00Z',
-      interval_ended_at: '2026-08-16T22:10:00Z',
-      usage: usage(1000, 1, true, 10),
-      tokens_per_point: 1000,
-      cost_per_point: 1,
-      cost_per_point_available: true,
-    }]
+    completedEstimateResponse.cycles[1].transitions = [completedTransition()]
     fetchCodexQuotaHistory.mockResolvedValue(completedEstimateResponse)
 
     await act(async () => {
@@ -443,6 +445,27 @@ describe('CodexQuotaHistoryPanel', () => {
       .toBe('usage_stats.credentials_quota_history_cost_missing')
     expect(completedSummary?.querySelector('[data-codex-quota-summary="full-estimate"]')?.textContent).toContain('—')
     expect(completedSummary?.querySelector('[data-codex-quota-summary="estimated-unused"]')?.textContent).toContain('—')
+  })
+
+  it('keeps completed settled estimates visible while marking unavailable Cost', async () => {
+    const missingCycleCostResponse = cloneResponse()
+    missingCycleCostResponse.cycles[1].transitions = [completedTransition(false)]
+    fetchCodexQuotaHistory.mockResolvedValue(missingCycleCostResponse)
+    await act(async () => {
+      root.render(<CodexQuotaHistoryPanel authIndex="codex-auth" />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const completedSummary = document.body.querySelector('[data-codex-quota-cycle-id="1"] [data-codex-quota-cycle-summary]')
+    expect(completedSummary?.querySelector('[data-codex-quota-summary="full-estimate"] [data-codex-quota-summary-metric="tokens"]')?.textContent)
+      .toBe('100.00K')
+    expect(completedSummary?.querySelector('[data-codex-quota-summary="full-estimate"] [data-codex-quota-summary-metric="cost"]')?.textContent)
+      .toBe('usage_stats.credentials_quota_history_cost_missing')
+    expect(completedSummary?.querySelector('[data-codex-quota-summary="estimated-unused"] [data-codex-quota-summary-metric="tokens"]')?.textContent)
+      .toBe('98.00K')
+    expect(completedSummary?.querySelector('[data-codex-quota-summary="estimated-unused"] [data-codex-quota-summary-metric="cost"]')?.textContent)
+      .toBe('usage_stats.credentials_quota_history_cost_missing')
   })
 
   it('uses the Analysis tooltip surface in dark mode', async () => {

--- a/web/src/components/usage/credentials/test/CodexQuotaHistoryPanel.test.tsx
+++ b/web/src/components/usage/credentials/test/CodexQuotaHistoryPanel.test.tsx
@@ -149,7 +149,7 @@ describe('CodexQuotaHistoryPanel', () => {
     vi.restoreAllMocks()
   })
 
-  it('expands crossed intervals into one-percent estimates and shows Token plus Cost together', async () => {
+  it('expands crossed intervals and estimates full quota only from settled percentage points', async () => {
     await act(async () => {
       root.render(<CodexQuotaHistoryPanel authIndex="codex-auth" />)
       await Promise.resolve()
@@ -223,9 +223,9 @@ describe('CodexQuotaHistoryPanel', () => {
     expect(usedSummary?.querySelector('[data-codex-quota-summary-metric="tokens"]')?.textContent).toBe('5.00K')
     expect(usedSummary?.querySelector('[data-codex-quota-summary-metric="cost"]')?.textContent).toBe('$5.00')
     expect(fullEstimateSummary?.textContent).toContain('usage_stats.credentials_quota_history_full_estimate')
-    expect(fullEstimateSummary?.querySelector('[data-codex-quota-summary-metric="requests"]')?.textContent).toBe('100')
-    expect(fullEstimateSummary?.querySelector('[data-codex-quota-summary-metric="tokens"]')?.textContent).toBe('35.71K')
-    expect(fullEstimateSummary?.querySelector('[data-codex-quota-summary-metric="cost"]')?.textContent).toBe('$35.71')
+    expect(fullEstimateSummary?.querySelector('[data-codex-quota-summary-metric="requests"]')?.textContent).toBe('1.75K')
+    expect(fullEstimateSummary?.querySelector('[data-codex-quota-summary-metric="tokens"]')?.textContent).toBe('100.00K')
+    expect(fullEstimateSummary?.querySelector('[data-codex-quota-summary-metric="cost"]')?.textContent).toBe('$100.00')
     expect(medianSummary?.textContent).toContain('usage_stats.credentials_quota_history_median_per_point')
     expect(medianSummary?.querySelector('[data-codex-quota-summary-metric="requests"]')?.textContent).toBe('20')
     expect(medianSummary?.querySelector('[data-codex-quota-summary-metric="tokens"]')?.textContent).toBe('1.00K')
@@ -307,7 +307,7 @@ describe('CodexQuotaHistoryPanel', () => {
     expect(currentSummary?.querySelector('[data-codex-quota-summary="median"] [data-codex-quota-summary-metric="tokens"]')?.textContent).toBe('1.00K')
     expect(currentSummary?.querySelector('[data-codex-quota-summary="median"] [data-codex-quota-summary-metric="cost"]')?.textContent).toBe('$1.00')
     expect(currentSummary?.querySelector('[data-codex-quota-summary="used"] [data-codex-quota-summary-metric="requests"]')?.textContent).toBe('14')
-    expect(currentSummary?.querySelector('[data-codex-quota-summary="full-estimate"] [data-codex-quota-summary-metric="tokens"]')?.textContent).toBe('35.71K')
+    expect(currentSummary?.querySelector('[data-codex-quota-summary="full-estimate"] [data-codex-quota-summary-metric="tokens"]')?.textContent).toBe('100.00K')
     expect(currentSummary?.querySelector('[data-codex-quota-summary="estimated-unused"]')).toBeNull()
 
     const completedRecord = document.body.querySelector('[data-codex-quota-cycle-id="1"]')
@@ -321,15 +321,41 @@ describe('CodexQuotaHistoryPanel', () => {
     ])
     expect(completedSummary?.querySelector('[data-codex-quota-summary="median"]')?.textContent).toContain('—')
     expect(completedSummary?.querySelector('[data-codex-quota-summary="used"] [data-codex-quota-summary-metric="tokens"]')?.textContent).toBe('2.00K')
-    expect(completedSummary?.querySelector('[data-codex-quota-summary="full-estimate"] [data-codex-quota-summary-metric="tokens"]')?.textContent).toBe('28.57K')
+    expect(completedSummary?.querySelector('[data-codex-quota-summary="full-estimate"]')?.textContent).toContain('—')
     const estimatedUnused = completedSummary?.querySelector('[data-codex-quota-summary="estimated-unused"]')
     expect(estimatedUnused?.textContent).toContain('usage_stats.credentials_quota_history_estimated_unused')
-    expect([...estimatedUnused!.querySelectorAll('[data-codex-quota-summary-metric]')]
-      .map((metric) => metric.getAttribute('data-codex-quota-summary-metric'))).toEqual(['percentage', 'tokens', 'cost'])
-    expect(estimatedUnused?.querySelector('[data-codex-quota-summary-metric="percentage"]')?.textContent).toBe('93%')
-    expect(estimatedUnused?.querySelector('[data-codex-quota-summary-metric="percentage"] img')?.getAttribute('src')).toContain('Unused%20percentage')
-    expect(estimatedUnused?.querySelector('[data-codex-quota-summary-metric="tokens"]')?.textContent).toBe('26.57K')
-    expect(estimatedUnused?.querySelector('[data-codex-quota-summary-metric="cost"]')?.textContent).toBe('$26.57')
+    expect(estimatedUnused?.textContent).toContain('—')
+    expect(estimatedUnused?.querySelector('[data-codex-quota-summary-metric]')).toBeNull()
+  })
+
+  it('derives completed full-quota and unused estimates from settled transitions', async () => {
+    const completedEstimateResponse = cloneResponse()
+    completedEstimateResponse.cycles[1].transitions = [{
+      from_remaining_percent: 93,
+      to_remaining_percent: 92,
+      percentage_points: 1,
+      is_direct: true,
+      interval_started_at: '2026-08-16T22:00:00Z',
+      interval_ended_at: '2026-08-16T22:10:00Z',
+      usage: usage(1000, 1, true, 10),
+      tokens_per_point: 1000,
+      cost_per_point: 1,
+      cost_per_point_available: true,
+    }]
+    fetchCodexQuotaHistory.mockResolvedValue(completedEstimateResponse)
+
+    await act(async () => {
+      root.render(<CodexQuotaHistoryPanel authIndex="codex-auth" />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const completedSummary = document.body.querySelector('[data-codex-quota-cycle-id="1"] [data-codex-quota-cycle-summary]')
+    expect(completedSummary?.querySelector('[data-codex-quota-summary="full-estimate"] [data-codex-quota-summary-metric="tokens"]')?.textContent).toBe('100.00K')
+    const estimatedUnused = completedSummary?.querySelector('[data-codex-quota-summary="estimated-unused"]')
+    expect(estimatedUnused?.querySelector('[data-codex-quota-summary-metric="percentage"]')?.textContent).toBe('98%')
+    expect(estimatedUnused?.querySelector('[data-codex-quota-summary-metric="tokens"]')?.textContent).toBe('98.00K')
+    expect(estimatedUnused?.querySelector('[data-codex-quota-summary-metric="cost"]')?.textContent).toBe('$98.00')
   })
 
   it('keeps a current 76 percent baseline visible in the cycle list before any transition exists', async () => {
@@ -354,7 +380,7 @@ describe('CodexQuotaHistoryPanel', () => {
     const chartSummary = document.body.querySelector('[data-codex-quota-current-cycle="true"] [data-codex-quota-chart-summary]')
     expect(chartSummary?.querySelector('[data-codex-quota-summary="median"]')?.textContent).toContain('—')
     expect(chartSummary?.querySelector('[data-codex-quota-summary="used"] [data-codex-quota-summary-metric="tokens"]')?.textContent).toBe('5.00K')
-    expect(chartSummary?.querySelector('[data-codex-quota-summary="full-estimate"] [data-codex-quota-summary-metric="tokens"]')?.textContent).toBe('20.83K')
+    expect(chartSummary?.querySelector('[data-codex-quota-summary="full-estimate"]')?.textContent).toContain('—')
   })
 
   it('shows the selected single window and cycle range in the current efficiency card', async () => {
@@ -402,7 +428,7 @@ describe('CodexQuotaHistoryPanel', () => {
     expect(document.body.querySelector('[aria-label="usage_stats.credentials_quota_history_window_selector"]')).toBeNull()
   })
 
-  it('explains why an ended cycle total Cost is unavailable', async () => {
+  it('keeps an ended cycle total Cost unavailable without inventing estimates when no transition exists', async () => {
     const missingCycleCostResponse = cloneResponse()
     missingCycleCostResponse.cycles[1].usage.cost_available = false
     fetchCodexQuotaHistory.mockResolvedValue(missingCycleCostResponse)
@@ -415,10 +441,8 @@ describe('CodexQuotaHistoryPanel', () => {
     const completedSummary = document.body.querySelector('[data-codex-quota-cycle-id="1"] [data-codex-quota-cycle-summary]')
     expect(completedSummary?.querySelector('[data-codex-quota-summary="used"] [data-codex-quota-summary-metric="cost"]')?.textContent)
       .toBe('usage_stats.credentials_quota_history_cost_missing')
-    expect(completedSummary?.querySelector('[data-codex-quota-summary="full-estimate"] [data-codex-quota-summary-metric="cost"]')?.textContent)
-      .toBe('usage_stats.credentials_quota_history_cost_missing')
-    expect(completedSummary?.querySelector('[data-codex-quota-summary="estimated-unused"] [data-codex-quota-summary-metric="cost"]')?.textContent)
-      .toBe('usage_stats.credentials_quota_history_cost_missing')
+    expect(completedSummary?.querySelector('[data-codex-quota-summary="full-estimate"]')?.textContent).toContain('—')
+    expect(completedSummary?.querySelector('[data-codex-quota-summary="estimated-unused"]')?.textContent).toContain('—')
   })
 
   it('uses the Analysis tooltip surface in dark mode', async () => {
@@ -527,6 +551,9 @@ describe('CodexQuotaHistoryPanel', () => {
     expect(warning?.parentElement?.tagName).toBe('HEADER')
     expect(warning?.textContent).toBe('usage_stats.credentials_quota_history_cost_unavailable')
     expect(document.body.querySelector('[data-codex-quota-summary="median"]')?.textContent).toContain(
+      'usage_stats.credentials_quota_history_cost_missing',
+    )
+    expect(document.body.querySelector('[data-codex-quota-summary="full-estimate"]')?.textContent).toContain(
       'usage_stats.credentials_quota_history_cost_missing',
     )
     expect(latestChartData?.datasets[1]?.data).toEqual([1, null, null, null])

--- a/web/src/components/usage/credentials/test/CodexQuotaHistoryPanel.test.tsx
+++ b/web/src/components/usage/credentials/test/CodexQuotaHistoryPanel.test.tsx
@@ -64,8 +64,8 @@ const completedTransition = (costAvailable = true) => ({
   to_remaining_percent: 92,
   percentage_points: 1,
   is_direct: true,
-  interval_started_at: '2026-08-16T22:00:00Z',
-  interval_ended_at: '2026-08-16T22:10:00Z',
+  interval_started_at: '2026-08-10T03:00:00Z',
+  interval_ended_at: '2026-08-16T23:50:00Z',
   usage: usage(1000, 1, costAvailable, 10),
   tokens_per_point: 1000,
   cost_per_point: 1,
@@ -343,7 +343,9 @@ describe('CodexQuotaHistoryPanel', () => {
 
   it('derives completed full-quota and unused estimates from settled transitions', async () => {
     const completedEstimateResponse = cloneResponse()
-    completedEstimateResponse.cycles[1].transitions = [completedTransition()]
+    const completedCycle = completedEstimateResponse.cycles[1]
+    completedCycle.last_remaining_percent = 92
+    completedCycle.transitions = [completedTransition()]
     fetchCodexQuotaHistory.mockResolvedValue(completedEstimateResponse)
 
     await act(async () => {
@@ -449,7 +451,10 @@ describe('CodexQuotaHistoryPanel', () => {
 
   it('keeps completed settled estimates visible while marking unavailable Cost', async () => {
     const missingCycleCostResponse = cloneResponse()
-    missingCycleCostResponse.cycles[1].transitions = [completedTransition(false)]
+    const completedCycle = missingCycleCostResponse.cycles[1]
+    completedCycle.last_remaining_percent = 92
+    completedCycle.usage.cost_available = false
+    completedCycle.transitions = [completedTransition(false)]
     fetchCodexQuotaHistory.mockResolvedValue(missingCycleCostResponse)
     await act(async () => {
       root.render(<CodexQuotaHistoryPanel authIndex="codex-auth" />)
@@ -464,6 +469,26 @@ describe('CodexQuotaHistoryPanel', () => {
       .toBe('usage_stats.credentials_quota_history_cost_missing')
     expect(completedSummary?.querySelector('[data-codex-quota-summary="estimated-unused"] [data-codex-quota-summary-metric="tokens"]')?.textContent)
       .toBe('98.00K')
+    expect(completedSummary?.querySelector('[data-codex-quota-summary="estimated-unused"] [data-codex-quota-summary-metric="cost"]')?.textContent)
+      .toBe('usage_stats.credentials_quota_history_cost_missing')
+  })
+
+  it('excludes unavailable unsettled Cost only from the full-quota estimate', async () => {
+    const unsettledCostResponse = cloneResponse()
+    const completedCycle = unsettledCostResponse.cycles[1]
+    completedCycle.last_remaining_percent = 92
+    completedCycle.usage.cost_available = false
+    completedCycle.transitions = [completedTransition()]
+    fetchCodexQuotaHistory.mockResolvedValue(unsettledCostResponse)
+    await act(async () => {
+      root.render(<CodexQuotaHistoryPanel authIndex="codex-auth" />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const completedSummary = document.body.querySelector('[data-codex-quota-cycle-id="1"] [data-codex-quota-cycle-summary]')
+    expect(completedSummary?.querySelector('[data-codex-quota-summary="full-estimate"] [data-codex-quota-summary-metric="cost"]')?.textContent)
+      .toBe('$100.00')
     expect(completedSummary?.querySelector('[data-codex-quota-summary="estimated-unused"] [data-codex-quota-summary-metric="cost"]')?.textContent)
       .toBe('usage_stats.credentials_quota_history_cost_missing')
   })
@@ -564,6 +589,7 @@ describe('CodexQuotaHistoryPanel', () => {
     const missingCostTransition = partialCostResponse.cycles[0].transitions[1]
     missingCostTransition.usage.cost_available = false
     missingCostTransition.cost_per_point_available = false
+    partialCostResponse.cycles[0].usage.cost_available = false
     fetchCodexQuotaHistory.mockResolvedValue(partialCostResponse)
     await act(async () => {
       root.render(<CodexQuotaHistoryPanel authIndex="codex-auth" />)


### PR DESCRIPTION
## Summary

- Base Full-quota estimate on settled percentage-transition usage
- Exclude pre-observation and trailing unsettled usage from extrapolation
- Preserve settled versus whole-cycle Cost availability for completed estimates

## Validation

- Project frontend verification: tests, ESLint, TypeScript, production build
- Quota history component tests under TZ=UTC and TZ=Asia/Shanghai