### PR TITLE
fix(credentials): fit expanded request details on mobile

### DIFF
--- a/web/src/components/usage/credentials/CredentialRequestEventsList.module.scss
+++ b/web/src/components/usage/credentials/CredentialRequestEventsList.module.scss
@@ -407,22 +407,62 @@
 }
 
 @include mobile {
+  .root {
+    // 宽表格仍需横向滚动，文字保持设计字号，避免 iOS 对展开内容额外放大。
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+  }
+
+  .scroller {
+    // 首轮布局预留滚动条，避免 WebKit 在展开后仍使用未扣除滚动条的容器宽度。
+    overflow-y: scroll;
+    container-type: inline-size;
+  }
+
   .table {
     min-width: 876px;
   }
 
+  .detailRow td {
+    // 由外层滚动容器裁切，让详情能够跟随其横向滚动保持可见。
+    overflow: visible;
+  }
+
   .detailLayout {
-    grid-template-columns: 1fr;
+    position: sticky;
+    left: 0;
+    // 使用抽屉内的可见宽度，兼顾独立页面和嵌入模式。
+    width: 100cqw;
+    grid-template-columns: minmax(0, 1fr);
     gap: 12px;
+    padding: 12px 16px 14px;
   }
 
   .detailGroup {
     padding: 0;
 
+    > h4 {
+      font-size: 12px;
+    }
+
     &:first-child {
       padding-bottom: 12px;
       border-right: 0;
       border-bottom: 1px solid var(--border-color);
+    }
+  }
+
+  .detailGrid {
+    column-gap: 12px;
+  }
+
+  .detailItem {
+    > span {
+      font-size: 11px;
+    }
+
+    > strong {
+      font-size: 12px;
     }
   }
 }


### PR DESCRIPTION
## Summary

Expanded request details in Auth Files and AI Providers inherited the full table width on phones. Metadata could extend beyond the visible drawer, and mobile text autosizing could inflate the detail text.

The detail panel now fits the visible scroller and stays in view during horizontal scrolling. Mobile typography is explicit, and reserved scrollbar space keeps WebKit width calculations consistent. Desktop layout is unchanged.

## Validation

- Frontend suite: 155 files / 1,277 tests passed. The final scrollbar adjustment also passed 37 focused tests.
- ESLint, TypeScript, and production build passed; the build was repeated after the final adjustment.
- Chromium and Linux WebKit mobile emulation passed at 360/430/768px, covering narrower containers, orientation changes, long User Agent values, and virtualized rows. Desktop geometry matched the baseline.
- Physical iPhone testing has not been performed.
