### PR TITLE
fix(ui): improve mobile dropdown positioning and search

### DIFF
--- a/web/src/components/ui/Select.module.scss
+++ b/web/src/components/ui/Select.module.scss
@@ -69,7 +69,7 @@
 
 .dropdown {
   @include menu.surface;
-  position: fixed;
+  position: absolute;
   max-height: 240px;
   overflow: hidden;
 }
@@ -88,6 +88,32 @@
   &::placeholder {
     color: var(--text-tertiary);
   }
+
+  // iOS 聚焦小于 16px 的输入框会自动放大页面。
+  @media (pointer: coarse) {
+    font-size: 16px;
+  }
+}
+
+.touchSearchField {
+  position: relative;
+  flex-shrink: 0;
+  height: 44px;
+  margin-bottom: 6px;
+}
+
+.touchSearchInput {
+  // 保留 16px 的输入字号避免 iOS 自动缩放，视觉上与 13px 的触发器一致。
+  --search-scale: 0.8125;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: calc(100% / var(--search-scale));
+  height: calc(44px / var(--search-scale));
+  padding: 0 calc(12px / var(--search-scale));
+  border-radius: 999px;
+  transform: scale(var(--search-scale));
+  transform-origin: top left;
 }
 
 .searchIcon {

--- a/web/src/components/ui/Select.tsx
+++ b/web/src/components/ui/Select.tsx
@@ -10,6 +10,7 @@ import React, {
 } from 'react';
 import { createPortal } from 'react-dom';
 import { useAnchorPosition } from '@/hooks/useAnchorPosition';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { IconChevronDown } from './icons';
 import { MenuScrollArea } from './MenuScrollArea';
 import styles from './Select.module.scss';
@@ -67,20 +68,24 @@ const findNextEnabledOptionIndex = (
   return -1;
 };
 
-const resolveDropdownStyle = (rect: DOMRect, dropdownMinWidth?: number): CSSProperties => {
-  const viewportWidth = window.innerWidth;
-  const viewportHeight = window.innerHeight;
+const resolveDropdownStyle = (rect: DOMRect, dropdownMinWidth?: number, touch = false): CSSProperties => {
+  const viewport = window.visualViewport;
+  const viewportWidth = viewport?.width ?? window.innerWidth;
+  const viewportHeight = viewport?.height ?? window.innerHeight;
+  const viewportLeft = viewport?.offsetLeft ?? 0;
+  const viewportTop = viewport?.offsetTop ?? 0;
   const availableWidth = Math.max(0, viewportWidth - VIEWPORT_MARGIN * 2);
   const width = Math.min(Math.max(rect.width, dropdownMinWidth ?? 0), availableWidth);
   const left = clamp(
     rect.left,
-    VIEWPORT_MARGIN,
-    Math.max(VIEWPORT_MARGIN, viewportWidth - width - VIEWPORT_MARGIN)
+    viewportLeft + VIEWPORT_MARGIN,
+    Math.max(viewportLeft + VIEWPORT_MARGIN, viewportLeft + viewportWidth - width - VIEWPORT_MARGIN)
   );
-  const spaceBelow = viewportHeight - rect.bottom - VIEWPORT_MARGIN - DROPDOWN_OFFSET;
-  const spaceAbove = rect.top - VIEWPORT_MARGIN - DROPDOWN_OFFSET;
+  const spaceBelow = viewportTop + viewportHeight - rect.bottom - VIEWPORT_MARGIN - DROPDOWN_OFFSET;
+  const spaceAbove = rect.top - viewportTop - VIEWPORT_MARGIN - DROPDOWN_OFFSET;
+  // 触屏优先在控件下方保留可滚动的选项区，空间不足时才向上展开。
   const direction =
-    spaceBelow >= DROPDOWN_MAX_HEIGHT || spaceBelow >= spaceAbove ? 'down' : 'up';
+    spaceBelow >= (touch ? 160 : DROPDOWN_MAX_HEIGHT) || spaceBelow >= spaceAbove ? 'down' : 'up';
   const maxHeight = Math.max(
     0,
     Math.min(DROPDOWN_MAX_HEIGHT, direction === 'down' ? spaceBelow : spaceAbove)
@@ -88,17 +93,19 @@ const resolveDropdownStyle = (rect: DOMRect, dropdownMinWidth?: number): CSSProp
 
   return direction === 'down'
     ? {
-        position: 'fixed',
-        top: rect.bottom + DROPDOWN_OFFSET,
-        left,
+        // 使用文档坐标，避开 Safari 可视视口平移时 fixed 元素额外偏移。
+        position: 'absolute',
+        top: window.scrollY + rect.bottom + DROPDOWN_OFFSET,
+        left: window.scrollX + left,
         width,
         maxHeight,
         zIndex: DROPDOWN_Z_INDEX
       }
     : {
-        position: 'fixed',
-        bottom: viewportHeight - rect.top + DROPDOWN_OFFSET,
-        left,
+        position: 'absolute',
+        top: window.scrollY + rect.top - DROPDOWN_OFFSET,
+        transform: 'translateY(-100%)',
+        left: window.scrollX + left,
         width,
         maxHeight,
         zIndex: DROPDOWN_Z_INDEX
@@ -137,6 +144,8 @@ export function Select({
   const [dropdownStyle, setDropdownStyle] = useState<CSSProperties | null>(null);
   const isOpen = open && !disabled;
   const searchable = Boolean(search);
+  const touch = useMediaQuery('(pointer: coarse)');
+  const touchSearch = searchable && touch;
   // 搜索只缩小候选项，提交选择后才更新调用方的筛选值。
   const visibleOptions = useMemo(() => {
     const query = searchable ? searchQuery.trim().toLowerCase() : '';
@@ -156,13 +165,13 @@ export function Select({
       if (wrapRef.current?.contains(target) || dropdownRef.current?.contains(target)) return;
       setOpen(false);
     };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    document.addEventListener('pointerdown', handleClickOutside);
+    return () => document.removeEventListener('pointerdown', handleClickOutside);
   }, [disabled, open]);
 
   const updateDropdownStyle = useCallback((rect: DOMRect) => {
-    setDropdownStyle(resolveDropdownStyle(rect, dropdownMinWidth));
-  }, [dropdownMinWidth]);
+    setDropdownStyle(resolveDropdownStyle(rect, dropdownMinWidth, touch));
+  }, [dropdownMinWidth, touch]);
   useAnchorPosition(isOpen, wrapRef, updateDropdownStyle);
 
   const selectedIndex = useMemo(() => options.findIndex((option) => option.value === value), [options, value]);
@@ -182,14 +191,14 @@ export function Select({
     (nextIndex: number) => {
       const nextOption = visibleOptions[nextIndex];
       if (!nextOption || nextOption.disabled) return;
-      // 先保留输入焦点再关闭，避免 onFocus 在选中后重新展开列表。
-      if (searchable) searchInputRef.current?.focus();
-      else triggerRef.current?.focus();
+      // 触屏返回按钮以收起键盘；桌面保留输入焦点，且不滚动页面。
+      if (searchable && !touchSearch) searchInputRef.current?.focus({ preventScroll: true });
+      else triggerRef.current?.focus({ preventScroll: true });
       onChange(nextOption.value);
       setOpen(false);
       setHighlightedIndex(nextIndex);
     },
-    [onChange, searchable, visibleOptions]
+    [onChange, searchable, touchSearch, visibleOptions]
   );
 
   const moveHighlight = useCallback(
@@ -258,25 +267,42 @@ export function Select({
           event.preventDefault();
           // 嵌套在设置弹窗时，Esc 先关闭列表，下一次才交给父弹窗。
           event.stopPropagation();
-          if (searchable) searchInputRef.current?.focus();
-          else triggerRef.current?.focus();
+          if (searchable && !touchSearch) searchInputRef.current?.focus({ preventScroll: true });
+          else triggerRef.current?.focus({ preventScroll: true });
           setOpen(false);
           return;
         case 'Tab':
+          if (touchSearch && isOpen) {
+            if (event.currentTarget === triggerRef.current && !event.shiftKey) {
+              event.preventDefault();
+              searchInputRef.current?.focus({ preventScroll: true });
+              return;
+            }
+            if (editingSearch) {
+              triggerRef.current?.focus({ preventScroll: true });
+              if (event.shiftKey) event.preventDefault();
+            }
+          }
           if (isOpen) setOpen(false);
           return;
         default:
           return;
       }
     },
-    [commitSelection, disabled, isOpen, moveHighlight, openDropdown, searchable, visibleOptions.length, resolvedHighlightedIndex]
+    [commitSelection, disabled, isOpen, moveHighlight, openDropdown, searchable, touchSearch, visibleOptions.length, resolvedHighlightedIndex]
   );
 
   useEffect(() => {
     if (!isOpen || resolvedHighlightedIndex < 0 || !shouldScrollHighlightRef.current) return;
     const highlightedOption = document.getElementById(`${selectId}-option-${resolvedHighlightedIndex}`);
-    highlightedOption?.scrollIntoView({ block: 'nearest' });
-  }, [isOpen, resolvedHighlightedIndex, selectId, visibleOptions]);
+    const viewport = dropdownRef.current?.querySelector<HTMLElement>('[data-menu-scroll-viewport]');
+    if (!highlightedOption || !viewport) return;
+    // 只滚动菜单内部；scrollIntoView 会连带滚动页面，使 iOS 上的锚点跳动。
+    const optionRect = highlightedOption.getBoundingClientRect();
+    const viewportRect = viewport.getBoundingClientRect();
+    if (optionRect.top < viewportRect.top) viewport.scrollTop += optionRect.top - viewportRect.top;
+    else if (optionRect.bottom > viewportRect.bottom) viewport.scrollTop += optionRect.bottom - viewportRect.bottom;
+  }, [dropdownStyle, isOpen, resolvedHighlightedIndex, selectId, visibleOptions]);
 
   const optionButtons = isOpen && visibleOptions.map((opt, index) => {
     const active = opt.value === value;
@@ -311,6 +337,44 @@ export function Select({
     );
   });
 
+  const searchField = search ? (
+    <input
+      ref={searchInputRef}
+      id={touchSearch ? `${selectId}-search` : selectId}
+      className={`${styles.trigger} ${styles.searchInput} ${touchSearch ? styles.touchSearchInput : ''}`}
+      type="text"
+      role="combobox"
+      aria-label={ariaLabel ?? search.placeholder}
+      aria-labelledby={ariaLabelledBy}
+      aria-describedby={ariaDescribedBy}
+      aria-autocomplete="list"
+      aria-expanded={isOpen}
+      aria-controls={isOpen ? listboxId : undefined}
+      aria-activedescendant={isOpen && resolvedHighlightedIndex >= 0 ? `${selectId}-option-${resolvedHighlightedIndex}` : undefined}
+      placeholder={search.placeholder}
+      value={isOpen || touchSearch ? searchQuery : selected?.triggerLabel ?? selected?.label ?? ''}
+      autoComplete="off"
+      autoCapitalize="none"
+      spellCheck={false}
+      disabled={disabled}
+      onFocus={touchSearch ? undefined : openDropdown}
+      onClick={() => {
+        if (!isOpen) openDropdown();
+      }}
+      onChange={(event) => {
+        shouldScrollHighlightRef.current = true;
+        setSearchQuery(event.target.value);
+        setHighlightedIndex(-1);
+        setOpen(true);
+      }}
+      onBlur={(event) => {
+        if (touchSearch && !event.relatedTarget) return;
+        if (!dropdownRef.current?.contains(event.relatedTarget) && !wrapRef.current?.contains(event.relatedTarget)) setOpen(false);
+      }}
+      onKeyDown={handleKeyDown}
+    />
+  ) : null;
+
   const dropdown =
     isOpen && dropdownStyle
       ? (
@@ -322,6 +386,7 @@ export function Select({
             aria-label={searchable ? undefined : ariaLabel}
             style={dropdownStyle}
           >
+            {touchSearch && <div className={styles.touchSearchField}>{searchField}</div>}
             <MenuScrollArea id={searchable ? listboxId : undefined} role={searchable ? 'listbox' : undefined} ariaLabel={searchable ? ariaLabel : undefined}>
               {optionButtons}
             </MenuScrollArea>
@@ -336,42 +401,9 @@ export function Select({
         className={`${styles.wrap} ${fullWidth ? styles.wrapFullWidth : ''} ${className ?? ''}`}
         ref={wrapRef}
       >
-        {search ? (
+        {search && !touchSearch ? (
           <>
-            <input
-              ref={searchInputRef}
-              id={selectId}
-              className={`${styles.trigger} ${styles.searchInput}`}
-              type="text"
-              role="combobox"
-              aria-label={ariaLabel ?? search.placeholder}
-              aria-labelledby={ariaLabelledBy}
-              aria-describedby={ariaDescribedBy}
-              aria-autocomplete="list"
-              aria-expanded={isOpen}
-              aria-controls={isOpen ? listboxId : undefined}
-              aria-activedescendant={isOpen && resolvedHighlightedIndex >= 0 ? `${selectId}-option-${resolvedHighlightedIndex}` : undefined}
-              placeholder={search.placeholder}
-              value={isOpen ? searchQuery : selected?.triggerLabel ?? selected?.label ?? ''}
-              autoComplete="off"
-              autoCapitalize="none"
-              spellCheck={false}
-              disabled={disabled}
-              onFocus={openDropdown}
-              onClick={() => {
-                if (!isOpen) openDropdown();
-              }}
-              onChange={(event) => {
-                shouldScrollHighlightRef.current = true;
-                setSearchQuery(event.target.value);
-                setHighlightedIndex(-1);
-                setOpen(true);
-              }}
-              onBlur={(event) => {
-                if (!dropdownRef.current?.contains(event.relatedTarget)) setOpen(false);
-              }}
-              onKeyDown={handleKeyDown}
-            />
+            {searchField}
             <span className={`${styles.triggerIcon} ${styles.searchIcon}`} aria-hidden="true">
               <IconChevronDown size={14} />
             </span>
@@ -391,7 +423,7 @@ export function Select({
               ? `${selectId}-option-${resolvedHighlightedIndex}`
               : undefined
           }
-          aria-label={ariaLabel}
+          aria-label={ariaLabel ?? search?.placeholder}
           aria-labelledby={ariaLabelledBy}
           aria-describedby={ariaDescribedBy}
           disabled={disabled}

--- a/web/src/components/ui/test/Select.test.tsx
+++ b/web/src/components/ui/test/Select.test.tsx
@@ -20,15 +20,135 @@ it.each([false, true])('does not interrupt pointer scrolling with automatic opti
     const trigger = container.querySelector<HTMLInputElement | HTMLButtonElement>(searchable ? 'input' : 'button')!;
     await act(async () => trigger.click());
     const options = document.querySelectorAll<HTMLButtonElement>('[role="option"]');
-    const pointerScroll = vi.spyOn(options[1], 'scrollIntoView');
-    const keyboardScroll = vi.spyOn(options[2], 'scrollIntoView');
+    const viewport = document.querySelector<HTMLElement>('[data-menu-scroll-viewport]')!;
+    vi.spyOn(viewport, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 100, 200, 100));
+    vi.spyOn(options[1], 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 250, 200, 36));
+    vi.spyOn(options[2], 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 300, 200, 36));
+    const pageScroll = vi.spyOn(options[2], 'scrollIntoView');
     await act(async () => options[1].dispatchEvent(new MouseEvent('mouseover', { bubbles: true })));
-    expect(pointerScroll).not.toHaveBeenCalled();
+    expect(viewport.scrollTop).toBe(0);
     await act(async () => trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })));
-    expect(keyboardScroll).toHaveBeenCalledWith({ block: 'nearest' });
+    expect(viewport.scrollTop).toBe(136);
+    expect(pageScroll).not.toHaveBeenCalled();
   } finally {
     await act(async () => root.unmount());
     container.remove();
+    vi.restoreAllMocks();
+  }
+});
+
+it('opens touch search as a choice list and only focuses text input when requested', async () => {
+  vi.stubGlobal('innerHeight', 640);
+  const matchMedia = window.matchMedia.bind(window);
+  vi.spyOn(window, 'matchMedia').mockImplementation((query) => {
+    const media = matchMedia(query);
+    Object.defineProperty(media, 'matches', { value: query === '(pointer: coarse)' });
+    return media;
+  });
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+  const onChange = vi.fn();
+  try {
+    await act(async () => root.render(<Select value="a" ariaLabel="Model"
+      options={[{ value: 'a', label: 'Alpha' }, { value: 'b', label: 'Beta' }]}
+      search={{ placeholder: 'Search models', noResultsText: 'No models' }} onChange={onChange} />));
+    const trigger = container.querySelector<HTMLButtonElement>('button[aria-label="Model"]')!;
+    expect(trigger).not.toBeNull();
+    vi.spyOn(trigger.parentElement!, 'getBoundingClientRect').mockReturnValue(new DOMRect(20, 400, 170, 40));
+    await act(async () => trigger.click());
+    const input = document.querySelector<HTMLInputElement>('input[role="combobox"]')!;
+    expect(input).not.toBeNull();
+    expect(document.activeElement).not.toBe(input);
+    expect(input.closest<HTMLElement>('[style]')!.style.top).toBe('448px');
+    expect(document.querySelectorAll('[role="option"]')).toHaveLength(2);
+    await act(async () => document.querySelectorAll<HTMLButtonElement>('[role="option"]')[1].click());
+    expect(onChange).toHaveBeenCalledExactlyOnceWith('b');
+    expect(document.querySelector('[role="listbox"]')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+
+    await act(async () => trigger.click());
+    const searchInput = document.querySelector<HTMLInputElement>('input[role="combobox"]')!;
+    await act(async () => {
+      searchInput.focus();
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!.call(searchInput, 'bet');
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(document.activeElement).toBe(searchInput);
+    expect(Array.from(document.querySelectorAll('[role="option"]'), (option) => option.textContent)).toEqual(['Beta']);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    await act(async () => searchInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })));
+    expect(document.querySelector('[role="listbox"]')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+    await act(async () => trigger.click());
+    expect(document.querySelectorAll('[role="option"]')).toHaveLength(2);
+    await act(async () => document.body.dispatchEvent(new PointerEvent('pointerdown', { pointerType: 'touch', bubbles: true })));
+    expect(document.querySelector('[role="listbox"]')).toBeNull();
+
+    await act(async () => trigger.click());
+    await act(async () => trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true })));
+    const keyboardInput = document.querySelector<HTMLInputElement>('input[role="combobox"]')!;
+    expect(document.activeElement).toBe(keyboardInput);
+    await act(async () => keyboardInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true })));
+    expect(document.activeElement).toBe(trigger);
+    expect(document.querySelector('[role="listbox"]')).toBeNull();
+
+    await act(async () => trigger.click());
+    const dismissInput = document.querySelector<HTMLInputElement>('input[role="combobox"]')!;
+    await act(async () => dismissInput.focus());
+    await act(async () => dismissInput.blur());
+    expect(document.querySelector('[role="listbox"]')).not.toBeNull();
+    await act(async () => trigger.click());
+    expect(document.querySelector('[role="listbox"]')).toBeNull();
+  } finally {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  }
+});
+
+it('tracks the visible viewport after keyboard resize and pan without moving over the trigger', async () => {
+  const viewport = Object.assign(new EventTarget(), { width: 390, height: 700, offsetLeft: 0, offsetTop: 0 });
+  vi.stubGlobal('visualViewport', viewport);
+  vi.stubGlobal('innerWidth', 390);
+  vi.stubGlobal('innerHeight', 700);
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+  try {
+    await act(async () => root.render(<Select value="a" options={[{ value: 'a', label: 'Alpha' }]} onChange={vi.fn()} />));
+    const trigger = container.querySelector('button')!;
+    vi.spyOn(trigger.parentElement!, 'getBoundingClientRect').mockReturnValue(new DOMRect(220, 200, 160, 40));
+    await act(async () => trigger.click());
+    const menu = document.querySelector<HTMLElement>('[role="listbox"]')!;
+    expect(menu.style.top).toBe('248px');
+    viewport.height = 280;
+    await act(async () => viewport.dispatchEvent(new Event('resize')));
+    expect(menu.style.top).toBe('192px');
+    expect(menu.style.transform).toBe('translateY(-100%)');
+    expect(menu.style.maxHeight).toBe('184px');
+
+    viewport.width = 300;
+    viewport.height = 500;
+    viewport.offsetTop = 100;
+    viewport.offsetLeft = 20;
+    await act(async () => viewport.dispatchEvent(new Event('scroll')));
+    expect(menu.style.top).toBe('248px');
+    expect(menu.style.transform).toBe('');
+    expect(menu.style.left).toBe('152px');
+
+    // 固定工具条中的锚点不动时，文档滚动也应更新菜单的文档坐标。
+    vi.stubGlobal('scrollY', 300);
+    vi.stubGlobal('scrollX', 30);
+    await act(async () => window.dispatchEvent(new Event('scroll')));
+    expect(menu.style.position).toBe('absolute');
+    expect(menu.style.top).toBe('548px');
+    expect(menu.style.left).toBe('182px');
+  } finally {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   }
 });

--- a/web/src/components/usage/credentials/test/AuthFileCredentialsSection.test.ts
+++ b/web/src/components/usage/credentials/test/AuthFileCredentialsSection.test.ts
@@ -84,6 +84,7 @@ describe('AuthFileCredentialsSection title', () => {
   it('renders the 5h cache rate in health mode', () => {
     const storage = new Map<string, string>([['cpa.credentials.authFiles.displayMode', 'health']])
     vi.stubGlobal('window', {
+      matchMedia: () => ({ matches: false }),
       localStorage: {
         getItem: (key: string) => storage.get(key) ?? null,
         setItem: (key: string, value: string) => storage.set(key, value),

--- a/web/src/hooks/useAnchorPosition.ts
+++ b/web/src/hooks/useAnchorPosition.ts
@@ -9,17 +9,36 @@ export function useAnchorPosition(
   useLayoutEffect(() => {
     if (!open) return;
     let frame = 0;
-    let previous: { rect: DOMRect; width: number; height: number } | undefined;
+    const viewport = window.visualViewport;
+    let previous: {
+      rect: DOMRect;
+      width: number;
+      height: number;
+      visibleWidth: number;
+      visibleHeight: number;
+      left: number;
+      top: number;
+      scrollX: number;
+      scrollY: number;
+    } | undefined;
     const update = () => {
       const anchor = anchorRef.current;
       if (!anchor) return;
       const rect = anchor.getBoundingClientRect();
       const width = window.innerWidth;
       const height = window.innerHeight;
+      const visibleWidth = viewport?.width ?? width;
+      const visibleHeight = viewport?.height ?? height;
+      const left = viewport?.offsetLeft ?? 0;
+      const top = viewport?.offsetTop ?? 0;
+      const { scrollX, scrollY } = window;
       if (!previous || rect.x !== previous.rect.x || rect.y !== previous.rect.y
         || rect.width !== previous.rect.width || rect.height !== previous.rect.height
-        || width !== previous.width || height !== previous.height) {
-        previous = { rect, width, height };
+        || width !== previous.width || height !== previous.height
+        || visibleWidth !== previous.visibleWidth || visibleHeight !== previous.visibleHeight
+        || left !== previous.left || top !== previous.top
+        || scrollX !== previous.scrollX || scrollY !== previous.scrollY) {
+        previous = { rect, width, height, visibleWidth, visibleHeight, left, top, scrollX, scrollY };
         updatePosition(rect);
       }
     };
@@ -30,11 +49,16 @@ export function useAnchorPosition(
     for (let element = anchorRef.current; element; element = element.parentElement) observer?.observe(element);
     window.addEventListener('resize', update);
     window.addEventListener('scroll', update, true);
+    // iOS 键盘与页面缩放只改变可视视口时，也需要重算弹层。
+    viewport?.addEventListener('resize', update);
+    viewport?.addEventListener('scroll', update);
     return () => {
       cancelAnimationFrame(frame);
       observer?.disconnect();
       window.removeEventListener('resize', update);
       window.removeEventListener('scroll', update, true);
+      viewport?.removeEventListener('resize', update);
+      viewport?.removeEventListener('scroll', update);
     };
   }, [open, anchorRef, updatePosition]);
 }

--- a/web/src/hooks/useMediaQuery.ts
+++ b/web/src/hooks/useMediaQuery.ts
@@ -6,10 +6,11 @@ import { useState, useEffect } from 'react';
 
 export function useMediaQuery(query: string): boolean {
   const [matches, setMatches] = useState(() => {
-    return window.matchMedia(query).matches;
+    return typeof window !== 'undefined' && window.matchMedia(query).matches;
   });
 
   useEffect(() => {
+    if (typeof window === 'undefined') return;
     const media = window.matchMedia(query);
 
     const listener = (event: MediaQueryListEvent) => {


### PR DESCRIPTION
## Summary

Searchable dropdowns on iOS Safari could open the keyboard immediately and drift over their triggers. Touch users can now choose an option directly or tap the search field when needed; desktop users keep direct typing in the filter bar.

- Keep shared dropdowns aligned using document coordinates and visible viewport tracking, with option scrolling confined to the menu.
- Apply the interaction to Model, API Key, and Source filters. Keep touch search text visually at 13px without reducing the 16px input font used to avoid iOS focus zoom, with 44px controls and an 8px gap above the options.

## Validation

- Frontend tests, ESLint, TypeScript checks, and production builds passed; affected checks were rerun after follow-up changes.
- Chromium and WebKit checks covered mobile and desktop selection, search, positioning, scrolling, visible text size, and search-to-option spacing.
- Manual iOS Safari testing confirmed the final interaction and layout.
