### PR TITLE
perf(sync): reduce CPA sync and quota polling overhead

### DIFF
--- a/internal/cpa/client.go
+++ b/internal/cpa/client.go
@@ -135,10 +135,15 @@ func (c *Client) doManagementJSONRequestWithBody(ctx context.Context, method str
 	})
 }
 
-const defaultRequestLogStreamIdleTimeout = 30 * time.Second
+const (
+	defaultRequestLogStreamIdleTimeout = 30 * time.Second
+	// 同时覆盖七路 metadata 和默认十个 quota worker（部分每个发两次请求）的空闲连接复用。
+	defaultMaxIdleConnsPerHost = 32
+)
 
 func NewClient(baseURL, managementKey string, timeout time.Duration, tlsSkipVerify bool) *Client {
 	transport := cloneDefaultHTTPTransport()
+	transport.MaxIdleConnsPerHost = max(transport.MaxIdleConnsPerHost, defaultMaxIdleConnsPerHost)
 	if tlsSkipVerify {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}

--- a/internal/cpa/test/client_connection_reuse_test.go
+++ b/internal/cpa/test/client_connection_reuse_test.go
@@ -1,0 +1,59 @@
+package cpa_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/cpa"
+)
+
+func TestClientReusesConnectionsAcrossConcurrentMetadataRequests(t *testing.T) {
+	const concurrency = 7
+	var connections atomic.Int32
+	var requests atomic.Int32
+	gates := []chan struct{}{make(chan struct{}), make(chan struct{})}
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		arrival := int(requests.Add(1))
+		wave := (arrival - 1) / concurrency
+		if arrival%concurrency == 0 {
+			close(gates[wave])
+		}
+		// 每轮等全部请求到达再响应，确保真正使用七条并发连接。
+		select {
+		case <-gates[wave]:
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"files":[]}`)
+		case <-r.Context().Done():
+		}
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			connections.Add(1)
+		}
+	}
+	server.Start()
+	defer server.Close()
+	client := cpa.NewClient(server.URL, "test-management-key", 5*time.Second, false)
+
+	for wave := 0; wave < len(gates); wave++ {
+		var wg sync.WaitGroup
+		for range concurrency {
+			wg.Go(func() {
+				if _, err := client.FetchAuthFiles(context.Background()); err != nil {
+					t.Errorf("fetch auth files: %v", err)
+				}
+			})
+		}
+		wg.Wait()
+		if got := connections.Load(); got != concurrency {
+			t.Fatalf("wave %d opened %d connections; want reuse of the original %d", wave+1, got, concurrency)
+		}
+	}
+}

--- a/internal/quota/refresh.go
+++ b/internal/quota/refresh.go
@@ -17,6 +17,8 @@ import (
 
 type RefreshSource string
 
+const refreshTaskReadCleanupInterval = time.Minute
+
 const (
 	RefreshSourceManual        RefreshSource = "manual"
 	RefreshSourceInspection    RefreshSource = "inspection"
@@ -112,9 +114,10 @@ func (s *Service) GetCachedQuota(ctx context.Context, request CacheRequest) (Cac
 		return CacheResponse{}, fmt.Errorf("%w: auth_indexes are required", ErrValidation)
 	}
 	response := CacheResponse{Items: make([]CachedQuotaItem, 0, len(request.AuthIndexes))}
-	s.cleanupExpiredRefreshTasks(time.Now())
+	now := time.Now()
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
+	s.cleanupRefreshTasksForReadLocked(now)
 	// 按请求顺序去重并读取每个 auth_index 最近一次完成的任务缓存。
 	seen := make(map[string]struct{}, len(request.AuthIndexes))
 	for _, rawAuthIndex := range request.AuthIndexes {
@@ -126,7 +129,7 @@ func (s *Service) GetCachedQuota(ctx context.Context, request CacheRequest) (Cac
 			continue
 		}
 		seen[authIndex] = struct{}{}
-		task, ok := s.refreshTasks[authIndex]
+		task, ok := s.refreshTaskForReadLocked(authIndex, now)
 		if !ok {
 			continue
 		}
@@ -260,10 +263,11 @@ func (s *Service) GetRefreshTaskByAuthIndex(ctx context.Context, authIndex strin
 	if authIndex == "" {
 		return RefreshTaskResponse{}, fmt.Errorf("%w: auth_index is required", ErrValidation)
 	}
-	s.cleanupExpiredRefreshTasks(time.Now())
+	now := time.Now()
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
-	task, ok := s.refreshTasks[authIndex]
+	s.cleanupRefreshTasksForReadLocked(now)
+	task, ok := s.refreshTaskForReadLocked(authIndex, now)
 	if !ok {
 		return RefreshTaskResponse{}, ErrTaskNotFound
 	}
@@ -559,6 +563,24 @@ func (s *Service) cleanupExpiredRefreshTasksLocked(now time.Time) {
 		}
 		delete(s.refreshTasks, authIndex)
 	}
+	s.nextRefreshTaskCleanupAt = now.Add(refreshTaskReadCleanupInterval)
+}
+
+func (s *Service) cleanupRefreshTasksForReadLocked(now time.Time) {
+	// 高频逐项轮询共享一分钟清理窗口；刷新、巡检等既有入口仍可立即全量清理。
+	if !now.Before(s.nextRefreshTaskCleanupAt) {
+		s.cleanupExpiredRefreshTasksLocked(now)
+	}
+}
+
+func (s *Service) refreshTaskForReadLocked(authIndex string, now time.Time) (*RefreshTaskRecord, bool) {
+	task, ok := s.refreshTasks[authIndex]
+	// 全量清理可以延后，但当前请求项到期后必须立即不可见，不能延长失败缓存 TTL。
+	if ok && !task.ExpiresAt.IsZero() && !now.Before(task.ExpiresAt) {
+		delete(s.refreshTasks, authIndex)
+		return nil, false
+	}
+	return task, ok
 }
 
 func (t *RefreshTaskRecord) isActive() bool {

--- a/internal/quota/service.go
+++ b/internal/quota/service.go
@@ -39,6 +39,8 @@ type Service struct {
 
 	refreshMu    sync.Mutex
 	refreshTasks map[string]*RefreshTaskRecord
+	// nextRefreshTaskCleanupAt 由 refreshMu 保护，只限制读取接口的全量清理频率。
+	nextRefreshTaskCleanupAt time.Time
 	// resetInFlight 按 auth_index 记录正在消费的 reset credit，避免并发重复扣减官方次数。
 	resetMu       sync.Mutex
 	resetInFlight map[string]struct{}

--- a/internal/quota/test/refresh_cache_cleanup_test.go
+++ b/internal/quota/test/refresh_cache_cleanup_test.go
@@ -1,0 +1,69 @@
+package test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/quota"
+)
+
+func TestRefreshCacheReadsRejectExpiryAfterRecentCleanup(t *testing.T) {
+	service := &quota.Service{}
+	setRefreshTasks(service, make(map[string]*quota.RefreshTaskRecord))
+	now := time.Now()
+	cleanupExpiredRefreshTasks(service, now)
+	unauthorized := http.StatusUnauthorized
+	// 在刚完成全量清理后放入过期项，读取仍须立即遵守 TTL。
+	for _, authIndex := range []string{"task-expired", "cache-expired"} {
+		setRefreshTask(service, authIndex, &quota.RefreshTaskRecord{
+			AuthIndex: authIndex, Status: quota.RefreshTaskStatusFailed,
+			HTTPStatusCode: &unauthorized, ExpiresAt: now.Add(-time.Second),
+		})
+	}
+	setRefreshTask(service, "valid-error", &quota.RefreshTaskRecord{
+		AuthIndex: "valid-error", Status: quota.RefreshTaskStatusFailed,
+		HTTPStatusCode: &unauthorized, ExpiresAt: now.Add(time.Hour),
+	})
+	setRefreshTask(service, "completed", &quota.RefreshTaskRecord{
+		AuthIndex: "completed", Status: quota.RefreshTaskStatusCompleted,
+		Quota: &quota.CheckResponse{ID: "completed"},
+	})
+	if _, err := service.GetRefreshTaskByAuthIndex(context.Background(), "task-expired"); !errors.Is(err, quota.ErrTaskNotFound) {
+		t.Fatalf("expired task must be absent: %v", err)
+	}
+	cache, err := service.GetCachedQuota(context.Background(), quota.CacheRequest{
+		AuthIndexes: []string{"cache-expired", "valid-error", "completed"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cache.Items) != 2 || cache.Items[0].AuthIndex != "valid-error" || cache.Items[1].AuthIndex != "completed" {
+		t.Fatalf("unexpected cache after expiry: %+v", cache.Items)
+	}
+}
+
+func BenchmarkRefreshTaskLookup(b *testing.B) {
+	for _, count := range []int{1000, 10000} {
+		b.Run(fmt.Sprintf("cached_%d", count), func(b *testing.B) {
+			service := &quota.Service{}
+			tasks := make(map[string]*quota.RefreshTaskRecord, count)
+			for i := range count {
+				key := fmt.Sprintf("auth-%d", i)
+				tasks[key] = &quota.RefreshTaskRecord{AuthIndex: key, Status: quota.RefreshTaskStatusCompleted}
+			}
+			setRefreshTasks(service, tasks)
+			ctx := context.Background()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := service.GetRefreshTaskByAuthIndex(ctx, "auth-0"); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/internal/repository/dto/usage_identities.go
+++ b/internal/repository/dto/usage_identities.go
@@ -13,8 +13,8 @@ type UsageIdentityStatsDelta struct {
 	CachedTokens    int64
 	CacheReadTokens int64
 	TotalTokens     int64
-	FirstUsedAt     *time.Time
-	LastUsedAt      *time.Time
+	FirstUsedAt     *time.Time `gorm:"serializer:storageTime"`
+	LastUsedAt      *time.Time `gorm:"serializer:storageTime"`
 	MaxUsageEventID int64
 }
 

--- a/internal/repository/query_projection_test.go
+++ b/internal/repository/query_projection_test.go
@@ -30,8 +30,6 @@ func TestRepositoryQueriesAvoidKnownFullEntityReads(t *testing.T) {
 	assertFileContains(t, "usage_identities.go",
 		"Select(usageIdentityReadColumns)",
 		"Select(usageIdentityAggregationColumns)",
-		"Select(\"timestamp\").Where(\"id > ?\", identity.LastAggregatedUsageEventID).Order(\"timestamp asc, id asc\").First(&firstEvent)",
-		"Select(\"timestamp\").Where(\"id > ?\", identity.LastAggregatedUsageEventID).Order(\"timestamp desc, id desc\").First(&lastEvent)",
 	)
 
 	assertFileContains(t, "redis_usage_inbox.go",

--- a/internal/repository/test/usage_identity_time_bounds_test.go
+++ b/internal/repository/test/usage_identity_time_bounds_test.go
@@ -1,0 +1,57 @@
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/entities"
+	"cpa-usage-keeper/internal/repository"
+)
+
+func TestUsageIdentityAggregationPreservesStoredTimeBounds(t *testing.T) {
+	for _, legacy := range []bool{false, true} {
+		name := "current"
+		if legacy {
+			name = "legacy"
+		}
+		t.Run(name, func(t *testing.T) {
+			db := openTestDatabase(t)
+			identity := entities.UsageIdentity{Identity: "time-bounds", AuthType: entities.UsageIdentityAuthTypeAuthFile, Type: "codex"}
+			if err := db.Create(&identity).Error; err != nil {
+				t.Fatal(err)
+			}
+			base := time.Date(2026, 9, 12, 23, 0, 0, 123456789, time.Local)
+			first, last := base.Add(-time.Hour), base.Add(2*time.Hour)
+			// 插入顺序与时间顺序不同，并跨自然日，首尾时间不能按事件 ID 推断。
+			events := []entities.UsageEvent{
+				{AuthType: "oauth", AuthIndex: identity.Identity, Timestamp: last, TotalTokens: 30},
+				{AuthType: "oauth", AuthIndex: identity.Identity, Timestamp: first, TotalTokens: 10},
+				{AuthType: "oauth", AuthIndex: identity.Identity, Timestamp: base, TotalTokens: 20},
+			}
+			if _, _, err := repository.InsertUsageEvents(db, events); err != nil {
+				t.Fatal(err)
+			}
+			if legacy {
+				for _, event := range events {
+					if err := db.Model(&entities.UsageEvent{}).Where("id = ?", event.ID).
+						Update("timestamp", event.Timestamp.Format("2006-01-02 15:04:05.999999999")).Error; err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			if err := repository.AggregateUsageIdentityStats(context.Background(), db, last.Add(time.Hour)); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.First(&identity, identity.ID).Error; err != nil {
+				t.Fatal(err)
+			}
+			if identity.FirstUsedAt == nil || !identity.FirstUsedAt.Equal(first) || identity.LastUsedAt == nil || !identity.LastUsedAt.Equal(last) {
+				t.Fatalf("unexpected time bounds: first=%v last=%v; want %v / %v", identity.FirstUsedAt, identity.LastUsedAt, first, last)
+			}
+			if identity.TotalRequests != 3 || identity.TotalTokens != 60 || identity.LastAggregatedUsageEventID != events[2].ID {
+				t.Fatalf("aggregation totals or cursor changed: requests=%d tokens=%d cursor=%d", identity.TotalRequests, identity.TotalTokens, identity.LastAggregatedUsageEventID)
+			}
+		})
+	}
+}

--- a/internal/repository/usage_identities.go
+++ b/internal/repository/usage_identities.go
@@ -529,7 +529,8 @@ func aggregateUsageIdentityDelta(tx *gorm.DB, identity entities.UsageIdentity) (
 		return delta, nil
 	}
 
-	// 再用 last_aggregated_usage_event_id 做增量游标，只累计上次之后的新事件。
+	// 同一次增量查询取齐累计和首尾时间，减少唯一 writer 事务内的重复查询。
+	// MIN/MAX 沿用原先 timestamp 排序口径，DTO serializer 兼容新旧存储时间格式。
 	if err := query.
 		Select(`
 			COUNT(*) AS total_requests,
@@ -541,36 +542,13 @@ func aggregateUsageIdentityDelta(tx *gorm.DB, identity entities.UsageIdentity) (
 			COALESCE(SUM(cached_tokens), 0) AS cached_tokens,
 			COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
 			COALESCE(SUM(total_tokens), 0) AS total_tokens,
+			MIN(timestamp) AS first_used_at,
+			MAX(timestamp) AS last_used_at,
 			COALESCE(MAX(id), 0) AS max_usage_event_id`).
 		Where("id > ?", identity.LastAggregatedUsageEventID).
 		Scan(&delta).Error; err != nil {
 		return delta, fmt.Errorf("aggregate usage identity stats for %q: %w", identity.Identity, err)
 	}
-	if delta.TotalRequests == 0 {
-		return delta, nil
-	}
-
-	// 统计总量不包含首尾时间，首尾时间用同一组身份过滤条件分别取最早和最晚事件。
-	var firstEvent struct {
-		Timestamp time.Time
-	}
-	firstQuery, _ := usageIdentityEventsQuery(tx.Model(&entities.UsageEvent{}), identity)
-	if err := firstQuery.Select("timestamp").Where("id > ?", identity.LastAggregatedUsageEventID).Order("timestamp asc, id asc").First(&firstEvent).Error; err != nil {
-		return delta, fmt.Errorf("find first usage identity event for %q: %w", identity.Identity, err)
-	}
-	firstUsedAt := firstEvent.Timestamp
-	delta.FirstUsedAt = &firstUsedAt
-
-	var lastEvent struct {
-		Timestamp time.Time
-	}
-	lastQuery, _ := usageIdentityEventsQuery(tx.Model(&entities.UsageEvent{}), identity)
-	if err := lastQuery.Select("timestamp").Where("id > ?", identity.LastAggregatedUsageEventID).Order("timestamp desc, id desc").First(&lastEvent).Error; err != nil {
-		return delta, fmt.Errorf("find last usage identity event for %q: %w", identity.Identity, err)
-	}
-	lastUsedAt := lastEvent.Timestamp
-	delta.LastUsedAt = &lastUsedAt
-
 	return delta, nil
 }
 

--- a/internal/service/redis_usage.go
+++ b/internal/service/redis_usage.go
@@ -148,6 +148,10 @@ func (d queuedUsageDetail) toUsageEvent(fetchedAt time.Time) entities.UsageEvent
 }
 
 func (d queuedUsageDetail) toUsageHeaderSnapshot(event entities.UsageEvent) *quota.UsageHeaderSnapshot {
+	// event 已规范化；没有 OAuth 身份的 Header 不会产生额度快照，无需解析响应头。
+	if event.AuthType != "oauth" || event.AuthIndex == "" {
+		return nil
+	}
 	headers, ok := decodeRedisUsageResponseHeaders(d.ResponseHeaders)
 	if !ok {
 		return nil

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -583,6 +583,10 @@ func tokenViolationCodes(violations []tokenprocessor.Violation) []string {
 }
 
 func logTokenProcessingBatch(items []normalizedUsageEvent, inboxStatus string, processedRows, successfulEvents, decodeFailed int, failures redisInboxFailureCounts) {
+	// 默认 Info 不消费批次汇总，提前跳过逐事件计数和日志 map 分配。
+	if !logrus.IsLevelEnabled(logrus.DebugLevel) {
+		return
+	}
 	// outcome map 预先放入全部枚举，零计数也稳定出现在结构化日志中，便于监控直接聚合。
 	outcomeCounts := map[string]int{
 		string(tokenprocessor.TokenOutcomeValid):         0,

--- a/internal/service/test/redis_usage_header_performance_test.go
+++ b/internal/service/test/redis_usage_header_performance_test.go
@@ -1,0 +1,54 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"cpa-usage-keeper/internal/service"
+)
+
+func TestUsageHeaderSnapshotRequiresOAuthIdentity(t *testing.T) {
+	for _, tc := range []struct {
+		name, authType, authIndex string
+		wantSnapshot              bool
+	}{
+		{"oauth", " OAuth ", "auth-1", true},
+		{"api_key", "api_key", "auth-1", false},
+		{"missing_identity", "oauth", "  ", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := fmt.Sprintf(`{"request_id":"header-eligibility","auth_type":%q,"auth_index":%q,"provider":"unknown","response_headers":{"X-Codex-Primary-Used-Percent":["5"],"X-Codex-Primary-Window-Minutes":["300"],"X-Codex-Primary-Reset-After-Seconds":["60"]}}`, tc.authType, tc.authIndex)
+			// provider 提示不能代替身份来源判定；有效 OAuth Header 仍需进入快照。
+			event, raw, snapshot, err := service.DecodeRedisUsageMessageWithHeaders(payload, time.Now())
+			if err != nil || event.RequestID != "header-eligibility" || string(raw) != payload {
+				t.Fatalf("usage event changed: request=%q err=%v", event.RequestID, err)
+			}
+			if (snapshot != nil) != tc.wantSnapshot {
+				t.Fatalf("snapshot presence=%v, want %v", snapshot != nil, tc.wantSnapshot)
+			}
+		})
+	}
+}
+
+func BenchmarkDecodeAPIKeyUsageWithResponseHeaders(b *testing.B) {
+	headers := make(map[string][]string, 24)
+	for i := range 24 {
+		headers[fmt.Sprintf("X-Synthetic-%02d", i)] = []string{strings.Repeat("v", 32)}
+	}
+	rawHeaders, err := json.Marshal(headers)
+	if err != nil {
+		b.Fatal(err)
+	}
+	payload := `{"request_id":"benchmark","auth_type":"apikey","auth_index":"key-1","response_headers":` + string(rawHeaders) + `}`
+	fetchedAt := time.Date(2026, 9, 12, 0, 0, 0, 0, time.UTC)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, snapshot, err := service.DecodeRedisUsageMessageWithHeaders(payload, fetchedAt); err != nil || snapshot != nil {
+			b.Fatalf("unexpected snapshot or error: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Reduce repeated work during CPA usage ingestion, credential aggregation, and quota polling:

- Skip debug-only batch accounting when Debug is disabled and avoid decoding quota headers for events without an OAuth identity.
- Read credential totals and first/last usage times in one query, preserving incremental cursors and stored-time handling.
- Retain at least 32 idle HTTP connections per host to reuse concurrent metadata and quota requests.
- Limit full quota-cache sweeps on reads to once per minute while checking requested entries for expiry immediately.

## Validation

- Backend package checks passed across `./cmd/...` and `./internal/...`; `./internal/repository` was rechecked after removing obsolete query-shape assertions.
- Race checks passed for quota refresh and CPA client tests.
- Identity aggregation and reset checks passed under UTC and Asia/Shanghai.
- The connection reuse regression test reduced connections across two seven-request waves from 12 to 7.
- Local microbenchmarks: API-key usage decoding fell from 32.7 to 12.7 microseconds/op and 121 to 13 allocations/op; task lookup with 10,000 cached entries fell from 145 to 0.10 microseconds/op. These measure individual paths, not end-to-end throughput.
