### PR TITLE
feat(credentials): refine request event history layout

### DIFF
--- a/web/src/components/usage/credentials/CredentialRequestEventsList.module.scss
+++ b/web/src/components/usage/credentials/CredentialRequestEventsList.module.scss
@@ -19,8 +19,6 @@
 
 .table {
   width: 100%;
-  min-width: 876px;
-  table-layout: fixed;
   border-collapse: separate;
   border-spacing: 0;
   color: var(--text-primary);
@@ -74,7 +72,6 @@
 }
 
 .timestamp {
-  width: 112px;
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
 }
@@ -163,35 +160,28 @@
   }
 }
 
+.apiKey {
+  max-width: 240px;
+}
+
 .model {
-  width: 126px;
-}
-
-.request {
-  width: 100px;
-}
-
-.resultColumn {
-  width: 78px;
+  min-width: 110px;
+  max-width: 240px;
 }
 
 .tokens {
-  width: 170px;
   font-variant-numeric: tabular-nums;
 }
 
 .cache {
-  width: 102px;
   font-variant-numeric: tabular-nums;
 }
 
 .performance {
-  width: 100px;
   font-variant-numeric: tabular-nums;
 }
 
 .cost {
-  width: 88px;
   font-variant-numeric: tabular-nums;
 }
 

--- a/web/src/components/usage/credentials/CredentialRequestEventsList.tsx
+++ b/web/src/components/usage/credentials/CredentialRequestEventsList.tsx
@@ -306,6 +306,12 @@ const formatSpeedMode = (value: unknown, t: (key: string) => string): string => 
   return labelKey ? t(labelKey) : normalized
 }
 
