### PR TITLE
fix(ui): preserve Safari page menu clicks

### DIFF
--- a/web/src/components/dashboard/DashboardToolbar.tsx
+++ b/web/src/components/dashboard/DashboardToolbar.tsx
@@ -169,7 +169,10 @@ export function DashboardToolbar<T extends string>({ items, activeId, onNavigate
   useEffect(() => {
     if (!menuOpen) return;
     menuRef.current?.querySelector<HTMLElement>('[aria-current="page"]')?.focus();
-    const onPointer = (event: PointerEvent) => { if (!hostRef.current?.contains(event.target as Node)) setMenuOpen(false); };
+    const onPointer = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (!menuRef.current?.contains(target) && !triggerRef.current?.contains(target)) setMenuOpen(false);
+    };
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') { event.preventDefault(); setMenuOpen(false); triggerRef.current?.focus(); }
     };
@@ -230,7 +233,10 @@ export function DashboardToolbar<T extends string>({ items, activeId, onNavigate
           const index = choices.indexOf(document.activeElement as HTMLAnchorElement);
           const next = event.key === 'ArrowDown' ? (index + 1) % choices.length : event.key === 'ArrowUp' ? (index + choices.length - 1) % choices.length : event.key === 'Home' ? 0 : event.key === 'End' ? choices.length - 1 : -1;
           if (next >= 0) { event.preventDefault(); choices[next]?.focus(); }
-        }} onBlur={(event) => { if (!event.currentTarget.contains(event.relatedTarget) && !triggerRef.current?.contains(event.relatedTarget)) setMenuOpen(false); }}>
+        }} onBlur={(event) => {
+          // Safari 触摸可能在 click 前失焦且 relatedTarget 为空；外部点击由 pointerdown 判断。
+          if (event.relatedTarget && !event.currentTarget.contains(event.relatedTarget) && !triggerRef.current?.contains(event.relatedTarget)) setMenuOpen(false);
+        }}>
           <MenuScrollArea>
           {items.map((item) => <a key={item.id} role="menuitem" href={item.href} aria-current={item.id === activeId ? 'page' : undefined} onClick={(event) => navigate(event, item.id)} onKeyDown={(event) => {
             if (event.key === ' ') { event.preventDefault(); activatePage(item.id); }

--- a/web/src/components/dashboard/test/DashboardToolbar.test.tsx
+++ b/web/src/components/dashboard/test/DashboardToolbar.test.tsx
@@ -86,6 +86,71 @@ describe('DashboardToolbar', () => {
     expect(document.activeElement).toBe(trigger());
   });
 
+  it.each([false, true])('commits a touch selection after a blur with no focus target, remounting toolbar: %s', async (remount) => {
+    function Pages() {
+      const [page, setPage] = useState('overview');
+      return <DashboardToolbar key={remount ? page : 'shared'} items={items} activeId={page} onNavigate={(id) => { navigate(id); setPage(id); }} onRefresh={refresh} />;
+    }
+    await act(async () => root.render(<Pages />));
+    const trigger = () => container.querySelector<HTMLButtonElement>('[data-dashboard-page-trigger]')!;
+    await act(async () => trigger().click());
+    const next = container.querySelector<HTMLAnchorElement>('[data-dashboard-page-menu] a[href="/cpa/analysis"]')!;
+    await act(async () => next.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerType: 'touch' })));
+    // Safari 的触摸点击可能先失焦，且不会把 relatedTarget 指向被点击的链接。
+    await act(async () => (document.activeElement as HTMLElement).blur());
+    expect(next.isConnected).toBe(true);
+    await act(async () => next.click());
+    expect(navigate).toHaveBeenCalledExactlyOnceWith('analysis');
+    expect(trigger().getAttribute('aria-label')).toContain('Analysis');
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+    expect(document.activeElement).toBe(trigger());
+  });
+
+  it.each([
+    { part: 'name', pointerType: 'touch' },
+    { part: 'arrow', pointerType: 'touch' },
+    { part: 'name', pointerType: 'mouse' },
+    { part: 'arrow', pointerType: 'mouse' },
+  ])('toggles from the $part with $pointerType when blur has no focus target', async ({ part, pointerType }) => {
+    await render();
+    const trigger = container.querySelector<HTMLButtonElement>('[data-dashboard-page-trigger]')!;
+    const target = trigger.querySelector(part === 'name' ? '[data-dashboard-page-label]' : 'svg')!;
+    await act(async () => target.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    await act(async () => target.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerType })));
+    await act(async () => (document.activeElement as HTMLElement).blur());
+    await act(async () => target.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(container.querySelector('[data-dashboard-page-menu]')).toBeNull();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it.each(['toolbar', 'page'])('closes before an outside touch moves focus: %s', async (target) => {
+    await render();
+    const trigger = container.querySelector<HTMLButtonElement>('[data-dashboard-page-trigger]')!;
+    await act(async () => trigger.click());
+    const outside = target === 'toolbar' ? container.querySelector<HTMLButtonElement>('[data-dashboard-refresh]')! : document.body;
+    await act(async () => outside.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerType: 'touch' })));
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    if (target === 'toolbar') {
+      await act(async () => outside.click());
+      expect(refresh).toHaveBeenCalledOnce();
+    }
+  });
+
+  it('keeps keyboard focus inside the menu and closes when focus moves to a filter', async () => {
+    await render();
+    const trigger = container.querySelector<HTMLButtonElement>('[data-dashboard-page-trigger]')!;
+    await act(async () => trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })));
+    const current = container.querySelector<HTMLAnchorElement>('[data-dashboard-page-menu] a[aria-current="page"]')!;
+    expect(document.activeElement).toBe(current);
+    await act(async () => current.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })));
+    expect(document.activeElement?.getAttribute('href')).toBe('/cpa/analysis');
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    await act(async () => container.querySelector<HTMLButtonElement>('[data-dashboard-filters] button')!.focus());
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
   it('keeps the current scroll position when reselecting the current page or refreshing', async () => {
     const scroll = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
     await render();


### PR DESCRIPTION
## Summary

Safari taps could blur the page menu before the selected link received its click, preventing navigation or closing and immediately reopening the chooser. Keep the menu mounted when blur has no focus destination, and dismiss pointer interactions outside the menu and its full trigger button.

Both the page name and chevron continue to toggle the same menu on desktop and mobile. Keyboard navigation, outside clicks, and focus restoration across page changes remain supported.

## Validation

- Frontend tests passed: 167 files, 1,382 tests; lint, typecheck, and production build passed.
- Ten Chromium/WebKit desktop and mobile component scenarios passed, including controlled null-focus blur events, name/chevron toggling, page selection, remounts, and keyboard dismissal.
- The reported Safari interaction was confirmed working in the backend-served preview.
