### PR TITLE
perf(quota): reduce quota history query overhead

### DIFF
--- a/internal/repository/codex_quota_efficiency.go
+++ b/internal/repository/codex_quota_efficiency.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -206,7 +207,7 @@ func BuildCodexQuotaEfficiencyHistory(ctx context.Context, db *gorm.DB, query re
 	}
 
 	// 单次有序流只从 SQLite 逐行读取必需字段；Go 线性归类后仅保留少量 pricing 分组。
-	if err := streamCodexQuotaEfficiencyUsage(ctx, db, query.AuthIndex, works, costResolver); err != nil {
+	if err := streamCodexQuotaEfficiencyUsage(ctx, db, query.AuthIndex, works, costResolver, false); err != nil {
 		return result, err
 	}
 	// 流式聚合结束后再计算每百分点值，保证 CostAvailable 已吸收所有 pricing 分组。
@@ -397,7 +398,7 @@ func buildCodexQuotaEfficiencyTransitions(segments []entities.QuotaPercentSegmen
 	return transitions
 }
 
-func streamCodexQuotaEfficiencyUsage(ctx context.Context, db *gorm.DB, authIndex string, works []codexQuotaEfficiencyCycleWork, costResolver pricing.Resolver) error {
+func streamCodexQuotaEfficiencyUsage(ctx context.Context, db *gorm.DB, authIndex string, works []codexQuotaEfficiencyCycleWork, costResolver pricing.Resolver, keepAllPricingFields bool) error {
 	if len(works) == 0 {
 		return nil
 	}
@@ -424,10 +425,9 @@ func streamCodexQuotaEfficiencyUsage(ctx context.Context, db *gorm.DB, authIndex
 
 	// SQLite 只做索引范围扫描和时间排序；Rows 迭代器避免把整个月的事件装入 Go 切片。
 	rows, err := db.WithContext(ctx).Clauses(dbresolver.Read).Raw(`SELECT
-		api_group_key, model, COALESCE(model_alias, '') AS model_alias,
-		service_tier, response_service_tier, reasoning_effort, endpoint, executor_type,
-		timestamp, failed, input_tokens, output_tokens, reasoning_tokens,
-		cache_read_tokens, cache_creation_tokens, total_tokens
+		`+codexQuotaEfficiencyPricingProjection(costResolver.ActiveFields(), keepAllPricingFields)+`,
+		timestamp, COALESCE(failed, 0), COALESCE(input_tokens, 0), COALESCE(output_tokens, 0), COALESCE(reasoning_tokens, 0),
+		cache_read_tokens, cache_creation_tokens, COALESCE(total_tokens, 0)
 	FROM usage_events INDEXED BY idx_usage_events_auth_index_timestamp_id
 	WHERE auth_type = ? AND auth_index = ? AND timestamp >= ? AND timestamp < ?
 	ORDER BY timestamp ASC, id ASC`,
@@ -449,9 +449,15 @@ func streamCodexQuotaEfficiencyUsage(ctx context.Context, db *gorm.DB, authIndex
 
 	workIndex := 0
 	transitionIndex := 0
+	// 投影列固定，直接读取并复用行对象，避免为每条请求重复执行 GORM 结构体映射。
+	var event codexQuotaEfficiencyUsageEventRow
 	for rows.Next() {
-		var event codexQuotaEfficiencyUsageEventRow
-		if err := db.ScanRows(rows, &event); err != nil {
+		if err := rows.Scan(
+			&event.APIGroupKey, &event.Model, &event.ModelAlias,
+			&event.ServiceTier, &event.ResponseServiceTier, &event.ReasoningEffort, &event.Endpoint, &event.ExecutorType,
+			&event.Timestamp, &event.Failed, &event.InputTokens, &event.OutputTokens, &event.ReasoningTokens,
+			&event.CacheReadTokens, &event.CacheCreationTokens, &event.TotalTokens,
+		); err != nil {
 			return fmt.Errorf("scan codex quota efficiency usage: %w", err)
 		}
 		event.Timestamp = timeutil.NormalizeStorageTime(event.Timestamp)
@@ -468,6 +474,21 @@ func streamCodexQuotaEfficiencyUsage(ctx context.Context, db *gorm.DB, authIndex
 			continue
 		}
 		cycleAccumulators[workIndex].add(event)
+		if !keepAllPricingFields && (!codexQuotaEfficiencyTokensAreAdditive(event.InputTokens, event.OutputTokens, event.CacheReadTokens, event.CacheCreationTokens, event.TotalTokens) ||
+			!codexQuotaEfficiencyTokensAreAdditive(work.record.Usage.InputTokens, work.record.Usage.OutputTokens, work.record.Usage.CacheReadTokens, work.record.Usage.CacheCreationTokens, work.record.Usage.TotalTokens)) {
+			// 负 Token、缓存超出输入或累计溢出时，原分组的归零处理不再满足可加性。
+			// 关闭当前流并清除部分结果，只重读一次完整维度，保留旧数据的费用口径。
+			if err := rows.Close(); err != nil {
+				return fmt.Errorf("close codex quota efficiency usage before full pricing scan: %w", err)
+			}
+			for _, work := range works {
+				work.record.Usage = repositorydto.CodexQuotaEfficiencyUsage{CostAvailable: true}
+				for index := range work.record.Transitions {
+					work.record.Transitions[index].Usage = repositorydto.CodexQuotaEfficiencyUsage{CostAvailable: true}
+				}
+			}
+			return streamCodexQuotaEfficiencyUsage(ctx, db, authIndex, works, costResolver, true)
+		}
 
 		transitions := work.record.Transitions
 		// 只在事件真正越过右边界时才前进，边界同时刻的所有事件都归前一次下降。
@@ -494,6 +515,25 @@ func streamCodexQuotaEfficiencyUsage(ctx context.Context, db *gorm.DB, authIndex
 		}
 	}
 	return nil
+}
+
+func codexQuotaEfficiencyPricingProjection(active pricing.ActiveFields, keepAll bool) string {
+	columns := []string{"api_group_key", "model", "model_alias", "service_tier", "response_service_tier", "reasoning_effort", "endpoint", "executor_type"}
+	activeColumns := UsagePricingDimensionColumns(active)
+	for index, column := range columns {
+		// 固定列位置供直接 Scan；未参与本次价格规则的维度不读取，也不拆分计价组。
+		if keepAll || slices.Contains(activeColumns, column) {
+			columns[index] = "COALESCE(" + column + ", '')"
+		} else {
+			columns[index] = "''"
+		}
+	}
+	return strings.Join(columns, ", ")
+}
+
+func codexQuotaEfficiencyTokensAreAdditive(input, output, cacheRead, cacheCreation, total int64) bool {
+	return input >= 0 && output >= 0 && cacheRead >= 0 && cacheCreation >= 0 && total >= 0 &&
+		cacheRead <= input && cacheCreation <= input-cacheRead
 }
 
 func newCodexQuotaEfficiencyUsageAccumulator(target *repositorydto.CodexQuotaEfficiencyUsage) codexQuotaEfficiencyUsageAccumulator {

--- a/internal/repository/test/codex_quota_efficiency_query_test.go
+++ b/internal/repository/test/codex_quota_efficiency_query_test.go
@@ -1,0 +1,240 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/config"
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/pricing"
+	"cpa-usage-keeper/internal/repository"
+	repositorydto "cpa-usage-keeper/internal/repository/dto"
+)
+
+func TestCodexQuotaEfficiencyPricingProjectionFollowsSnapshot(t *testing.T) {
+	for _, field := range []string{"api_group_key", "service_tier", "response_service_tier", "reasoning_effort", "endpoint", "executor_type", "model_alias"} {
+		t.Run(field, func(t *testing.T) {
+			db := openTestDatabase(t)
+			now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+			seedCodexQuotaEfficiencyCycle(t, db, "codex-auth", now.Add(-5*time.Hour), now.Add(time.Hour), []codexQuotaEfficiencySegmentSeed{
+				{remaining: 90, first: now.Add(-3 * time.Hour), last: now.Add(-3 * time.Hour)},
+				{remaining: 89, first: now.Add(-time.Hour), last: now.Add(-time.Hour)},
+			})
+			seedCodexQuotaEfficiencyUsage(t, db,
+				usageEventForQuotaEfficiency("normal", "oauth", "codex-auth", now.Add(-2*time.Hour), 1_000_000),
+				usageEventForQuotaEfficiency("special", "oauth", "codex-auth", now.Add(-90*time.Minute), 1_000_000),
+			)
+			if err := db.Model(&entities.UsageEvent{}).Where("event_key = ?", "special").Update(field, "special").Error; err != nil {
+				t.Fatal(err)
+			}
+			// 同一份历史分别用无规则及有规则快照查询；字段只有实际参与规则时才影响金额。
+			for _, active := range []bool{false, true} {
+				var rules []pricing.RuleConfig
+				wantCost := 2.0
+				if active {
+					rules = []pricing.RuleConfig{{Key: field, Value: "special", Multiplier: 2}}
+					wantCost = 3
+				}
+				result, err := repository.BuildCodexQuotaEfficiencyHistory(context.Background(), db, repositorydto.CodexQuotaEfficiencyQuery{
+					AuthIndex: "codex-auth", Now: now, RangeStart: now.Add(-30 * 24 * time.Hour),
+				}, codexQuotaEfficiencyPricingResolverWithRules(t, rules))
+				if err != nil {
+					t.Fatal(err)
+				}
+				assertCodexQuotaEfficiencyUsage(t, result.Cycles[0].Usage, 2_000_000, wantCost, true)
+				assertCodexQuotaEfficiencyUsage(t, result.Cycles[0].Transitions[0].Usage, 2_000_000, wantCost, true)
+			}
+		})
+	}
+}
+
+func TestCodexQuotaEfficiencyPreservesLegacyPricingGroups(t *testing.T) {
+	for _, testCase := range []struct {
+		name     string
+		mutate   func(*entities.UsageEvent)
+		wantCost float64
+	}{
+		{name: "cache exceeds input", mutate: func(e *entities.UsageEvent) { e.CacheReadTokens = 2_000_000 }, wantCost: 1},
+		{name: "cache creation exceeds input", mutate: func(e *entities.UsageEvent) { e.CacheCreationTokens = 2_000_000 }, wantCost: 1},
+		{name: "negative input", mutate: func(e *entities.UsageEvent) { e.InputTokens = -1_000_000 }, wantCost: 1},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			db := openTestDatabase(t)
+			now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+			seedCodexQuotaEfficiencyCycle(t, db, "codex-auth", now.Add(-10*time.Hour), now.Add(-5*time.Hour), []codexQuotaEfficiencySegmentSeed{
+				{remaining: 80, first: now.Add(-9 * time.Hour), last: now.Add(-9 * time.Hour)},
+				{remaining: 79, first: now.Add(-8 * time.Hour), last: now.Add(-8 * time.Hour)},
+			})
+			seedCodexQuotaEfficiencyCycle(t, db, "codex-auth", now.Add(-5*time.Hour), now.Add(time.Hour), []codexQuotaEfficiencySegmentSeed{
+				{remaining: 90, first: now.Add(-3 * time.Hour), last: now.Add(-3 * time.Hour)},
+				{remaining: 89, first: now.Add(-time.Hour), last: now.Add(-time.Hour)},
+			})
+			normal := usageEventForQuotaEfficiency("normal", "oauth", "codex-auth", now.Add(-2*time.Hour), 1_000_000)
+			legacy := usageEventForQuotaEfficiency("legacy", "oauth", "codex-auth", now.Add(-90*time.Minute), 1_000_000)
+			legacy.ReasoningEffort = "high"
+			testCase.mutate(&legacy)
+			seedCodexQuotaEfficiencyUsage(t, db,
+				usageEventForQuotaEfficiency("completed", "oauth", "codex-auth", now.Add(-8*time.Hour-30*time.Minute), 400_000),
+				normal, legacy,
+			)
+			result, err := repository.BuildCodexQuotaEfficiencyHistory(context.Background(), db, repositorydto.CodexQuotaEfficiencyQuery{
+				AuthIndex: "codex-auth", Now: now, RangeStart: now.Add(-30 * 24 * time.Hour),
+			}, codexQuotaEfficiencyPricingResolver(t))
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertCodexQuotaEfficiencyUsage(t, result.Cycles[0].Usage, 2_000_000, testCase.wantCost, true)
+			assertCodexQuotaEfficiencyUsage(t, result.Cycles[0].Transitions[0].Usage, 2_000_000, testCase.wantCost, true)
+			// 旧数据位于后一个周期时，已经处理过的周期及变化区间也不能重复累加。
+			assertCodexQuotaEfficiencyUsage(t, result.Cycles[1].Usage, 400_000, 0.4, true)
+			assertCodexQuotaEfficiencyUsage(t, result.Cycles[1].Transitions[0].Usage, 400_000, 0.4, true)
+			if result.Cycles[0].Usage.Requests != 2 || result.Cycles[0].Transitions[0].Usage.Requests != 2 {
+				t.Fatalf("unexpected request totals: %+v", result.Cycles[0])
+			}
+		})
+	}
+}
+
+func TestCodexQuotaEfficiencyReadsNullableLegacyFieldsAndAlias(t *testing.T) {
+	db := openTestDatabase(t)
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	seedCodexQuotaEfficiencyCycle(t, db, "codex-auth", now.Add(-5*time.Hour), now.Add(time.Hour), []codexQuotaEfficiencySegmentSeed{
+		{remaining: 90, first: now.Add(-3 * time.Hour), last: now.Add(-3 * time.Hour)},
+		{remaining: 89, first: now.Add(-time.Hour), last: now.Add(-time.Hour)},
+	})
+	event := usageEventForQuotaEfficiency("legacy-null", "oauth", "codex-auth", now.Add(-time.Hour), 0)
+	seedCodexQuotaEfficiencyUsage(t, db, event)
+	if err := db.Model(&entities.UsageEvent{}).Where("event_key = ?", event.EventKey).Updates(map[string]any{
+		"api_group_key": nil, "endpoint": nil, "model": nil, "failed": nil, "input_tokens": nil,
+		"output_tokens": nil, "reasoning_tokens": nil, "total_tokens": nil,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	alias := "priced-model"
+	aliased := usageEventForQuotaEfficiency("alias", "oauth", "codex-auth", now.Add(-time.Hour), 1_000_000)
+	aliased.Model, aliased.ModelAlias, aliased.Failed = "unknown-model", &alias, true
+	seedCodexQuotaEfficiencyUsage(t, db, aliased)
+	result, err := repository.BuildCodexQuotaEfficiencyHistory(context.Background(), db, repositorydto.CodexQuotaEfficiencyQuery{
+		AuthIndex: "codex-auth", Now: now, RangeStart: now.Add(-30 * 24 * time.Hour),
+	}, codexQuotaEfficiencyPricingResolver(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, usage := range []repositorydto.CodexQuotaEfficiencyUsage{result.Cycles[0].Usage, result.Cycles[0].Transitions[0].Usage} {
+		assertCodexQuotaEfficiencyUsage(t, usage, 1_000_000, 1, true)
+		if usage.Requests != 2 || usage.SuccessfulRequests != 1 || usage.FailedRequests != 1 {
+			t.Fatalf("unexpected nullable/boundary counters: %+v", usage)
+		}
+	}
+}
+
+func TestCodexQuotaEfficiencyPreservesTokenComponents(t *testing.T) {
+	db := openTestDatabase(t)
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	seedCodexQuotaEfficiencyCycle(t, db, "codex-auth", now.Add(-5*time.Hour), now.Add(time.Hour), []codexQuotaEfficiencySegmentSeed{
+		{remaining: 90, first: now.Add(-3 * time.Hour), last: now.Add(-3 * time.Hour)},
+		{remaining: 89, first: now.Add(-time.Hour), last: now.Add(-time.Hour)},
+	})
+	first := usageEventForQuotaEfficiency("first", "oauth", "codex-auth", now.Add(-2*time.Hour), 1_000_000)
+	first.OutputTokens, first.ReasoningTokens = 200_000, 70_000
+	first.CacheReadTokens, first.CacheCreationTokens, first.TotalTokens = 100_000, 50_000, 1_200_000
+	second := usageEventForQuotaEfficiency("second", "oauth", "codex-auth", now.Add(-90*time.Minute), 2_000_000)
+	second.OutputTokens, second.ReasoningTokens = 300_000, 80_000
+	second.CacheReadTokens, second.CacheCreationTokens, second.TotalTokens = 200_000, 25_000, 2_300_000
+	second.Endpoint, second.Failed = "/different-endpoint", true
+	seedCodexQuotaEfficiencyUsage(t, db, first, second)
+	snapshot, err := pricing.CompileSnapshot([]pricing.ModelConfig{{Pricing: entities.ModelPriceSetting{
+		Model: "priced-model", PromptPricePer1M: 2, CompletionPricePer1M: 4, CacheReadPricePer1M: 0.5, CacheWritePricePer1M: 1,
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := repository.BuildCodexQuotaEfficiencyHistory(context.Background(), db, repositorydto.CodexQuotaEfficiencyQuery{
+		AuthIndex: "codex-auth", Now: now, RangeStart: now.Add(-30 * 24 * time.Hour),
+	}, pricing.NewCatalog(snapshot).NewResolver())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, usage := range []repositorydto.CodexQuotaEfficiencyUsage{result.Cycles[0].Usage, result.Cycles[0].Transitions[0].Usage} {
+		assertCodexQuotaEfficiencyUsage(t, usage, 3_500_000, 7.475, true)
+		if usage.InputTokens != 3_000_000 || usage.OutputTokens != 500_000 || usage.ReasoningTokens != 150_000 ||
+			usage.CacheReadTokens != 300_000 || usage.CacheCreationTokens != 75_000 ||
+			usage.Requests != 2 || usage.SuccessfulRequests != 1 || usage.FailedRequests != 1 {
+			t.Fatalf("unexpected token components or counters: %+v", usage)
+		}
+	}
+}
+
+func BenchmarkCodexQuotaEfficiencyHistory(b *testing.B) {
+	for _, testCase := range []struct {
+		name   string
+		events int
+		rules  []pricing.RuleConfig
+	}{
+		{name: "30k_no_rules", events: 30_000},
+		{name: "100k_no_rules", events: 100_000},
+		{name: "30k_with_rules", events: 30_000, rules: []pricing.RuleConfig{
+			{Key: "service_tier", Value: "priority", Multiplier: 2},
+			{Key: "reasoning_effort", Value: "high", Multiplier: 1.5},
+		}},
+	} {
+		b.Run(testCase.name, func(b *testing.B) {
+			db, err := repository.OpenDatabase(config.Config{SQLitePath: filepath.Join(b.TempDir(), "quota.db")})
+			if err != nil {
+				b.Fatal(err)
+			}
+			sqlDB, err := db.DB()
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.Cleanup(func() { _ = sqlDB.Close() })
+			now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+			start := now.Add(-30 * 24 * time.Hour)
+			for cycleIndex := 0; cycleIndex < 144; cycleIndex++ {
+				cycleStart := start.Add(time.Duration(cycleIndex) * 5 * time.Hour)
+				segments := make([]codexQuotaEfficiencySegmentSeed, 101)
+				for point := range segments {
+					observed := cycleStart.Add(time.Duration(point) * 3 * time.Minute)
+					segments[point] = codexQuotaEfficiencySegmentSeed{remaining: 100 - point, first: observed, last: observed}
+				}
+				seedCodexQuotaEfficiencyCycle(b, db, "codex-auth", cycleStart, cycleStart.Add(5*time.Hour), segments)
+			}
+			for offset := 0; offset < testCase.events; offset += 100 {
+				events := make([]entities.UsageEvent, 0, 100)
+				for index := offset; index < min(offset+100, testCase.events); index++ {
+					at := start.Add(time.Duration(index) * (30 * 24 * time.Hour / time.Duration(testCase.events)))
+					event := usageEventForQuotaEfficiency(fmt.Sprintf("event-%d", index), "oauth", "codex-auth", at, 1000)
+					event.APIGroupKey = fmt.Sprintf("group-%d", index%7)
+					event.Endpoint = fmt.Sprintf("/endpoint-%d", index%3)
+					event.ServiceTier = []string{"standard", "priority"}[index%2]
+					event.ReasoningEffort = []string{"low", "medium", "high"}[index%3]
+					events = append(events, event)
+				}
+				seedCodexQuotaEfficiencyUsage(b, db, events...)
+			}
+			resolver := codexQuotaEfficiencyPricingResolverWithRules(b, testCase.rules)
+			query := repositorydto.CodexQuotaEfficiencyQuery{AuthIndex: "codex-auth", Now: now, RangeStart: start}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for iteration := 0; iteration < b.N; iteration++ {
+				result, err := repository.BuildCodexQuotaEfficiencyHistory(context.Background(), db, query, resolver)
+				if err != nil {
+					b.Fatal(err)
+				}
+				var requests int64
+				var cost float64
+				for _, cycle := range result.Cycles {
+					requests += cycle.Usage.Requests
+					cost += cycle.Usage.TotalCostUSD
+				}
+				if len(result.Cycles) != 144 || requests != int64(testCase.events) || (len(testCase.rules) == 0 && math.Abs(cost-float64(testCase.events)/1000) > 1e-8) {
+					b.Fatalf("unexpected history: cycles=%d requests=%d cost=%f", len(result.Cycles), requests, cost)
+				}
+			}
+		})
+	}
+}

--- a/internal/repository/test/codex_quota_efficiency_test.go
+++ b/internal/repository/test/codex_quota_efficiency_test.go
@@ -430,11 +430,11 @@ type codexQuotaEfficiencySegmentSeed struct {
 	last      time.Time
 }
 
-func seedCodexQuotaEfficiencyCycle(t *testing.T, db *gorm.DB, authIndex string, start, reset time.Time, segments []codexQuotaEfficiencySegmentSeed) entities.QuotaCycle {
+func seedCodexQuotaEfficiencyCycle(t testing.TB, db *gorm.DB, authIndex string, start, reset time.Time, segments []codexQuotaEfficiencySegmentSeed) entities.QuotaCycle {
 	return seedCodexQuotaEfficiencyRoleCycle(t, db, authIndex, entities.CodexQuotaWindowRolePrimary, start, reset, segments)
 }
 
-func seedCodexQuotaEfficiencyRoleCycle(t *testing.T, db *gorm.DB, authIndex string, role entities.CodexQuotaWindowRole, start, reset time.Time, segments []codexQuotaEfficiencySegmentSeed) entities.QuotaCycle {
+func seedCodexQuotaEfficiencyRoleCycle(t testing.TB, db *gorm.DB, authIndex string, role entities.CodexQuotaWindowRole, start, reset time.Time, segments []codexQuotaEfficiencySegmentSeed) entities.QuotaCycle {
 	t.Helper()
 	quotaKey := "rate_limit.primary_window"
 	if role == entities.CodexQuotaWindowRoleSecondary {
@@ -486,18 +486,18 @@ func usageEventForQuotaEfficiency(key, authType, authIndex string, timestamp tim
 	}
 }
 
-func seedCodexQuotaEfficiencyUsage(t *testing.T, db *gorm.DB, events ...entities.UsageEvent) {
+func seedCodexQuotaEfficiencyUsage(t testing.TB, db *gorm.DB, events ...entities.UsageEvent) {
 	t.Helper()
 	if err := db.Create(&events).Error; err != nil {
 		t.Fatalf("seed quota efficiency usage events: %v", err)
 	}
 }
 
-func codexQuotaEfficiencyPricingResolver(t *testing.T) pricing.Resolver {
+func codexQuotaEfficiencyPricingResolver(t testing.TB) pricing.Resolver {
 	return codexQuotaEfficiencyPricingResolverWithRules(t, nil)
 }
 
-func codexQuotaEfficiencyPricingResolverWithRules(t *testing.T, rules []pricing.RuleConfig) pricing.Resolver {
+func codexQuotaEfficiencyPricingResolverWithRules(t testing.TB, rules []pricing.RuleConfig) pricing.Resolver {
 	t.Helper()
 	multiplier := 1.0
 	snapshot, err := pricing.CompileSnapshot([]pricing.ModelConfig{{


### PR DESCRIPTION
## Summary

Loading Codex quota history spends substantial time mapping individual usage rows through GORM. Read the ordered event stream directly and group pricing tokens by the fields used by the current pricing snapshot. The complete 30-day response and existing page behavior stay the same.

Negative token values, cache tokens exceeding input, or accumulation overflow retain the original pricing groups through one bounded rescan. Partial cycle and percentage-interval totals are cleared before retrying so historical costs remain consistent.

Fixes #495

## Validation

- Full backend tests passed with `TZ=UTC` and `-count=1`: `go test ./cmd/... ./internal/...`.
- Quota history repository tests passed in UTC and Asia/Shanghai, covering active price rules, nullable legacy fields, aliases, token components, and rescan totals across cycles.
- `git diff --check` passed.
- `BenchmarkCodexQuotaEfficiencyHistory` ran with `-benchtime=2x -count=3 -cpu=1` on local synthetic 30-day histories with 144 cycles. Median repository query times:

| Dataset | Baseline | Updated |
| --- | ---: | ---: |
| 30,000 requests, no price rules | 543 ms | 338 ms |
| 100,000 requests, no price rules | 1,365 ms | 626 ms |
| 30,000 requests, price rules enabled | 525 ms | 318 ms |

Allocated bytes per operation fell by approximately 42–65%. Direct scanning provides most of the timing improvement; trimming pricing dimensions reduces allocations but did not consistently improve timing in the smaller no-rule sample.