+const formatSpeedModeDetailValue = (value: unknown, t: (key: string) => string): string => {
+  const rawValue = optionalText(value)
+  const displayValue = formatSpeedMode(rawValue, t)
+  return rawValue === '-' ? displayValue : `${displayValue} (${rawValue})`
+}
+
 const formatSpeed = (value: unknown): string => {
   const speed = Number(value)
   return Number.isFinite(speed) && speed > 0 ? `${speed.toFixed(1)} t/s` : '-'
@@ -370,8 +376,8 @@ const buildRow = (
   const inputTokens = toNumber(event.tokens?.input_tokens)
   const cacheReadTokens = toNumber(event.tokens?.cache_read_tokens)
   const apiKey = optionalText(event.api_key)
-  const requestTier = formatSpeedMode(event.service_tier, t)
-  const responseTier = formatSpeedMode(event.response_service_tier, t)
+  const requestTier = formatSpeedModeDetailValue(event.service_tier, t)
+  const responseTier = formatSpeedModeDetailValue(event.response_service_tier, t)
   const executorType = optionalText(event.executor_type)
   const clientIP = optionalText(event.client_ip)
   const xForwardedFor = optionalText(event.x_forwarded_for)
@@ -422,7 +428,7 @@ const buildRow = (
     clientIP,
     xForwardedFor,
     userAgent,
-    canExpand: [apiKey, requestTier, responseTier, executorType, clientIP, xForwardedFor, userAgent]
+    canExpand: [requestTier, responseTier, executorType, clientIP, xForwardedFor, userAgent]
       .some((value) => value !== '-'),
   }
 }
@@ -637,6 +643,12 @@ export function CredentialRequestEventsList({
             )}
           </td>
           <td
+            className={`${styles.stackedCell} ${styles.apiKey}`.trim()}
+            data-credential-request-api-key={row.id}
+          >
+            {renderOverflowText('strong', row.apiKey)}
+          </td>
+          <td
             className={`${styles.stackedCell} ${styles.model}`.trim()}
             data-credential-request-model={row.id}
           >
@@ -644,11 +656,11 @@ export function CredentialRequestEventsList({
             {renderOverflowText('small', row.modelAlias)}
             {renderLabeledOverflowText(t('usage_stats.reasoning_effort'), row.reasoningEffort)}
           </td>
-          <td className={`${styles.stackedCell} ${styles.request}`.trim()}>
+          <td className={styles.stackedCell}>
             {renderOverflowText('strong', row.requestType)}
             {renderOverflowText('small', row.endpoint)}
           </td>
-          <td className={styles.resultColumn}>
+          <td>
             <RequestEventResultBadge
               failed={row.failed}
               loading={logLoading}
@@ -725,15 +737,11 @@ export function CredentialRequestEventsList({
             className={styles.detailRow}
             data-credential-request-event-details={row.id}
           >
-            <td colSpan={8}>
+            <td colSpan={9}>
               <div className={styles.detailLayout}>
                 <section className={styles.detailGroup} data-credential-request-detail-group="request">
                   <h4>{t('usage_stats.credentials_detail_request_context')}</h4>
                   <div className={styles.detailGrid}>
-                    <div className={styles.detailItem} data-credential-request-detail-item>
-                      <span>{t('usage_stats.api_key_filter')}</span>
-                      {renderOverflowText('strong', row.apiKey)}
-                    </div>
                     <div className={styles.detailItem} data-credential-request-detail-item>
                       <span>{t('usage_stats.credentials_detail_request_tier')}</span>
                       {renderOverflowText('strong', row.requestTier)}
@@ -787,13 +795,14 @@ export function CredentialRequestEventsList({
           <thead>
             <tr>
               <th className={styles.timestamp}>{t('usage_stats.request_events_timestamp')}</th>
+              <th className={styles.apiKey}>{t('usage_stats.api_key_filter')}</th>
               <th className={styles.model}>{t('usage_stats.model_name')}</th>
-              <th className={styles.request}>{t('usage_stats.request_type')}</th>
-              <th className={styles.resultColumn}>{t('usage_stats.request_events_result')}</th>
-              <th className={styles.tokens}>{t('usage_stats.total_tokens')}</th>
+              <th>{t('usage_stats.request_type')}</th>
+              <th>{t('usage_stats.request_events_result')}</th>
+              <th className={styles.tokens}>{t('usage_stats.request_events_tokens')}</th>
               <th className={styles.cache}>{t('usage_stats.credentials_detail_cache_column')}</th>
               <th className={styles.performance}>{t('usage_stats.latency')}</th>
-              <th className={styles.cost}>{t('usage_stats.total_cost')}</th>
+              <th className={styles.cost}>{t('usage_stats.request_events_cost')}</th>
             </tr>
           </thead>
           {virtualizeRows ? (
@@ -801,7 +810,7 @@ export function CredentialRequestEventsList({
               {virtualPaddingTop > 0 ? (
                 <tbody aria-hidden="true">
                   <tr className={styles.virtualSpacerRow} style={{ height: `${virtualPaddingTop}px` }} aria-hidden="true" data-credential-request-events-spacer>
-                    <td colSpan={8} />
+                    <td colSpan={9} />
                   </tr>
                 </tbody>
               ) : null}
@@ -809,7 +818,7 @@ export function CredentialRequestEventsList({
               {virtualPaddingBottom > 0 ? (
                 <tbody aria-hidden="true">
                   <tr className={styles.virtualSpacerRow} style={{ height: `${virtualPaddingBottom}px` }} aria-hidden="true" data-credential-request-events-spacer>
-                    <td colSpan={8} />
+                    <td colSpan={9} />
                   </tr>
                 </tbody>
               ) : null}

--- a/web/src/components/usage/credentials/test/CredentialRequestEventsList.styles.test.ts
+++ b/web/src/components/usage/credentials/test/CredentialRequestEventsList.styles.test.ts
@@ -3,12 +3,32 @@ import { describe, expect, it } from 'vitest'
 
 const styles = readFileSync(new URL('../CredentialRequestEventsList.module.scss', import.meta.url), 'utf8')
 
+const styleRuleBlock = (selector: string): string => {
+  const start = styles.indexOf(`${selector} {`)
+  if (start < 0) return ''
+  const end = styles.indexOf('\n}', start)
+  return end < 0 ? styles.slice(start) : styles.slice(start, end + 2)
+}
+
 describe('CredentialRequestEventsList compact table styles', () => {
-  it('fits the eight-column table inside the default credential drawer before falling back to horizontal scrolling', () => {
-    expect(styles).toContain('table-layout: fixed;')
-    expect(styles).toContain('min-width: 876px;')
-    expect(styles).toContain('box-sizing: border-box;')
-    expect(styles).toContain('padding: 10px 8px;')
+  it('uses content-driven widths while bounding the API Key and Model columns', () => {
+    const tableBlock = styleRuleBlock('.table')
+    const apiKeyBlock = styleRuleBlock('.apiKey')
+    const modelBlock = styleRuleBlock('.model')
+
+    expect(tableBlock).toContain('width: 100%;')
+    expect(tableBlock).not.toContain('table-layout: fixed;')
+    expect(tableBlock).not.toContain('min-width: 876px;')
+    expect(apiKeyBlock).toContain('max-width: 240px;')
+    expect(apiKeyBlock).not.toContain('min-width:')
+    expect(modelBlock).toContain('min-width: 110px;')
+    expect(modelBlock).toContain('max-width: 240px;')
+
+    for (const selector of ['.timestamp', '.tokens', '.cache', '.performance', '.cost']) {
+      expect(styleRuleBlock(selector)).not.toMatch(/(?:^|\n)\s*width:/)
+    }
+    expect(styles).not.toContain('.request {')
+    expect(styles).not.toContain('.resultColumn {')
   })
 
   it('shows each expanded detail as one label-value row without allowing long metadata to overflow', () => {

--- a/web/src/components/usage/credentials/test/CredentialRequestEventsList.test.tsx
+++ b/web/src/components/usage/credentials/test/CredentialRequestEventsList.test.tsx
@@ -185,7 +185,9 @@ describe('CredentialRequestEventsList', () => {
     ))
 
     expect(container.querySelector('[data-credential-request-events-list="true"]')).not.toBeNull()
-    expect(container.textContent).not.toContain('Team Alpha')
+    const apiKeyCell = container.querySelector('tbody tr:first-child td:nth-child(2)')
+    expect(apiKeyCell?.textContent).toBe('Team Alpha')
+    expect(apiKeyCell?.className).toContain('apiKey')
     expect(container.textContent).toContain('gpt-5.6')
     expect(container.textContent).toContain('keeper-gpt')
     expect(container.textContent).toContain('high')
@@ -217,8 +219,8 @@ describe('CredentialRequestEventsList', () => {
       'usage_stats.speed',
     ])
     const metricCells = container.querySelectorAll<HTMLTableCellElement>('tbody tr:first-child td')
-    const tokenCell = metricCells[4]
-    const cacheCell = metricCells[5]
+    const tokenCell = metricCells[5]
+    const cacheCell = metricCells[6]
     expect(tokenCell.tabIndex).toBe(0)
     expect(cacheCell.tabIndex).toBe(0)
     expect(tokenCell.getAttribute('aria-label')).toContain('usage_stats.total_tokens: 1,300')
@@ -230,13 +232,14 @@ describe('CredentialRequestEventsList', () => {
     expect(container.querySelectorAll('[data-cache-operation="write"]')).toHaveLength(1)
     expect(Array.from(container.querySelectorAll('thead th')).map((cell) => cell.textContent)).toEqual([
       'usage_stats.request_events_timestamp',
+      'usage_stats.api_key_filter',
       'usage_stats.model_name',
       'usage_stats.request_type',
       'usage_stats.request_events_result',
-      'usage_stats.total_tokens',
+      'usage_stats.request_events_tokens',
       'usage_stats.credentials_detail_cache_column',
       'usage_stats.latency',
-      'usage_stats.total_cost',
+      'usage_stats.request_events_cost',
     ])
     expect(container.textContent).not.toContain('usage_stats.request_events_title')
     expect(container.textContent).not.toContain('usage_stats.request_events_subtitle')
@@ -271,8 +274,8 @@ describe('CredentialRequestEventsList', () => {
     ))
 
     const cells = container.querySelectorAll<HTMLTableCellElement>('tbody tr:first-child td')
-    const tokenCell = cells[4]
-    const cacheCell = cells[5]
+    const tokenCell = cells[5]
+    const cacheCell = cells[6]
     expect(tokenCell.textContent).toContain('5.68M')
     expect(tokenCell.textContent).toContain('1.23M')
     expect(tokenCell.textContent).toContain('2.35M')
@@ -325,15 +328,15 @@ describe('CredentialRequestEventsList', () => {
     expect(toggle?.getAttribute('aria-expanded')).toBe('true')
     expect(toggle?.querySelector('path')?.getAttribute('d')).toBe('m6 9 6 6 6-6')
     expect(details?.querySelectorAll('[data-credential-request-detail-group]')).toHaveLength(2)
-    expect(details?.querySelectorAll('[data-credential-request-detail-item]')).toHaveLength(7)
+    expect(details?.querySelectorAll('[data-credential-request-detail-item]')).toHaveLength(6)
     for (const item of details?.querySelectorAll('[data-credential-request-detail-item]') ?? []) {
       expect(item.children).toHaveLength(2)
     }
     expect(details?.textContent).toContain('usage_stats.credentials_detail_request_context')
     expect(details?.textContent).toContain('usage_stats.credentials_detail_client_context')
-    expect(details?.textContent).toContain('Team Alpha')
-    expect(details?.textContent).toContain('usage_stats.speed_mode_fast')
-    expect(details?.textContent).toContain('usage_stats.speed_mode_flex')
+    expect(details?.textContent).not.toContain('Team Alpha')
+    expect(details?.textContent).toContain('usage_stats.speed_mode_fast (priority)')
+    expect(details?.textContent).toContain('usage_stats.speed_mode_flex (flex)')
     expect(details?.textContent).toContain('OpenAIResponsesExecutor')
     expect(details?.textContent).toContain('192.0.2.10')
     expect(details?.textContent).toContain('198.51.100.7, 192.0.2.10')
@@ -341,6 +344,31 @@ describe('CredentialRequestEventsList', () => {
     expect(details?.textContent).not.toContain('request-1')
     expect(details?.textContent).not.toContain('keeper-gpt')
     expect(details?.textContent).not.toContain('42.5 t/s')
+  })
+
+  it('does not expand a row when API Key is the only extra value', async () => {
+    await act(async () => root.render(
+      <CredentialRequestEventsList
+        events={[{
+          ...event,
+          service_tier: '',
+          response_service_tier: '',
+          executor_type: '',
+          client_ip: '',
+          x_forwarded_for: '',
+          user_agent: '',
+        }]}
+        loading={false}
+        hasMore={false}
+        loadingMore={false}
+        autoLoadMore
+        onLoadMore={() => undefined}
+      />,
+    ))
+
+    expect(container.textContent).toContain('Team Alpha')
+    expect(container.querySelector('[data-credential-request-event-toggle="1"]')).toBeNull()
+    expect(container.querySelector('[data-credential-request-event-details="1"]')).toBeNull()
   })
 
   it('shows the shared tooltip only when compact or detail text is actually truncated', async () => {


### PR DESCRIPTION
## Summary
- show API Key directly after Timestamp in shared Auth Files and AI Provider request histories
- show mapped request and response service tiers together with their raw returned values in details
- align Tokens and Cost labels with Request Events and use content-driven column widths while preserving the two-line User Agent

## Validation
- frontend gate: 155 test files and 1274 tests passed
- ESLint
- TypeScript
- Vite production build
- git diff --check