### PR TITLE
perf: stop SQLite from crying under heavy load (composite index + synchronous NORMAL)

### DIFF
--- a/internal/entities/usage_event.go
+++ b/internal/entities/usage_event.go
@@ -6,7 +6,7 @@ import "time"
 type UsageEvent struct {
 	ID                  int64 `gorm:"primaryKey;index:idx_usage_events_timestamp_id,sort:desc,priority:2;index:idx_usage_events_auth_type_auth_index_id,priority:3;index:idx_usage_events_auth_index_timestamp_id,priority:3"`
 	EventKey            string
-	APIGroupKey         string    `gorm:"index:idx_usage_events_api_group_key"`
+	APIGroupKey         string    `gorm:"index:idx_usage_events_api_group_key;index:idx_usage_events_api_group_key_timestamp,priority:1"`
 	Provider            string    `gorm:"column:provider"`
 	Endpoint            string    `gorm:"column:endpoint"`
 	AuthType            string    `gorm:"column:auth_type;index:idx_usage_events_auth_type_auth_index_id,priority:1"`
@@ -20,7 +20,7 @@ type UsageEvent struct {
 	ServiceTier         string    `gorm:"column:service_tier;not null;default:''"`
 	ResponseServiceTier string    `gorm:"column:response_service_tier;not null;default:''"`
 	ExecutorType        string    `gorm:"column:executor_type;not null;default:''"`
-	Timestamp           time.Time `gorm:"serializer:storageTime;index:idx_usage_events_timestamp_id,sort:desc,priority:1;index:idx_usage_events_auth_index_timestamp_id,priority:2"`
+	Timestamp           time.Time `gorm:"serializer:storageTime;index:idx_usage_events_timestamp_id,sort:desc,priority:1;index:idx_usage_events_auth_index_timestamp_id,priority:2;index:idx_usage_events_api_group_key_timestamp,sort:desc,priority:2"`
 	Source              string
 	AuthIndex           string `gorm:"index:idx_usage_events_auth_index;index:idx_usage_events_auth_type_auth_index_id,priority:2;index:idx_usage_events_auth_index_timestamp_id,priority:1"`
 	Failed              bool

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -125,7 +125,12 @@ func OpenDatabase(cfg config.Config) (*gorm.DB, error) {
 	if !sqliteDatabaseRequiresSinglePool(cfg.SQLitePath) && !strings.EqualFold(strings.TrimSpace(journalMode), "wal") {
 		return nil, fmt.Errorf("enable sqlite WAL: journal mode is %q", journalMode)
 	}
-	if err := db.Exec("PRAGMA busy_timeout=5000").Error; err != nil {
+	if strings.EqualFold(strings.TrimSpace(journalMode), "wal") {
+		if err := db.Exec("PRAGMA synchronous=NORMAL").Error; err != nil {
+			return nil, fmt.Errorf("set sqlite synchronous normal: %w", err)
+		}
+	}
+	if err := db.Exec("PRAGMA busy_timeout=15000").Error; err != nil {
 		return nil, fmt.Errorf("set sqlite busy timeout: %w", err)
 	}
 	if err := db.Exec("PRAGMA foreign_keys=ON").Error; err != nil {
@@ -217,7 +222,7 @@ func sqliteDSN(path string) string {
 	if strings.Contains(trimmed, "?") {
 		return trimmed
 	}
-	return trimmed + "?_busy_timeout=5000&_foreign_keys=on"
+	return trimmed + "?_busy_timeout=15000&_foreign_keys=on"
 }
 
 // sqliteReadDSN 把文件路径规范化为 SQLite URI，并强制底层只读模式与连接级 query_only 保护。
@@ -235,7 +240,7 @@ func sqliteReadDSN(path string) (string, error) {
 	}
 	// 无自定义 query 时沿用 writer 的连接级默认值；显式参数则保持旧 DSN 的覆盖语义。
 	if !hasQuery {
-		query.Set("_busy_timeout", "5000")
+		query.Set("_busy_timeout", "15000")
 		query.Set("_foreign_keys", "on")
 	}
 	// Set 会删除同名冲突值，保证调用方不能用参数顺序关闭 reader 的两层保护。

--- a/internal/repository/migration/20260905_usage_event_api_group_key_timestamp_index.go
+++ b/internal/repository/migration/20260905_usage_event_api_group_key_timestamp_index.go
@@ -1,0 +1,19 @@
+package migration
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// addUsageEventAPIGroupKeyTimestampIndexMigration adds composite index on (api_group_key, timestamp DESC)
+// to optimize dashboard time-window filtering and key-scoped aggregations.
+func addUsageEventAPIGroupKeyTimestampIndexMigration(tx *gorm.DB) error {
+	if !tx.Migrator().HasTable("usage_events") {
+		return nil
+	}
+	if err := tx.Exec(`CREATE INDEX IF NOT EXISTS idx_usage_events_api_group_key_timestamp ON usage_events(api_group_key, timestamp DESC)`).Error; err != nil {
+		return fmt.Errorf("create idx_usage_events_api_group_key_timestamp: %w", err)
+	}
+	return nil
+}

--- a/internal/repository/migration/migration.go
+++ b/internal/repository/migration/migration.go
@@ -92,6 +92,8 @@ const (
 	migrationResetQuotaHistory = "20260827_reset_quota_history"
 	// migrationRepairUsageEventQuotaWindowIndex 修复旧 migration 记录与物理索引不一致的数据库。
 	migrationRepairUsageEventQuotaWindowIndex = "20260902_repair_usage_event_quota_window_index"
+	// migrationAddUsageEventAPIGroupKeyTimestampIndex 为 (api_group_key, timestamp DESC) 添加复合索引以加速时序聚合与范围查询。
+	migrationAddUsageEventAPIGroupKeyTimestampIndex = "20260905_usage_event_api_group_key_timestamp_index"
 )
 
 type schemaMigration struct {
@@ -235,6 +237,8 @@ func orderedMigrations() []databaseMigration {
 		{version: migrationResetQuotaHistory, run: resetQuotaHistoryMigration, destructive: true},
 		// 历史 migration 不会重跑；用新版本幂等补齐额度历史查询强制依赖的索引。
 		{version: migrationRepairUsageEventQuotaWindowIndex, run: repairUsageEventQuotaWindowIndexMigration},
+		// 为 API Group 和 Timestamp 补复合索引，加速看板过滤与排行榜聚合。
+		{version: migrationAddUsageEventAPIGroupKeyTimestampIndex, run: addUsageEventAPIGroupKeyTimestampIndexMigration},
 	}
 }
 

--- a/internal/repository/migration/migration_test.go
+++ b/internal/repository/migration/migration_test.go
@@ -87,6 +87,7 @@ func TestOrderedMigrationsPreservesExecutionOrder(t *testing.T) {
 		"20260824_add_auth_session_alias",
 		"20260827_reset_quota_history",
 		"20260902_repair_usage_event_quota_window_index",
+		"20260905_usage_event_api_group_key_timestamp_index",
 	}
 	assertStringSlicesEqual(t, want, got)
 }

--- a/internal/repository/migration/test/usage_event_api_group_key_timestamp_index_test.go
+++ b/internal/repository/migration/test/usage_event_api_group_key_timestamp_index_test.go
@@ -1,0 +1,77 @@
+package test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"cpa-usage-keeper/internal/repository/migration"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const (
+	usageEventAPIGroupKeyTimestampIndexName = "idx_usage_events_api_group_key_timestamp"
+	usageEventAPIGroupKeyTimestampMigration = "20260905_usage_event_api_group_key_timestamp_index"
+)
+
+func TestUsageEventAPIGroupKeyTimestampIndexMigration(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		seedIndex bool
+	}{
+		{name: "missing index", seedIndex: false},
+		{name: "existing index", seedIndex: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "existing.db")), &gorm.Config{})
+			if err != nil {
+				t.Fatalf("open existing database: %v", err)
+			}
+			closeMigrationTestDatabase(t, db)
+
+			if err := db.Exec(`CREATE TABLE usage_events (
+				id INTEGER PRIMARY KEY,
+				api_group_key TEXT NOT NULL,
+				timestamp DATETIME NOT NULL
+			)`).Error; err != nil {
+				t.Fatalf("create usage_events table: %v", err)
+			}
+			if test.seedIndex {
+				if err := db.Exec(`CREATE INDEX idx_usage_events_api_group_key_timestamp
+					ON usage_events(api_group_key, timestamp DESC)`).Error; err != nil {
+					t.Fatalf("seed index: %v", err)
+				}
+			}
+			if err := db.Exec(`INSERT INTO usage_events (id, api_group_key, timestamp)
+				VALUES (1, 'default-key', '2026-09-05T00:00:00Z')`).Error; err != nil {
+				t.Fatalf("seed usage event: %v", err)
+			}
+			if err := migration.MarkAllAsApplied(db); err != nil {
+				t.Fatalf("mark historical migrations applied: %v", err)
+			}
+			if err := db.Table("schema_migrations").Where("version = ?", usageEventAPIGroupKeyTimestampMigration).Delete(nil).Error; err != nil {
+				t.Fatalf("make index migration pending: %v", err)
+			}
+
+			if err := migration.Run(db); err != nil {
+				t.Fatalf("Run returned error: %v", err)
+			}
+
+			if !db.Migrator().HasIndex("usage_events", usageEventAPIGroupKeyTimestampIndexName) {
+				t.Fatalf("expected index %s to exist", usageEventAPIGroupKeyTimestampIndexName)
+			}
+			var eventIDs []int64
+			if err := db.Raw(`SELECT id
+				FROM usage_events
+				WHERE api_group_key = ? AND timestamp >= ? AND timestamp < ?
+				ORDER BY timestamp DESC`,
+				"default-key", "2026-09-01T00:00:00Z", "2026-09-06T00:00:00Z").Scan(&eventIDs).Error; err != nil {
+				t.Fatalf("query usage events through index: %v", err)
+			}
+			if len(eventIDs) != 1 || eventIDs[0] != 1 {
+				t.Fatalf("expected query to return event 1, got %v", eventIDs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What's cooking here

When you have a few hundred thousand events in SQLite and hit dashboard or ranking queries, SQLite decides it wants to do full table scans and locks up the database like it is 1999.

This PR adds two simple fixes that make everything silky smooth:

1. **Composite index on `(api_group_key, timestamp DESC)`**:
   - Queries filtering by API key within time windows now fly instead of scanning the whole universe.
   - Added migration `20260905_usage_event_api_group_key_timestamp_index` with unit test.

2. **WAL mode turbo boost (`PRAGMA synchronous=NORMAL`)**:
   - In WAL mode, `FULL` synchronous fsyncs every transaction to disk, which creates massive write contention. `NORMAL` is the official SQLite recommended standard for WAL, providing huge write throughput while staying crash-safe.
   - Bumped default `busy_timeout` to 15s to give concurrent queries more breathing room.

### Verification
- `go test -count=1 ./...` all passing clean.