### PR TITLE
feat(usage): persist upstream session hierarchy

### DIFF
--- a/internal/benchmark/capacity/dataset.go
+++ b/internal/benchmark/capacity/dataset.go
@@ -337,7 +337,7 @@ func insertGeneratedEvents(ctx context.Context, sqlDB *sql.DB, options GenerateO
 		if err != nil {
 			return fmt.Errorf("begin benchmark event batch: %w", err)
 		}
-		placeholders := strings.TrimSuffix(strings.Repeat("?,", 31), ",")
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", 33), ",")
 		statement, err := tx.PrepareContext(ctx, "INSERT INTO usage_events ("+usageEventInsertColumns+") VALUES ("+placeholders+")")
 		if err != nil {
 			tx.Rollback()
@@ -515,6 +515,7 @@ func eventInsertArgs(event generatedEvent) []any {
 	timestamp := timeutil.FormatStorageTime(event.Timestamp)
 	return []any{
 		event.ID, event.EventKey, event.APIGroupKey, event.Provider, event.Endpoint, event.AuthType, event.RequestID,
+		"", "",
 		nil, nil, nil, event.Model, event.ModelAlias, event.ReasoningEffort, event.ServiceTier, event.ResponseServiceTier,
 		event.ExecutorType, timestamp, event.Source, event.AuthIndex, event.Failed, true, event.LatencyMS, event.TTFTMS,
 		event.InputTokens, event.OutputTokens, event.ReasoningTokens, event.CachedTokens, event.CacheReadTokens,

--- a/internal/entities/usage_event.go
+++ b/internal/entities/usage_event.go
@@ -11,6 +11,8 @@ type UsageEvent struct {
 	Endpoint            string    `gorm:"column:endpoint"`
 	AuthType            string    `gorm:"column:auth_type;index:idx_usage_events_auth_type_auth_index_id,priority:1"`
 	RequestID           string    `gorm:"column:request_id"`
+	SessionID           string    `gorm:"column:session_id"`
+	ParentSessionID     string    `gorm:"column:parent_session_id"`
 	ClientIP            *string   `gorm:"column:client_ip"`
 	XForwardedFor       *string   `gorm:"column:x_forwarded_for"`
 	UserAgent           *string   `gorm:"column:user_agent"`

--- a/internal/entities/usage_event_archive.go
+++ b/internal/entities/usage_event_archive.go
@@ -3,7 +3,7 @@ package entities
 import "time"
 
 // UsageEventStorageColumns 是 hot/archive 原始事件复制使用的完整持久化列契约。
-const UsageEventStorageColumns = "id, event_key, api_group_key, provider, endpoint, auth_type, request_id, client_ip, x_forwarded_for, user_agent, model, model_alias, reasoning_effort, service_tier, response_service_tier, executor_type, timestamp, source, auth_index, failed, generate, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens, created_at"
+const UsageEventStorageColumns = "id, event_key, api_group_key, provider, endpoint, auth_type, request_id, session_id, parent_session_id, client_ip, x_forwarded_for, user_agent, model, model_alias, reasoning_effort, service_tier, response_service_tier, executor_type, timestamp, source, auth_index, failed, generate, latency_ms, ttft_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens, created_at"
 
 // UsageEventArchive 永久保存已经离开 hot usage_events 的原始事件。
 // 字段必须与 UsageEvent 的持久化列保持一致，但 archive 不承担在线查询，因此不复制二级索引。
@@ -15,6 +15,8 @@ type UsageEventArchive struct {
 	Endpoint            string  `gorm:"column:endpoint"`
 	AuthType            string  `gorm:"column:auth_type"`
 	RequestID           string  `gorm:"column:request_id"`
+	SessionID           string  `gorm:"column:session_id"`
+	ParentSessionID     string  `gorm:"column:parent_session_id"`
 	ClientIP            *string `gorm:"column:client_ip"`
 	XForwardedFor       *string `gorm:"column:x_forwarded_for"`
 	UserAgent           *string `gorm:"column:user_agent"`

--- a/internal/repository/migration/20260912_usage_event_session_fields.go
+++ b/internal/repository/migration/20260912_usage_event_session_fields.go
@@ -1,0 +1,11 @@
+package migration
+
+import (
+	"gorm.io/gorm"
+
+	"cpa-usage-keeper/internal/entities"
+)
+
+func addUsageEventSessionFieldsMigration(tx *gorm.DB) error {
+	return tx.AutoMigrate(&entities.UsageEvent{}, &entities.UsageEventArchive{})
+}

--- a/internal/repository/migration/20260912_usage_event_session_fields.go
+++ b/internal/repository/migration/20260912_usage_event_session_fields.go
@@ -1,11 +1,38 @@
 package migration
 
 import (
+	"fmt"
+
 	"gorm.io/gorm"
 
 	"cpa-usage-keeper/internal/entities"
 )
 
 func addUsageEventSessionFieldsMigration(tx *gorm.DB) error {
-	return tx.AutoMigrate(&entities.UsageEvent{}, &entities.UsageEventArchive{})
+	for _, table := range []struct {
+		model any
+		name  string
+	}{
+		{model: &entities.UsageEvent{}, name: "usage_events"},
+		{model: &entities.UsageEventArchive{}, name: "usage_events_archive"},
+	} {
+		if !tx.Migrator().HasTable(table.model) {
+			continue
+		}
+		for _, column := range []struct {
+			name  string
+			field string
+		}{
+			{name: "session_id", field: "SessionID"},
+			{name: "parent_session_id", field: "ParentSessionID"},
+		} {
+			if tx.Migrator().HasColumn(table.model, column.name) {
+				continue
+			}
+			if err := tx.Migrator().AddColumn(table.model, column.field); err != nil {
+				return fmt.Errorf("add %s.%s column: %w", table.name, column.name, err)
+			}
+		}
+	}
+	return nil
 }

--- a/internal/repository/migration/migration.go
+++ b/internal/repository/migration/migration.go
@@ -95,6 +95,7 @@ const (
 	// migrationAddUsageEventAPIGroupKeyTimestampIndex 用 (api_group_key, timestamp) 复合索引替代单列 Key 索引。
 	migrationAddUsageEventAPIGroupKeyTimestampIndex = "20260905_usage_event_api_group_key_timestamp_index"
 	migrationAddUsageIdentityStatsReset             = "20260910_usage_identity_stats_reset"
+	migrationAddUsageEventSessionFields             = "20260912_usage_event_session_fields"
 )
 
 type schemaMigration struct {
@@ -241,6 +242,7 @@ func orderedMigrations() []databaseMigration {
 		// 将单列 Key 索引收敛为 Key+时间复合索引，支持请求记录和历史边界查询。
 		{version: migrationAddUsageEventAPIGroupKeyTimestampIndex, run: addUsageEventAPIGroupKeyTimestampIndexMigration},
 		{version: migrationAddUsageIdentityStatsReset, run: addUsageIdentityStatsResetMigration},
+		{version: migrationAddUsageEventSessionFields, run: addUsageEventSessionFieldsMigration},
 	}
 }
 

--- a/internal/repository/migration/migration_test.go
+++ b/internal/repository/migration/migration_test.go
@@ -89,6 +89,7 @@ func TestOrderedMigrationsPreservesExecutionOrder(t *testing.T) {
 		"20260902_repair_usage_event_quota_window_index",
 		"20260905_usage_event_api_group_key_timestamp_index",
 		"20260910_usage_identity_stats_reset",
+		"20260912_usage_event_session_fields",
 	}
 	assertStringSlicesEqual(t, want, got)
 }

--- a/internal/repository/test/usage_event_archive_test.go
+++ b/internal/repository/test/usage_event_archive_test.go
@@ -68,7 +68,7 @@ func TestArchiveExpiredUsageEventsPreservesOriginalRowAndHotSequence(t *testing.
 	events := []entities.UsageEvent{
 		{
 			EventKey: "archive-me", APIGroupKey: "group-a", Provider: "openai", Endpoint: "/v1/responses",
-			AuthType: "oauth", RequestID: "request-a", ClientIP: &clientIP, Model: "gpt-5", ReasoningEffort: "high",
+			AuthType: "oauth", RequestID: "request-a", SessionID: "session-child", ParentSessionID: "session-root", ClientIP: &clientIP, Model: "gpt-5", ReasoningEffort: "high",
 			ServiceTier: "priority", ResponseServiceTier: "priority", ExecutorType: "codex", Timestamp: now.AddDate(0, 0, -91),
 			Source: "auth-a", AuthIndex: "auth-a", Failed: true, Generate: &generate, LatencyMS: 999, TTFTMS: &ttft,
 			InputTokens: 10, OutputTokens: 20, ReasoningTokens: 5, CachedTokens: 4, CacheReadTokens: 3, CacheCreationTokens: 2, TotalTokens: 35,
@@ -97,7 +97,7 @@ func TestArchiveExpiredUsageEventsPreservesOriginalRowAndHotSequence(t *testing.
 	if err := db.Where("id = ?", original.ID).Take(&archived).Error; err != nil {
 		t.Fatalf("load archived usage event: %v", err)
 	}
-	if archived.ID != original.ID || archived.EventKey != original.EventKey || archived.RequestID != original.RequestID || archived.TotalTokens != original.TotalTokens {
+	if archived.ID != original.ID || archived.EventKey != original.EventKey || archived.RequestID != original.RequestID || archived.SessionID != original.SessionID || archived.ParentSessionID != original.ParentSessionID || archived.TotalTokens != original.TotalTokens {
 		t.Fatalf("archive row did not preserve original values: original=%+v archive=%+v", original, archived)
 	}
 	var oldHotCount int64

--- a/internal/service/redis_usage.go
+++ b/internal/service/redis_usage.go
@@ -58,6 +58,8 @@ type queuedUsageDetail struct {
 	AuthType            string          `json:"auth_type"`
 	APIKey              string          `json:"api_key"`
 	RequestID           string          `json:"request_id"`
+	SessionID           string          `json:"session_id"`
+	ParentSessionID     string          `json:"parent_session_id"`
 	ResponseHeaders     json.RawMessage `json:"response_headers"`
 }
 
@@ -120,6 +122,8 @@ func (d queuedUsageDetail) toUsageEvent(fetchedAt time.Time) entities.UsageEvent
 		Endpoint:            strings.TrimSpace(d.Endpoint),
 		AuthType:            normalizeRedisAuthType(d.AuthType),
 		RequestID:           strings.TrimSpace(d.RequestID),
+		SessionID:           strings.TrimSpace(d.SessionID),
+		ParentSessionID:     strings.TrimSpace(d.ParentSessionID),
 		ClientIP:            d.ClientIP,
 		XForwardedFor:       d.XForwardedFor,
 		UserAgent:           d.UserAgent,

--- a/internal/service/redis_usage_test.go
+++ b/internal/service/redis_usage_test.go
@@ -30,6 +30,8 @@ func TestDecodeRedisUsageMessageMapsPayloadToUsageEvent(t *testing.T) {
 		"auth_type":"api_key",
 		"api_key":"raw-key",
 		"request_id":"req-123",
+		"session_id":"session-root",
+		"parent_session_id":"session-parent",
 		"unknown":"ignored"
 	}`, fetchedAt)
 	if err != nil {
@@ -43,6 +45,9 @@ func TestDecodeRedisUsageMessageMapsPayloadToUsageEvent(t *testing.T) {
 	}
 	if event.Provider != "claude" || event.Endpoint != "/v1/messages" || event.AuthType != "apikey" || event.RequestID != "req-123" {
 		t.Fatalf("unexpected redis identity fields: %+v", event)
+	}
+	if event.SessionID != "session-root" || event.ParentSessionID != "session-parent" {
+		t.Fatalf("unexpected session fields: session_id=%q parent_session_id=%q", event.SessionID, event.ParentSessionID)
 	}
 	if event.ModelAlias == nil || *event.ModelAlias != "claude-sonnet-alias" {
 		t.Fatalf("expected model alias to decode, got %+v", event.ModelAlias)


### PR DESCRIPTION
## Summary

Persist the upstream CPA session hierarchy in usage event storage without rebuilding legacy SQLite tables.

- Decode `session_id` and `parent_session_id` from Redis usage payloads.
- Add both fields to `usage_events` and `usage_events_archive`.
- Add the session columns with idempotent `AddColumn` migrations so existing event fields and archive rows are preserved.
- Keep archive copy and migration replay column contracts synchronized.
- Update benchmark fixtures and regression tests for the expanded storage schema.

## Validation

- Targeted session, Redis, archive, migration, and service tests pass.
- Full backend verification passes with `go test ./cmd/... ./internal/...`.
- The migration preserves existing `event_key`, Redis backfill, and usage identity fields on legacy databases.
