### PR TITLE
perf(storage): consolidate API key time indexes

### DIFF
--- a/internal/entities/usage_event.go
+++ b/internal/entities/usage_event.go
@@ -6,7 +6,7 @@ import "time"
 type UsageEvent struct {
 	ID                  int64 `gorm:"primaryKey;index:idx_usage_events_timestamp_id,sort:desc,priority:2;index:idx_usage_events_auth_type_auth_index_id,priority:3;index:idx_usage_events_auth_index_timestamp_id,priority:3"`
 	EventKey            string
-	APIGroupKey         string    `gorm:"index:idx_usage_events_api_group_key;index:idx_usage_events_api_group_key_timestamp,priority:1"`
+	APIGroupKey         string    `gorm:"index:idx_usage_events_api_group_key_timestamp,priority:1"`
 	Provider            string    `gorm:"column:provider"`
 	Endpoint            string    `gorm:"column:endpoint"`
 	AuthType            string    `gorm:"column:auth_type;index:idx_usage_events_auth_type_auth_index_id,priority:1"`
@@ -20,7 +20,7 @@ type UsageEvent struct {
 	ServiceTier         string    `gorm:"column:service_tier;not null;default:''"`
 	ResponseServiceTier string    `gorm:"column:response_service_tier;not null;default:''"`
 	ExecutorType        string    `gorm:"column:executor_type;not null;default:''"`
-	Timestamp           time.Time `gorm:"serializer:storageTime;index:idx_usage_events_timestamp_id,sort:desc,priority:1;index:idx_usage_events_auth_index_timestamp_id,priority:2;index:idx_usage_events_api_group_key_timestamp,sort:desc,priority:2"`
+	Timestamp           time.Time `gorm:"serializer:storageTime;index:idx_usage_events_timestamp_id,sort:desc,priority:1;index:idx_usage_events_auth_index_timestamp_id,priority:2;index:idx_usage_events_api_group_key_timestamp,priority:2"`
 	Source              string
 	AuthIndex           string `gorm:"index:idx_usage_events_auth_index;index:idx_usage_events_auth_type_auth_index_id,priority:2;index:idx_usage_events_auth_index_timestamp_id,priority:1"`
 	Failed              bool

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -125,11 +125,6 @@ func OpenDatabase(cfg config.Config) (*gorm.DB, error) {
 	if !sqliteDatabaseRequiresSinglePool(cfg.SQLitePath) && !strings.EqualFold(strings.TrimSpace(journalMode), "wal") {
 		return nil, fmt.Errorf("enable sqlite WAL: journal mode is %q", journalMode)
 	}
-	if strings.EqualFold(strings.TrimSpace(journalMode), "wal") {
-		if err := db.Exec("PRAGMA synchronous=NORMAL").Error; err != nil {
-			return nil, fmt.Errorf("set sqlite synchronous normal: %w", err)
-		}
-	}
 	if err := db.Exec("PRAGMA busy_timeout=15000").Error; err != nil {
 		return nil, fmt.Errorf("set sqlite busy timeout: %w", err)
 	}

--- a/internal/repository/migration/20260506_usage_performance_indexes_test.go
+++ b/internal/repository/migration/20260506_usage_performance_indexes_test.go
@@ -18,7 +18,7 @@ func TestOpenDatabaseAddsUsagePerformanceIndexes(t *testing.T) {
 
 	for _, indexName := range []string{
 		"idx_usage_events_timestamp_id",
-		"idx_usage_events_api_group_key",
+		"idx_usage_events_api_group_key_timestamp",
 		"idx_usage_events_auth_index",
 		"idx_usage_events_model",
 		"idx_usage_events_auth_index_timestamp_id",
@@ -36,6 +36,7 @@ func TestOpenDatabaseAddsUsagePerformanceIndexes(t *testing.T) {
 	}
 
 	for _, indexName := range []string{
+		"idx_usage_events_api_group_key",
 		"idx_usage_events_timestamp",
 		"idx_usage_events_trim_model",
 		"idx_usage_events_trim_source",
@@ -120,7 +121,7 @@ func TestUsagePerformanceIndexesSupportRepresentativeQueryPlans(t *testing.T) {
 		EXPLAIN QUERY PLAN SELECT id FROM usage_events
 		WHERE auth_index = ?`, "authidx-main")
 
-	assertQueryPlanUsesIndex(t, db, "idx_usage_events_api_group_key", `
+	assertQueryPlanUsesIndex(t, db, "idx_usage_events_api_group_key_timestamp", `
 		EXPLAIN QUERY PLAN SELECT api_group_key, COUNT(*) FROM usage_events
 		GROUP BY api_group_key`)
 

--- a/internal/repository/migration/20260905_usage_event_api_group_key_timestamp_index.go
+++ b/internal/repository/migration/20260905_usage_event_api_group_key_timestamp_index.go
@@ -3,17 +3,33 @@ package migration
 import (
 	"fmt"
 
+	"cpa-usage-keeper/internal/entities"
+
 	"gorm.io/gorm"
 )
 
-// addUsageEventAPIGroupKeyTimestampIndexMigration adds composite index on (api_group_key, timestamp DESC)
-// to optimize dashboard time-window filtering and key-scoped aggregations.
+// addUsageEventAPIGroupKeyTimestampIndexMigration 用 Key+时间升序复合索引替代单列 Key 索引。
 func addUsageEventAPIGroupKeyTimestampIndexMigration(tx *gorm.DB) error {
-	if !tx.Migrator().HasTable("usage_events") {
+	migrator := tx.Migrator()
+	if !migrator.HasTable(&entities.UsageEvent{}) {
 		return nil
 	}
-	if err := tx.Exec(`CREATE INDEX IF NOT EXISTS idx_usage_events_api_group_key_timestamp ON usage_events(api_group_key, timestamp DESC)`).Error; err != nil {
+	const indexName = "idx_usage_events_api_group_key_timestamp"
+	// 同名旧索引可能是 timestamp DESC；重建为实体声明，反向扫描即可满足 timestamp DESC, id DESC。
+	if migrator.HasIndex(&entities.UsageEvent{}, indexName) {
+		if err := migrator.DropIndex(&entities.UsageEvent{}, indexName); err != nil {
+			return fmt.Errorf("drop previous idx_usage_events_api_group_key_timestamp: %w", err)
+		}
+	}
+	if err := migrator.CreateIndex(&entities.UsageEvent{}, indexName); err != nil {
 		return fmt.Errorf("create idx_usage_events_api_group_key_timestamp: %w", err)
+	}
+	// 复合索引的最左列继续支持 Key 查询，移除单列索引以减少每次写入的维护成本。
+	const singleKeyIndexName = "idx_usage_events_api_group_key"
+	if migrator.HasIndex(&entities.UsageEvent{}, singleKeyIndexName) {
+		if err := migrator.DropIndex(&entities.UsageEvent{}, singleKeyIndexName); err != nil {
+			return fmt.Errorf("drop redundant idx_usage_events_api_group_key: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/repository/migration/migration.go
+++ b/internal/repository/migration/migration.go
@@ -92,7 +92,7 @@ const (
 	migrationResetQuotaHistory = "20260827_reset_quota_history"
 	// migrationRepairUsageEventQuotaWindowIndex 修复旧 migration 记录与物理索引不一致的数据库。
 	migrationRepairUsageEventQuotaWindowIndex = "20260902_repair_usage_event_quota_window_index"
-	// migrationAddUsageEventAPIGroupKeyTimestampIndex 为 (api_group_key, timestamp DESC) 添加复合索引以加速时序聚合与范围查询。
+	// migrationAddUsageEventAPIGroupKeyTimestampIndex 用 (api_group_key, timestamp) 复合索引替代单列 Key 索引。
 	migrationAddUsageEventAPIGroupKeyTimestampIndex = "20260905_usage_event_api_group_key_timestamp_index"
 )
 
@@ -237,7 +237,7 @@ func orderedMigrations() []databaseMigration {
 		{version: migrationResetQuotaHistory, run: resetQuotaHistoryMigration, destructive: true},
 		// 历史 migration 不会重跑；用新版本幂等补齐额度历史查询强制依赖的索引。
 		{version: migrationRepairUsageEventQuotaWindowIndex, run: repairUsageEventQuotaWindowIndexMigration},
-		// 为 API Group 和 Timestamp 补复合索引，加速看板过滤与排行榜聚合。
+		// 将单列 Key 索引收敛为 Key+时间复合索引，支持请求记录和历史边界查询。
 		{version: migrationAddUsageEventAPIGroupKeyTimestampIndex, run: addUsageEventAPIGroupKeyTimestampIndexMigration},
 	}
 }

--- a/internal/repository/migration/test/usage_event_api_group_key_timestamp_index_test.go
+++ b/internal/repository/migration/test/usage_event_api_group_key_timestamp_index_test.go
@@ -2,9 +2,16 @@ package test
 
 import (
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
+	"time"
 
+	"cpa-usage-keeper/internal/config"
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
 	"cpa-usage-keeper/internal/repository/migration"
+	"cpa-usage-keeper/internal/timeutil"
 
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -18,60 +25,207 @@ const (
 func TestUsageEventAPIGroupKeyTimestampIndexMigration(t *testing.T) {
 	for _, test := range []struct {
 		name      string
-		seedIndex bool
+		fresh     bool
+		seedIndex string
 	}{
-		{name: "missing index", seedIndex: false},
-		{name: "existing index", seedIndex: true},
+		{name: "fresh database", fresh: true},
+		{name: "single key index"},
+		{name: "existing descending index", seedIndex: "timestamp DESC"},
+		{name: "existing ascending index", seedIndex: "timestamp"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "existing.db")), &gorm.Config{})
+			dbPath := filepath.Join(t.TempDir(), "app.db")
+			var db *gorm.DB
+			var err error
+			if test.fresh {
+				db, err = repository.OpenDatabase(config.Config{SQLitePath: dbPath})
+			} else {
+				db, err = gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+			}
 			if err != nil {
-				t.Fatalf("open existing database: %v", err)
+				t.Fatalf("open database: %v", err)
 			}
 			closeMigrationTestDatabase(t, db)
 
-			if err := db.Exec(`CREATE TABLE usage_events (
-				id INTEGER PRIMARY KEY,
-				api_group_key TEXT NOT NULL,
-				timestamp DATETIME NOT NULL
-			)`).Error; err != nil {
-				t.Fatalf("create usage_events table: %v", err)
+			if !test.fresh {
+				// 旧库只保留本次迁移需要的列，历史版本标记为完成，避免其它迁移影响测试。
+				if err := db.Exec(`CREATE TABLE usage_events (
+					id INTEGER PRIMARY KEY,
+					api_group_key TEXT NOT NULL,
+					timestamp DATETIME NOT NULL,
+					total_tokens INTEGER NOT NULL
+				)`).Error; err != nil {
+					t.Fatalf("create usage_events table: %v", err)
+				}
+				if err := db.Exec(`CREATE INDEX idx_usage_events_api_group_key ON usage_events(api_group_key)`).Error; err != nil {
+					t.Fatalf("seed single key index: %v", err)
+				}
+				if test.seedIndex != "" {
+					if err := db.Exec(`CREATE INDEX idx_usage_events_api_group_key_timestamp ON usage_events(api_group_key, ` + test.seedIndex + `)`).Error; err != nil {
+						t.Fatalf("seed compound index: %v", err)
+					}
+				}
+				if err := migration.MarkAllAsApplied(db); err != nil {
+					t.Fatalf("mark historical migrations applied: %v", err)
+				}
+				makeAPIGroupKeyTimestampMigrationPending(t, db)
 			}
-			if test.seedIndex {
-				if err := db.Exec(`CREATE INDEX idx_usage_events_api_group_key_timestamp
-					ON usage_events(api_group_key, timestamp DESC)`).Error; err != nil {
-					t.Fatalf("seed index: %v", err)
+
+			start := time.Date(2026, 9, 5, 12, 0, 0, 0, time.Local)
+			end := start.Add(time.Minute)
+			for _, event := range []struct {
+				id     int
+				key    string
+				offset time.Duration
+				tokens int
+			}{
+				{1, "target", -time.Second, 100},
+				{2, "other", 30 * time.Second, 200},
+				{3, "target", 0, 30},
+				{4, "target", 30 * time.Second, 40},
+				{5, "target", 30 * time.Second, 50},
+				{6, "target", time.Minute, 60},
+			} {
+				if err := db.Exec(`INSERT INTO usage_events (id, api_group_key, timestamp, total_tokens) VALUES (?, ?, ?, ?)`,
+					event.id, event.key, timeutil.FormatStorageTime(start.Add(event.offset)), event.tokens).Error; err != nil {
+					t.Fatalf("seed usage event: %v", err)
 				}
 			}
-			if err := db.Exec(`INSERT INTO usage_events (id, api_group_key, timestamp)
-				VALUES (1, 'default-key', '2026-09-05T00:00:00Z')`).Error; err != nil {
-				t.Fatalf("seed usage event: %v", err)
-			}
-			if err := migration.MarkAllAsApplied(db); err != nil {
-				t.Fatalf("mark historical migrations applied: %v", err)
-			}
-			if err := db.Table("schema_migrations").Where("version = ?", usageEventAPIGroupKeyTimestampMigration).Delete(nil).Error; err != nil {
-				t.Fatalf("make index migration pending: %v", err)
-			}
 
-			if err := migration.Run(db); err != nil {
-				t.Fatalf("Run returned error: %v", err)
-			}
-
-			if !db.Migrator().HasIndex("usage_events", usageEventAPIGroupKeyTimestampIndexName) {
-				t.Fatalf("expected index %s to exist", usageEventAPIGroupKeyTimestampIndexName)
-			}
-			var eventIDs []int64
-			if err := db.Raw(`SELECT id
-				FROM usage_events
-				WHERE api_group_key = ? AND timestamp >= ? AND timestamp < ?
-				ORDER BY timestamp DESC`,
-				"default-key", "2026-09-01T00:00:00Z", "2026-09-06T00:00:00Z").Scan(&eventIDs).Error; err != nil {
-				t.Fatalf("query usage events through index: %v", err)
-			}
-			if len(eventIDs) != 1 || eventIDs[0] != 1 {
-				t.Fatalf("expected query to return event 1, got %v", eventIDs)
+			// 第二轮显式重跑原版本，验证已有最终索引时仍安全且不会重复记录版本。
+			for pass := 0; pass < 2; pass++ {
+				if pass > 0 {
+					makeAPIGroupKeyTimestampMigrationPending(t, db)
+				}
+				if err := migration.Run(db); err != nil {
+					t.Fatalf("Run returned error: %v", err)
+				}
+				assertAPIGroupKeyTimestampIndex(t, db)
+				assertAPIGroupKeyTimestampQueries(t, db, start, end)
+				var count int64
+				if err := db.Table("schema_migrations").Where("version = ?", usageEventAPIGroupKeyTimestampMigration).Count(&count).Error; err != nil || count != 1 {
+					t.Fatalf("expected one migration record, got %d, error %v", count, err)
+				}
+				if err := db.Table("usage_events").Count(&count).Error; err != nil || count != 6 {
+					t.Fatalf("expected all six usage events preserved, got %d, error %v", count, err)
+				}
 			}
 		})
+	}
+}
+
+func makeAPIGroupKeyTimestampMigrationPending(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	if err := db.Table("schema_migrations").Where("version = ?", usageEventAPIGroupKeyTimestampMigration).Delete(nil).Error; err != nil {
+		t.Fatalf("make index migration pending: %v", err)
+	}
+}
+
+func TestUsageEventAPIGroupKeyTimestampIndexMigrationRollsBackOnFailure(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "invalid-schema.db")), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	closeMigrationTestDatabase(t, db)
+	// 缺少 timestamp 让重建失败，验证原索引删除和迁移版本记录都在同一事务中回滚。
+	for _, statement := range []string{
+		`CREATE TABLE usage_events (id INTEGER PRIMARY KEY, api_group_key TEXT NOT NULL)`,
+		`CREATE INDEX idx_usage_events_api_group_key ON usage_events(api_group_key)`,
+		`CREATE INDEX idx_usage_events_api_group_key_timestamp ON usage_events(api_group_key, id)`,
+		`INSERT INTO usage_events (id, api_group_key) VALUES (1, 'target')`,
+	} {
+		if err := db.Exec(statement).Error; err != nil {
+			t.Fatalf("seed invalid schema: %v", err)
+		}
+	}
+	if err := migration.MarkAllAsApplied(db); err != nil {
+		t.Fatalf("mark historical migrations applied: %v", err)
+	}
+	makeAPIGroupKeyTimestampMigrationPending(t, db)
+	if err := migration.Run(db); err == nil {
+		t.Fatal("expected missing timestamp column to fail migration")
+	}
+	var columns []string
+	if err := db.Raw(`SELECT name FROM pragma_index_info(?) ORDER BY seqno`, usageEventAPIGroupKeyTimestampIndexName).Scan(&columns).Error; err != nil || !reflect.DeepEqual(columns, []string{"api_group_key", "id"}) {
+		t.Fatalf("expected original compound index to survive rollback, got %v, error %v", columns, err)
+	}
+	if !db.Migrator().HasIndex(&entities.UsageEvent{}, "idx_usage_events_api_group_key") {
+		t.Fatal("expected original single key index to survive rollback")
+	}
+	var count int64
+	if err := db.Table("schema_migrations").Where("version = ?", usageEventAPIGroupKeyTimestampMigration).Count(&count).Error; err != nil || count != 0 {
+		t.Fatalf("expected failed migration not to be recorded, got %d, error %v", count, err)
+	}
+	if err := db.Table("usage_events").Count(&count).Error; err != nil || count != 1 {
+		t.Fatalf("expected usage event to survive rollback, got %d, error %v", count, err)
+	}
+}
+
+func assertAPIGroupKeyTimestampIndex(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	if db.Migrator().HasIndex(&entities.UsageEvent{}, "idx_usage_events_api_group_key") {
+		t.Fatal("expected redundant single key index to be removed")
+	}
+	var columns []struct {
+		Name string
+		Desc int
+	}
+	if err := db.Raw(`SELECT name, "desc" FROM pragma_index_xinfo(?) WHERE key = 1 ORDER BY seqno`, usageEventAPIGroupKeyTimestampIndexName).Scan(&columns).Error; err != nil {
+		t.Fatalf("read compound index columns: %v", err)
+	}
+	if len(columns) != 2 || columns[0].Name != "api_group_key" || columns[1].Name != "timestamp" || columns[0].Desc != 0 || columns[1].Desc != 0 {
+		t.Fatalf("expected ascending (api_group_key, timestamp) index, got %+v", columns)
+	}
+}
+
+func assertAPIGroupKeyTimestampQueries(t *testing.T, db *gorm.DB, start, end time.Time) {
+	t.Helper()
+	args := []any{"target", timeutil.FormatStorageTime(start), timeutil.FormatStorageTime(end)}
+	predicate := `api_group_key = ? AND timestamp >= ? AND timestamp < ?`
+	listSQL := `SELECT id FROM usage_events WHERE ` + predicate + ` ORDER BY timestamp DESC, id DESC LIMIT 2`
+	var ids []int64
+	if err := db.Raw(listSQL, args...).Scan(&ids).Error; err != nil || !reflect.DeepEqual(ids, []int64{5, 4}) {
+		t.Fatalf("expected descending timestamp/id page [5 4], got %v, error %v", ids, err)
+	}
+	var count int64
+	countSQL := `SELECT COUNT(*) FROM usage_events WHERE ` + predicate
+	if err := db.Raw(countSQL, args...).Scan(&count).Error; err != nil || count != 3 {
+		t.Fatalf("expected three in-window target events, got %d, error %v", count, err)
+	}
+	boundarySQL := `SELECT total_tokens FROM usage_events WHERE ` + predicate + ` ORDER BY timestamp ASC`
+	var tokens []int64
+	if err := db.Raw(boundarySQL, args...).Scan(&tokens).Error; err != nil {
+		t.Fatalf("query boundary tokens: %v", err)
+	}
+	var total int64
+	for _, tokenCount := range tokens {
+		total += tokenCount
+	}
+	if len(tokens) != 3 || total != 120 {
+		t.Fatalf("expected only in-window target boundary tokens, got %v", tokens)
+	}
+	for _, query := range []struct {
+		sql  string
+		args []any
+	}{
+		{listSQL, args},
+		{countSQL, args},
+		{boundarySQL, args},
+		{`SELECT COUNT(*) FROM usage_events WHERE api_group_key = ?`, []any{"target"}},
+	} {
+		var plan []struct{ Detail string }
+		if err := db.Raw("EXPLAIN QUERY PLAN "+query.sql, query.args...).Scan(&plan).Error; err != nil {
+			t.Fatalf("explain query plan: %v", err)
+		}
+		usesIndex := false
+		for _, step := range plan {
+			usesIndex = usesIndex || strings.Contains(step.Detail, usageEventAPIGroupKeyTimestampIndexName)
+			if strings.Contains(step.Detail, "TEMP B-TREE") {
+				t.Fatalf("expected index ordering without temporary sorting: %+v", plan)
+			}
+		}
+		if !usesIndex {
+			t.Fatalf("expected compound index for %s, got %+v", query.sql, plan)
+		}
 	}
 }

--- a/internal/repository/test/db_test.go
+++ b/internal/repository/test/db_test.go
@@ -121,7 +121,7 @@ func TestOpenDatabaseCreatesFreshDatabaseFromCurrentSchemaWithoutRunningMigratio
 		}
 	}
 	for _, indexName := range []string{
-		"idx_usage_events_api_group_key",
+		"idx_usage_events_api_group_key_timestamp",
 		"idx_usage_events_auth_index",
 		"idx_usage_events_model",
 		"idx_usage_events_auth_type_auth_index_id",
@@ -143,6 +143,7 @@ func TestOpenDatabaseCreatesFreshDatabaseFromCurrentSchemaWithoutRunningMigratio
 		assertSQLiteIndexExists(t, db, indexName)
 	}
 	for _, indexName := range []string{
+		"idx_usage_events_api_group_key",
 		"idx_usage_events_api_group_key_timestamp_id",
 		"idx_usage_events_event_key",
 		"idx_usage_events_failed",
@@ -183,8 +184,16 @@ func TestOpenDatabaseConfiguresSQLiteRuntime(t *testing.T) {
 	if err := db.Raw("PRAGMA busy_timeout").Scan(&busyTimeout).Error; err != nil {
 		t.Fatalf("read busy timeout: %v", err)
 	}
-	if busyTimeout < 5000 {
-		t.Fatalf("expected busy timeout at least 5000ms, got %d", busyTimeout)
+	if busyTimeout != 15000 {
+		t.Fatalf("expected busy timeout 15000ms, got %d", busyTimeout)
+	}
+
+	var synchronous int
+	if err := db.Raw("PRAGMA synchronous").Scan(&synchronous).Error; err != nil {
+		t.Fatalf("read synchronous mode: %v", err)
+	}
+	if synchronous != 1 {
+		t.Fatalf("expected NORMAL synchronous mode, got %d", synchronous)
 	}
 
 	var foreignKeys int


### PR DESCRIPTION
## Summary

The API key time index added in #509 duplicates the single-key index and requires extra sorting for `timestamp DESC, id DESC` pages. Replace both with one ascending `(api_group_key, timestamp)` index, retaining the global timestamp and credential indexes.

Update the unreleased migration and fresh-schema definition together. The migration version stays unchanged, so databases that already recorded it will not rerun it. Remove the redundant synchronous assignment while retaining the driver's NORMAL default and the 15-second busy timeout.

Follow-up to #509.

## Validation

- Backend test packages under `./cmd/...` and `./internal/...` passed. Six packages initially blocked by local listener restrictions passed when rerun with loopback access.
- Migration tests passed under `TZ=UTC` and `TZ=Asia/Shanghai`, covering fresh and existing schemas, repeat execution, rollback, data preservation, index column order, and query plans without temporary sorting.
- Three synthetic runs per index layout used 300,000 historical events across 50 API keys and 50,000 appended events. Compared with #509, median append time fell from 10.675s to 9.682s (9.3%), database size from 210.63 to 169.36 MiB (19.6%), and key-scoped page time from 0.744ms to 0.655ms. These are local workload results, not production capacity guarantees.
- `git diff --check` passed.
